### PR TITLE
build: add missing eslint-config-prettier dependency

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -34,6 +34,7 @@
 				"@vitest/coverage-istanbul": "^4.1.2",
 				"axe-core": "^4.11.1",
 				"eslint": "^9.39.4",
+				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-import-x": "^4.16.2",
 				"eslint-plugin-jsx-a11y": "^6.10.2",
 				"eslint-plugin-prettier": "^5.5.5",
@@ -7732,6 +7733,23 @@
 				"jiti": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/eslint-config-prettier": {
+			"version": "10.1.8",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"eslint-config-prettier": "bin/cli.js"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-config-prettier"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.0.0"
 			}
 		},
 		"node_modules/eslint-import-context": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,6 +43,7 @@
 		"@vitest/coverage-istanbul": "^4.1.2",
 		"axe-core": "^4.11.1",
 		"eslint": "^9.39.4",
+		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-import-x": "^4.16.2",
 		"eslint-plugin-jsx-a11y": "^6.10.2",
 		"eslint-plugin-prettier": "^5.5.5",


### PR DESCRIPTION
## Summary

`eslint-plugin-prettier/recommended` requires `eslint-config-prettier` as a peer dependency. It was missing from `package.json` after PR #137, causing CI to fail with:

```
Error: Cannot find module 'eslint-config-prettier'
```

One dependency added, no code changes.

## Test plan

- [x] CI ESLint step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)