### PR TITLE
feat: add API Docs link and footer branding to sidebar

### DIFF
--- a/ui/src/components/layout/Layout.tsx
+++ b/ui/src/components/layout/Layout.tsx
@@ -69,6 +69,8 @@ export function Layout() {
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-3 px-4 py-2 rounded-md text-sm text-foreground hover:bg-muted hover:text-primary transition-all duration-150"
+            aria-label="API Docs (opens in a new tab)"
+            title="API Docs (opens in a new tab)"
           >
             <BookOpen className="h-4 w-4" />
             <span className="font-semibold">API Docs</span>


### PR DESCRIPTION
- BookOpen icon + link to /docs in the sidebar footer
- 'jentic mini · self-hosted' label below it
- Revert Sidebar.tsx to clean state (component is not rendered; Layout.tsx contains the inline sidebar)