### PR TITLE
fix: scope broker catch-all to dot-in-first-segment paths only

### DIFF
--- a/src/routers/broker.py
+++ b/src/routers/broker.py
@@ -354,12 +354,14 @@ def _is_broker_path(path: str) -> bool:
 # Custom Starlette path convertor so the broker catch-all only matches paths
 # whose first segment looks like a hostname (contains a dot, e.g. api.stripe.com).
 # This means UI routes like /search or /catalog never reach the broker at all —
-# they fall through to a 404 handler which proxies them to Vite in dev mode.
+# they are handled by earlier registered routes or the SPA catch-all in main.py.
 from starlette.convertors import Convertor, CONVERTOR_TYPES  # noqa: E402
 
 class _BrokerHostConvertor(Convertor):
-    # First segment must contain a dot and not start with one (rules out /@vite/client etc.)
-    regex = r"[^/]*\.[^/.][^/]*(?:/.*)?$"
+    # First segment must contain a dot, not start with one, and have at least one char before the dot.
+    # Rejects: .well-known/..., /@vite/..., empty first segment
+    # Matches: api.stripe.com/v1/customers, httpbin.org/get
+    regex = r"[^/.][^/]*\.[^/.][^/]*(?:/.*)?$"
 
     def convert(self, value: str) -> str:
         return value


### PR DESCRIPTION
Adds a custom Starlette path convertor `_BrokerHostConvertor` with regex `[^/]*\.[^/.][^/]*` registered as CONVERTOR_TYPES["brokerhost"].

Both broker catch-all routes change from `/{target:path}` to `/{target:brokerhost}`. The broker now only matches paths whose first segment looks like a hostname (e.g. api.stripe.com). UI routes like /search and /catalog are invisible to it and fall through cleanly to 404 instead of being silently proxied.