### PR TITLE
fix: workflow credential injection via requests.Session headers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -415,7 +415,7 @@ Description is abbreviated to ≤3 sentences by `utils._abbreviate()` to keep se
 
 **Source:** Installed from PyPI (`arazzo-runner` package).
 
-The arazzo-runner executes workflows, routing HTTP calls through the broker for credential injection.
+The arazzo-runner executes workflows via a `requests.Session` with the caller's API key as a default header, routing all HTTP calls through the broker for credential injection.
 
 ### Preprocessing in `workflows.py`
 

--- a/src/routers/workflows.py
+++ b/src/routers/workflows.py
@@ -11,17 +11,21 @@ The identity of a workflow is: POST/{jentic_hostname}/workflows/{slug}
 Workflow capability IDs in search/inspect use the same METHOD/host/path format
 as operation IDs. The backend detects them by matching the Jentic hostname.
 """
+import asyncio
 import copy
 import html as _html
 import json
+import os
 import pathlib
+import sys
 import tempfile
+import time
 import uuid
 import yaml
 from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Path, Query, Request
-from fastapi.responses import HTMLResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, Response
 
 from jentic.apitools.openapi.common.uri import is_http_https_url
 from src.db import get_db
@@ -433,7 +437,6 @@ async def dispatch_workflow(
                     0.0 = return 202 immediately; None = block indefinitely
     callback_url  : X-Jentic-Callback URL to POST result when async job completes
     """
-    import asyncio
     async with get_db() as db:
         async with db.execute(
             "SELECT arazzo_path, name FROM workflows WHERE slug=?", (slug,)
@@ -596,7 +599,6 @@ async def dispatch_workflow(
             )
 
     # ── Synchronous execution path (no Prefer: wait header) ──────────────────
-    from fastapi.responses import JSONResponse
     return await _execute_workflow_core(
         slug=slug, name=name, doc=doc, workflow_id=workflow_id,
         inputs=inputs, arazzo_path=arazzo_path,
@@ -618,10 +620,6 @@ async def _execute_workflow_core(
     is_simulate: bool,
     trace_id: str | None,
 ):
-    import asyncio
-    import sys
-    import time
-    from fastapi.responses import JSONResponse
     from src.routers.traces import write_trace, new_trace_id
 
     if not trace_id:
@@ -638,17 +636,16 @@ async def _execute_workflow_core(
     # the broker can look up the right toolkit's credentials.
     # caller_api_key passed in as parameter
 
-    _VENDOR_PATH = "/app/vendor/arazzo-engine/runner"
     script = f"""
-import sys
-sys.path.insert(0, {repr(_VENDOR_PATH)})
 from arazzo_runner import ArazzoRunner
-from arazzo_runner.models import RuntimeParams
+import os
+import requests
 import json
 
-runner = ArazzoRunner.from_arazzo_path({repr(temp_arazzo)})
-rp = RuntimeParams(auth_headers={{"X-Jentic-API-Key": {repr(caller_api_key)}}})
-result = runner.execute_workflow({repr(workflow_id)}, {repr(inputs)}, runtime_params=rp)
+session = requests.Session()
+session.headers["X-Jentic-API-Key"] = os.environ["_JENTIC_CALLER_KEY"]
+runner = ArazzoRunner.from_arazzo_path({repr(temp_arazzo)}, http_client=session)
+result = runner.execute_workflow({repr(workflow_id)}, {repr(inputs)})
 if hasattr(result, '__dataclass_fields__') or hasattr(result, '__dict__'):
     out = {{
         'status': str(result.status),
@@ -663,8 +660,8 @@ else:
 print(json.dumps(out, default=str))
 """
     trace_id = new_trace_id()
-    # No vault env vars — broker handles credential injection
     env = dict(os.environ)
+    env["_JENTIC_CALLER_KEY"] = caller_api_key
     t0 = time.monotonic()
     proc = await asyncio.create_subprocess_exec(
         sys.executable, "-c", script,

--- a/tests/test_workflow_auth_passthrough.py
+++ b/tests/test_workflow_auth_passthrough.py
@@ -1,0 +1,97 @@
+"""Verify that broker credential injection requires X-Jentic-API-Key.
+
+Workflow execution routes HTTP calls through the broker via a requests.Session
+that includes the caller's API key. Without the key, broker requests are
+anonymous and credentials are not injected — upstream APIs would fail auth.
+
+This test ensures the broker correctly distinguishes authenticated from
+anonymous requests, validating the session header injection used by
+arazzo-runner workflow execution.
+"""
+import asyncio
+import json
+import os
+
+import aiosqlite
+import pytest
+
+from src import vault
+
+WORKFLOW_AUTH_HOST = "127.0.10.50"
+
+
+@pytest.fixture(scope="module")
+def workflow_auth_credential(client, admin_session, agent_key_header):
+    """Set up a credential to test auth vs anonymous broker paths."""
+
+    async def setup():
+        db_path = os.environ["DB_PATH"]
+        async with aiosqlite.connect(db_path) as db:
+            enc = vault.encrypt("wf-test-secret-key")
+            await db.execute(
+                "INSERT OR IGNORE INTO credentials "
+                "(id, label, env_var, encrypted_value, api_id, auth_type, scheme) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("wf-auth-test", "Workflow Auth Test", "WF_AUTH_TEST",
+                 enc, WORKFLOW_AUTH_HOST, "apiKey",
+                 json.dumps({"in": "header", "name": "X-Api-Key"})),
+            )
+            await db.execute(
+                "INSERT OR IGNORE INTO credential_routes (credential_id, host) VALUES (?, ?)",
+                ("wf-auth-test", WORKFLOW_AUTH_HOST),
+            )
+            await db.execute(
+                "INSERT OR IGNORE INTO toolkit_credentials (toolkit_id, credential_id) VALUES ('default', ?)",
+                ("wf-auth-test",),
+            )
+            await db.commit()
+
+    asyncio.run(setup())
+    yield
+
+    async def teardown():
+        db_path = os.environ["DB_PATH"]
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute("DELETE FROM credential_routes WHERE credential_id='wf-auth-test'")
+            await db.execute("DELETE FROM toolkit_credentials WHERE credential_id='wf-auth-test'")
+            await db.execute("DELETE FROM credentials WHERE id='wf-auth-test'")
+            await db.commit()
+
+    asyncio.run(teardown())
+
+
+def test_broker_injects_credentials_with_api_key(client, agent_key_header, workflow_auth_credential):
+    """Broker injects credentials when X-Jentic-API-Key is present (authenticated path)."""
+    resp = client.get(
+        f"/{WORKFLOW_AUTH_HOST}/api/test",
+        headers={**agent_key_header, "X-Jentic-Simulate": "true"},
+    )
+    assert resp.status_code == 200, f"Simulate failed: {resp.text}"
+    body = resp.json()
+    headers = {k.lower(): v for k, v in body["would_send"]["headers"].items()}
+    assert "x-api-key" in headers, f"Expected credential injection, got headers: {list(headers.keys())}"
+    assert headers["x-api-key"] == "wf-test-secret-key"
+
+
+def test_broker_skips_credentials_without_api_key(workflow_auth_credential):
+    """Broker skips credential injection when no X-Jentic-API-Key is present (anonymous path).
+
+    This is the path arazzo-runner subprocess requests took before the
+    session header fix — requests went through the broker but without
+    an API key, so no toolkit was resolved and credentials were not injected.
+
+    Uses a fresh client to avoid session cookie leakage.
+    """
+    from starlette.testclient import TestClient
+    from src.main import app
+    with TestClient(app, raise_server_exceptions=False) as anon_client:
+        resp = anon_client.get(
+            f"/{WORKFLOW_AUTH_HOST}/api/test",
+            headers={"X-Jentic-Simulate": "true"},
+        )
+    assert resp.status_code == 200, f"Simulate failed: {resp.text}"
+    body = resp.json()
+    headers = {k.lower(): v for k, v in body["would_send"]["headers"].items()}
+    assert "x-api-key" not in headers, (
+        f"Expected NO credential injection for anonymous request, but got x-api-key in headers"
+    )


### PR DESCRIPTION
## Summary

- **Fix**: `RuntimeParams(auth_headers=...)` was silently dropped by arazzo-runner because the field doesn't exist on the upstream Pydantic model. Workflow subprocess HTTP calls went through the broker anonymously — no toolkit resolved, no credentials injected.
- **Solution**: Pass a `requests.Session` with `X-Jentic-API-Key` as a default header to `ArazzoRunner.from_arazzo_path(http_client=session)`. Every HTTP call the runner makes now includes the caller's API key.
- Remove dead `_VENDOR_PATH` / `sys.path.insert` hack
- Add tests verifying broker auth vs anonymous credential injection paths

## How it was verified

```python
# With API key (new behavior) — broker resolves toolkit, enforces policy:
session = requests.Session()
session.headers["X-Jentic-API-Key"] = "tk_xxx"
resp = session.get("http://localhost:8900/httpbin.org/get")
# → 403 "No credential configured for 'httpbin.org'" (correct — toolkit resolved)

# Without API key (old broken behavior) — broker passes through anonymously:
resp = requests.get("http://localhost:8900/httpbin.org/get")
# → 200 (passes straight to upstream, no credential injection)
```

## Test plan

- [x] 91 tests pass (89 existing + 2 new)
- [x] `test_broker_injects_credentials_with_api_key` — verifies credential injection with API key
- [x] `test_broker_skips_credentials_without_api_key` — verifies anonymous path skips injection
- [x] CI backend tests pass