### PR TITLE
docs: add OpenClaw/ClawHub integration section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ injecting credentials at runtime, and brokering the request. Secrets never touch
 
 > ⚠️ **Early Access** — Jentic Mini is new and under active development. It may contain bugs, rough edges, and security gaps we haven't found yet. It is **not recommended for production use** at this stage. We're sharing it early so the community can explore it, test it, and help shape it. Use it in personal or development environments, and please [report issues](https://github.com/jentic/jentic-mini/issues) as you find them.
 
-**Jentic Mini** is the open-source, self-hosted implementation of the Jentic API — fully API-compatible with the [Jentic hosted and VPC editions](https://jentic.com).
-
 ## Quick Start
 
 **Using OpenClaw?** The fastest way to get started is via the Jentic skill on [ClawHub](https://clawhub.com) — it will guide you through your installation options and connect your agent automatically. Just tell your OpenClaw agent:


### PR DESCRIPTION
Adds a short section explaining how OpenClaw users can connect to Jentic Mini using the Jentic skill on ClawHub, including the one-liner prompt to install and configure it.