### PR TITLE
chore: install arazzo-runner from PyPI instead of git clone

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,7 +78,7 @@ Credentials are **never** exposed to agents or passed as env vars. The broker:
 6. Logs a trace
 
 ### Workflow execution
-Arazzo workflows use `arazzo-engine` (cloned at Docker build time from `github.com/jentic/arazzo-engine`). The runner patches `servers[0].url` in source specs to route all HTTP calls through the local broker (`http://localhost:8900/{host}`), ensuring every step gets credential injection, tracing, and policy enforcement.
+Arazzo workflows use `arazzo-runner` (installed from PyPI). The runner patches `servers[0].url` in source specs to route all HTTP calls through the local broker (`http://localhost:8900/{host}`), ensuring every step gets credential injection, tracing, and policy enforcement.
 
 ### ID formats
 - **Capability ID**: `METHOD/host/path` (e.g., `GET/api.elevenlabs.io/v1/voices`)

--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,10 @@ __pycache__/
 .env
 data/*
 !data/.gitkeep
-vendor/arazzo-engine/
 .DS_Store
 *.tmp
 /tmp/
 node_modules
-vendor/arazzo-engine
 /static/
 /src/specs/
 /src/workflows/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,22 +8,14 @@ RUN cd ui && npm ci --ignore-scripts && npm run build
 # Stage 2: Install Python dependencies
 FROM python:3.11-slim AS py-deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc libffi-dev curl git \
+    gcc libffi-dev curl \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
-
-RUN pip install --no-cache-dir --upgrade pip wheel setuptools
 
 # Install PDM (recommended method, pinned version)
 RUN curl -sSL https://pdm-project.org/install-pdm.py | python3 - --version 2.25.5
 
 COPY pyproject.toml pdm.lock ./
-RUN /root/.local/bin/pdm venv create --with-pip
-
-# Clone arazzo-engine and install runner from source
-RUN git clone --depth 1 https://github.com/jentic/arazzo-engine.git /opt/arazzo-engine \
-    && /app/.venv/bin/pip install --no-cache-dir -e /opt/arazzo-engine/runner
-
 RUN /root/.local/bin/pdm install --prod --no-editable --no-self --frozen-lockfile
 
 # Stage 3: Runtime
@@ -43,7 +35,6 @@ LABEL maintainer="vladimir@jentic.com" \
 WORKDIR /app
 
 COPY --from=py-deps /app/.venv /app/.venv
-COPY --from=py-deps /opt/arazzo-engine /opt/arazzo-engine
 ENV PATH="/app/.venv/bin:$PATH"
 
 RUN mkdir -p /app/data /app/src

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -413,9 +413,9 @@ Description is abbreviated to ≤3 sentences by `utils._abbreviate()` to keep se
 
 ## Arazzo Engine
 
-**Source:** Cloned at Docker build time from `github.com/jentic/arazzo-engine`.
+**Source:** Installed from PyPI (`arazzo-runner` package).
 
-The arazzo-engine runner adds runtime parameters so workflows route through the broker.
+The arazzo-runner executes workflows, routing HTTP calls through the broker via a custom `requests.Session` with the caller's API key.
 
 ### Preprocessing in `workflows.py`
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -280,30 +280,6 @@ FROM executions ORDER BY created_at DESC LIMIT 20;
 
 ---
 
-## Vendored Arazzo Runner
-
-The arazzo-runner package is vendored at `/mnt/jentic-pe/vendor/arazzo-engine/`, branch `jpe-patches`.
-
-**Do not** `pip install arazzo-runner` from PyPI inside the container — the vendored version contains JPE-specific patches that enable broker routing.
-
-### Key patched files
-
-| File | What was changed |
-|---|---|
-| `models.py` | `RuntimeParams` extended with `auth_headers` and `server_base_url` |
-| `http.py` | `HTTPExecutor.execute_request` injects extra auth headers |
-| `runner.py` | `ArazzoRunner.__init__` accepts `runtime_params`; `_apply_jpe_runtime_params()` rewrites server URLs |
-
-### Upgrading the vendor fork
-
-If you need a feature from a newer upstream arazzo-runner:
-
-1. Check if it can be cherry-picked onto the `jpe-patches` branch
-2. If yes: `cd /mnt/jentic-pe/vendor/arazzo-engine && git fetch origin && git cherry-pick <commit>`
-3. If no: merge upstream `main` into `jpe-patches`, resolve conflicts, re-verify the patches still apply
-
-**Never** replace the vendor fork with a fresh PyPI install without re-applying the patches.
-
 ---
 
 ## Debug Endpoints

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,13 +64,9 @@ Set in `/configs/jentic-personal-edition/docker-compose.yml`:
       debug.py               ← /debug/... (hidden from OpenAPI schema)
     static/                  ← Swagger UI + Redoc assets (no CDN, works offline)
     specs/                   ← Downloaded OpenAPI spec files + Arazzo workflows
-  vendor/
-    arazzo-engine/           ← Forked arazzo-runner (branch: jpe-patches)
   data/                      ← SQLite DB + vault.key (Docker volume, NOT in git)
   docs/                      ← This documentation
 ```
-
-**Path mapping:** `/configs/jentic-personal-edition/` on the host maps to `/app/` inside the container. `/mnt/jentic-pe/` is a bind mount to the same directory (Shirka's workspace path). They are the same files.
 
 ## Current API Corpus
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:07c9cde53baa0dce75dce892b4c9a068e53dd39b4373a7b2da0026a2f6fdf8fa"
+content_hash = "sha256:81830e10b88b5f4e901fa95f7f6fa7d7dd8cd0999d20ba11ea736a5e4c8fba72"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
@@ -211,6 +211,24 @@ files = [
 ]
 
 [[package]]
+name = "arazzo-runner"
+version = "0.9.5"
+requires_python = "<4.0,>=3.11"
+summary = "Execution libraries and test tools for Arazzo workflows and Open API operations"
+groups = ["default"]
+dependencies = [
+    "jsonpath-ng>=1.5.0",
+    "jsonpointer>=3.0.0",
+    "pydantic>=2.0.0",
+    "pyyaml>=6.0",
+    "requests>=2.28.0",
+]
+files = [
+    {file = "arazzo_runner-0.9.5-py3-none-any.whl", hash = "sha256:2a114f5f45e05e51f677e586570da0372319046806e8010a649b63641d213ef6"},
+    {file = "arazzo_runner-0.9.5.tar.gz", hash = "sha256:fa1fb68aad6d05a33d9d7f6cdfec08eec72e58d0037f7ce9eedea973fe29f9cf"},
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 requires_python = ">=3.9"
@@ -295,13 +313,13 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2026.2.25"
+version = "2026.4.22"
 requires_python = ">=3.7"
 summary = "Python package for providing Mozilla's CA Bundle."
 groups = ["default", "dev"]
 files = [
-    {file = "certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa"},
-    {file = "certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"},
+    {file = "certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"},
+    {file = "certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580"},
 ]
 
 [[package]]
@@ -382,7 +400,7 @@ name = "charset-normalizer"
 version = "3.4.7"
 requires_python = ">=3.7"
 summary = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7"},
     {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7"},
@@ -938,6 +956,27 @@ groups = ["default"]
 files = [
     {file = "jentic_openapi_common-1.0.0a55-py3-none-any.whl", hash = "sha256:99a47697442749b4f2880bfdd2b30ba3a383024005a7368d945beaaed03df962"},
     {file = "jentic_openapi_common-1.0.0a55.tar.gz", hash = "sha256:6f36fb17bfad598a507aa14497ebc2aa00d121cb80252bd46773c7894cb9bdfb"},
+]
+
+[[package]]
+name = "jsonpath-ng"
+version = "1.8.0"
+summary = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
+groups = ["default"]
+files = [
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+requires_python = ">=3.10"
+summary = "Identify specific nodes in a JSON document (RFC 6901) "
+groups = ["default"]
+files = [
+    {file = "jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca"},
+    {file = "jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900"},
 ]
 
 [[package]]
@@ -1801,7 +1840,7 @@ name = "requests"
 version = "2.33.1"
 requires_python = ">=3.10"
 summary = "Python HTTP for Humans."
-groups = ["dev"]
+groups = ["default", "dev"]
 dependencies = [
     "certifi>=2023.5.7",
     "charset-normalizer<4,>=2",
@@ -2132,7 +2171,7 @@ name = "urllib3"
 version = "2.6.3"
 requires_python = ">=3.9"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
     {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "python-multipart>=0.0.26",
   "alembic>=1.18.4,<2",
   "jentic-openapi-common>=1.0.0a51",
+  "arazzo-runner>=0.9.5",
 ]
 
 [project.urls]

--- a/src/routers/workflows.py
+++ b/src/routers/workflows.py
@@ -638,19 +638,15 @@ async def _execute_workflow_core(
     # the broker can look up the right toolkit's credentials.
     # caller_api_key passed in as parameter
 
-    _VENDOR_PATH = "/app/vendor/arazzo-engine/runner"
     script = f"""
-import sys
-sys.path.insert(0, {repr(_VENDOR_PATH)})
 from arazzo_runner import ArazzoRunner
-from arazzo_runner.models import RuntimeParams
+import requests
 import json
 
-runner = ArazzoRunner.from_arazzo_path({repr(temp_arazzo)})
-# auth_headers injects X-Jentic-API-Key on every HTTP call the runner makes,
-# so the broker can authenticate and look up the correct toolkit credentials.
-rp = RuntimeParams(auth_headers={{"X-Jentic-API-Key": {repr(caller_api_key)}}})
-result = runner.execute_workflow({repr(workflow_id)}, {repr(inputs)}, runtime_params=rp)
+session = requests.Session()
+session.headers["X-Jentic-API-Key"] = {repr(caller_api_key)}
+runner = ArazzoRunner.from_arazzo_path({repr(temp_arazzo)}, http_client=session)
+result = runner.execute_workflow({repr(workflow_id)}, {repr(inputs)})
 if hasattr(result, '__dataclass_fields__') or hasattr(result, '__dict__'):
     out = {{
         'status': str(result.status),

--- a/tests/test_workflow_auth_passthrough.py
+++ b/tests/test_workflow_auth_passthrough.py
@@ -1,0 +1,97 @@
+"""Verify that broker credential injection requires X-Jentic-API-Key.
+
+Workflow execution routes HTTP calls through the broker via a requests.Session
+that includes the caller's API key. Without the key, broker requests are
+anonymous and credentials are not injected — upstream APIs would fail auth.
+
+This test ensures the broker correctly distinguishes authenticated from
+anonymous requests, validating the session header injection used by
+arazzo-runner workflow execution.
+"""
+import asyncio
+import json
+import os
+
+import aiosqlite
+import pytest
+
+from src import vault
+
+WORKFLOW_AUTH_HOST = "127.0.10.50"
+
+
+@pytest.fixture(scope="module")
+def workflow_auth_credential(client, admin_session, agent_key_header):
+    """Set up a credential to test auth vs anonymous broker paths."""
+
+    async def setup():
+        db_path = os.environ["DB_PATH"]
+        async with aiosqlite.connect(db_path) as db:
+            enc = vault.encrypt("wf-test-secret-key")
+            await db.execute(
+                "INSERT OR IGNORE INTO credentials "
+                "(id, label, env_var, encrypted_value, api_id, auth_type, scheme) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("wf-auth-test", "Workflow Auth Test", "WF_AUTH_TEST",
+                 enc, WORKFLOW_AUTH_HOST, "apiKey",
+                 json.dumps({"in": "header", "name": "X-Api-Key"})),
+            )
+            await db.execute(
+                "INSERT OR IGNORE INTO credential_routes (credential_id, host) VALUES (?, ?)",
+                ("wf-auth-test", WORKFLOW_AUTH_HOST),
+            )
+            await db.execute(
+                "INSERT OR IGNORE INTO toolkit_credentials (toolkit_id, credential_id) VALUES ('default', ?)",
+                ("wf-auth-test",),
+            )
+            await db.commit()
+
+    asyncio.run(setup())
+    yield
+
+    async def teardown():
+        db_path = os.environ["DB_PATH"]
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute("DELETE FROM credential_routes WHERE credential_id='wf-auth-test'")
+            await db.execute("DELETE FROM toolkit_credentials WHERE credential_id='wf-auth-test'")
+            await db.execute("DELETE FROM credentials WHERE id='wf-auth-test'")
+            await db.commit()
+
+    asyncio.run(teardown())
+
+
+def test_broker_injects_credentials_with_api_key(client, agent_key_header, workflow_auth_credential):
+    """Broker injects credentials when X-Jentic-API-Key is present (authenticated path)."""
+    resp = client.get(
+        f"/{WORKFLOW_AUTH_HOST}/api/test",
+        headers={**agent_key_header, "X-Jentic-Simulate": "true"},
+    )
+    assert resp.status_code == 200, f"Simulate failed: {resp.text}"
+    body = resp.json()
+    headers = {k.lower(): v for k, v in body["would_send"]["headers"].items()}
+    assert "x-api-key" in headers, f"Expected credential injection, got headers: {list(headers.keys())}"
+    assert headers["x-api-key"] == "wf-test-secret-key"
+
+
+def test_broker_skips_credentials_without_api_key(agent_only_client, workflow_auth_credential):
+    """Broker skips credential injection when no X-Jentic-API-Key is present (anonymous path).
+
+    This is the path arazzo-runner subprocess requests took before the
+    session header fix — requests went through the broker but without
+    an API key, so no toolkit was resolved and credentials were not injected.
+
+    Uses a fresh client to avoid session cookie leakage.
+    """
+    from starlette.testclient import TestClient
+    from src.main import app
+    with TestClient(app, raise_server_exceptions=False) as anon_client:
+        resp = anon_client.get(
+            f"/{WORKFLOW_AUTH_HOST}/api/test",
+            headers={"X-Jentic-Simulate": "true"},
+        )
+    assert resp.status_code == 200, f"Simulate failed: {resp.text}"
+    body = resp.json()
+    headers = {k.lower(): v for k, v in body["would_send"]["headers"].items()}
+    assert "x-api-key" not in headers, (
+        f"Expected NO credential injection for anonymous request, but got x-api-key in headers"
+    )


### PR DESCRIPTION
## Summary

- Replace vendored git-cloned `arazzo-engine` with `arazzo-runner>=0.9.5` from PyPI — the `jpe-patches` branch no longer exists and `main` HEAD matches the PyPI release (same commit SHA `5129905`)
- Remove git clone, `/opt/arazzo-engine` copy, and `git` from Dockerfile build deps
- Remove stale vendor docs and `.gitignore` entries

## Test plan

- [x] 89 tests pass
- [x] Docker build succeeds (no git clone, smaller image)
- [x] Container starts and serves health check