### PR TITLE
fix: require human session for credential permissions write endpoints

### DIFF
--- a/src/routers/toolkits.py
+++ b/src/routers/toolkits.py
@@ -721,6 +721,7 @@ async def get_credential_permissions(toolkit_id: str, cred_id: str):
     summary="Replace permission rules for a specific credential",
     tags=["toolkits"],
     response_model=list[PermissionRule],
+    dependencies=[Depends(require_human_session)],
 )
 async def set_credential_permissions(toolkit_id: str, cred_id: str, body: list[PolicyRule]):
     """Replaces the entire agent rule list for this credential.
@@ -741,6 +742,7 @@ async def set_credential_permissions(toolkit_id: str, cred_id: str, body: list[P
     summary="Add or remove individual permission rules for a specific credential",
     tags=["toolkits"],
     response_model=list[PermissionRule],
+    dependencies=[Depends(require_human_session)],
 )
 async def patch_credential_permissions(toolkit_id: str, cred_id: str, body: PermissionsPatch):
     """Incrementally update rules for this credential without replacing the full list.


### PR DESCRIPTION
## Problem

`PUT` and `PATCH` on `/toolkits/{id}/credentials/{cred_id}/permissions` were accessible with an agent API key (`X-Jentic-API-Key: tk_xxx`). This allowed an agent to grant itself new API permissions **without going through the human approval flow** — bypassing the core security model.

The intended flow is:
1. Agent submits `POST /toolkits/{id}/access-requests`
2. Human reviews and approves in the UI
3. UI (human session) writes the permission rule

What was actually possible: agent calls `PUT` or `PATCH` on permissions directly, skipping steps 1 and 2 entirely.

This was caught during install testing where an agent added a Gmail drafts allow rule to itself without requesting approval.

## Fix

Add `require_human_session` to both write endpoints:
- `PUT /toolkits/{id}/credentials/{cred_id}/permissions` — replace full rule list
- `PATCH /toolkits/{id}/credentials/{cred_id}/permissions` — add/remove individual rules

`GET` remains agent-accessible (read-only, no security risk — agents need to read their own permissions).

## Security Impact

Without this fix, a compromised agent or prompt injection attack could silently escalate its own API access. This is exactly the threat the human approval flow is designed to prevent.