### PR TITLE
fix(ci): fix CI concurrency and duplicate Docker builds on main

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,8 +1,6 @@
 name: Docker Build & E2E
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   workflow_call:
@@ -10,7 +8,7 @@ on:
 
 concurrency:
   group: docker-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   docker-e2e:

--- a/.github/workflows/ci-ui.yml
+++ b/.github/workflows/ci-ui.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: ui-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   ui-tests:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   ci:
     uses: ./.github/workflows/ci-docker.yml


### PR DESCRIPTION
## Summary

Three issues fixed:

1. **Cancellation on main**: `cancel-in-progress: true` in `ci-docker.yml` and `ci-ui.yml` was cancelling CI runs when multiple PRs merged to main in quick succession — also cancelling the publish workflow. Changed to `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` so only PR branch runs get cancelled.

2. **Duplicate Docker builds**: `ci-docker.yml` triggered on `push` to main AND was called by `docker-publish.yml` (also on push to main) — running the full Docker build twice per merge. Removed the `push` trigger from `ci-docker.yml` since the publish workflow already calls it via `workflow_call`.

3. **No publish concurrency protection**: `docker-publish.yml` had no concurrency block, allowing duplicate publish runs to race on Docker image tags. Added a `publish-${{ github.ref }}` concurrency group with `cancel-in-progress: false` (queue instead of skip).

Made with [Cursor](https://cursor.com)