### PR TITLE
Fix LoginPage test navigation crash in Vitest browser mode

### DIFF
--- a/ui/src/__tests__/pages/LoginPage.test.tsx
+++ b/ui/src/__tests__/pages/LoginPage.test.tsx
@@ -1,8 +1,14 @@
 import { screen, renderWithProviders, userEvent } from '../test-utils'
 import { worker } from '../mocks/browser'
-import { http, HttpResponse } from 'msw'
+import { delay, http, HttpResponse } from 'msw'
 import axe from 'axe-core'
 import LoginPage from '../../pages/LoginPage'
+
+// Prevent window.location.href navigation from breaking the Vitest browser iframe.
+// LoginPage sets window.location.href on successful login — intercept it
+// by ensuring the login response stays pending long enough for assertions.
+// In browser mode we can't mock window.location, so tests that trigger
+// successful login use delayed MSW responses instead.
 
 describe('LoginPage', () => {
   it('renders the login form', () => {
@@ -18,7 +24,9 @@ describe('LoginPage', () => {
 
     worker.use(
       http.post('/user/login', async () => {
-        await new Promise(r => setTimeout(r, 500))
+        // Keep pending indefinitely so onSuccess (window.location.href)
+        // never fires — that navigation breaks the Vitest browser iframe.
+        await delay('infinite')
         return HttpResponse.json({ logged_in: true })
       }),
     )
@@ -81,8 +89,8 @@ describe('LoginPage', () => {
     worker.use(
       http.post('/user/login', async () => {
         loginCalled = true
-        // Keep pending to avoid window.location.href redirect breaking the test iframe
-        await new Promise(r => setTimeout(r, 2000))
+        // Keep pending — see comment at top of file
+        await delay('infinite')
         return HttpResponse.json({ logged_in: true, username: 'admin' })
       }),
     )


### PR DESCRIPTION
## Summary

LoginPage sets `window.location.href` on successful login, which navigates the Vitest browser iframe away and crashes the test runner. This worked in PR but fails on main because the timed delays (500ms/2000ms) were race conditions.

## Fix

Replace `setTimeout` delays with MSW's `delay('infinite')` — the mutation stays pending indefinitely, assertions run against the loading state, and `onSuccess` never fires. `worker.resetHandlers()` in `afterEach` cleans up pending handlers between tests.

## Test plan

- [x] All 6 LoginPage tests pass locally (`npx vitest run src/__tests__/pages/LoginPage.test.tsx`)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)