### PR TITLE
Fix toolkit list showing 0 keys and 0 credentials

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -163,6 +163,8 @@ class ToolkitOut(BaseModel):
     description: str | None = None
     created_at: float | None = None
     disabled: bool = False
+    key_count: int | None = None
+    credential_count: int | None = None
     keys: list[ToolkitKeyOut] = Field(default_factory=list)
     credentials: list[CredentialBindingOut] = Field(default_factory=list)
     permissions: list[dict] = Field(default_factory=list)

--- a/src/routers/toolkits.py
+++ b/src/routers/toolkits.py
@@ -270,19 +270,26 @@ async def list_toolkits(request: Request):
             """
             SELECT
                 t.id, t.name, t.description, t.simulate, t.disabled, t.created_at,
-                COUNT(DISTINCT tk.id) AS key_count,
-                COUNT(DISTINCT tc.rowid) AS bound_credential_count
+                COALESCE(tk.key_count, 0) AS key_count,
+                COALESCE(tc.bound_credential_count, 0) AS bound_credential_count
             FROM toolkits t
-            LEFT JOIN toolkit_keys tk ON t.id = tk.toolkit_id AND tk.revoked_at IS NULL
-            LEFT JOIN toolkit_credentials tc ON t.id = tc.toolkit_id
-            GROUP BY t.id
+            LEFT JOIN (
+                SELECT toolkit_id, COUNT(*) AS key_count
+                FROM toolkit_keys
+                WHERE revoked_at IS NULL
+                GROUP BY toolkit_id
+            ) AS tk ON t.id = tk.toolkit_id
+            LEFT JOIN (
+                SELECT toolkit_id, COUNT(*) AS bound_credential_count
+                FROM toolkit_credentials
+                GROUP BY toolkit_id
+            ) AS tc ON t.id = tc.toolkit_id
             """
         ) as cur:
             rows = await cur.fetchall()
 
         # The default toolkit implicitly sees ALL credentials, not just
         # those explicitly bound via toolkit_credentials.
-        total_cred_count = 0
         async with db.execute("SELECT COUNT(*) FROM credentials") as cur:
             total_cred_count = (await cur.fetchone())[0]
 


### PR DESCRIPTION
## Summary
- The `list_toolkits` endpoint was not returning `key_count` or `credential_count`, so the UI always showed dashes
- Added a JOIN query to count active keys and bound credentials per toolkit
- The default toolkit implicitly owns all credentials (queried from `credentials` table directly, not `toolkit_credentials`), so the count now mirrors the detail endpoint's logic

Fixes #60

## Test plan
- [x] Create credentials bound to the default toolkit, verify counts appear on the toolkits list page
- [x] Create a non-default toolkit with explicit credential bindings, verify its counts are correct
- [x] Verify the toolkit detail page still shows the correct credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)