### PR TITLE
fix: widen CredentialOut.auth_type from Literal to str

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -127,7 +127,7 @@ class CredentialOut(BaseModel):
     identity: str | None = None
     """Identity field (username, client ID, etc.) — returned so clients can confirm what was stored."""
     api_id: str | None = None
-    auth_type: Literal["bearer", "basic", "apiKey", "pipedream_oauth"] | None = None
+    auth_type: str | None = None
     created_at: float | None = None
     updated_at: float | None = None
 


### PR DESCRIPTION
## Problem

`GET /toolkits/{id}/credentials` crashes with a Pydantic `literal_error` when any credential has an `auth_type` value not in the hardcoded `Literal["bearer", "basic", "apiKey", "pipedream_oauth"]`.

Confirmed error from logs:
```
'type': 'literal_error', 'msg': "Input should be 'bearer', 'basic', 'apiKey' or 'pipedream_oauth'", 'input': 'JenticApiKey'
```

The offending credential is the self-registered internal credential created at startup with `scheme_name="JenticApiKey"`. Pipedream OAuth credentials may also trigger this with their own scheme names.

## Fix

Change `auth_type` in `CredentialOut` from `Literal[...]` to `str | None`.

The credentials listing endpoint is a read path returning stored values — not user input requiring strict validation. The set of valid auth schemes is open-ended (any OAuth broker or custom scheme can introduce new values), so a hardcoded allowlist is the wrong tool here.