### PR TITLE
ci: disable provenance attestation in GHCR publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          provenance: true
+          provenance: false
           tags: ghcr.io/jentic/jentic-mini:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Removes the `unknown/unknown` manifest entry that appears in the GHCR package UI alongside the real platform images. Caused by SLSA provenance attestation being enabled.

One-line change: `provenance: true` → `provenance: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)