### PR TITLE
fix(ci): update docker-publish to reference ci-docker.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: ./.github/workflows/ci-docker.yml
 
   publish:
     needs: ci


### PR DESCRIPTION
## Summary

`ci.yml` was removed in #121 when CI was split into `ci-ui.yml` + `ci-docker.yml`. The publish workflow (`docker-publish.yml`) still referenced the old file, breaking the workflow.

One-line fix: `./.github/workflows/ci.yml` → `./.github/workflows/ci-docker.yml`

Made with [Cursor](https://cursor.com)