### PR TITLE
fix: serve React login page for all /login routes

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -62,7 +62,7 @@ SKIP = {
     "/", "/health",
     "/docs", "/openapi.json", "/redoc",
     "/favicon.ico", "/favicon.png", "/favicon.svg",
-    "/login",  # HTML login form page (served from main.py)
+    "/login",  # React login page (SPA route)
     "/user/login",  # API login endpoint — must be public (bug fix: was missing)
     "/user/token",  # OAuth2 password grant for Swagger UI
     "/user/create",  # One-time root account creation — must be public before account exists

--- a/src/main.py
+++ b/src/main.py
@@ -271,55 +271,6 @@ async def favicon():
     return FileResponse(path, media_type="image/png")
 
 
-@app.get("/login", include_in_schema=False)
-async def login_page(error: str | None = None):
-    """Human-friendly login form — POSTs to /user/login?redirect_to=/docs."""
-    from fastapi.responses import HTMLResponse
-    err_html = f'<p class="error">{error}</p>' if error else ""
-    html = f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Jentic Mini — Log In</title>
-  <style>
-    * {{ box-sizing: border-box; margin: 0; padding: 0; }}
-    body {{ background: #1a1a2e; color: #e0e0e0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-           display: flex; align-items: center; justify-content: center; min-height: 100vh; }}
-    .card {{ background: #16213e; border: 1px solid #0f3460; border-radius: 12px; padding: 2.5rem; width: 100%; max-width: 380px; }}
-    h1 {{ font-size: 1.4rem; color: #a5b4fc; margin-bottom: 0.25rem; }}
-    .sub {{ font-size: 0.85rem; color: #888; margin-bottom: 1.75rem; }}
-    label {{ display: block; font-size: 0.8rem; color: #aaa; margin-bottom: 0.35rem; margin-top: 1rem; }}
-    input {{ width: 100%; padding: 0.6rem 0.8rem; background: #0f3460; border: 1px solid #334; border-radius: 6px;
-             color: #e0e0e0; font-size: 0.95rem; outline: none; }}
-    input:focus {{ border-color: #a5b4fc; }}
-    button {{ margin-top: 1.5rem; width: 100%; padding: 0.7rem; background: #6366f1; border: none; border-radius: 6px;
-              color: #fff; font-size: 1rem; cursor: pointer; font-weight: 600; }}
-    button:hover {{ background: #818cf8; }}
-    .error {{ color: #f87171; font-size: 0.85rem; margin-top: 1rem; text-align: center; }}
-    .back {{ text-align: center; margin-top: 1rem; font-size: 0.8rem; }}
-    .back a {{ color: #a5b4fc; text-decoration: none; }}
-  </style>
-</head>
-<body>
-  <div class="card">
-    <h1>Jentic Mini</h1>
-    <p class="sub">Admin login</p>
-    <form method="POST" action="/user/login?redirect_to=/docs">
-      <label for="username">Username</label>
-      <input id="username" name="username" type="text" autocomplete="username" required autofocus>
-      <label for="password">Password</label>
-      <input id="password" name="password" type="password" autocomplete="current-password" required>
-      {err_html}
-      <button type="submit">Log in →</button>
-    </form>
-    <p class="back"><a href="/docs">← Back to API docs</a></p>
-  </div>
-</body>
-</html>"""
-    return HTMLResponse(html)
-
-
 @app.get("/", tags=["meta"], include_in_schema=False)
 async def root():
     index_path = STATIC_DIR / "index.html"
@@ -401,7 +352,7 @@ if STATIC_DIR.exists():
 # Browsers (Accept: text/html) get the React SPA.
 _SPA_PATHS = {
     "/approve", "/search", "/catalog", "/workflows", "/toolkits",
-    "/credentials", "/traces", "/jobs", "/oauth-brokers", "/setup",
+    "/credentials", "/traces", "/jobs", "/oauth-brokers", "/setup", "/login",
 }
 
 @app.middleware("http")


### PR DESCRIPTION
Direct browser access to /login was serving a hardcoded HTML form instead of the React SPA, causing inconsistent branding and wrong post-login redirects (/docs instead of home).

Changes:
- Add /login to _SPA_PATHS to ensure React app is served for all /login URLs
- Remove legacy @app.get("/login") endpoint (no longer needed)
- Update auth.py comment to reflect SPA routing

Fixes issue where /login and /login?next=/ showed different UIs depending on browser cache state.

fixes: #45