### PR TITLE
fix: move static assets to project root to avoid bind mount conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build Docker image
-        run: docker compose build
-
-      - name: Start services without dev bind mounts
-        run: |
-          docker run -d --name jentic-mini \
-            -p 8900:8900 \
-            -v $(pwd)/data:/app/data \
-            jentic-mini:latest
+      - name: Build and start services
+        run: docker compose up -d --build
 
       - name: Wait for server to be ready
         run: |
@@ -34,7 +27,7 @@ jobs:
             sleep 2
           done
           echo "Server failed to start"
-          docker logs jentic-mini
+          docker compose logs
           exit 1
 
       - name: Health check
@@ -60,8 +53,8 @@ jobs:
 
       - name: Dump logs on failure
         if: failure()
-        run: docker logs jentic-mini
+        run: docker compose logs
 
       - name: Stop services
         if: always()
-        run: docker rm -f jentic-mini
+        run: docker compose down

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,6 @@ vendor/arazzo-engine/
 /tmp/
 node_modules
 vendor/arazzo-engine
-src/static/
+/static/
 src/specs/
 src/workflows/catalog_*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:24-slim AS ui-build
 WORKDIR /build
 COPY ui/ ./ui/
-RUN mkdir -p src/static
+RUN mkdir -p static
 RUN cd ui && npm ci --ignore-scripts && npm run build
 
 # Stage 2: Python runtime
@@ -26,8 +26,9 @@ RUN mkdir -p /app/data /app/src
 # Copy source into /app/src so that `from src.xxx` imports work from WORKDIR /app
 COPY src/ /app/src/
 
-# Copy built UI assets from stage 1
-COPY --from=ui-build /build/src/static/ /app/src/static/
+# Copy built UI assets from stage 1 — placed outside /app/src/ so the
+# dev bind mount (./src:/app/src) doesn't hide them at runtime.
+COPY --from=ui-build /build/static/ /app/static/
 
 COPY src/docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod +x /app/docker-entrypoint.sh

--- a/src/main.py
+++ b/src/main.py
@@ -159,7 +159,7 @@ app.add_middleware(APIKeyMiddleware)
 app.middleware("http")(negotiate_middleware)
 
 # ── Static dir — defined early so route handlers can reference it ──────────────
-STATIC_DIR = Path(__file__).parent / "static"
+STATIC_DIR = Path(__file__).resolve().parent.parent / "static"
 
 app.include_router(capability_router.router, tags=["inspect"])
 app.include_router(workflows_router.router)

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -10,7 +10,7 @@ function copyApiDocsAssets(): import('vite').Plugin {
   return {
     name: 'copy-api-docs-assets',
     closeBundle() {
-      const outDir = resolve(__dirname, '../src/static')
+      const outDir = resolve(__dirname, '../static')
       const nm = resolve(__dirname, 'node_modules')
       copyFileSync(resolve(nm, 'swagger-ui-dist/swagger-ui-bundle.js'), resolve(outDir, 'swagger-ui-bundle.js'))
       copyFileSync(resolve(nm, 'swagger-ui-dist/swagger-ui.css'), resolve(outDir, 'swagger-ui.css'))
@@ -22,7 +22,7 @@ function copyApiDocsAssets(): import('vite').Plugin {
 export default defineConfig({
   plugins: [react(), copyApiDocsAssets()],
   base: '/',
-  build: { outDir: '../src/static', emptyOutDir: true },
+  build: { outDir: '../static', emptyOutDir: true },
   server: {
     proxy: {
       '/api': 'http://localhost:8900',


### PR DESCRIPTION
Docker's ./src:/app/src volume mount was hiding built UI assets
at runtime. Static output now goes to /static/ (project root),
outside the mount path.