### PR TITLE
docs: Notion tutorial as primary example, Gmail as optional follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ injecting credentials at runtime, and brokering the request. Secrets never touch
 
 **Just want Jentic Mini standalone?** See [Getting Started](#getting-started) below.
 
-**Already running?** Jump to the [hands-on tutorial](docs/TUTORIAL.md) — connect the Notion API, see the permissions model in action, and have your agent create pages with controlled access.
+**Already running?** Jump to the [hands-on tutorial](docs/tutorials/01-notion-permissions.md) — connect the Notion API, see the permissions model in action, and have your agent create pages with controlled access.
 
 ## What is Jentic Mini?
 
@@ -89,7 +89,7 @@ docker compose up -d
 
 Open `http://localhost:8900` to complete setup.
 
-**Next:** Follow the [hands-on tutorial](docs/TUTORIAL.md) — connect the Notion API and see the permissions model in action.
+**Next:** Follow the [hands-on tutorial](docs/tutorials/01-notion-permissions.md) — connect the Notion API and see the permissions model in action.
 
 ### Configuration
 

--- a/docs/tutorials/01-notion-permissions.md
+++ b/docs/tutorials/01-notion-permissions.md
@@ -2,7 +2,7 @@
 
 This tutorial connects the Notion API to Jentic Mini and shows how the permissions model works in practice. Your agent will try to create a page, get blocked, request access, and then succeed — all through natural conversation.
 
-> **Prerequisites:** You need Jentic Mini running and connected to your agent. If you haven't set that up yet, the fastest path is via the [Jentic skill on ClawHub](https://clawhub.com) — tell your OpenClaw agent *"install and set up the jentic skill from ClawHub"* and it will walk you through everything. For manual setup, see [Getting Started](../README.md#getting-started).
+> **Prerequisites:** You need Jentic Mini running and connected to your agent. If you haven't set that up yet, the fastest path is via the [Jentic skill on ClawHub](https://clawhub.com) — tell your OpenClaw agent *"install and set up the jentic skill from ClawHub"* and it will walk you through everything. For manual setup, see [Getting Started](../../README.md#getting-started).
 
 You'll also need a Notion account with a [Notion integration](https://www.notion.so/my-integrations) (free to create).
 
@@ -92,16 +92,16 @@ The agent will attempt to call the Notion API with a DELETE or an archive PATCH.
 
 ## Next: Gmail with OAuth and fine-grained permissions
 
-The Notion example uses a simple API key. For APIs that require OAuth (Gmail, Slack, Google Drive, etc.), Jentic Mini integrates with [Pipedream Connect](PIPEDREAM.md) to handle the OAuth flow — your agent generates a link, you click it, and the token is stored in the vault automatically.
+The Notion example uses a simple API key. For APIs that require OAuth (Gmail, Slack, Google Drive, etc.), Jentic Mini integrates with [Pipedream Connect](../PIPEDREAM.md) to handle the OAuth flow — your agent generates a link, you click it, and the token is stored in the vault automatically.
 
-The [Gmail tutorial](TUTORIAL-GMAIL.md) walks through connecting Gmail and setting permissions so your agent can draft emails but not send them — a boundary that Gmail's own OAuth scopes don't offer.
+The [Gmail tutorial](02-gmail-oauth-permissions.md) walks through connecting Gmail and setting permissions so your agent can draft emails but not send them — a boundary that Gmail's own OAuth scopes don't offer.
 
 ---
 
 ## More next steps
 
 - **Add more APIs** — ask your agent to search the Jentic catalog for any API you use, or browse at `http://localhost:8900/catalog`
-- **Connect OAuth apps** — Slack, Google Drive, Salesforce, and 3,000+ more via [Pipedream Connect](PIPEDREAM.md)
+- **Connect OAuth apps** — Slack, Google Drive, Salesforce, and 3,000+ more via [Pipedream Connect](../PIPEDREAM.md)
 - **Create additional toolkits** — scope different agents to different APIs and permissions
-- **Explore workflows** — multi-step Arazzo workflows chain operations across APIs — see [WORKFLOWS.md](WORKFLOWS.md)
+- **Explore workflows** — multi-step Arazzo workflows chain operations across APIs — see [WORKFLOWS.md](../WORKFLOWS.md)
 - **Read the full API docs** — Swagger UI at `http://localhost:8900/docs`

--- a/docs/tutorials/02-gmail-oauth-permissions.md
+++ b/docs/tutorials/02-gmail-oauth-permissions.md
@@ -4,7 +4,7 @@ This tutorial connects Gmail to Jentic Mini and shows how the permissions model 
 
 Gmail's own OAuth scopes don't offer "drafts only, no send" — `gmail.compose` grants both. Jentic Mini's permission rules add that boundary at the proxy layer.
 
-> **Prerequisites:** You need Jentic Mini running and connected to your agent. If you haven't set that up yet, the fastest path is via the [Jentic skill on ClawHub](https://clawhub.com) — tell your OpenClaw agent *"install and set up the jentic skill from ClawHub"* and it will walk you through everything. For manual setup, see [Getting Started](../README.md#getting-started).
+> **Prerequisites:** You need Jentic Mini running and connected to your agent. If you haven't set that up yet, the fastest path is via the [Jentic skill on ClawHub](https://clawhub.com) — tell your OpenClaw agent *"install and set up the jentic skill from ClawHub"* and it will walk you through everything. For manual setup, see [Getting Started](../../README.md#getting-started).
 
 You'll also need a Google account and a free [Pipedream](https://pipedream.com) account (your agent will guide you through Pipedream setup if it's your first time).
 
@@ -25,7 +25,7 @@ Your agent will:
 
 The OAuth token is stored encrypted and never returned via the API. Your agent knows the credential exists but can never retrieve the token value.
 
-> **First time using OAuth?** If you haven't set up a Pipedream broker yet, your agent will guide you through it — or see the [Pipedream Connect setup guide](PIPEDREAM.md#setup-required-before-first-use). It's a one-time setup that takes about 5 minutes.
+> **First time using OAuth?** If you haven't set up a Pipedream broker yet, your agent will guide you through it — or see the [Pipedream Connect setup guide](../PIPEDREAM.md#setup-required-before-first-use). It's a one-time setup that takes about 5 minutes.
 
 ## Step 2 — Try to create a draft
 
@@ -96,7 +96,7 @@ The agent will attempt to call the Gmail send endpoint. Jentic Mini blocks it �
 ## Next steps
 
 - **Add more APIs** — ask your agent to search the Jentic catalog for any API you use, or browse at `http://localhost:8900/catalog`
-- **Connect more OAuth apps** — Slack, Google Drive, Salesforce, and 3,000+ more via [Pipedream Connect](PIPEDREAM.md)
+- **Connect more OAuth apps** — Slack, Google Drive, Salesforce, and 3,000+ more via [Pipedream Connect](../PIPEDREAM.md)
 - **Create additional toolkits** — scope different agents to different APIs and permissions
-- **Explore workflows** — multi-step Arazzo workflows chain operations across APIs — see [WORKFLOWS.md](WORKFLOWS.md)
+- **Explore workflows** — multi-step Arazzo workflows chain operations across APIs — see [WORKFLOWS.md](../WORKFLOWS.md)
 - **Read the full API docs** — Swagger UI at `http://localhost:8900/docs`


### PR DESCRIPTION
## Summary

- Replaces the Gmail tutorial with Notion as the primary getting-started example
- Notion uses a simple API key (bearer token) — no Pipedream/OAuth setup needed, so the tutorial focuses purely on the permissions model
- Gmail tutorial preserved as `TUTORIAL-GMAIL.md`, linked as optional next reading for users who want to see OAuth + finer-grained permissions (draft vs send)
- README links updated

## Tutorial flow

1. Create a Notion integration and add the API key to Jentic
2. Try to create a page → get blocked by default deny-all-writes policy
3. Agent requests permission → human approves via link
4. Retry → page created successfully
5. Verify deletes are blocked

## Test plan
- [ ] Walk through the Notion tutorial with a running instance
- [ ] Verify Gmail tutorial still reads correctly as standalone
- [ ] Check README links render on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)