### PR TITLE
fix: allow agent keys to list and get OAuth brokers

### DIFF
--- a/src/routers/oauth_brokers.py
+++ b/src/routers/oauth_brokers.py
@@ -258,9 +258,13 @@ async def create_oauth_broker(body: OAuthBrokerCreate):
 @router.get(
     "",
     summary="List registered OAuth brokers",
+    tags=["inspect"],
 )
 async def list_oauth_brokers():
-    """Return all registered OAuth brokers as a flat list. `client_secret` is never included."""
+    """Return all registered OAuth brokers as a flat list. `client_secret` is never included.
+
+    Accessible to both agents (toolkit key) and humans (session).
+    """
     async with get_db() as db:
         async with db.execute(
             "SELECT id, type, client_id, project_id, created_at FROM oauth_brokers"
@@ -273,6 +277,7 @@ async def list_oauth_brokers():
 @router.get(
     "/{broker_id}",
     summary="Get an OAuth broker",
+    tags=["inspect"],
 )
 async def get_oauth_broker(broker_id: BrokerIdPath):
     async with get_db() as db:
@@ -481,6 +486,7 @@ async def sync_broker_accounts(broker_id: BrokerIdPath, body: SyncRequest, reque
 @router.get(
     "/{broker_id}/accounts",
     summary="List connected accounts for an OAuth broker",
+    tags=["inspect"],
 )
 async def list_broker_accounts(broker_id: BrokerIdPath, external_user_id: ExternalUserIdQuery = None):
     """List the OAuth-connected account mappings stored for this broker.


### PR DESCRIPTION
## Problem

Several read-only OAuth broker endpoints were restricted to human sessions only, meaning agents had to ask the user to read IDs and account status from the UI — breaking the setup flow.

## Changes

Remove `require_human_session` from three read-only endpoints:

- `GET /oauth-brokers` — list all brokers (agent needs broker IDs to generate connect links)
- `GET /oauth-brokers/{id}` — get a single broker
- `GET /oauth-brokers/{id}/accounts` — list connected accounts (agent needs this to confirm OAuth sync completed and accounts are healthy)

All three return only metadata — no credentials or secrets are ever included (`client_secret` is excluded by `_row_to_out`; accounts return only `api_host`, `app_slug`, `account_id`, `healthy`, `synced_at`).

## Security

Read-only metadata access poses no security risk. The global auth middleware still enforces authentication on all three endpoints — unauthenticated requests are rejected as before.

All write operations (create broker, update, delete, connect-link, sync, delete account) remain human-session-only.