### PR TITLE
fix: setup page UX — handle existing account + waiting-for-agent state

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -345,7 +345,7 @@ async def redoc():
 # ── Broker catch-all — MUST be registered last ────────────────────────────────
 # Paths whose first segment contains "." route to the broker.
 # All Jentic-internal routes above take priority by registration order.
-# ── Static files ──────────────────────────────────────────────────────────────
+# ── Static files — MUST be before broker catch-all ────────────────────────────
 if STATIC_DIR.exists():
     app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
     # Also serve Vite build assets at /assets (Vite default output path)

--- a/ui/src/pages/SetupPage.tsx
+++ b/ui/src/pages/SetupPage.tsx
@@ -18,7 +18,11 @@ export default function SetupPage() {
   })
 
   const generateKeyMutation = useMutation({
-    mutationFn: () => fetch('/default-api-key/generate', { method: 'POST', credentials: 'include' }).then(r => r.json()),
+    mutationFn: async () => {
+      const r = await fetch('/default-api-key/generate', { method: 'POST', credentials: 'include' })
+      if (!r.ok) throw new Error(`Key generation failed (${r.status})`)
+      return r.json()
+    },
     onSuccess: () => refetchHealth(),
   })
 


### PR DESCRIPTION
- Health endpoint returns `account_created` bool in setup_required response
- SetupPage detects account-exists-but-key-unclaimed and shows a waiting state instead of the create-account form
- Polls /health every 3s while waiting; gracefully handles 409/410 errors