### PR TITLE
fix: allow broker to forward requests to no-auth APIs without credentials

### DIFF
--- a/src/routers/broker.py
+++ b/src/routers/broker.py
@@ -51,6 +51,7 @@ log = logging.getLogger("jentic.broker")
 from jentic.apitools.openapi.common.uri import is_http_https_url
 from src.config import JENTIC_PUBLIC_HOSTNAME
 from src.db import get_db
+from src.routers.credentials import api_has_native_scheme
 import src.vault as vault
 from src.routers.traces import new_trace_id, safe_write_trace
 # Lazy import to avoid circular deps — imported inline where needed
@@ -196,11 +197,15 @@ async def _find_credential_for_host(
     _broker_log.debug("CRED LOOKUP: %d cred(s) for api_id=%r host=%r: %s", len(creds), api_id, host, [c.get("id") for c in creds])
 
     if not creds and toolkit_id:
-        raise ValueError(
-            f"No credentials found for host '{host}' (resolved api_id '{api_id}') "
-            f"in toolkit '{toolkit_id}'. "
-            f"Use POST /toolkits/{toolkit_id}/access-requests to request access."
-        )
+        # Don't block no-auth APIs — only raise if the API spec defines security schemes.
+        # If someone added an overlay with security schemes, they'd also have created
+        # a credential — so creds wouldn't be empty and we'd never reach this branch.
+        if await api_has_native_scheme(api_id):
+            raise ValueError(
+                f"No credentials found for host '{host}' (resolved api_id '{api_id}') "
+                f"in toolkit '{toolkit_id}'. "
+                f"Use POST /toolkits/{toolkit_id}/access-requests to request access."
+            )
 
     is_ambiguous = False
 

--- a/src/routers/credentials.py
+++ b/src/routers/credentials.py
@@ -1,6 +1,9 @@
 """Upstream API credentials vault routes."""
+import json
 import logging
 import uuid
+
+import yaml
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 from src.models import CredentialCreate, CredentialOut, CredentialPatch
@@ -61,10 +64,8 @@ async def _get_confirmed_scheme(api_id: str, scheme_name: str | None) -> dict | 
     return row
 
 
-async def _api_has_native_scheme(api_id: str) -> bool:
+async def api_has_native_scheme(api_id: str) -> bool:
     """True if the API's own OpenAPI spec defines at least one security scheme."""
-    import json as _json
-    import yaml as _yaml
     async with get_db() as db:
         async with db.execute("SELECT spec_path FROM apis WHERE id=?", (api_id,)) as cur:
             row = await cur.fetchone()
@@ -74,12 +75,12 @@ async def _api_has_native_scheme(api_id: str) -> bool:
         with open(row[0]) as f:
             raw = f.read()
         if row[0].endswith((".yaml", ".yml")):
-            spec = _yaml.safe_load(raw)
+            spec = yaml.safe_load(raw)
         else:
             try:
-                spec = _json.loads(raw)
-            except _json.JSONDecodeError:
-                spec = _yaml.safe_load(raw)
+                spec = json.loads(raw)
+            except json.JSONDecodeError:
+                spec = yaml.safe_load(raw)
         schemes = spec.get("components", {}).get("securitySchemes", {})
         return bool(schemes)
     except Exception:
@@ -153,7 +154,7 @@ async def create(body: CredentialCreate, request: Request):
             log.warning("Workflow auto-import failed for '%s' (non-fatal): %s", api_id, _wf_err)
 
         # Check native spec first
-        has_native = await _api_has_native_scheme(api_id)
+        has_native = await api_has_native_scheme(api_id)
         if not has_native:
             # Check for any overlay (pending OR confirmed) — pending is enough to proceed.
             # The first successful broker call will confirm it. This is intentional bootstrap flow:

--- a/tests/test_no_auth_api.py
+++ b/tests/test_no_auth_api.py
@@ -1,0 +1,88 @@
+"""No-auth API passthrough tests — broker should forward without credentials
+when the API spec has no securitySchemes, and block when it does.
+
+Covers issue #48: importing a no-auth API spec should not break broker calls.
+"""
+import asyncio
+import json
+import os
+
+import aiosqlite
+import pytest
+
+
+NO_AUTH_HOST = "127.0.0.3"
+AUTH_HOST = "127.0.0.4"
+
+
+@pytest.fixture(scope="module")
+def registered_apis(client, admin_session):
+    """Register two APIs: one without security schemes, one with."""
+
+    async def setup():
+        db_path = os.environ["DB_PATH"]
+        specs_dir = os.path.join(os.path.dirname(db_path), "specs")
+        os.makedirs(specs_dir, exist_ok=True)
+
+        # No-auth spec (no securitySchemes)
+        no_auth_spec = {
+            "openapi": "3.0.3",
+            "info": {"title": "No-Auth API", "version": "1.0"},
+            "paths": {
+                "/get": {
+                    "get": {"operationId": "getStuff", "responses": {"200": {"description": "OK"}}}
+                }
+            },
+        }
+        no_auth_path = os.path.join(specs_dir, "no_auth_api.json")
+        with open(no_auth_path, "w") as f:
+            json.dump(no_auth_spec, f)
+
+        # Auth spec (has securitySchemes)
+        auth_spec = {
+            "openapi": "3.0.3",
+            "info": {"title": "Auth API", "version": "1.0"},
+            "components": {
+                "securitySchemes": {
+                    "BearerAuth": {"type": "http", "scheme": "bearer"}
+                }
+            },
+            "security": [{"BearerAuth": []}],
+            "paths": {
+                "/data": {
+                    "get": {"operationId": "getData", "responses": {"200": {"description": "OK"}}}
+                }
+            },
+        }
+        auth_path = os.path.join(specs_dir, "auth_api.json")
+        with open(auth_path, "w") as f:
+            json.dump(auth_spec, f)
+
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute(
+                "INSERT OR IGNORE INTO apis (id, name, base_url, spec_path) VALUES (?, ?, ?, ?)",
+                (NO_AUTH_HOST, "No-Auth API", f"https://{NO_AUTH_HOST}", no_auth_path),
+            )
+            await db.execute(
+                "INSERT OR IGNORE INTO apis (id, name, base_url, spec_path) VALUES (?, ?, ?, ?)",
+                (AUTH_HOST, "Auth API", f"https://{AUTH_HOST}", auth_path),
+            )
+            await db.commit()
+
+    asyncio.run(setup())
+
+
+def test_no_auth_api_forwards_without_credentials(client, agent_key_header, registered_apis):
+    """A registered API with no securitySchemes should not require credentials."""
+    resp = client.get(f"/{NO_AUTH_HOST}/get", headers=agent_key_header)
+    # The upstream is non-routable so we expect a connection error (502),
+    # NOT a credential lookup error (500).
+    assert resp.status_code == 502, f"Expected 502 (upstream unreachable), got {resp.status_code}: {resp.text}"
+
+
+def test_auth_api_requires_credentials(client, agent_key_header, registered_apis):
+    """A registered API with securitySchemes should fail without credentials."""
+    resp = client.get(f"/{AUTH_HOST}/data", headers=agent_key_header)
+    assert resp.status_code == 500
+    body = resp.json()
+    assert "CREDENTIAL_LOOKUP_FAILED" in body.get("error", "")


### PR DESCRIPTION
## Summary

When a registered API has no `securitySchemes` in its OpenAPI spec, the broker now forwards requests without credentials instead of returning `CREDENTIAL_LOOKUP_FAILED`.

Closes #48

## Root cause

The broker resolved `host → api_id`, found the API in the `apis` table, then looked up credentials. If none existed, it raised `ValueError` — even for APIs that don't require auth (e.g. httpbin). Importing an API spec actually made it *harder* to call if it didn't need credentials.

## Fix

Before raising the "no credentials" error, check `_api_has_native_scheme(api_id)`. If the spec defines no `securitySchemes`, forward without credentials (same behavior as unregistered hosts).

No overlay check needed — if someone submitted a security scheme overlay, they'd also have created a credential, so the `not creds` branch wouldn't be reached.

## Test plan

- [x] 53 backend tests pass
- [x] Fresh setup: import httpbin spec → `GET /httpbin.org/get` proxies successfully without credentials
- [x] APIs with security schemes still require credentials (existing behavior unchanged)