### PR TITLE
Add CodeQL security scanning for Python and JS/TS

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '16 04 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript-typescript', 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- Adds CodeQL analysis workflow scanning both **Python** (FastAPI backend) and **JavaScript/TypeScript** (React UI)
- Triggers on push to main, PRs targeting main, and weekly schedule (Tuesdays 04:16 UTC)
- Uses `actions/checkout@v6` and `github/codeql-action@v4`

## Test plan

- [ ] Workflow runs successfully on this PR
- [ ] Both Python and JavaScript/TypeScript languages are analyzed

🤖 Generated with [Claude Code](https://claude.com/claude-code)