### PR TITLE
Return default_external_user_id in OAuth broker API responses

### DIFF
--- a/src/routers/oauth_brokers.py
+++ b/src/routers/oauth_brokers.py
@@ -145,11 +145,15 @@ class SyncRequest(NormModel):
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 def _row_to_out(row: tuple, accounts_discovered: int = 0) -> OAuthBrokerOut:
-    broker_id, broker_type, client_id, project_id, created_at = row
+    broker_id, broker_type, client_id, project_id, default_external_user_id, created_at = row
     return OAuthBrokerOut(
         id=broker_id,
         type=broker_type,
-        config={"client_id": client_id, "project_id": project_id},
+        config={
+            "client_id": client_id,
+            "project_id": project_id,
+            "default_external_user_id": default_external_user_id or "default",
+        },
         created_at=created_at,
         accounts_discovered=accounts_discovered,
     )
@@ -249,7 +253,7 @@ async def create_oauth_broker(body: OAuthBrokerCreate):
     return OAuthBrokerOut(
         id=broker_id,
         type=body.type,
-        config={"client_id": client_id, "project_id": project_id},
+        config={"client_id": client_id, "project_id": project_id, "default_external_user_id": "default"},
         created_at=time.time(),
         accounts_discovered=accounts_discovered,
     )
@@ -267,7 +271,7 @@ async def list_oauth_brokers():
     """
     async with get_db() as db:
         async with db.execute(
-            "SELECT id, type, client_id, project_id, created_at FROM oauth_brokers"
+            "SELECT id, type, client_id, project_id, default_external_user_id, created_at FROM oauth_brokers"
         ) as cur:
             rows = await cur.fetchall()
 
@@ -282,7 +286,7 @@ async def list_oauth_brokers():
 async def get_oauth_broker(broker_id: BrokerIdPath):
     async with get_db() as db:
         async with db.execute(
-            "SELECT id, type, client_id, project_id, created_at "
+            "SELECT id, type, client_id, project_id, default_external_user_id, created_at "
             "FROM oauth_brokers WHERE id=?",
             (broker_id,),
         ) as cur:


### PR DESCRIPTION
## Summary

The list and get broker endpoints omitted `default_external_user_id` from the SELECT query and config output. The UI reads this field to determine which `external_user_id` to use for sync/connect operations — without it, the UI always defaults to `"default"`, causing sync to find 0 accounts when the Pipedream account was connected under a different user ID.

## Changes

- Add `default_external_user_id` to SELECT in `list_oauth_brokers` and `get_oauth_broker`
- Include it in `_row_to_out` config dict (falls back to `"default"` if NULL)

## Test plan

- [ ] `GET /oauth-brokers` response includes `config.default_external_user_id`
- [ ] UI sync button uses the correct external_user_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)