### PR TITLE
ci: disable telemetry in smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           docker run -d --name jentic-mini \
             -p 8900:8900 \
             -v jentic-ci-data:/app/data \
+            -e JENTIC_TELEMETRY=off \
             jentic-mini:latest
 
       - name: Wait for server to be ready


### PR DESCRIPTION
Adds JENTIC_TELEMETRY=off to CI docker run. Closes #39.