### PR TITLE
fix(security): reject unknown fields in permission rules

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -210,7 +210,9 @@ class PermissionRule(BaseModel):
     E.g. `["tts", "speech"]` matches any operation whose ID contains "tts" or "speech".
 
     System safety rules (always active, cannot be removed) are marked `_system: true` in
-    `GET .../permissions` responses. They deny sensitive paths and write methods by default.
+    `GET .../permissions` responses (see `PermissionRuleOut`). They deny sensitive paths
+    and write methods by default. The `_system` and `_comment` fields are response-only
+    and will be rejected in request bodies.
 
     **Examples:**
     ```json
@@ -240,9 +242,8 @@ class PermissionRule(BaseModel):
         default=None,
         description="List of regexes matched against the operation ID. E.g. `[\"tts\", \"speech\"]`."
     )
-    # Read-only server fields on system rules (ignored on write)
     model_config = {
-        "extra": "allow",  # allows _system/_comment through in responses
+        "extra": "forbid",
         "json_schema_extra": {
             "examples": [
                 {"effect": "allow", "methods": ["POST"], "path": "text-to-speech"},
@@ -250,6 +251,16 @@ class PermissionRule(BaseModel):
                 {"effect": "allow", "operations": ["^github_get_repo$"]},
             ]
         }
+    }
+
+
+class PermissionRuleOut(PermissionRule):
+    """Permission rule as returned by the API — includes read-only server fields."""
+    system: bool | None = Field(default=None, alias="_system")
+    comment: str | None = Field(default=None, alias="_comment")
+    model_config = {
+        "extra": "allow",
+        "populate_by_name": True,
     }
 
 

--- a/src/routers/toolkits.py
+++ b/src/routers/toolkits.py
@@ -25,7 +25,7 @@ from src.db import get_db, DEFAULT_TOOLKIT_ID
 import src.vault as vault
 from src.models import (
     ToolkitOut, ToolkitKeyOut, ToolkitKeyCreated,
-    CredentialBindingOut, PermissionRule, PermissionsPatch,
+    CredentialBindingOut, PermissionRule, PermissionRuleOut, PermissionsPatch,
 )
 
 router = APIRouter(prefix="/toolkits")
@@ -717,7 +717,7 @@ async def remove_credential_from_toolkit(toolkit_id: str, credential_id: str):
     "/{toolkit_id}/credentials/{cred_id:path}/permissions",
     summary="Get the permission rules for a specific credential in this toolkit",
     tags=["toolkits"],
-    response_model=list[PermissionRule],
+    response_model=list[PermissionRuleOut],
 )
 async def get_credential_permissions(toolkit_id: str, cred_id: str):
     """Returns all rules in evaluation order for this credential: agent-defined rules first,
@@ -752,7 +752,7 @@ async def get_credential_permissions(toolkit_id: str, cred_id: str):
     "/{toolkit_id}/credentials/{cred_id:path}/permissions",
     summary="Replace permission rules for a specific credential",
     tags=["toolkits"],
-    response_model=list[PermissionRule],
+    response_model=list[PermissionRuleOut],
     dependencies=[Depends(require_human_session)],
 )
 async def set_credential_permissions(toolkit_id: str, cred_id: str, body: list[PolicyRule]):
@@ -773,7 +773,7 @@ async def set_credential_permissions(toolkit_id: str, cred_id: str, body: list[P
     "/{toolkit_id}/credentials/{cred_id:path}/permissions",
     summary="Add or remove individual permission rules for a specific credential",
     tags=["toolkits"],
-    response_model=list[PermissionRule],
+    response_model=list[PermissionRuleOut],
     dependencies=[Depends(require_human_session)],
 )
 async def patch_credential_permissions(toolkit_id: str, cred_id: str, body: PermissionsPatch):
@@ -812,9 +812,8 @@ async def patch_credential_permissions(toolkit_id: str, cred_id: str, body: Perm
 
 async def _write_credential_permissions(credential_id: str, rules_list: list[dict]) -> list:
     """Persist agent rules for a credential and return the flat effective rule list."""
-    clean = [{k: v for k, v in r.items() if not k.startswith("_")} for r in rules_list]
-    summary = _generate_policy_summary(clean)
-    rules_json = json.dumps(clean)
+    summary = _generate_policy_summary(rules_list)
+    rules_json = json.dumps(rules_list)
     now = time.time()
     policy_id = str(uuid.uuid4())
 
@@ -830,7 +829,7 @@ async def _write_credential_permissions(credential_id: str, rules_list: list[dic
         )
         await db.commit()
 
-    return clean + SYSTEM_SAFETY_RULES
+    return rules_list + SYSTEM_SAFETY_RULES
 
 
 # ── Policy Enforcement (called by broker) ─────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #95 — `PermissionRule` had `extra: "allow"` (Pydantic config), so unknown fields like `"pattern"` were silently accepted. A rule with only unrecognized fields has no conditions → matches everything → allows the request before system safety rules are reached.

## Root cause

The reporter's rules used `"pattern"` (not a recognized field). Pydantic accepted it silently. The rule became `{"effect": "allow"}` with no conditions — matched everything, first-match-wins allowed the POST before system safety deny-write was reached.

## Changes

- **`PermissionRule`**: `extra: "forbid"` — Pydantic rejects unknown fields on input (422)
- **`PermissionRuleOut`**: new output model extending `PermissionRule`, adds `_system`/`_comment` via aliases for read responses
- **`_write_credential_permissions`**: removed manual `_`-prefix stripping (redundant with strict input validation)
- **`response_model`**: three endpoints updated to use `PermissionRuleOut`

## Test results

```
PASS: rejected unknown field — ValidationError
PASS: valid rule accepted — {'effect': 'allow', 'methods': ['GET']}
PASS: catch-all deny accepted — {'effect': 'deny'}
PASS: system rule in response — {'effect': 'deny', '_system': True, '_comment': 'Deny writes'}
```

## Test plan

- [x] `PUT .../permissions` with `{"effect": "allow", "pattern": "..."}` → 422 rejected
- [x] `PUT` with valid fields → succeeds
- [x] `GET .../permissions` returns `_system` and `_comment` on system rules
- [x] PATCH add/remove works with valid fields
- [x] Access requests with unknown fields → rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)