### PR TITLE
docs: README improvements — early access disclaimer and positioning clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The **Jentic hosted and VPC editions** offer deeper implementations across four 
 | **Simulation** | Basic simulate mode | Full sandbox for simulating API calls and toolkit behaviour (enterprise-only) |
 | **Catalog** | ~1,044 APIs + ~380 workflow sources from [jentic-public-apis](https://github.com/jentic/jentic-public-apis); auto-imported on credential add | Central catalog — aggregates the collective know-how of agents across API definitions and Arazzo workflows |
 
-Jentic Mini is a self-hosted deployment option for individuals and small teams who want full control over their data and credentials. For production use at scale, [hosted Jentic](https://jentic.com) is the first-class alternative.
+Jentic Mini is a self-hosted deployment option for individuals and small teams who want full control over their data and credentials. For teams that need managed scaling, SLAs, or enterprise features, [Jentic](https://jentic.com) offers hosted and on-premises editions — [get in touch](https://jentic.com/contact) to find out more.
 
 ## Getting Started
 


### PR DESCRIPTION
Two README updates:

**1. Early access disclaimer**
Adds a prominent warning at the top that Jentic Mini is new and under active development, not recommended for production use yet, and encourages issue reports. Honest about where the project is without underselling it.

**2. Hosted vs self-hosted positioning**
Removes the "build locally, point at hosted for production" framing, which implied Jentic Mini is a dev tool rather than a production deployment option. Replaces with language that treats self-hosted and hosted as parallel first-class options for different needs (control/data sovereignty vs managed scaling/SLA).