### PR TITLE
fix(security): prevent path traversal in debug and catalog endpoints

### DIFF
--- a/src/routers/catalog.py
+++ b/src/routers/catalog.py
@@ -302,6 +302,7 @@ async def lazy_import_catalog_workflows(api_id: str) -> list[str]:
     # Import each workflow as a separate single-workflow arazzo file
     safe_id = re.sub(r"[^a-z0-9_-]", "_", source_id.lower())
     imported_slugs: list[str] = []
+    workflows_root = WORKFLOWS_DIR.resolve()
 
     for wf in doc.get("workflows", []):
         workflow_id = wf.get("workflowId", "")
@@ -313,7 +314,13 @@ async def lazy_import_catalog_workflows(api_id: str) -> list[str]:
 
         # Save as a single-workflow arazzo file so execution always picks the right one
         single_doc = {**doc, "workflows": [wf]}
-        arazzo_path = str(WORKFLOWS_DIR / f"catalog_{safe_id}_{slug}.json")
+        arazzo_file = (WORKFLOWS_DIR / f"catalog_{safe_id}_{slug}.json").resolve()
+        try:
+            arazzo_file.relative_to(workflows_root)
+        except ValueError:
+            log.warning("Path traversal blocked for workflow '%s'", workflow_id)
+            continue
+        arazzo_path = str(arazzo_file)
         with open(arazzo_path, "w") as f:
             json.dump(single_doc, f, indent=2)
 

--- a/src/routers/debug.py
+++ b/src/routers/debug.py
@@ -3,6 +3,8 @@ import os, json, inspect
 from pathlib import Path
 from fastapi import APIRouter, Request
 
+from src.config import DATA_DIR
+
 router = APIRouter(prefix="/debug", tags=["debug"], include_in_schema=False)
 
 
@@ -77,10 +79,29 @@ async def env_mappings(arazzo_path: str = ""):
 
 @router.get("/spec")
 async def spec_info(path: str = ""):
-    p = Path(path)
+    if not path:
+        return {"error": "path is required", "exists": False}
+    data_root = DATA_DIR.resolve()
+    p = (data_root / path).resolve()
+    # Restrict to the data directory to prevent path traversal
+    try:
+        p.relative_to(data_root)
+    except ValueError:
+        return {"error": "path must be inside the data directory", "exists": False}
     if not p.exists():
         return {"exists": False, "path": path}
-    doc = json.loads(p.read_text())
+    if not p.is_file():
+        return {"error": "path must point to a regular file", "exists": True}
+    if p.suffix.lower() != ".json":
+        return {"error": "only .json files are supported", "exists": True}
+    try:
+        raw_text = p.read_text()
+    except UnicodeDecodeError:
+        return {"error": "file is not valid UTF-8 text", "exists": True}
+    try:
+        doc = json.loads(raw_text)
+    except json.JSONDecodeError:
+        return {"error": "file does not contain valid JSON", "exists": True}
     paths = doc.get("paths", {})
     sample = []
     for api_path, methods in list(paths.items())[:5]:


### PR DESCRIPTION
## Summary

Addresses CodeQL alerts (path injection — high severity).

### debug.py `/spec` endpoint

The `path` query parameter was passed directly to `Path(path).read_text()` — an attacker could read any file on the filesystem. Now resolves the path and verifies it's inside `DATA_DIR` before reading.

### catalog.py workflow import

The `arazzo_path` was constructed from user-influenced `source_id` and `workflow_id`. Although both are sanitised with regex, a resolve + startswith check is added as defence in depth to prevent writing outside `WORKFLOWS_DIR`.

## Test plan

- [ ] `GET /debug/spec?path=../../etc/passwd` → rejected ("path must be inside the data directory")
- [ ] `GET /debug/spec?path=/app/data/specs/some-spec.json` → works as before
- [ ] Catalog workflow import still writes to correct directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)