### PR TITLE
feat: credential routes + slug-based IDs (WIP)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,10 +107,10 @@ auth header, forwards to the upstream API, logs a trace, and returns the
 response verbatim.
 
 **Multiple credentials for the same host** (e.g. Google Calendar + Gmail both on
-`www.googleapis.com`): add `X-Jentic-Service: google_calendar` to select by
-service name. The response includes `X-Jentic-Credential-Used` so you can verify
-which credential was injected. If ambiguous, `X-Jentic-Credential-Ambiguous: true`
-is set as a warning.
+`www.googleapis.com`): each credential declares `routes` (host+path prefixes) so
+the broker selects the right one by longest prefix match. Use
+`X-Jentic-Credential: work-gmail` to select explicitly by ID. The response
+includes `X-Jentic-Credential-Used` so you can verify which credential was injected.
 
 ## Workflow Execution
 

--- a/alembic/versions/0004_credential_routes_and_slug.py
+++ b/alembic/versions/0004_credential_routes_and_slug.py
@@ -1,0 +1,233 @@
+"""Add routes field, replace credential IDs with human-readable slugs, drop api_id.
+
+Breaking change: credential IDs change from opaque values (e.g. 'pipedream-apn_xxx-host')
+to human-readable slugs derived from labels (e.g. 'work-gmail'). The api_id column is
+replaced by a routes JSON array of host+path prefixes for deterministic broker matching.
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-04-09
+"""
+import json
+import re
+
+from alembic import op
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+# ── Slug generation (must be self-contained — no app imports in migrations) ──
+
+_COMMON_WORDS = {"api", "key", "token", "secret", "auth", "oauth", "credential",
+                 "credentials", "access", "the", "a", "an", "my", "for"}
+
+
+def _slugify(label: str) -> str:
+    """Generate a URL-safe slug from a label. Lowercase, hyphens, no trailing."""
+    slug = re.sub(r"[^a-z0-9]+", "-", label.lower()).strip("-")
+    return slug or "credential"
+
+
+def _unique_slug(slug: str, existing: set[str]) -> str:
+    """Ensure slug is unique by appending -2, -3, etc."""
+    if slug not in existing:
+        return slug
+    n = 2
+    while f"{slug}-{n}" in existing:
+        n += 1
+    return f"{slug}-{n}"
+
+
+# ── Pipedream app_slug → catalog path mapping (subset for route derivation) ──
+# Only need the reverse direction: slug → host+path prefix for routes.
+
+_PD_SLUG_TO_ROUTE: dict[str, str] = {
+    "gmail": "www.googleapis.com/gmail",
+    "google_calendar": "www.googleapis.com/calendar",
+    "google_sheets": "sheets.googleapis.com",
+    "google_drive": "www.googleapis.com/drive",
+    "google_docs": "docs.googleapis.com",
+    "google_contacts": "people.googleapis.com",
+    "github": "api.github.com",
+    "slack": "slack.com/api",
+    "stripe": "api.stripe.com",
+    "openai": "api.openai.com",
+    "discord": "discord.com/api",
+    "notion": "api.notion.com",
+    "airtable": "api.airtable.com",
+    "twilio": "api.twilio.com",
+    "sendgrid": "api.sendgrid.com",
+    "hubspot": "api.hubapi.com",
+    "jira": "api.atlassian.com",
+    "linear": "api.linear.app",
+    "asana": "app.asana.com/api",
+}
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # ── 1. Read existing credentials ─────────────────────────────────────
+    rows = conn.execute(
+        "SELECT id, label, env_var, encrypted_value, created_at, updated_at, "
+        "api_id, auth_type, identity FROM credentials"
+    ).fetchall()
+
+    # ── 2. Read oauth_broker_accounts for Pipedream route derivation ─────
+    try:
+        broker_accounts = conn.execute(
+            "SELECT account_id, api_host, app_slug FROM oauth_broker_accounts"
+        ).fetchall()
+    except Exception:
+        broker_accounts = []
+
+    # Build account_id → app_slug lookup
+    account_slugs: dict[str, str] = {}
+    for ba in broker_accounts:
+        account_slugs[ba[0]] = ba[2]  # account_id → app_slug
+
+    # ── 3. Generate new IDs and routes ───────────────────────────────────
+    used_slugs: set[str] = set()
+    id_mapping: dict[str, str] = {}  # old_id → new_id
+    migrated: list[dict] = []
+
+    for row in rows:
+        old_id, label, env_var, enc_val, created, updated, api_id, auth_type, identity = row
+
+        # Generate new slug-based ID
+        new_id = _unique_slug(_slugify(label), used_slugs)
+        used_slugs.add(new_id)
+        id_mapping[old_id] = new_id
+
+        # Derive routes from api_id
+        routes: list[str] = []
+        if auth_type == "pipedream_oauth":
+            # Try to derive host+path route from Pipedream app_slug
+            # Extract account_id from old ID format: {broker_id}-{account_id}-{host_slug}
+            parts = old_id.split("-")
+            if len(parts) >= 3:
+                # account_id is the second part (e.g. "apn_xxx")
+                account_id_candidate = parts[1]
+                # Handle account_ids with hyphens (e.g. "apn_xxx")
+                # The format is: broker_id-account_id-host_slug
+                # Since host_slug replaces dots with hyphens, we need to find
+                # the account_id from the broker_accounts table
+                for acct_id, slug in account_slugs.items():
+                    if acct_id in old_id:
+                        route = _PD_SLUG_TO_ROUTE.get(slug)
+                        if route:
+                            routes = [route]
+                        break
+            if not routes and api_id:
+                routes = [api_id]
+        elif api_id:
+            routes = [api_id]
+
+        migrated.append({
+            "id": new_id,
+            "label": label,
+            "env_var": env_var,
+            "encrypted_value": enc_val,
+            "created_at": created,
+            "updated_at": updated,
+            "routes": json.dumps(routes),
+            "auth_type": auth_type,
+            "identity": identity,
+        })
+
+    # ── 4. Disable FK checks during table rebuild ────────────────────────
+    conn.execute("PRAGMA foreign_keys = OFF")
+
+    # ── 5. Recreate credentials table with routes, without api_id ────────
+    op.execute("DROP TABLE IF EXISTS credentials_new")
+    op.execute("""
+    CREATE TABLE credentials_new (
+        id              TEXT PRIMARY KEY,
+        label           TEXT NOT NULL,
+        env_var         TEXT UNIQUE,
+        encrypted_value TEXT NOT NULL,
+        created_at      REAL DEFAULT (unixepoch()),
+        updated_at      REAL,
+        routes          TEXT NOT NULL DEFAULT '[]',
+        auth_type       TEXT,
+        identity        TEXT
+    )
+    """)
+
+    # ── 6. Insert migrated data ──────────────────────────────────────────
+    for m in migrated:
+        conn.execute(
+            "INSERT INTO credentials_new "
+            "(id, label, env_var, encrypted_value, created_at, updated_at, routes, auth_type, identity) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (m["id"], m["label"], m["env_var"], m["encrypted_value"],
+             m["created_at"], m["updated_at"], m["routes"], m["auth_type"], m["identity"]),
+        )
+
+    # ── 7. Update FK references ──────────────────────────────────────────
+    for old_id, new_id in id_mapping.items():
+        conn.execute(
+            "UPDATE toolkit_credentials SET credential_id=? WHERE credential_id=?",
+            (new_id, old_id),
+        )
+        conn.execute(
+            "UPDATE credential_policies SET credential_id=? WHERE credential_id=?",
+            (new_id, old_id),
+        )
+
+    # ── 8. Swap tables ───────────────────────────────────────────────────
+    op.execute("DROP TABLE credentials")
+    op.execute("ALTER TABLE credentials_new RENAME TO credentials")
+
+    # ── 9. Re-enable FK checks ───────────────────────────────────────────
+    conn.execute("PRAGMA foreign_keys = ON")
+
+
+def downgrade():
+    """Reverse: add api_id back, remove routes. Slug IDs are kept (no reverse mapping)."""
+    conn = op.get_bind()
+    conn.execute("PRAGMA foreign_keys = OFF")
+
+    # Read current data
+    rows = conn.execute(
+        "SELECT id, label, env_var, encrypted_value, created_at, updated_at, "
+        "routes, auth_type, identity FROM credentials"
+    ).fetchall()
+
+    op.execute("DROP TABLE IF EXISTS credentials_old")
+    op.execute("ALTER TABLE credentials RENAME TO credentials_old")
+
+    op.execute("""
+    CREATE TABLE credentials (
+        id              TEXT PRIMARY KEY,
+        label           TEXT NOT NULL,
+        env_var         TEXT UNIQUE,
+        encrypted_value TEXT NOT NULL,
+        created_at      REAL DEFAULT (unixepoch()),
+        updated_at      REAL,
+        api_id          TEXT,
+        auth_type       TEXT,
+        identity        TEXT
+    )
+    """)
+
+    for row in rows:
+        cid, label, env_var, enc_val, created, updated, routes_json, auth_type, identity = row
+        # Derive api_id from first route entry
+        try:
+            routes = json.loads(routes_json) if routes_json else []
+        except (json.JSONDecodeError, TypeError):
+            routes = []
+        api_id = routes[0] if routes else None
+
+        conn.execute(
+            "INSERT INTO credentials "
+            "(id, label, env_var, encrypted_value, created_at, updated_at, api_id, auth_type, identity) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (cid, label, env_var, enc_val, created, updated, api_id, auth_type, identity),
+        )
+
+    op.execute("DROP TABLE credentials_old")
+    conn.execute("PRAGMA foreign_keys = ON")

--- a/alembic/versions/0004_credential_routes_and_slug.py
+++ b/alembic/versions/0004_credential_routes_and_slug.py
@@ -12,6 +12,7 @@ import json
 import re
 
 from alembic import op
+from sqlalchemy import text
 
 revision = "0004"
 down_revision = "0003"
@@ -70,16 +71,16 @@ def upgrade():
     conn = op.get_bind()
 
     # ── 1. Read existing credentials ─────────────────────────────────────
-    rows = conn.execute(
+    rows = conn.execute(text(
         "SELECT id, label, env_var, encrypted_value, created_at, updated_at, "
         "api_id, auth_type, identity FROM credentials"
-    ).fetchall()
+    )).fetchall()
 
     # ── 2. Read oauth_broker_accounts for Pipedream route derivation ─────
     try:
-        broker_accounts = conn.execute(
+        broker_accounts = conn.execute(text(
             "SELECT account_id, api_host, app_slug FROM oauth_broker_accounts"
-        ).fetchall()
+        )).fetchall()
     except Exception:
         broker_accounts = []
 
@@ -138,7 +139,7 @@ def upgrade():
         })
 
     # ── 4. Disable FK checks during table rebuild ────────────────────────
-    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.execute(text("PRAGMA foreign_keys = OFF"))
 
     # ── 5. Recreate credentials table with routes, without api_id ────────
     op.execute("DROP TABLE IF EXISTS credentials_new")
@@ -158,43 +159,41 @@ def upgrade():
 
     # ── 6. Insert migrated data ──────────────────────────────────────────
     for m in migrated:
-        conn.execute(
+        conn.execute(text(
             "INSERT INTO credentials_new "
             "(id, label, env_var, encrypted_value, created_at, updated_at, routes, auth_type, identity) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (m["id"], m["label"], m["env_var"], m["encrypted_value"],
-             m["created_at"], m["updated_at"], m["routes"], m["auth_type"], m["identity"]),
-        )
+            "VALUES (:id, :label, :env_var, :enc, :created, :updated, :routes, :auth_type, :identity)"
+        ), {"id": m["id"], "label": m["label"], "env_var": m["env_var"], "enc": m["encrypted_value"],
+            "created": m["created_at"], "updated": m["updated_at"], "routes": m["routes"],
+            "auth_type": m["auth_type"], "identity": m["identity"]})
 
     # ── 7. Update FK references ──────────────────────────────────────────
     for old_id, new_id in id_mapping.items():
-        conn.execute(
-            "UPDATE toolkit_credentials SET credential_id=? WHERE credential_id=?",
-            (new_id, old_id),
-        )
-        conn.execute(
-            "UPDATE credential_policies SET credential_id=? WHERE credential_id=?",
-            (new_id, old_id),
-        )
+        conn.execute(text(
+            "UPDATE toolkit_credentials SET credential_id=:new WHERE credential_id=:old"
+        ), {"new": new_id, "old": old_id})
+        conn.execute(text(
+            "UPDATE credential_policies SET credential_id=:new WHERE credential_id=:old"
+        ), {"new": new_id, "old": old_id})
 
     # ── 8. Swap tables ───────────────────────────────────────────────────
     op.execute("DROP TABLE credentials")
     op.execute("ALTER TABLE credentials_new RENAME TO credentials")
 
     # ── 9. Re-enable FK checks ───────────────────────────────────────────
-    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(text("PRAGMA foreign_keys = ON"))
 
 
 def downgrade():
     """Reverse: add api_id back, remove routes. Slug IDs are kept (no reverse mapping)."""
     conn = op.get_bind()
-    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.execute(text("PRAGMA foreign_keys = OFF"))
 
     # Read current data
-    rows = conn.execute(
+    rows = conn.execute(text(
         "SELECT id, label, env_var, encrypted_value, created_at, updated_at, "
         "routes, auth_type, identity FROM credentials"
-    ).fetchall()
+    )).fetchall()
 
     op.execute("DROP TABLE IF EXISTS credentials_old")
     op.execute("ALTER TABLE credentials RENAME TO credentials_old")
@@ -222,12 +221,13 @@ def downgrade():
             routes = []
         api_id = routes[0] if routes else None
 
-        conn.execute(
+        conn.execute(text(
             "INSERT INTO credentials "
             "(id, label, env_var, encrypted_value, created_at, updated_at, api_id, auth_type, identity) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (cid, label, env_var, enc_val, created, updated, api_id, auth_type, identity),
-        )
+            "VALUES (:id, :label, :env, :enc, :created, :updated, :api_id, :auth, :ident)"
+        ), {"id": cid, "label": label, "env": env_var, "enc": enc_val,
+            "created": created, "updated": updated, "api_id": api_id,
+            "auth": auth_type, "ident": identity})
 
     op.execute("DROP TABLE credentials_old")
-    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(text("PRAGMA foreign_keys = ON"))

--- a/docs/BROKER-CLI.md
+++ b/docs/BROKER-CLI.md
@@ -36,8 +36,7 @@ Two request headers control credential selection:
 | Header | Purpose |
 |--------|---------|
 | `X-Jentic-API-Key` | Selects your toolkit (required) |
-| `X-Jentic-Credential` | Selects a specific credential by ID (optional; hard override) |
-| `X-Jentic-Service` | Selects by service name, e.g. `google_calendar` (optional; friendlier than `X-Jentic-Credential`) |
+| `X-Jentic-Credential` | Selects a specific credential by ID/slug (optional; hard override) |
 
 ---
 
@@ -173,7 +172,7 @@ Set `identity` on the credential if the API requires a specific username.
 
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
-| 403 from upstream | Wrong credential selected | Add `X-Jentic-Service: google_calendar` (or `X-Jentic-Credential`) to select the right one |
+| 403 from upstream | Wrong credential selected | Add `X-Jentic-Credential: work-gmail` to select the right one, or update credential `routes` |
 | 400 from GitHub git push | Wrong BasicAuth encoding | Check the `identity` field on the credential — should be `token` or any non-empty string |
 | No auth injected | Credential not bound to toolkit | `POST /toolkits/{id}/credentials` |
 | No auth injected | API has no security scheme | Submit an overlay via `POST /apis/{api_id}/overlays` |

--- a/llms.txt
+++ b/llms.txt
@@ -35,7 +35,7 @@ Getting started:
 - [POST /default-api-key/generate](/docs#/user/generate_default_key_default_api_key_generate_post): Claim agent API key (first call, subnet-restricted)
 - [GET /search?q=TEXT](/docs#/search/search_search_get): Find APIs and workflows by intent
 - [GET /inspect/{id}](/docs#/inspect/get_capability_inspect__capability_id__get): Full capability schema, parameters, auth, errors
-- [/{host}/{path}](/docs#/execute/broker_get): Execute via broker with credential injection (supports all HTTP methods). When multiple credentials share a host (e.g. Google APIs), use `X-Jentic-Service: {app_slug}` to select the right one.
+- [/{host}/{path}](/docs#/execute/broker_get): Execute via broker with credential injection (supports all HTTP methods). Credentials declare `routes` (host+path prefixes) for deterministic matching.
 - [GET /workflows](/docs#/catalog/list_workflows_workflows_get): List available workflows
 - [GET /workflows/{slug}](/docs#/catalog/get_workflow_workflows__slug__get): Inspect workflow definition and input schema
 - [GET /health](/docs#/meta/health_health_get): Instance status and bootstrap info

--- a/src/brokers/pipedream.py
+++ b/src/brokers/pipedream.py
@@ -38,10 +38,11 @@ def broker_account_row_id(broker_id: str, external_user_id: str, api_host: str, 
     return f"{broker_id}:{external_user_id}:{api_host}:{account_id}"
 
 
-def broker_credential_id(broker_id: str, account_id: str, api_host: str) -> str:
-    """Stable credential ID for Pipedream OAuth credentials."""
-    host_slug = api_host.replace(".", "-")
-    return f"{broker_id}-{account_id}-{host_slug}"
+def _slugify(label: str) -> str:
+    """Generate a URL-safe slug from a label for credential IDs."""
+    import re
+    slug = re.sub(r"[^a-z0-9]+", "-", label.lower()).strip("-")
+    return slug or "credential"
 
 
 # ── App slug ↔ api_id mapping ─────────────────────────────────────────────────
@@ -162,6 +163,30 @@ def api_host_to_pd_slug(host: str) -> str | None:
         if host.endswith(pattern) or pattern.endswith(host):
             return slug
     return None
+
+
+def pd_slug_to_route(slug: str, base_proxy_host: str | None = None) -> str:
+    """Derive a route (host+path prefix) from a Pipedream app slug.
+
+    Uses the _API_ID_TO_PD_SLUG reverse mapping. For mapped apps, returns
+    the host+path prefix (e.g. google_calendar → www.googleapis.com/calendar).
+    For unmapped apps, falls back to base_proxy_host (host-only route).
+    """
+    # Reverse lookup: find catalog key for this slug, extract path component
+    for api_key, s in _API_ID_TO_PD_SLUG.items():
+        if s == slug:
+            # api_key is like "googleapis.com/calendar" or "api.github.com"
+            # For path-style keys, prepend www. if no subdomain
+            parts = api_key.split("/", 1)
+            host_part = parts[0]
+            path_part = parts[1] if len(parts) > 1 else ""
+            # Determine the real HTTP host
+            if path_part:
+                # e.g. googleapis.com/calendar → www.googleapis.com/calendar
+                return f"www.{host_part}/{path_part}" if not host_part.startswith("www.") else f"{host_part}/{path_part}"
+            return host_part
+    # Unmapped — use base proxy host or slug as fallback
+    return base_proxy_host or slug
 
 
 def pd_slug_to_hosts(slug: str) -> list[str]:
@@ -576,37 +601,49 @@ class PipedreamOAuthBroker:
 
                     # Upsert a credential in the vault so users can provision it to toolkits.
                     # Label is always copied from oauth_broker_accounts (single source of truth).
-                    host_slug = api_host.replace(".", "-")
-                    cred_id = broker_credential_id(self.broker_id, account_id, api_host)
+                    # Credential ID is a slug derived from the label.
+                    import json as _json
+                    route = pd_slug_to_route(app_slug, base_proxy_host=api_host)
+                    routes_json = _json.dumps([route])
                     enc_account_id = vault.encrypt(account_id)
+
+                    # Find existing credential by route match (not by constructed ID)
                     async with db.execute(
-                        "SELECT id FROM credentials WHERE id=?", (cred_id,)
+                        """SELECT id FROM credentials
+                           WHERE auth_type='pipedream_oauth'
+                           AND EXISTS (SELECT 1 FROM json_each(routes) WHERE value=?)""",
+                        (route,),
                     ) as cur:
                         existing_cred = await cur.fetchone()
 
                     if existing_cred:
-                        # Existing credential: update the encrypted value and sync the label
-                        # from oauth_broker_accounts (the authoritative source). Never read
-                        # the label from credentials — that creates divergence.
+                        cred_id = existing_cred[0]
                         await db.execute(
                             "UPDATE credentials SET label=?, encrypted_value=?, "
-                            "api_id=?, auth_type='pipedream_oauth', "
+                            "routes=?, auth_type='pipedream_oauth', "
                             "updated_at=unixepoch() WHERE id=?",
-                            (effective_label, enc_account_id, api_host, cred_id),
+                            (effective_label, enc_account_id, routes_json, cred_id),
                         )
                     else:
-                        # New credential: use the effective_label from oauth_broker_accounts.
-                        # env_var must be unique per (account_id, api_host) — include
-                        # the host slug so multiple APIs sharing one Pipedream account
-                        # (e.g. googleapis.com/gmail and googleapis.com/calendar) each
-                        # get their own env_var and don't collide on the UNIQUE constraint.
+                        cred_id = _slugify(effective_label)
+                        # Collision-safe: append suffix if slug exists
+                        suffix_n = 2
+                        base_slug = cred_id
+                        while True:
+                            async with db.execute("SELECT id FROM credentials WHERE id=?", (cred_id,)) as cur:
+                                if not await cur.fetchone():
+                                    break
+                            cred_id = f"{base_slug}-{suffix_n}"
+                            suffix_n += 1
+
+                        host_slug = api_host.replace(".", "-")
                         safe_host = host_slug.upper().replace("/", "_").replace("-", "_")
                         env_var = f"PIPEDREAM_{account_id.upper().replace('-', '_')}_{safe_host}"
                         await db.execute(
                             "INSERT INTO credentials "
-                            "(id, label, env_var, encrypted_value, api_id, auth_type) "
+                            "(id, label, env_var, encrypted_value, routes, auth_type) "
                             "VALUES (?, ?, ?, ?, ?, 'pipedream_oauth')",
-                            (cred_id, effective_label, env_var, enc_account_id, api_host),
+                            (cred_id, effective_label, env_var, enc_account_id, routes_json),
                         )
 
                     count += 1
@@ -623,16 +660,28 @@ class PipedreamOAuthBroker:
             for stale_id in stale_ids:
                 # Stale accounts are already gone from Pipedream (not returned by API).
                 # Only clean up local rows — no upstream revoke needed.
-                # Find and remove all credential IDs derived from this account
+                # Find credentials whose routes match this account's api_host
                 async with db.execute(
-                    "SELECT id FROM credentials WHERE id LIKE ?",
-                    (f"{self.broker_id}-{stale_id}-%",),
+                    "SELECT api_host FROM oauth_broker_accounts "
+                    "WHERE broker_id=? AND account_id=?",
+                    (self.broker_id, stale_id),
                 ) as cur:
-                    stale_creds = [r[0] for r in await cur.fetchall()]
-                for cred_id in stale_creds:
-                    await db.execute("DELETE FROM toolkit_credentials WHERE credential_id=?", (cred_id,))
-                    await db.execute("DELETE FROM credentials WHERE id=?", (cred_id,))
-                    log.info("Removed stale credential %s (account %s disconnected)", cred_id, stale_id)
+                    stale_hosts = [r[0] for r in await cur.fetchall()]
+                for stale_host in stale_hosts:
+                    stale_route = pd_slug_to_route(
+                        account_slugs.get(stale_id, ""), base_proxy_host=stale_host
+                    )
+                    async with db.execute(
+                        """SELECT id FROM credentials
+                           WHERE auth_type='pipedream_oauth'
+                           AND EXISTS (SELECT 1 FROM json_each(routes) WHERE value=?)""",
+                        (stale_route,),
+                    ) as cur:
+                        stale_creds = [r[0] for r in await cur.fetchall()]
+                    for cred_id in stale_creds:
+                        await db.execute("DELETE FROM toolkit_credentials WHERE credential_id=?", (cred_id,))
+                        await db.execute("DELETE FROM credentials WHERE id=?", (cred_id,))
+                        log.info("Removed stale credential %s (account %s disconnected)", cred_id, stale_id)
 
                 # Remove account row
                 await db.execute(

--- a/src/models.py
+++ b/src/models.py
@@ -12,16 +12,25 @@ from src.validators import NormModel, NormStr
 
 class CredentialCreate(NormModel):
     label: str
+    """Human-readable name. Also used to derive the credential ID (slug) if `id` is not provided."""
     value: str
     """Plain-text secret; encrypted before storage. Always the primary credential — token, password, API key."""
+    id: str | None = None
+    """Optional custom ID (slug). If omitted, auto-generated from `label`. Immutable once set."""
     identity: str | None = None
     """Optional identity field — username, client ID, account SID etc.
     Required for http/basic and http/digest schemes (username + password).
     For compound apiKey schemes (overlay uses canonical 'Secret'/'Identity' names), the
     Identity scheme header is injected from this field.
     Leave null for Bearer tokens, single-value API keys, and GitHub PAT-style BasicAuth."""
-    api_id: str | None = None
-    """API this credential belongs to (e.g. 'techpreneurs.ie'). Required for broker injection."""
+    routes: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Host+path prefixes this credential covers. The broker matches requests "
+            "by longest prefix — e.g. `['www.googleapis.com/calendar']` matches "
+            "`www.googleapis.com/calendar/v3/events`. Multiple entries supported."
+        ),
+    )
     auth_type: Literal["bearer", "basic", "apiKey"] | None = Field(
         default=None,
         description=(
@@ -31,7 +40,7 @@ class CredentialCreate(NormModel):
             "| Value | Injects as | When to use |\n"
             "|---|---|---|\n"
             "| `bearer` | `Authorization: Bearer {value}` | REST APIs, OAuth access tokens, JWTs. GitHub REST API, Deepgram, Slack, etc. |\n"
-            "| `basic` | `Authorization: Basic base64({identity??'token'}:{value})` | HTTP Basic auth, git-over-HTTPS. Set `identity` to the username; omit for GitHub PATs (any username accepted). |\n"
+            "| `basic` | `Authorization: Basic base64({identity or 'token'}:{value})` | HTTP Basic auth, git-over-HTTPS. Set `identity` to the username; omit for GitHub PATs (any username accepted). |\n"
             "| `apiKey` | Custom header or query param `= {value}` | API key in a named header (X-API-Key, Api-Key, X-Auth-Key, etc.). For **compound** schemes (e.g. Discourse Api-Key + Api-Username) where the overlay uses canonical `Secret`/`Identity` scheme names, set `identity` to the username/account — a single credential covers both headers. |"
         ),
     )
@@ -42,7 +51,8 @@ class CredentialPatch(NormModel):
     value: str | None = None
     identity: str | None = None
     """Update the identity (username / client ID) for this credential."""
-    api_id: str | None = None
+    routes: list[str] | None = None
+    """Update the host+path prefixes this credential covers."""
     auth_type: Literal["bearer", "basic", "apiKey"] | None = Field(
         default=None,
         description="Update the auth type for this credential. See `POST /credentials` for valid values and semantics.",
@@ -123,16 +133,15 @@ class CapabilityOut(BaseModel):
 class CredentialOut(BaseModel):
     model_config = {"extra": "ignore"}
     id: str
+    """Human-readable slug (e.g. 'work-gmail'). Immutable, set at creation."""
     label: str
     identity: str | None = None
     """Identity field (username, client ID, etc.) — returned so clients can confirm what was stored."""
-    api_id: str | None = None
+    routes: list[str] = Field(default_factory=list)
+    """Host+path prefixes this credential covers."""
     auth_type: str | None = None
     created_at: float | None = None
     updated_at: float | None = None
-    account_id: str | None = None
-    app_slug: str | None = None
-    synced_at: float | None = None
 
 
 # ── Toolkits (output) ─────────────────────────────────────────────────────────

--- a/src/routers/access_requests.py
+++ b/src/routers/access_requests.py
@@ -75,7 +75,7 @@ class AccessRequestBody(NormModel):
     credential_id: str = Field(
         description=(
             "The upstream API credential to act on. "
-            "Discover available IDs and labels via `GET /credentials` or `GET /credentials?api_id=<host>`."
+            "Discover available IDs and labels via `GET /credentials` or `GET /credentials?route=<host>`."
         )
     )
     rules: list[PermissionRule] = Field(
@@ -141,7 +141,7 @@ async def create_access_request(toolkit_id: str, request: Request, body: AccessR
     """Agent submits an access request. A human approves or denies it at the `approve_url`.
 
     **Workflow:**
-    1. `GET /credentials?api_id=<host>` — find the `credential_id` you need
+    1. `GET /credentials?route=<host>` — find the `credential_id` you need
     2. `POST` this endpoint with `type`, `credential_id`, `rules`, and optional `reason`
     3. Return the `approve_url` to your user and poll `status` until `approved` or `denied`
 
@@ -466,7 +466,7 @@ async def _describe_request(req_type: str, payload: dict) -> str:
         if cred_id:
             async with get_db() as db:
                 async with db.execute(
-                    "SELECT label, api_id FROM credentials WHERE id=?", (cred_id,)
+                    "SELECT label, routes FROM credentials WHERE id=?", (cred_id,)
                 ) as cur:
                     row = await cur.fetchone()
             base = f"Grant access to credential '{row[0]}' (for {row[1] or 'unknown API'})" if row else f"Grant access to credential '{cred_id}'"

--- a/src/routers/apis.py
+++ b/src/routers/apis.py
@@ -364,7 +364,7 @@ async def list_apis(
     - `has_credentials: bool` — whether credentials have been configured for this API
 
     Use `?source=local` or `?source=catalog` to filter. Default returns all.
-    To use a catalog API: call `POST /credentials` with `api_id` set — the spec is imported automatically.
+    To use a catalog API: call `POST /credentials` with `routes` set — the spec is imported automatically.
     """
     from src.routers.catalog import _load_manifest, _catalog_vendor_set, GITHUB_REPO
 
@@ -372,9 +372,19 @@ async def list_apis(
     async with get_db() as db:
         async with db.execute("SELECT id, name, description, spec_path, base_url, created_at FROM apis ORDER BY id") as cur:
             local_rows = await cur.fetchall()
-        # Which local API ids have credentials?
-        async with db.execute("SELECT DISTINCT api_id FROM credentials WHERE api_id IS NOT NULL") as cur:
-            cred_api_ids: set[str] = {r[0] for r in await cur.fetchall()}
+        # Which local API ids have credentials? Check by route prefix match.
+        import json as _json
+        async with db.execute("SELECT routes FROM credentials WHERE routes IS NOT NULL AND routes != '[]'") as cur:
+            all_routes: set[str] = set()
+            for r in await cur.fetchall():
+                try:
+                    all_routes.update(_json.loads(r[0]))
+                except (ValueError, TypeError):
+                    pass
+        # Build a set of API IDs that have at least one credential route matching
+        def _has_cred(api_id: str) -> bool:
+            return any(route.startswith(api_id) or api_id.startswith(route) for route in all_routes)
+        cred_api_ids = _has_cred  # used as a callable below
         # Fetch oauth broker mappings for all local APIs
         local_api_ids = [r[0] for r in local_rows]
         broker_map = await _fetch_oauth_brokers(db, local_api_ids)
@@ -385,7 +395,7 @@ async def list_apis(
             "name": r[1],
             "vendor": _extract_vendor(r[0]),
             "source": "local",
-            "has_credentials": r[0] in cred_api_ids,
+            "has_credentials": cred_api_ids(r[0]),
             "description": r[2],
             "base_url": r[4],
             "created_at": r[5],
@@ -615,8 +625,8 @@ async def get_api(
        - `http bearer` → `secret` (token)
        - `http basic` → `secret` (password) + optional `identity` (username)
        - `apiKey` → `secret` (key value); if compound, check scheme names for Secret/Identity
-    3. Prompt user for values, then `POST /credentials` with `api_id`, `auth_type`, `value` (and `identity` if needed).
-    4. Verify with `GET /credentials?api_id={api_id}`
+    3. Prompt user for values, then `POST /credentials` with `routes`, `auth_type`, `value` (and `identity` if needed).
+    4. Verify with `GET /credentials?route={api_id}`
 
     **Optional sections** (add via `?sections=`):
     - `tags` — tag objects with names and descriptions
@@ -653,7 +663,9 @@ async def get_api(
         # Which security schemes already have at least one credential bound?
         # Used by client UIs to show "configured" vs "missing" per scheme.
         async with db.execute(
-            "SELECT DISTINCT auth_type FROM credentials WHERE api_id=? AND auth_type IS NOT NULL",
+            """SELECT DISTINCT auth_type FROM credentials
+               WHERE auth_type IS NOT NULL
+               AND EXISTS (SELECT 1 FROM json_each(routes) WHERE ? LIKE (value || '%'))""",
             (api_id,),
         ) as cur:
             cred_rows = await cur.fetchall()

--- a/src/routers/broker.py
+++ b/src/routers/broker.py
@@ -106,10 +106,28 @@ async def _find_credential_for_host(
     import logging as _log
     _broker_log = _log.getLogger("jentic.broker")
 
-    # Route-based credential lookup — no apis table dependency
-    creds = await vault.get_credentials_for_route(toolkit_id, host, path)
-    _broker_log.debug("CRED LOOKUP: host=%r path=%r → %d cred(s): %s",
-                      host, path, len(creds), [c.get("id") for c in creds])
+    is_ambiguous = False
+
+    if alias:
+        # Alias is a hard override — look up directly by ID, bypass route matching
+        async with get_db() as db:
+            async with db.execute(
+                "SELECT id, env_var, encrypted_value, auth_type, identity FROM credentials WHERE id=?",
+                (alias,),
+            ) as cur:
+                row = await cur.fetchone()
+        if row:
+            creds = [{"id": row[0], "value": vault.decrypt(row[2]), "auth_type": row[3],
+                       "identity": row[4] if len(row) > 4 else None}]
+            _broker_log.debug("CRED LOOKUP: alias %r → direct lookup", alias)
+        else:
+            _broker_log.warning("CRED LOOKUP: alias %r not found", alias)
+            creds = []
+    else:
+        # Route-based credential lookup — no apis table dependency
+        creds = await vault.get_credentials_for_route(toolkit_id, host, path)
+        _broker_log.debug("CRED LOOKUP: host=%r path=%r → %d cred(s): %s",
+                          host, path, len(creds), [c.get("id") for c in creds])
 
     if not creds and toolkit_id:
         raise ValueError(
@@ -120,17 +138,6 @@ async def _find_credential_for_host(
 
     if not creds:
         return {}, None, None, False
-
-    is_ambiguous = False
-
-    if alias and creds:
-        matched = [c for c in creds if c.get("id") == alias]
-        if matched:
-            _broker_log.debug("CRED LOOKUP: alias %r matched → using %r", alias, matched[0].get("id"))
-            creds = matched
-        else:
-            _broker_log.warning("CRED LOOKUP: alias %r not found in %s — falling back to first cred",
-                                alias, [c.get("id") for c in creds])
 
     # Ambiguity: routes-based lookup returns credentials ordered by longest prefix.
     # If the top two have the same prefix length, it's ambiguous.
@@ -281,7 +288,7 @@ async def _find_pipedream_credential_for_host(
     """
     if not toolkit_id:
         return None, None
-    full_path = f"{host}/{path}".rstrip("/")
+    full_path = f"{host}/{path.lstrip('/')}".rstrip("/")
     from src.db import DEFAULT_TOOLKIT_ID
     async with get_db() as db:
         if alias:

--- a/src/routers/broker.py
+++ b/src/routers/broker.py
@@ -21,9 +21,6 @@ Special request headers:
                         bypassing host-matching auto-selection entirely. Required when
                         multiple credentials share the same upstream host (e.g. multiple
                         Google services all routing through googleapis.com).
-  X-Jentic-Service    — service name (Pipedream app_slug, e.g. "google_calendar") to
-                        select the right credential when multiple share a host.
-                        Friendlier alternative to X-Jentic-Credential.
   X-Jentic-Callback   — webhook URL for async result delivery (TODO: phase 2)
 
 Response headers added:
@@ -58,10 +55,6 @@ from src.routers.traces import new_trace_id, safe_write_trace
 router = APIRouter(tags=["execute"])
 
 
-class ServiceNotFoundError(Exception):
-    """Raised when X-Jentic-Service doesn't match any credential for the host."""
-
-
 # Hop-by-hop headers that must NOT be forwarded
 _HOP_BY_HOP = {
     "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
@@ -73,7 +66,7 @@ _HOP_BY_HOP = {
     "content-length",
     # Jentic-specific — consumed here, not forwarded upstream
     "x-jentic-api-key", "x-jentic-simulate",
-    "x-jentic-credential", "x-jentic-service", "x-jentic-callback",
+    "x-jentic-credential", "x-jentic-callback",
     # Host is set from the target URL
     "host",
     # Reverse-proxy headers injected by nginx/traefik/etc. — these describe
@@ -86,38 +79,13 @@ _HOP_BY_HOP = {
     "x-real-ip", "x-scheme",
 }
 
-# How we detect credentials for a given API host
-# Looks up the api in the apis table by id (which is the scheme-stripped base URL)
-# then finds matching credentials by api_id + auth_type and injects them as HTTP headers.
-async def _resolve_credential_ids(host: str, toolkit_id: str | None) -> tuple[str | None, list[str]]:
-    """Resolve host → (api_id, [credential_ids]) without decrypting anything.
+async def _resolve_credential_ids(host: str, path: str, toolkit_id: str | None) -> list[str]:
+    """Resolve host+path → [credential_ids] via routes, without decrypting anything.
     Used for policy checks before the vault is touched.
     """
-    candidates = [host]
-    parts = host.split(".")
-    if len(parts) > 2:
-        candidates.append(".".join(parts[1:]))
-
-    api_id = None
-    async with get_db() as db:
-        for candidate in candidates:
-            # ORDER BY length(id) DESC ensures longest (most specific) match wins,
-            # making selection deterministic when multiple APIs share a host prefix
-            # (e.g. googleapis.com/calendar vs googleapis.com/gmail).
-            async with db.execute(
-                "SELECT id FROM apis WHERE id=? OR id LIKE ? ORDER BY length(id) DESC LIMIT 1",
-                (candidate, f"{candidate}%"),
-            ) as cur:
-                row = await cur.fetchone()
-            if row:
-                api_id = row[0]
-                break
-
-    if not api_id or not toolkit_id:
-        return api_id, []
-
-    cred_ids = await vault.get_credential_ids_for_api(toolkit_id, api_id)
-    return api_id, cred_ids
+    if not toolkit_id:
+        return []
+    return await vault.get_credential_ids_for_route(toolkit_id, host, path)
 
 
 async def _find_credential_for_host(
@@ -125,81 +93,33 @@ async def _find_credential_for_host(
     path: str,
     toolkit_id: str,
     alias: str | None,
-    service: str | None = None,
 ) -> tuple[dict[str, str], str | None, str | None, bool]:
     """
     Return (headers_to_inject, api_id, credential_id, is_ambiguous) for the given upstream host.
 
-    credential_id is the ID of the first credential used for injection — used by the
-    caller to enforce per-credential policy rules.
+    Credential resolution is based on the `routes` JSON array on each credential —
+    longest-prefix match against host+path. No dependency on the apis table.
 
-    is_ambiguous is True when multiple credentials matched and no alias/service
-    was provided to disambiguate.
+    credential_id is the ID of the first credential used for injection.
+    is_ambiguous is True when multiple credentials matched with the same prefix length.
     """
     import logging as _log
     _broker_log = _log.getLogger("jentic.broker")
 
-    # Resolve host → api_id
-    candidates = [host]
-    parts = host.split(".")
-    if len(parts) > 2:
-        candidates.append(".".join(parts[1:]))
-
-    api_id = None
-    async with get_db() as db:
-        for candidate in candidates:
-            # For subdomain-style hosts (e.g. calendar.googleapis.com), also try
-            # the catalog convention of parent-domain/subdomain (googleapis.com/calendar)
-            # by extracting the leftmost subdomain label as a path hint.
-            sub_hint = host.split(".")[0] if host != candidate else None
-            row = None
-
-            # 1. Exact match
-            async with db.execute("SELECT id FROM apis WHERE id=?", (candidate,)) as cur:
-                row = await cur.fetchone()
-
-            # 2. Subdomain-hinted prefix match (e.g. googleapis.com/calendar)
-            if not row and sub_hint:
-                async with db.execute(
-                    "SELECT id FROM apis WHERE id LIKE ? ORDER BY length(id) DESC LIMIT 1",
-                    (f"{candidate}/{sub_hint}%",),
-                ) as cur:
-                    row = await cur.fetchone()
-
-            # 3. General longest-prefix match (fallback)
-            if not row:
-                async with db.execute(
-                    "SELECT id FROM apis WHERE id LIKE ? ORDER BY length(id) DESC LIMIT 1",
-                    (f"{candidate}%",),
-                ) as cur:
-                    row = await cur.fetchone()
-
-            if row:
-                api_id = row[0]
-                break
-
-    # Credentials are always stored under api_id (the canonical ID from the apis
-    # table), which matches how POST /credentials stores them and how
-    # _resolve_credential_ids (the policy check path) looks them up.
-    _broker_log.debug("CRED LOOKUP: host=%r → api_id=%r (toolkit=%r alias=%r)", host, api_id, toolkit_id, alias)
-
-    if not api_id:
-        return {}, None, None, False
-
-    # Get credentials bound to this toolkit + api
-    creds = await vault.get_credentials_for_api(toolkit_id, api_id)
-    # TODO: remove hostname fallback once Pipedream credential storage is
-    # updated to use catalog api_id instead of HTTP hostname (see #79).
-    if not creds and host != api_id:
-        creds = await vault.get_credentials_for_api(toolkit_id, host)
-    _broker_log.debug("CRED LOOKUP: %d cred(s) for api_id=%r host=%r: %s", len(creds), api_id, host, [c.get("id") for c in creds])
+    # Route-based credential lookup — no apis table dependency
+    creds = await vault.get_credentials_for_route(toolkit_id, host, path)
+    _broker_log.debug("CRED LOOKUP: host=%r path=%r → %d cred(s): %s",
+                      host, path, len(creds), [c.get("id") for c in creds])
 
     if not creds and toolkit_id:
         raise ValueError(
-            f"No credentials found for host '{host}' (resolved api_id '{api_id}') "
+            f"No credentials found for host '{host}' path '{path}' "
             f"in toolkit '{toolkit_id}'. "
             f"Use POST /toolkits/{toolkit_id}/access-requests to request access."
         )
+
+    if not creds:
+        return {}, None, None, False
 
     is_ambiguous = False
 
@@ -209,52 +129,35 @@ async def _find_credential_for_host(
             _broker_log.debug("CRED LOOKUP: alias %r matched → using %r", alias, matched[0].get("id"))
             creds = matched
         else:
-            _broker_log.warning("CRED LOOKUP: alias %r not found in %s — falling back to first cred", alias, [c.get("id") for c in creds])
-        # If alias doesn't match any credential, fall through with all creds (best-effort)
+            _broker_log.warning("CRED LOOKUP: alias %r not found in %s — falling back to first cred",
+                                alias, [c.get("id") for c in creds])
 
-    elif service and creds and len(creds) > 1:
-        # X-Jentic-Service: select by Pipedream app_slug (e.g. "google_calendar")
-        # Look up which credentials belong to accounts with this app_slug.
-        async with get_db() as db:
-            async with db.execute(
-                "SELECT id FROM credentials WHERE id IN "
-                "(SELECT broker_id || '-' || account_id || '-' || replace(api_host, '.', '-') "
-                " FROM oauth_broker_accounts WHERE app_slug=?)",
-                (service,),
-            ) as cur:
-                service_cred_ids = {r[0] for r in await cur.fetchall()}
-        matched = [c for c in creds if c["id"] in service_cred_ids]
-        if matched:
-            _broker_log.debug("CRED LOOKUP: service %r matched %d cred(s)", service, len(matched))
-            creds = matched
-        else:
-            # Service name doesn't match any credential for this host — fail with
-            # a 409 listing available services so the agent can self-correct.
-            async with get_db() as db:
-                async with db.execute(
-                    "SELECT DISTINCT app_slug FROM oauth_broker_accounts "
-                    "WHERE api_host=? AND app_slug IS NOT NULL",
-                    (host,),
-                ) as cur:
-                    available = [r[0] for r in await cur.fetchall()]
-            raise ServiceNotFoundError(
-                f"Service '{service}' not found for host '{host}'. "
-                f"Available services: {available}"
-            )
-
-    if len(creds) > 1 and not alias and not service:
+    # Ambiguity: routes-based lookup returns credentials ordered by longest prefix.
+    # If the top two have the same prefix length, it's ambiguous.
+    if len(creds) > 1 and not alias:
         is_ambiguous = True
         _broker_log.warning(
-            "CRED AMBIGUITY: %d credentials for host=%r api_id=%r — using first. "
-            "Set X-Jentic-Service or X-Jentic-Credential header to disambiguate. "
+            "CRED AMBIGUITY: %d credentials for host=%r path=%r — using first. "
+            "Set X-Jentic-Credential header to disambiguate. "
             "Credential IDs: %s",
-            len(creds), host, api_id,
+            len(creds), host, path,
             [c.get("id") for c in creds],
         )
 
-    # Get merged security schemes (spec + confirmed overlays)
+    # Resolve api_id from apis table for scheme lookup (best-effort, not required)
+    api_id = None
+    async with get_db() as db:
+        async with db.execute(
+            "SELECT id FROM apis WHERE id=? OR id LIKE ? ORDER BY length(id) DESC LIMIT 1",
+            (host, f"{host}%"),
+        ) as cur:
+            row = await cur.fetchone()
+        if row:
+            api_id = row[0]
+
+    # Get merged security schemes (spec + confirmed overlays) — best-effort
     from src.routers.overlays import get_merged_security_schemes
-    schemes = await get_merged_security_schemes(api_id)
+    schemes = await get_merged_security_schemes(api_id) if api_id else {}
 
     # Note: schemes may be empty if no spec or overlay is registered for this API.
     # That is fine — credentials with an explicit auth_type can still be injected
@@ -370,23 +273,18 @@ async def _find_pipedream_credential_for_host(
     """Return (account_id, credential_id) for a Pipedream-managed credential in this toolkit.
 
     Pipedream credentials have auth_type='pipedream_oauth' and their encrypted value
-    IS the Pipedream account_id (apn_xxx). This bypasses the apis table lookup —
-    Pipedream-connected APIs may not have a spec in the local catalog.
+    IS the Pipedream account_id (apn_xxx).
 
-    Uses longest-prefix matching: the credential whose api_id is the longest prefix
-    of (host + path) wins. This correctly disambiguates googleapis.com/calendar from
-    googleapis.com/gmail when both are provisioned.
-
+    Uses longest-prefix matching against the routes JSON array.
     If alias is specified, only the credential with that ID is considered.
     Returns (None, None) if no Pipedream credential is provisioned for this host+toolkit.
     """
     if not toolkit_id:
         return None, None
-    full_path = host + path  # e.g. "googleapis.com/calendar/v3/calendars/primary"
+    full_path = f"{host}/{path}".rstrip("/")
     from src.db import DEFAULT_TOOLKIT_ID
     async with get_db() as db:
         if alias:
-            # Caller specified an exact credential — use it directly if it's Pipedream
             async with db.execute(
                 "SELECT id, encrypted_value FROM credentials "
                 "WHERE id=? AND auth_type='pipedream_oauth'",
@@ -394,22 +292,32 @@ async def _find_pipedream_credential_for_host(
             ) as cur:
                 row = await cur.fetchone()
         elif toolkit_id == DEFAULT_TOOLKIT_ID:
-            # Longest-prefix match: find the credential whose api_id is a prefix of host+path
             async with db.execute(
-                "SELECT id, encrypted_value FROM credentials "
-                "WHERE ? LIKE (api_id || '%') AND auth_type='pipedream_oauth' "
-                "ORDER BY length(api_id) DESC LIMIT 1",
-                (full_path,),
+                """SELECT id, encrypted_value FROM credentials
+                   WHERE auth_type='pipedream_oauth'
+                   AND EXISTS (
+                       SELECT 1 FROM json_each(routes) WHERE ? LIKE (value || '%')
+                   )
+                   ORDER BY (
+                       SELECT MAX(length(value)) FROM json_each(routes)
+                       WHERE ? LIKE (value || '%')
+                   ) DESC LIMIT 1""",
+                (full_path, full_path),
             ) as cur:
                 row = await cur.fetchone()
         else:
             async with db.execute(
                 """SELECT c.id, c.encrypted_value FROM credentials c
                    JOIN toolkit_credentials tc ON tc.credential_id = c.id
-                   WHERE tc.toolkit_id=? AND ? LIKE (c.api_id || '%')
-                   AND c.auth_type='pipedream_oauth'
-                   ORDER BY length(c.api_id) DESC LIMIT 1""",
-                (toolkit_id, full_path),
+                   WHERE tc.toolkit_id=? AND c.auth_type='pipedream_oauth'
+                   AND EXISTS (
+                       SELECT 1 FROM json_each(c.routes) WHERE ? LIKE (value || '%')
+                   )
+                   ORDER BY (
+                       SELECT MAX(length(value)) FROM json_each(c.routes)
+                       WHERE ? LIKE (value || '%')
+                   ) DESC LIMIT 1""",
+                (toolkit_id, full_path, full_path),
             ) as cur:
                 row = await cur.fetchone()
     if not row:
@@ -454,7 +362,6 @@ _BROKER_DESCRIPTION = (
     "**Headers:**\n"
     "- `X-Jentic-Simulate: true` — validate and preview the call without sending it\n"
     "- `X-Jentic-Credential: {alias}` — select a specific credential when multiple exist for an API\n"
-    "- `X-Jentic-Service: {app_slug}` — select by service name (e.g. `google_calendar`, `gmail`) when multiple credentials share a host\n"
     "- `X-Jentic-Dry-Run: true` — alias for Simulate (deprecated)\n\n"
     "Returns upstream response verbatim plus `X-Jentic-Execution-Id` for trace correlation."
 )
@@ -586,7 +493,6 @@ async def broker(request: Request, target: str):
         or request.headers.get("x-jentic-simulate", "").lower() == "true"
     )
     credential_alias = request.headers.get("x-jentic-credential")
-    credential_service = request.headers.get("x-jentic-service")
     callback_url = request.headers.get("x-jentic-callback")
 
     # ── Killswitch: reject all requests for disabled toolkits ─────────────────
@@ -625,24 +531,15 @@ async def broker(request: Request, target: str):
     # (e.g. googleapis.com) where auto-selection would otherwise target the wrong
     # credential (e.g. Calendar when the caller wants Gmail), causing spurious 403s
     # with a misleading credential_id in the error body.
-    _api_id_for_host: str | None = None
     _resolved_cred_ids: list[str] = []
 
     if credential_alias and toolkit_id:
         # Hard override: use the named credential directly for policy enforcement.
-        # Also attempt to resolve api_id for context (error messages etc.) but
-        # never let it change which credential gets checked.
         _resolved_cred_ids = [credential_alias]
-        try:
-            _api_id_for_host, _ = await _resolve_credential_ids(
-                host=upstream_host, toolkit_id=toolkit_id
-            )
-        except Exception:
-            pass
     elif toolkit_id:
         try:
-            _api_id_for_host, _resolved_cred_ids = await _resolve_credential_ids(
-                host=upstream_host, toolkit_id=toolkit_id
+            _resolved_cred_ids = await _resolve_credential_ids(
+                host=upstream_host, path=upstream_path, toolkit_id=toolkit_id
             )
         except Exception:
             # Fail closed: if we can't resolve credentials for policy checking,
@@ -718,15 +615,6 @@ async def broker(request: Request, target: str):
             path=upstream_path,
             toolkit_id=toolkit_id,
             alias=credential_alias,
-            service=credential_service,
-        )
-    except ServiceNotFoundError as e:
-        await _write_trace("error", 409, str(e))
-        return Response(
-            content=json.dumps({"error": "SERVICE_NOT_FOUND", "message": str(e)}),
-            status_code=409,
-            media_type="application/json",
-            headers={"X-Jentic-Error": "true", "X-Jentic-Execution-Id": execution_id},
         )
     except Exception as e:
         log.exception("Credential lookup failed")

--- a/src/routers/credentials.py
+++ b/src/routers/credentials.py
@@ -1,8 +1,12 @@
 """Upstream API credentials vault routes."""
+import json
 import logging
+import re
 import uuid
+
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
+
 from src.models import CredentialCreate, CredentialOut, CredentialPatch
 import src.vault as vault
 from src.db import get_db
@@ -22,7 +26,7 @@ async def _agent_has_credential_write_permission(toolkit_id: str | None, method:
     """
     if not toolkit_id:
         return False
-    cred_ids = await vault.get_credential_ids_for_api(toolkit_id, _self_api_id())
+    cred_ids = await vault.get_credential_ids_for_route(toolkit_id, JENTIC_PUBLIC_HOSTNAME, "")
     if not cred_ids:
         return False
     from src.routers.toolkits import check_credential_policy
@@ -35,188 +39,51 @@ async def _agent_has_credential_write_permission(toolkit_id: str | None, method:
 router = APIRouter(prefix="/credentials")
 
 
-async def _get_confirmed_scheme(api_id: str, scheme_name: str | None) -> dict | None:
-    """
-    Return the confirmed overlay row for (api_id, scheme_name), or None.
-    If scheme_name is None, returns the first confirmed overlay for the API.
-    """
-    async with get_db() as db:
-        if scheme_name:
-            async with db.execute(
-                """SELECT id, overlay FROM api_overlays
-                   WHERE api_id=? AND status='confirmed'
-                   AND json_extract(overlay, '$.actions[0].update.components.securitySchemes."' || ? || '"') IS NOT NULL
-                   LIMIT 1""",
-                (api_id, scheme_name),
-            ) as cur:
-                row = await cur.fetchone()
-        else:
-            async with db.execute(
-                "SELECT id, overlay FROM api_overlays WHERE api_id=? AND status='confirmed' LIMIT 1",
-                (api_id,),
-            ) as cur:
-                row = await cur.fetchone()
-    return row
-
-
-async def _api_has_native_scheme(api_id: str) -> bool:
-    """True if the API's own OpenAPI spec defines at least one security scheme."""
-    import json as _json
-    import yaml as _yaml
-    async with get_db() as db:
-        async with db.execute("SELECT spec_path FROM apis WHERE id=?", (api_id,)) as cur:
-            row = await cur.fetchone()
-    if not row or not row[0]:
-        return False
-    try:
-        with open(row[0]) as f:
-            raw = f.read()
-        if row[0].endswith((".yaml", ".yml")):
-            spec = _yaml.safe_load(raw)
-        else:
-            try:
-                spec = _json.loads(raw)
-            except _json.JSONDecodeError:
-                spec = _yaml.safe_load(raw)
-        schemes = spec.get("components", {}).get("securitySchemes", {})
-        return bool(schemes)
-    except Exception:
-        return False
-
-
 @router.post("", response_model=CredentialOut, status_code=201, summary="Store an upstream API credential — add a secret to the vault for broker injection")
 async def create(body: CredentialCreate, request: Request):
     """Store an encrypted credential in the vault for automatic broker injection.
 
-    Values are encrypted at rest and **never returned** after creation. Set `api_id` to
-    bind the credential to an API; the broker will inject it automatically when proxying
-    calls to that API.
+    Values are encrypted at rest and **never returned** after creation. Set `routes` to
+    declare which host+path prefixes this credential covers; the broker will inject it
+    automatically when proxying calls matching any route.
 
     ---
 
     ### `auth_type` reference
 
     Set `auth_type` to tell the broker how to inject the credential into upstream requests.
-    Based on the [Postman auth type taxonomy](https://learning.postman.com/docs/sending-requests/authorization/authorization-types/).
 
-    | `auth_type` | Status | Broker injects | `value` | `identity` |
-    |---|---|---|---|---|
-    | `bearer` | ✅ implemented | `Authorization: Bearer {value}` | Token, PAT, or OAuth access token | Not used |
-    | `basic` | ✅ implemented | `Authorization: Basic base64({identity or "token"}:{value})` | Password or PAT | Username (optional — defaults to `"token"` if omitted, works for GitHub PATs) |
-    | `apiKey` | ✅ implemented | Custom header or query param `= {value}` | API key | For **compound schemes** (e.g. Discourse `Api-Key` + `Api-Username`): set `identity` to the username — one credential covers both headers when the overlay uses canonical `Secret`/`Identity` scheme names |
-    | `oauth2` | ⚠️ partial | `Authorization: Bearer {value}` — token must be pre-obtained | Access token (Pipedream-managed flows only via `pipedream_oauth`) | Not used |
-    | `digest` | 🔲 planned | RFC 2617 challenge-response (nonce/HMAC handshake) | Password | Username |
-    | `jwt` | 🔲 planned | `Authorization: Bearer {signed_jwt}` — auto-generated from signing key | Private key or secret | Key ID (`kid`) — signing algorithm and claims go in `context` |
-    | `aws_sig4` | 🔲 planned | `Authorization: AWS4-HMAC-SHA256 ...` signed headers | AWS Secret Access Key | AWS Access Key ID — region and service go in `context` |
-    | `oauth1` | 🔲 planned | HMAC-SHA1 signed request (nonce + timestamp) | OAuth secret | OAuth consumer key |
-    | `hawk` | 🔲 planned | `Authorization: Hawk ...` HMAC request signing | Hawk secret | Hawk key ID |
-    | `ntlm` | 🔲 not planned | Windows NTLM challenge-response | Password | Username + domain |
-    | `akamai_edgegrid` | 🔲 not planned | Akamai EdgeGrid signing | Client secret | Client token + access token in `context` |
-
-    **Notes:**
-    - `pipedream_oauth` is a reserved value written by the Pipedream integration — do not set it manually.
-    - For `oauth2` full flows (auth code, client credentials, PKCE, token refresh) see the roadmap.
-    - `context` (not yet exposed) will hold auxiliary fields for multi-value schemes (JWT claims, AWS region/service, etc.).
+    | `auth_type` | Broker injects | When to use |
+    |---|---|---|
+    | `bearer` | `Authorization: Bearer {value}` | REST APIs, OAuth access tokens, JWTs |
+    | `basic` | `Authorization: Basic base64({identity or 'token'}:{value})` | HTTP Basic auth, git-over-HTTPS |
+    | `apiKey` | Custom header `= {value}` | API key in a named header |
 
     ---
 
     ### Workflow
 
-    1. Call `GET /apis/{api_id}` — check `security_schemes` and `credentials_configured` to find gaps.
-    2. Post this endpoint with `api_id`, `auth_type`, `value` (and `identity` if needed).
-    3. The broker injects the credential automatically on every proxied call to that API.
-    4. To scope a credential to a specific toolkit: `POST /toolkits/{id}/credentials`.
-
-    If the API has no registered security scheme yet, submit an overlay first: `POST /apis/{api_id}/overlays`.
+    1. Post this endpoint with `routes`, `auth_type`, `value` (and `identity` if needed).
+    2. The broker injects the credential automatically on every proxied call matching a route.
+    3. To scope a credential to a specific toolkit: `POST /toolkits/{id}/credentials`.
     """
     if not request.state.is_human_session:
         if not await _agent_has_credential_write_permission(request.state.toolkit_id, "POST", "/credentials"):
             raise HTTPException(status_code=403, detail="Storing credentials requires a human session, or an agent key with an explicit POST /credentials allow rule on the jentic-mini credential.")
-    api_id = getattr(body, "api_id", None)
-    scheme_name = getattr(body, "auth_type", None)
-
-    if api_id:
-        # ── Lazy import: if api_id is a catalog API not yet locally registered, import it now ──
-        from src.routers.catalog import ensure_catalog_api_imported, lazy_import_catalog_workflows
-        resolved_id = await ensure_catalog_api_imported(api_id)
-        if resolved_id and resolved_id != api_id:
-            # Import changed the api_id (e.g. 'discord.com' → 'discord.com/api')
-            api_id = resolved_id
-            body = body.model_copy(update={"api_id": api_id})
-
-        # Also import associated catalog workflows (fire-and-forget on error)
-        try:
-            await lazy_import_catalog_workflows(api_id)
-        except Exception as _wf_err:
-            log.warning("Workflow auto-import failed for '%s' (non-fatal): %s", api_id, _wf_err)
-
-        # Check native spec first
-        has_native = await _api_has_native_scheme(api_id)
-        if not has_native:
-            # Check for any overlay (pending OR confirmed) — pending is enough to proceed.
-            # The first successful broker call will confirm it. This is intentional bootstrap flow:
-            # overlay submitted → credential added → broker call → overlay confirmed.
-            async with get_db() as db:
-                async with db.execute(
-                    "SELECT id FROM api_overlays WHERE api_id=? LIMIT 1",
-                    (api_id,),
-                ) as cur:
-                    any_overlay = await cur.fetchone()
-            if not any_overlay:
-                # No overlay at all — instruct the agent to contribute one
-                return JSONResponse(
-                    status_code=409,
-                    content={
-                        "error": "no_security_scheme",
-                        "api_id": api_id,
-                        "message": (
-                            f"No security scheme is on record for '{api_id}'. "
-                            f"Before adding a credential, submit an overlay that declares the scheme."
-                        ),
-                        "instructions": (
-                            f"Research how '{api_id}' authenticates requests, then submit an "
-                            f"OpenAPI Overlay 1.0 document to POST /apis/{api_id}/overlays. "
-                            f"Once submitted, retry POST /credentials."
-                        ),
-                        "submit_to": f"POST /apis/{api_id}/overlays",
-                        "examples": {
-                            "api_key_in_header": {
-                                "overlay": "1.0.0",
-                                "info": {"title": f"{api_id} auth", "version": "1.0.0"},
-                                "actions": [{"target": "$", "update": {"components": {"securitySchemes": {"ApiKeyAuth": {"type": "apiKey", "in": "header", "name": "Your-Header-Name"}}}}}],
-                            },
-                            "bearer_token": {
-                                "overlay": "1.0.0",
-                                "info": {"title": f"{api_id} auth", "version": "1.0.0"},
-                                "actions": [{"target": "$", "update": {"components": {"securitySchemes": {"BearerAuth": {"type": "http", "scheme": "bearer"}}}}}],
-                            },
-                            "basic_auth": {
-                                "overlay": "1.0.0",
-                                "info": {"title": f"{api_id} auth", "version": "1.0.0"},
-                                "actions": [{"target": "$", "update": {"components": {"securitySchemes": {"BasicAuth": {"type": "http", "scheme": "basic"}}}}}],
-                            },
-                        },
-                        "note": (
-                            "Set auth_type on the credential to 'bearer', 'basic', or 'apiKey' — "
-                            "the broker uses this to match the right security scheme from the spec."
-                        ),
-                    },
-                )
 
     try:
-        # Auto-generate a stable internal slug (not exposed via API)
-        import re
-        slug = re.sub(r"[^a-zA-Z0-9]+", "_", f"{body.api_id or ''}_{body.label}").strip("_").upper()
+        slug = re.sub(r"[^a-zA-Z0-9]+", "_", body.label).strip("_").upper()
         env_var = slug or f"CRED_{uuid.uuid4().hex[:8].upper()}"
         cred = await vault.create_credential(
             body.label,
             env_var,
             body.value,
-            api_id=api_id,
-            scheme_name=scheme_name,
+            routes=body.routes,
+            auth_type=body.auth_type,
             identity=getattr(body, "identity", None),
+            credential_id=body.id,
         )
-    except Exception as e:
+    except Exception:
         log.exception("Failed to create credential")
         raise HTTPException(400, "Failed to create credential.")
 
@@ -228,22 +95,27 @@ async def get_credential(cid: str):
     """Retrieve metadata for a single credential. Value is never returned."""
     async with get_db() as db:
         async with db.execute(
-            "SELECT id, label, api_id, auth_type, created_at, updated_at, identity FROM credentials WHERE id=?",
+            "SELECT id, label, routes, auth_type, created_at, updated_at, identity FROM credentials WHERE id=?",
             (cid,),
         ) as cur:
             row = await cur.fetchone()
     if not row:
         raise HTTPException(404, "Credential not found")
-    return {"id": row[0], "label": row[1], "api_id": row[2], "auth_type": row[3],
+    try:
+        routes = json.loads(row[2]) if row[2] else []
+    except (json.JSONDecodeError, TypeError):
+        routes = []
+    return {"id": row[0], "label": row[1], "routes": routes, "auth_type": row[3],
             "created_at": row[4], "updated_at": row[5], "identity": row[6] if len(row) > 6 else None}
 
 
-@router.patch("/{cid:path}", response_model=CredentialOut, summary="Update an upstream API credential — rotate a secret or fix its API binding")
+@router.patch("/{cid:path}", response_model=CredentialOut, summary="Update an upstream API credential — rotate a secret or update routes")
 async def patch(cid: str, body: CredentialPatch, request: Request):
     if not request.state.is_human_session:
         if not await _agent_has_credential_write_permission(request.state.toolkit_id, "PATCH", f"/credentials/{cid}"):
             raise HTTPException(status_code=403, detail="Updating credentials requires a human session, or an agent key with an explicit PATCH /credentials allow rule on the jentic-mini credential.")
-    row = await vault.patch_credential(cid, body.label, body.value, body.api_id, body.auth_type,
+    row = await vault.patch_credential(cid, body.label, body.value,
+                                       routes=body.routes, auth_type=body.auth_type,
                                        identity=getattr(body, "identity", None))
     if not row:
         raise HTTPException(404, "Credential not found")
@@ -259,51 +131,49 @@ async def delete(cid: str, request: Request):
         raise HTTPException(404, "Credential not found")
 
 
-@router.get("", summary="List upstream API credentials — labels and API bindings only, no secret values", response_model=list[CredentialOut])
-async def list_credentials(request: Request, api_id: str | None = None):
+@router.get("", summary="List upstream API credentials — labels and routes only, no secret values", response_model=list[CredentialOut])
+async def list_credentials(request: Request, route: str | None = None):
     """List stored upstream API credentials. Values are never returned.
 
     All authenticated callers (agent keys and human sessions) can see all credential
     labels and IDs — this is intentional. Labels are not secrets, and agents need
-    to discover credential IDs in order to file targeted `grant` access requests
-    (e.g. "bind Work Gmail" vs "bind Personal Gmail").
+    to discover credential IDs in order to file targeted `grant` access requests.
 
-    Use `GET /credentials/{id}` to retrieve a specific credential by ID.
-    Filter with `?api_id=api.github.com` to list all credentials for a given API.
+    Filter with `?route=www.googleapis.com` to list credentials matching a host prefix.
     """
-
-    conditions = []
-    params: list = []
-
-    if api_id:
-        conditions.append("c.api_id = ?")
-        params.append(api_id)
-
-    where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
-
     async with get_db() as db:
-        async with db.execute(
-            f"SELECT c.id, c.label, c.api_id, c.auth_type, c.created_at, c.updated_at, c.identity, "
-            f"       oba.account_id, oba.app_slug, oba.synced_at "
-            f"FROM credentials c "
-            f"LEFT JOIN oauth_broker_accounts oba ON oba.broker_id || '-' || oba.account_id || '-' || replace(oba.api_host, '.', '-') = c.id "
-            f"{where} ORDER BY c.created_at DESC",
-            params,
-        ) as cur:
-            rows = await cur.fetchall()
+        if route:
+            async with db.execute(
+                """SELECT id, label, routes, auth_type, created_at, updated_at, identity
+                   FROM credentials
+                   WHERE EXISTS (
+                       SELECT 1 FROM json_each(routes)
+                       WHERE value LIKE ? OR ? LIKE (value || '%')
+                   )
+                   ORDER BY created_at DESC""",
+                (f"{route}%", route),
+            ) as cur:
+                rows = await cur.fetchall()
+        else:
+            async with db.execute(
+                "SELECT id, label, routes, auth_type, created_at, updated_at, identity "
+                "FROM credentials ORDER BY created_at DESC",
+            ) as cur:
+                rows = await cur.fetchall()
 
-    return [
-        {
+    results = []
+    for r in rows:
+        try:
+            routes_parsed = json.loads(r[2]) if r[2] else []
+        except (json.JSONDecodeError, TypeError):
+            routes_parsed = []
+        results.append({
             "id": r[0],
             "label": r[1],
-            "api_id": r[2],
+            "routes": routes_parsed,
             "auth_type": r[3],
             "created_at": r[4],
             "updated_at": r[5],
             "identity": r[6] if len(r) > 6 else None,
-            "account_id": r[7] if len(r) > 7 else None,
-            "app_slug": r[8] if len(r) > 8 else None,
-            "synced_at": r[9] if len(r) > 9 else None,
-        }
-        for r in rows
-    ]
+        })
+    return results

--- a/src/routers/debug.py
+++ b/src/routers/debug.py
@@ -317,8 +317,8 @@ async def fix_credentials():
     import uuid as _uuid
     from src.db import get_db, DEFAULT_TOOLKIT_ID
     async with get_db() as db:
-        await db.execute("UPDATE credentials SET api_id='techpreneurs.ie', scheme_name='DiscourseApiKey' WHERE env_var='DISCOURSE_API_KEY'")
-        await db.execute("UPDATE credentials SET api_id='techpreneurs.ie', scheme_name='DiscourseUsername' WHERE env_var='DISCOURSE_API_USERNAME'")
+        await db.execute("UPDATE credentials SET routes='[\"techpreneurs.ie\"]', auth_type='apiKey' WHERE env_var='DISCOURSE_API_KEY'")
+        await db.execute("UPDATE credentials SET routes='[\"techpreneurs.ie\"]', auth_type='apiKey' WHERE env_var='DISCOURSE_API_USERNAME'")
         for ev in ('DISCOURSE_API_KEY', 'DISCOURSE_API_USERNAME', 'DISCOURSE_USERNAME'):
             async with db.execute('SELECT id FROM credentials WHERE env_var=?', (ev,)) as cur:
                 row = await cur.fetchone()
@@ -328,7 +328,7 @@ async def fix_credentials():
                     (str(_uuid.uuid4()), DEFAULT_TOOLKIT_ID, row[0])
                 )
         await db.commit()
-        async with db.execute("SELECT env_var, api_id, scheme_name FROM credentials WHERE api_id IS NOT NULL") as cur:
+        async with db.execute("SELECT env_var, routes, auth_type FROM credentials WHERE routes IS NOT NULL AND routes != '[]'") as cur:
             updated = await cur.fetchall()
     return {"updated": updated}
 
@@ -337,7 +337,7 @@ async def fix_credentials():
 async def check_creds():
     from src.db import get_db, DEFAULT_TOOLKIT_ID
     async with get_db() as db:
-        async with db.execute("SELECT id, env_var, api_id, scheme_name FROM credentials") as cur:
+        async with db.execute("SELECT id, env_var, routes, auth_type FROM credentials") as cur:
             creds = await cur.fetchall()
         async with db.execute("SELECT toolkit_id, credential_id FROM toolkit_credentials WHERE toolkit_id=?", (DEFAULT_TOOLKIT_ID,)) as cur:
             cc = await cur.fetchall()

--- a/src/routers/oauth_brokers.py
+++ b/src/routers/oauth_brokers.py
@@ -26,7 +26,7 @@ from src.validators import NormModel, NormStr
 from src.utils import build_absolute_url
 
 from src.auth import require_human_session
-from src.brokers.pipedream import api_host_to_pd_slug, broker_credential_id
+from src.brokers.pipedream import api_host_to_pd_slug, pd_slug_to_route
 from src.db import get_db
 from src.oauth_broker import registry as oauth_broker_registry
 import src.vault as vault
@@ -610,7 +610,17 @@ async def connect_callback(
                         old_rows = await cur.fetchall()
 
                 if old_rows:
-                    old_cred_ids = [broker_credential_id(broker_id, replace_account_id, r[0]) for r in old_rows]
+                    # Find credential IDs by route match for the old account's hosts
+                    old_cred_ids = []
+                    for old_r in old_rows:
+                        old_route = pd_slug_to_route("", base_proxy_host=old_r[0])
+                        async with get_db() as _cdb:
+                            async with _cdb.execute(
+                                """SELECT id FROM credentials WHERE auth_type='pipedream_oauth'
+                                   AND EXISTS (SELECT 1 FROM json_each(routes) WHERE value=?)""",
+                                (old_route,),
+                            ) as _ccur:
+                                old_cred_ids.extend([cr[0] for cr in await _ccur.fetchall()])
 
                     # 1. Revoke upstream in Pipedream (best-effort, async)
                     if live_broker is not None:
@@ -805,7 +815,17 @@ async def delete_broker_account(broker_id: BrokerIdPath, account_id: str):
     if not rows:
         raise HTTPException(404, f"No connected account '{account_id}' found for broker '{broker_id}'")
     # An account can map to multiple api_hosts (e.g. Google Sheets → sheets.googleapis.com + googleapis.com/sheets)
-    cred_ids = [broker_credential_id(broker_id, account_id, r[1]) for r in rows]
+    # Find credential IDs by route match for this account's hosts
+    cred_ids = []
+    async with get_db() as db:
+        for r in rows:
+            route = pd_slug_to_route("", base_proxy_host=r[1])
+            async with db.execute(
+                """SELECT id FROM credentials WHERE auth_type='pipedream_oauth'
+                   AND EXISTS (SELECT 1 FROM json_each(routes) WHERE value=?)""",
+                (route,),
+            ) as cur:
+                cred_ids.extend([cr[0] for cr in await cur.fetchall()])
 
     # 1. Revoke upstream in Pipedream
     pipedream_revoked = False
@@ -889,11 +909,20 @@ async def update_broker_account(broker_id: BrokerIdPath, account_id: str, body: 
             "UPDATE oauth_broker_accounts SET label=? WHERE broker_id=? AND account_id=?",
             (new_label.strip(), broker_id, account_id),
         )
-        # Also update the credential label in the vault if it exists
-        await db.execute(
-            "UPDATE credentials SET label=? WHERE id LIKE ?",
-            (new_label.strip(), f"{broker_id}-{account_id}-%"),
-        )
+        # Also update the credential label in the vault — find by route match
+        async with db.execute(
+            "SELECT api_host FROM oauth_broker_accounts WHERE broker_id=? AND account_id=?",
+            (broker_id, account_id),
+        ) as cur:
+            host_rows = await cur.fetchall()
+        for hr in host_rows:
+            route = pd_slug_to_route("", base_proxy_host=hr[0])
+            await db.execute(
+                """UPDATE credentials SET label=?, updated_at=unixepoch()
+                   WHERE auth_type='pipedream_oauth'
+                   AND EXISTS (SELECT 1 FROM json_each(routes) WHERE value=?)""",
+                (new_label.strip(), route),
+            )
         await db.commit()
     return {"account_id": account_id, "label": new_label.strip()}
 
@@ -1013,10 +1042,16 @@ async def delete_oauth_broker(broker_id: BrokerIdPath):
             (broker_id,),
         ) as cur:
             accounts = await cur.fetchall()
-        cred_ids = [
-            broker_credential_id(broker_id, account_id, api_host)
-            for account_id, api_host in accounts
-        ]
+        # Find credential IDs by route match
+        cred_ids = []
+        for account_id, api_host in accounts:
+            route = pd_slug_to_route("", base_proxy_host=api_host)
+            async with db.execute(
+                """SELECT id FROM credentials WHERE auth_type='pipedream_oauth'
+                   AND EXISTS (SELECT 1 FROM json_each(routes) WHERE value=?)""",
+                (route,),
+            ) as cur:
+                cred_ids.extend([cr[0] for cr in await cur.fetchall()])
 
         # Remove toolkit bindings and broker account rows
         for cred_id in cred_ids:

--- a/src/routers/oauth_brokers.py
+++ b/src/routers/oauth_brokers.py
@@ -727,14 +727,11 @@ async def sync_broker_accounts(broker_id: BrokerIdPath, body: SyncRequest, reque
     # Return the credential IDs created/updated so the caller knows what to provision
     async with get_db() as db:
         async with db.execute(
-            "SELECT id, label, api_id FROM credentials WHERE auth_type='pipedream_oauth' "
-            "AND api_id IN (SELECT api_host FROM oauth_broker_accounts "
-            "WHERE broker_id=? AND external_user_id=?)",
-            (broker_id, body.external_user_id),
+            "SELECT id, label, routes FROM credentials WHERE auth_type='pipedream_oauth'",
         ) as cur:
             cred_rows = await cur.fetchall()
 
-    credentials = [{"id": r[0], "label": r[1], "api_host": r[2]} for r in cred_rows]
+    credentials = [{"id": r[0], "label": r[1], "routes": r[2]} for r in cred_rows]
 
     return {
         "broker_id": broker_id,

--- a/src/routers/toolkits.py
+++ b/src/routers/toolkits.py
@@ -328,8 +328,8 @@ def _toolkit_to_markdown(data: dict) -> str:
             lines.append(f"### `{cred['credential_id']}`")
             if cred.get("label"):
                 lines.append(f"- **Label:** {cred['label']}")
-            if cred.get("api_id"):
-                lines.append(f"- **API:** `{cred['api_id']}`")
+            if cred.get("routes"):
+                lines.append(f"- **API:** `{cred['routes']}`")
             user_rules = [r for r in cred.get("permissions", []) if not r.get("_system")]
             if user_rules:
                 lines.append("- **Custom permissions:**")
@@ -381,12 +381,12 @@ async def get_toolkit(toolkit_id: str, request: Request):
         if toolkit_id == DEFAULT_TOOLKIT_ID:
             # Default toolkit sees all credentials implicitly
             async with db.execute(
-                "SELECT id, id, label, api_id, created_at FROM credentials ORDER BY created_at DESC",
+                "SELECT id, id, label, routes, created_at FROM credentials ORDER BY created_at DESC",
             ) as cur:
                 cred_rows = await cur.fetchall()
         else:
             async with db.execute(
-                """SELECT cc.id, cc.credential_id, c.label, c.api_id, cc.created_at
+                """SELECT cc.id, cc.credential_id, c.label, c.routes, cc.created_at
                    FROM toolkit_credentials cc
                    JOIN credentials c ON cc.credential_id = c.id
                    WHERE cc.toolkit_id = ?""",
@@ -411,7 +411,7 @@ async def get_toolkit(toolkit_id: str, request: Request):
         {
             "credential_id": r[1],
             "label": r[2],
-            "api_id": r[3],
+            "routes": r[3],
             "bound_at": r[4],
             "permissions": cred_policies.get(r[1], []) + SYSTEM_SAFETY_RULES,
             "_links": {
@@ -682,7 +682,7 @@ async def list_toolkit_credentials(toolkit_id: str, request: Request):
             raise HTTPException(403, "Agents may only list credentials for their own toolkit.")
     async with get_db() as db:
         async with db.execute(
-            """SELECT cc.id, cc.credential_id, c.label, c.api_id, cc.created_at
+            """SELECT cc.id, cc.credential_id, c.label, c.routes, cc.created_at
                FROM toolkit_credentials cc
                JOIN credentials c ON cc.credential_id = c.id
                WHERE cc.toolkit_id = ?""",
@@ -694,7 +694,7 @@ async def list_toolkit_credentials(toolkit_id: str, request: Request):
             "id": r[0],
             "credential_id": r[1],
             "credential_label": r[2],
-            "api_id": r[3],
+            "routes": r[3],
             "created_at": r[4],
         }
         for r in rows

--- a/src/startup.py
+++ b/src/startup.py
@@ -193,8 +193,8 @@ async def _ensure_internal_credential() -> None:
             label="Jentic Mini Admin Key",
             env_var="JENTIC_MINI_ADMIN_KEY",
             value=raw_key,
-            api_id=_public_hostname(),
-            scheme_name="JenticApiKey",
+            routes=[_public_hostname()],
+            auth_type="JenticApiKey",
         )
 
         # Override the semantic ID to our canonical internal ID (in case slug differs)

--- a/src/vault.py
+++ b/src/vault.py
@@ -1,47 +1,26 @@
 """Fernet-encrypted credential vault."""
+import json
 import os
 import re
-import uuid
 from pathlib import Path
+
 from cryptography.fernet import Fernet, InvalidToken
+
 from src.db import get_db
 
 _KEY_FILE = Path(os.getenv("DB_PATH", "/app/data/jentic-mini.db")).parent / "vault.key"
 
-_COMMON_WORDS = {
-    "api", "key", "token", "secret", "auth", "oauth",
-    "credential", "credentials", "access", "the", "a", "an",
-}
 
-
-def _credential_slug(api_id: str | None, label: str) -> str:
-    """Generate a semantic, URL-safe credential ID from api_id + label.
-
-    Strategy:
-      - Start with api_id (e.g. "api.elevenlabs.io")
-      - Tokenize label; strip tokens appearing in api_id or that are common words
-      - Slugify the remainder and append with '-' separator
-      - If nothing remains, use api_id alone
-      - If no api_id, slugify the label directly
+def _slugify(label: str) -> str:
+    """Generate a URL-safe slug from a label.
 
     Examples:
-      api.elevenlabs.io + "ElevenLabs API Key"  → "api.elevenlabs.io"
-      api.github.com    + "GitHub PAT"          → "api.github.com-pat"
-      api.openai.com    + "OpenAI Org Key"      → "api.openai.com-org"
-      api.stripe.com    + "Stripe Live Secret"  → "api.stripe.com-live"
+      "Work Gmail"       → "work-gmail"
+      "GitHub PAT"       → "github-pat"
+      "My Calendar (v2)" → "my-calendar-v2"
     """
-    if not api_id:
-        slug = re.sub(r"[^a-z0-9.-]+", "-", label.lower()).strip("-")
-        return slug or "credential"
-
-    api_tokens = set(re.split(r"[./\-_]", api_id.lower())) | _COMMON_WORDS
-    label_parts = re.split(r"[\s\-_./]+", label.lower())
-    remainder = [p for p in label_parts if p and p not in api_tokens]
-
-    if remainder:
-        suffix = re.sub(r"[^a-z0-9]+", "-", "-".join(remainder)).strip("-")
-        return f"{api_id}-{suffix}" if suffix else api_id
-    return api_id
+    slug = re.sub(r"[^a-z0-9]+", "-", label.lower()).strip("-")
+    return slug or "credential"
 
 
 def _fernet() -> Fernet:
@@ -76,15 +55,21 @@ async def create_credential(
     label: str,
     env_var: str,
     value: str,
-    api_id: str | None = None,
-    scheme_name: str | None = None,  # legacy param name kept for call-site compat; stored as auth_type
+    routes: list[str] | None = None,
+    auth_type: str | None = None,
     identity: str | None = None,
+    credential_id: str | None = None,
 ) -> dict:
-    base_slug = _credential_slug(api_id, label)
+    """Create a new credential in the vault.
+
+    If credential_id is provided, use it as-is. Otherwise auto-generate from label.
+    """
+    base_slug = credential_id or _slugify(label)
     enc = encrypt(value)
+    routes_json = json.dumps(routes or [])
 
     async with get_db() as db:
-        # Collision-safe semantic ID
+        # Collision-safe ID
         cid = base_slug
         suffix_n = 2
         while True:
@@ -95,8 +80,9 @@ async def create_credential(
             suffix_n += 1
 
         await db.execute(
-            "INSERT INTO credentials (id, label, env_var, encrypted_value, api_id, auth_type, identity) VALUES (?,?,?,?,?,?,?)",
-            (cid, label, env_var, enc, api_id, scheme_name, identity),
+            "INSERT INTO credentials (id, label, env_var, encrypted_value, routes, auth_type, identity) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (cid, label, env_var, enc, routes_json, auth_type, identity),
         )
         await db.commit()
         async with db.execute("SELECT * FROM credentials WHERE id=?", (cid,)) as cur:
@@ -105,7 +91,8 @@ async def create_credential(
 
 
 async def patch_credential(cid: str, label: str | None, value: str | None,
-                           api_id: str | None = None, scheme_name: str | None = None,
+                           routes: list[str] | None = None,
+                           auth_type: str | None = None,
                            identity: str | None = None) -> dict | None:
     async with get_db() as db:
         if label:
@@ -113,10 +100,10 @@ async def patch_credential(cid: str, label: str | None, value: str | None,
         if value:
             enc = encrypt(value)
             await db.execute("UPDATE credentials SET encrypted_value=?, updated_at=unixepoch() WHERE id=?", (enc, cid))
-        if api_id is not None:
-            await db.execute("UPDATE credentials SET api_id=?, updated_at=unixepoch() WHERE id=?", (api_id, cid))
-        if scheme_name is not None:
-            await db.execute("UPDATE credentials SET auth_type=?, updated_at=unixepoch() WHERE id=?", (scheme_name, cid))
+        if routes is not None:
+            await db.execute("UPDATE credentials SET routes=?, updated_at=unixepoch() WHERE id=?", (json.dumps(routes), cid))
+        if auth_type is not None:
+            await db.execute("UPDATE credentials SET auth_type=?, updated_at=unixepoch() WHERE id=?", (auth_type, cid))
         if identity is not None:
             await db.execute("UPDATE credentials SET identity=?, updated_at=unixepoch() WHERE id=?", (identity, cid))
         await db.commit()
@@ -132,12 +119,8 @@ async def delete_credential(cid: str) -> bool:
     return cur.rowcount > 0
 
 
-
 async def get_credential_value(db, vault_id: str) -> str | None:
-    """
-    Return the decrypted value for a credential by UUID.
-    Used by auth_override to resolve vault_id references.
-    """
+    """Return the decrypted value for a credential by ID."""
     async with db.execute(
         "SELECT encrypted_value FROM credentials WHERE id=?", (vault_id,)
     ) as cur:
@@ -147,47 +130,87 @@ async def get_credential_value(db, vault_id: str) -> str | None:
     return decrypt(row[0])
 
 
-async def get_credential_ids_for_api(toolkit_id: str, api_id: str) -> list[str]:
-    """Return credential IDs (no decryption) bound to a toolkit+api. Used for policy checks."""
+async def get_credential_ids_for_route(toolkit_id: str, host: str, path: str) -> list[str]:
+    """Return credential IDs (no decryption) matching a route. Used for policy checks.
+
+    Matches credentials whose routes JSON array contains a prefix of host/path.
+    Ordered by longest matching prefix (most specific first).
+    """
     from src.db import DEFAULT_TOOLKIT_ID
+    full_path = f"{host}/{path}".rstrip("/")
     async with get_db() as db:
         if toolkit_id == DEFAULT_TOOLKIT_ID:
             async with db.execute(
-                "SELECT id FROM credentials WHERE api_id = ?", (api_id,)
+                """SELECT c.id FROM credentials c
+                   WHERE EXISTS (
+                       SELECT 1 FROM json_each(c.routes)
+                       WHERE ? LIKE (value || '%')
+                   )
+                   ORDER BY (
+                       SELECT MAX(length(value)) FROM json_each(c.routes)
+                       WHERE ? LIKE (value || '%')
+                   ) DESC""",
+                (full_path, full_path),
             ) as cur:
                 rows = await cur.fetchall()
         else:
             async with db.execute(
                 """SELECT c.id FROM credentials c
                    JOIN toolkit_credentials cc ON c.id = cc.credential_id
-                   WHERE cc.toolkit_id = ? AND c.api_id = ?""",
-                (toolkit_id, api_id),
+                   WHERE cc.toolkit_id = ?
+                   AND EXISTS (
+                       SELECT 1 FROM json_each(c.routes)
+                       WHERE ? LIKE (value || '%')
+                   )
+                   ORDER BY (
+                       SELECT MAX(length(value)) FROM json_each(c.routes)
+                       WHERE ? LIKE (value || '%')
+                   ) DESC""",
+                (toolkit_id, full_path, full_path),
             ) as cur:
                 rows = await cur.fetchall()
     return [r[0] for r in rows]
 
 
-async def get_credentials_for_api(toolkit_id: str, api_id: str) -> list[dict]:
-    """
-    Return credentials bound to a specific api_id.
+async def get_credentials_for_route(toolkit_id: str, host: str, path: str) -> list[dict]:
+    """Return decrypted credentials matching a route, ordered by longest prefix match.
+
     The default toolkit implicitly contains ALL credentials — no join needed.
     Named toolkits are scoped via toolkit_credentials.
     """
     from src.db import DEFAULT_TOOLKIT_ID
+    full_path = f"{host}/{path}".rstrip("/")
     async with get_db() as db:
         if toolkit_id == DEFAULT_TOOLKIT_ID:
             async with db.execute(
-                "SELECT id, env_var, encrypted_value, auth_type, identity FROM credentials WHERE api_id = ?",
-                (api_id,),
+                """SELECT id, env_var, encrypted_value, auth_type, identity, routes
+                   FROM credentials
+                   WHERE EXISTS (
+                       SELECT 1 FROM json_each(routes)
+                       WHERE ? LIKE (value || '%')
+                   )
+                   ORDER BY (
+                       SELECT MAX(length(value)) FROM json_each(routes)
+                       WHERE ? LIKE (value || '%')
+                   ) DESC""",
+                (full_path, full_path),
             ) as cur:
                 rows = await cur.fetchall()
         else:
             async with db.execute(
-                """SELECT c.id, c.env_var, c.encrypted_value, c.auth_type, c.identity
+                """SELECT c.id, c.env_var, c.encrypted_value, c.auth_type, c.identity, c.routes
                    FROM credentials c
                    JOIN toolkit_credentials cc ON c.id = cc.credential_id
-                   WHERE cc.toolkit_id = ? AND c.api_id = ?""",
-                (toolkit_id, api_id),
+                   WHERE cc.toolkit_id = ?
+                   AND EXISTS (
+                       SELECT 1 FROM json_each(c.routes)
+                       WHERE ? LIKE (value || '%')
+                   )
+                   ORDER BY (
+                       SELECT MAX(length(value)) FROM json_each(c.routes)
+                       WHERE ? LIKE (value || '%')
+                   ) DESC""",
+                (toolkit_id, full_path, full_path),
             ) as cur:
                 rows = await cur.fetchall()
     return [
@@ -202,15 +225,24 @@ async def get_credentials_for_api(toolkit_id: str, api_id: str) -> list[dict]:
 
 
 def _row_to_dict(row) -> dict:
-    # columns: id, label, env_var, encrypted_value, created_at, updated_at, api_id, auth_type, identity
-    # env_var and encrypted_value are internal — not exposed in API responses
+    """Convert a credentials row to a dict for API responses.
+
+    Column order (after migration 0004):
+    0: id, 1: label, 2: env_var, 3: encrypted_value,
+    4: created_at, 5: updated_at, 6: routes, 7: auth_type, 8: identity
+    """
+    routes_raw = row[6] if len(row) > 6 else "[]"
+    try:
+        routes = json.loads(routes_raw) if routes_raw else []
+    except (json.JSONDecodeError, TypeError):
+        routes = []
     return {
         "id": row[0],
         "label": row[1],
         # encrypted_value (row[3]) intentionally omitted
         "created_at": row[4],
         "updated_at": row[5],
-        "api_id": row[6] if len(row) > 6 else None,
+        "routes": routes,
         "auth_type": row[7] if len(row) > 7 else None,
         "identity": row[8] if len(row) > 8 else None,
     }

--- a/src/vault.py
+++ b/src/vault.py
@@ -137,7 +137,7 @@ async def get_credential_ids_for_route(toolkit_id: str, host: str, path: str) ->
     Ordered by longest matching prefix (most specific first).
     """
     from src.db import DEFAULT_TOOLKIT_ID
-    full_path = f"{host}/{path}".rstrip("/")
+    full_path = f"{host}/{path.lstrip('/')}".rstrip("/")
     async with get_db() as db:
         if toolkit_id == DEFAULT_TOOLKIT_ID:
             async with db.execute(
@@ -179,7 +179,7 @@ async def get_credentials_for_route(toolkit_id: str, host: str, path: str) -> li
     Named toolkits are scoped via toolkit_credentials.
     """
     from src.db import DEFAULT_TOOLKIT_ID
-    full_path = f"{host}/{path}".rstrip("/")
+    full_path = f"{host}/{path.lstrip('/')}".rstrip("/")
     async with get_db() as db:
         if toolkit_id == DEFAULT_TOOLKIT_ID:
             async with db.execute(

--- a/tests/test_auth_boundary.py
+++ b/tests/test_auth_boundary.py
@@ -19,17 +19,15 @@ def test_valid_agent_key_returns_200(client, agent_key_header):
     assert resp.status_code == 200
 
 
-def test_agent_cannot_create_credentials(client, agent_key_header):
-    """Agents cannot create credentials without explicit permission.
-    Returns 403 (permission denied) or 409 (no security scheme) — either
-    way the credential is NOT created."""
-    resp = client.post("/credentials", headers=agent_key_header, json={
+def test_agent_cannot_create_credentials(agent_only_client):
+    """Agents cannot create credentials without explicit permission."""
+    resp = agent_only_client.post("/credentials", json={
         "label": "test",
         "value": "secret123",
-        "api_id": "test.example.com",
+        "routes": ["test.example.com"],
         "auth_type": "bearer",
     })
-    assert resp.status_code in (403, 409)
+    assert resp.status_code == 403
 
 
 def test_human_session_can_access_toolkits(client, admin_session):

--- a/tests/test_credential_ambiguity.py
+++ b/tests/test_credential_ambiguity.py
@@ -1,12 +1,12 @@
-"""Credential ambiguity tests — X-Jentic-Service header and ambiguity detection.
+"""Credential ambiguity tests — route-based resolution and disambiguation.
 
-Tests the broker's behavior when multiple credentials resolve to the same
-upstream host (e.g. Google Calendar + Gmail both on www.googleapis.com).
-Uses direct DB setup to create the ambiguous state, then makes broker
-requests to verify header behavior. The upstream calls will fail (non-routable)
-but we can still verify the credential selection via response headers.
+Tests the broker's behavior when multiple credentials have routes matching
+the same upstream host. Uses direct DB setup, then makes broker requests
+to verify header behavior. Upstream calls fail (non-routable) but we can
+verify credential selection via response headers.
 """
 import asyncio
+import json
 import os
 import uuid
 
@@ -17,73 +17,45 @@ import src.vault as vault
 
 
 API_HOST = "127.0.0.2"
-API_ID = API_HOST
-HOST_SLUG = API_HOST.replace(".", "-")
+ROUTE_CALENDAR = f"{API_HOST}/calendar"
+ROUTE_GMAIL = f"{API_HOST}/gmail"
 
-ACCOUNT_ID_A = "apn_cal"
-ACCOUNT_ID_B = "apn_gmail"
-APP_SLUG_A = "google_calendar"
-APP_SLUG_B = "gmail"
-BROKER_ID = "test-ambig-broker"
-
-# Credential IDs must match the broker_credential_id() pattern
-CRED_ID_A = f"{BROKER_ID}-{ACCOUNT_ID_A}-{HOST_SLUG}"
-CRED_ID_B = f"{BROKER_ID}-{ACCOUNT_ID_B}-{HOST_SLUG}"
+CRED_ID_A = "work-calendar"
+CRED_ID_B = "work-gmail"
 
 
 @pytest.fixture(scope="module")
 def ambiguous_credentials(client, admin_session):
-    """Set up two credentials for the same api_id with different app_slugs."""
+    """Set up two credentials with different route prefixes for the same host."""
 
     async def setup():
         db_path = os.environ["DB_PATH"]
         async with aiosqlite.connect(db_path) as db:
-            # Register the API
+            # Register the API (for scheme lookup)
             await db.execute(
                 "INSERT OR IGNORE INTO apis (id, name, base_url) VALUES (?, ?, ?)",
-                (API_ID, "Test API", f"https://{API_HOST}"),
+                (API_HOST, "Test API", f"https://{API_HOST}"),
             )
 
-            # Create two encrypted credentials with IDs matching broker_credential_id() pattern
             enc_a = vault.encrypt("fake-token-calendar")
             enc_b = vault.encrypt("fake-token-gmail")
 
             await db.execute(
-                "INSERT OR IGNORE INTO credentials (id, label, env_var, encrypted_value, api_id, auth_type) "
+                "INSERT OR IGNORE INTO credentials (id, label, env_var, encrypted_value, routes, auth_type) "
                 "VALUES (?, ?, ?, ?, ?, 'bearer')",
-                (CRED_ID_A, "Calendar Token", "CRED_A", enc_a, API_ID),
+                (CRED_ID_A, "Work Calendar", "CRED_A", enc_a, json.dumps([ROUTE_CALENDAR])),
             )
             await db.execute(
-                "INSERT OR IGNORE INTO credentials (id, label, env_var, encrypted_value, api_id, auth_type) "
+                "INSERT OR IGNORE INTO credentials (id, label, env_var, encrypted_value, routes, auth_type) "
                 "VALUES (?, ?, ?, ?, ?, 'bearer')",
-                (CRED_ID_B, "Gmail Token", "CRED_B", enc_b, API_ID),
+                (CRED_ID_B, "Work Gmail", "CRED_B", enc_b, json.dumps([ROUTE_GMAIL])),
             )
 
-            # Bind both to the default toolkit
             for cred_id in (CRED_ID_A, CRED_ID_B):
                 await db.execute(
                     "INSERT OR IGNORE INTO toolkit_credentials (id, toolkit_id, credential_id) VALUES (?, 'default', ?)",
                     (str(uuid.uuid4()), cred_id),
                 )
-
-            # Create broker and account entries with different app_slugs
-            await db.execute(
-                "INSERT OR IGNORE INTO oauth_brokers (id, type, client_id, client_secret_enc, project_id, environment, default_external_user_id, created_at) "
-                "VALUES (?, 'pipedream', 'test', 'test', 'proj_test', 'development', 'default', 0)",
-                (BROKER_ID,),
-            )
-            await db.execute(
-                "INSERT OR IGNORE INTO oauth_broker_accounts "
-                "(id, broker_id, external_user_id, api_host, app_slug, account_id, label, healthy, synced_at) "
-                "VALUES (?, ?, 'default', ?, ?, ?, 'Calendar', 1, 0)",
-                (f"{BROKER_ID}:default:{API_HOST}:{ACCOUNT_ID_A}", BROKER_ID, API_HOST, APP_SLUG_A, ACCOUNT_ID_A),
-            )
-            await db.execute(
-                "INSERT OR IGNORE INTO oauth_broker_accounts "
-                "(id, broker_id, external_user_id, api_host, app_slug, account_id, label, healthy, synced_at) "
-                "VALUES (?, ?, 'default', ?, ?, ?, 'Gmail', 1, 0)",
-                (f"{BROKER_ID}:default:{API_HOST}:{ACCOUNT_ID_B}", BROKER_ID, API_HOST, APP_SLUG_B, ACCOUNT_ID_B),
-            )
 
             await db.commit()
 
@@ -95,45 +67,31 @@ def ambiguous_credentials(client, admin_session):
         async with aiosqlite.connect(db_path) as db:
             await db.execute("DELETE FROM toolkit_credentials WHERE credential_id IN (?, ?)", (CRED_ID_A, CRED_ID_B))
             await db.execute("DELETE FROM credentials WHERE id IN (?, ?)", (CRED_ID_A, CRED_ID_B))
-            await db.execute("DELETE FROM oauth_broker_accounts WHERE broker_id=?", (BROKER_ID,))
-            await db.execute("DELETE FROM oauth_brokers WHERE id=?", (BROKER_ID,))
-            await db.execute("DELETE FROM apis WHERE id=?", (API_ID,))
+            await db.execute("DELETE FROM apis WHERE id=?", (API_HOST,))
             await db.commit()
 
     asyncio.run(teardown())
 
 
-def test_ambiguous_credentials_set_header(client, agent_key_header, ambiguous_credentials):
-    """When multiple credentials match and no service specified, X-Jentic-Credential-Ambiguous is set."""
-    resp = client.get(f"/{API_HOST}/v1/test", headers=agent_key_header)
-    assert resp.headers.get("x-jentic-credential-ambiguous") == "true"
-    assert resp.headers.get("x-jentic-credential-used") is not None
-
-
-def test_service_header_selects_credential(client, agent_key_header, ambiguous_credentials):
-    """X-Jentic-Service selects the right credential — no ambiguity header."""
-    headers = {**agent_key_header, "X-Jentic-Service": APP_SLUG_A}
-    resp = client.get(f"/{API_HOST}/v1/test", headers=headers)
-    assert resp.headers.get("x-jentic-credential-ambiguous") is None
-    # Verify the correct credential was selected
+def test_longest_prefix_selects_calendar(client, agent_key_header, ambiguous_credentials):
+    """Request to /calendar/v3/events selects the calendar credential (longest prefix match)."""
+    resp = client.get(f"/{API_HOST}/calendar/v3/events", headers=agent_key_header)
     assert resp.headers.get("x-jentic-credential-used") == CRED_ID_A
-
-
-def test_unknown_service_returns_409(client, agent_key_header, ambiguous_credentials):
-    """Unknown service name returns 409 with available services listed."""
-    headers = {**agent_key_header, "X-Jentic-Service": "nonexistent_app"}
-    resp = client.get(f"/{API_HOST}/v1/test", headers=headers)
-    assert resp.status_code == 409
-    data = resp.json()
-    assert data["error"] == "SERVICE_NOT_FOUND"
-    assert "nonexistent_app" in data["message"]
-    assert APP_SLUG_A in data["message"]
-    assert APP_SLUG_B in data["message"]
-
-
-def test_alias_overrides_no_ambiguity(client, agent_key_header, ambiguous_credentials):
-    """X-Jentic-Credential alias selects specific credential — no ambiguity."""
-    headers = {**agent_key_header, "X-Jentic-Credential": CRED_ID_A}
-    resp = client.get(f"/{API_HOST}/v1/test", headers=headers)
+    # Not ambiguous — different prefix lengths
     assert resp.headers.get("x-jentic-credential-ambiguous") is None
-    assert resp.headers.get("x-jentic-credential-used") == CRED_ID_A
+
+
+def test_longest_prefix_selects_gmail(client, agent_key_header, ambiguous_credentials):
+    """Request to /gmail/v1/messages selects the gmail credential."""
+    resp = client.get(f"/{API_HOST}/gmail/v1/messages", headers=agent_key_header)
+    assert resp.headers.get("x-jentic-credential-used") == CRED_ID_B
+    assert resp.headers.get("x-jentic-credential-ambiguous") is None
+
+
+def test_alias_overrides_route_match(client, agent_key_header, ambiguous_credentials):
+    """X-Jentic-Credential overrides route matching."""
+    headers = {**agent_key_header, "X-Jentic-Credential": CRED_ID_B}
+    resp = client.get(f"/{API_HOST}/calendar/v3/events", headers=headers)
+    # Alias forces gmail credential even for calendar path
+    assert resp.headers.get("x-jentic-credential-used") == CRED_ID_B
+    assert resp.headers.get("x-jentic-credential-ambiguous") is None

--- a/tests/test_credential_vault.py
+++ b/tests/test_credential_vault.py
@@ -3,48 +3,20 @@
 The single most important security property: credential values are
 accepted on write but NEVER returned on read.
 """
-import json
-
-
-def _register_api_with_scheme(client, cookies, api_id, scheme_type="bearer"):
-    """Helper: register a minimal API with a security scheme so credentials can be stored."""
-
-    if scheme_type == "bearer":
-        schemes = {"BearerAuth": {"type": "http", "scheme": "bearer"}}
-    else:
-        schemes = {"ApiKeyAuth": {"type": "apiKey", "in": "header", "name": "X-Api-Key"}}
-
-    spec = {
-        "openapi": "3.1.0",
-        "info": {"title": api_id, "version": "1.0.0"},
-        "servers": [{"url": f"https://{api_id}"}],
-        "components": {"securitySchemes": schemes},
-        "paths": {"/test": {"get": {"operationId": "test", "responses": {"200": {"description": "ok"}}}}},
-    }
-
-    resp = client.post("/import", cookies=cookies, json={
-        "sources": [{
-            "type": "inline",
-            "content": json.dumps(spec),
-            "filename": f"{api_id}.json",
-        }],
-    })
-    assert resp.status_code in (200, 201), f"Import failed: {resp.text}"
 
 
 def test_create_credential_returns_id_not_value(client, admin_session):
     """POST /credentials returns metadata but never the plaintext value."""
-    api_id = "vault-create.example.com"
-    _register_api_with_scheme(client, admin_session, api_id)
     resp = client.post("/credentials", cookies=admin_session, json={
         "label": "Test Bearer Token",
         "value": "sk-secret-test-value-12345",
-        "api_id": api_id,
+        "routes": ["vault-create.example.com"],
         "auth_type": "bearer",
     })
     assert resp.status_code in (200, 201), f"Create failed: {resp.text}"
     data = resp.json()
     assert "id" in data
+    assert data["id"] == "test-bearer-token"  # slug from label
     # INVARIANT: value must never appear in the response
     assert "value" not in data
     assert "encrypted_value" not in data
@@ -53,12 +25,10 @@ def test_create_credential_returns_id_not_value(client, admin_session):
 
 def test_get_credential_never_returns_value(client, admin_session):
     """GET /credentials/{id} must not include the plaintext value."""
-    api_id = "vault-read.example.com"
-    _register_api_with_scheme(client, admin_session, api_id, "apiKey")
     create_resp = client.post("/credentials", cookies=admin_session, json={
         "label": "Vault Read Test",
         "value": "my-secret-api-key",
-        "api_id": api_id,
+        "routes": ["vault-read.example.com"],
         "auth_type": "apiKey",
     })
     assert create_resp.status_code in (200, 201), f"Create failed: {create_resp.text}"
@@ -85,17 +55,15 @@ def test_list_credentials_never_returns_values(client, admin_session):
         assert "encrypted_value" not in item
 
 
-def test_credential_bound_to_api(client, admin_session):
-    """Created credential has the correct api_id."""
-    api_id = "vault-bound.example.com"
-    _register_api_with_scheme(client, admin_session, api_id)
+def test_credential_has_routes(client, admin_session):
+    """Created credential has the correct routes."""
     resp = client.post("/credentials", cookies=admin_session, json={
-        "label": "Bound Test",
+        "label": "Routes Test",
         "value": "secret",
-        "api_id": api_id,
+        "routes": ["vault-routes.example.com/api"],
         "auth_type": "bearer",
     })
     assert resp.status_code in (200, 201), f"Create failed: {resp.text}"
     cred_id = resp.json()["id"]
     data = client.get(f"/credentials/{cred_id}", cookies=admin_session).json()
-    assert data["api_id"] == api_id
+    assert data["routes"] == ["vault-routes.example.com/api"]


### PR DESCRIPTION
## Summary

Demonstrates the `routes` + meaningful credential IDs approach proposed by Sean.

### What's done
- **Migration 0004**: recreates credentials table with `routes` JSON array, slug-based `id`, drops `api_id`. Updates all FK references.
- **Models**: `CredentialCreate` accepts `routes: list[str]`, optional `id` slug. `CredentialOut` returns `routes`.
- **Vault**: `get_credentials_for_route()` with SQLite `json_each()` longest-prefix matching. `_slugify()` for ID generation.
- **Credential endpoints**: `?route=` filter replaces `?api_id=`. Removes the fragile `oauth_broker_accounts` SQL JOIN.
- **Broker**: `_find_credential_for_host` uses routes directly, no `apis` table dependency. Removes `X-Jentic-Service`.
- **Pipedream sync**: derives routes from `pd_slug_to_route()`, generates slug IDs from labels.
- **Docs**: AGENTS.md, BROKER-CLI.md, llms.txt updated.

### What's remaining (WIP)
~10 files still reference `credentials.api_id` column (dropped by migration):
- `src/routers/apis.py` — credential discovery queries
- `src/routers/toolkits.py` — credential listing
- `src/routers/access_requests.py` — credential label lookup
- `src/routers/debug.py` — backfill scripts
- `src/startup.py` — credential seeding
- `src/routers/oauth_brokers.py` — credential queries
- Tests need full update

### Breaking changes
See plan at `.claude/plans/vectorized-gathering-hanrahan.md`

Closes #34, closes #84