### PR TITLE
Fix stale column name in OAuth sync credential query

### DIFF
--- a/src/routers/oauth_brokers.py
+++ b/src/routers/oauth_brokers.py
@@ -461,7 +461,7 @@ async def sync_broker_accounts(broker_id: BrokerIdPath, body: SyncRequest, reque
     # Return the credential IDs created/updated so the caller knows what to provision
     async with get_db() as db:
         async with db.execute(
-            "SELECT id, label, api_id FROM credentials WHERE scheme_name='pipedream_oauth' "
+            "SELECT id, label, api_id FROM credentials WHERE auth_type='pipedream_oauth' "
             "AND api_id IN (SELECT api_host FROM oauth_broker_accounts "
             "WHERE broker_id=? AND external_user_id=?)",
             (broker_id, body.external_user_id),


### PR DESCRIPTION
## Summary

The sync endpoint query at `oauth_brokers.py:464` referenced `scheme_name` which was renamed to `auth_type` in a prior migration. This caused a 500 on every `POST /oauth-brokers/{id}/sync` call.

One-line fix: `scheme_name` → `auth_type`.

## Test plan

- [x] `POST /oauth-brokers/{id}/sync` returns credentials instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)