### PR TITLE
refactor: de-alias _name imports and hoist yaml in 0004 migration

### DIFF
--- a/alembic/versions/0004_credential_routes.py
+++ b/alembic/versions/0004_credential_routes.py
@@ -26,6 +26,7 @@ import os
 import re
 from typing import Optional
 
+import yaml
 from alembic import op
 from sqlalchemy import text
 
@@ -46,12 +47,7 @@ def _load_spec(spec_path: str) -> Optional[dict]:
         with open(spec_path) as f:
             content = f.read()
         if spec_path.endswith((".yaml", ".yml")):
-            try:
-                import yaml  # noqa: PLC0415  # optional dependency for YAML specs
-
-                return yaml.safe_load(content)
-            except ImportError:
-                pass
+            return yaml.safe_load(content)
         return json.loads(content)
     except Exception:
         return None

--- a/src/routers/access_requests.py
+++ b/src/routers/access_requests.py
@@ -18,7 +18,7 @@ URL structure (nested under /toolkits):
   GET    /toolkits/{toolkit_id}/access-requests/approve/{req_id}  (HTML UI)
 """
 
-import html as _html
+import html
 import json
 import logging
 import time
@@ -280,9 +280,9 @@ async def approval_ui_legacy(toolkit_id: str, req_id: str):
         }}
         </script>"""
     else:
-        resolved_html = f"<p><em>This request has already been resolved: <strong>{_html.escape(status)}</strong></em></p>"
+        resolved_html = f"<p><em>This request has already been resolved: <strong>{html.escape(status)}</strong></em></p>"
 
-    html = f"""<!DOCTYPE html>
+    body = f"""<!DOCTYPE html>
 <html>
 <head><title>Access Request — Jentic Mini</title>
 <style>
@@ -303,19 +303,19 @@ async def approval_ui_legacy(toolkit_id: str, req_id: str):
 <body>
   <h1>🔐 Access Request</h1>
   <div class="card">
-    <p><span class="label">Request ID</span><br>{_html.escape(row_id)}</p>
-    <p><span class="label">Type</span><br>{_html.escape(req_type)}</p>
-    <p><span class="label">Toolkit</span><br>{_html.escape(row_toolkit_id or "N/A")}</p>
-    <p><span class="label">Status</span><br><span class="status-{_html.escape(status)}">{_html.escape(status)}</span></p>
-    <p><span class="label">What the agent is requesting</span><br>{_html.escape(description)}</p>
-    <p><span class="label">Reason from agent</span><br>{_html.escape(reason) if reason else "<em>No reason provided</em>"}</p>
+    <p><span class="label">Request ID</span><br>{html.escape(row_id)}</p>
+    <p><span class="label">Type</span><br>{html.escape(req_type)}</p>
+    <p><span class="label">Toolkit</span><br>{html.escape(row_toolkit_id or "N/A")}</p>
+    <p><span class="label">Status</span><br><span class="status-{html.escape(status)}">{html.escape(status)}</span></p>
+    <p><span class="label">What the agent is requesting</span><br>{html.escape(description)}</p>
+    <p><span class="label">Reason from agent</span><br>{html.escape(reason) if reason else "<em>No reason provided</em>"}</p>
     <p><span class="label">Payload</span></p>
-    <pre>{_html.escape(json.dumps(payload, indent=2))}</pre>
+    <pre>{html.escape(json.dumps(payload, indent=2))}</pre>
   </div>
   {resolved_html}
 </body>
 </html>"""
-    return HTMLResponse(html)
+    return HTMLResponse(body)
 
 
 @router.get(

--- a/src/routers/broker.py
+++ b/src/routers/broker.py
@@ -53,7 +53,7 @@ from jentic.apitools.openapi.common.uri import is_http_https_url
 import src.vault as vault
 from src.config import JENTIC_PUBLIC_HOSTNAME
 from src.db import DEFAULT_TOOLKIT_ID, get_db
-from src.oauth_broker import registry as _oauth_registry
+from src.oauth_broker import registry
 from src.openapi_helpers import agent_hints
 from src.routers.credentials import api_has_native_scheme
 from src.routers.jobs import _running_tasks, create_job, update_job
@@ -920,7 +920,7 @@ async def broker(request: Request, target: str):
                     if _eurow:
                         _ext_user = _eurow[0]
             _pd_broker = None
-            for _b in _oauth_registry.brokers:
+            for _b in registry.brokers:
                 if hasattr(_b, "proxy_request_with_account"):
                     _pd_broker = _b
                     break

--- a/src/routers/user.py
+++ b/src/routers/user.py
@@ -16,7 +16,7 @@ import logging
 import uuid
 from typing import Annotated
 
-import bcrypt as _bcrypt
+import bcrypt
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
@@ -94,7 +94,7 @@ async def create_user(body: UserCreate, request: Request, response: Response):
     if len(body.password) < 8:
         raise HTTPException(400, "Password must be at least 8 characters.")
 
-    pw_hash = _bcrypt.hashpw(body.password.encode(), _bcrypt.gensalt()).decode()
+    pw_hash = bcrypt.hashpw(body.password.encode(), bcrypt.gensalt()).decode()
     user_id = str(uuid.uuid4())
 
     async with get_db() as db:
@@ -187,7 +187,7 @@ async def login(
             row = await cur.fetchone()
 
     ip = client_ip(request)
-    if not row or not _bcrypt.checkpw(password.encode(), row["password_hash"].encode()):
+    if not row or not bcrypt.checkpw(password.encode(), row["password_hash"].encode()):
         audit_log.warning("LOGIN_FAILED user=%s ip=%s", username.strip(), ip)
         raise HTTPException(
             401,
@@ -254,7 +254,7 @@ async def token(form_data: OAuth2PasswordRequestForm = Depends()):
         ) as cur:
             row = await cur.fetchone()
 
-    if not row or not _bcrypt.checkpw(password.encode(), row["password_hash"].encode()):
+    if not row or not bcrypt.checkpw(password.encode(), row["password_hash"].encode()):
         raise HTTPException(
             401,
             detail={

--- a/src/routers/workflows.py
+++ b/src/routers/workflows.py
@@ -14,7 +14,7 @@ as operation IDs. The backend detects them by matching the Jentic hostname.
 
 import asyncio
 import copy
-import html as _html
+import html
 import json
 import os
 import pathlib
@@ -370,19 +370,17 @@ async def get_workflow(
         )
 
     if "text/html" in accept:
-        _e = _html.escape
+        esc = html.escape
         steps_html = ""
         for s in meta.get("steps", []):
-            steps_html += (
-                f"<li><code>{_e(str(s.get('id', '')))}</code> — {_e(str(s.get('operation', '?')))}"
-            )
+            steps_html += f"<li><code>{esc(str(s.get('id', '')))}</code> — {esc(str(s.get('operation', '?')))}"
             if s.get("description"):
-                steps_html += f"<br><small>{_e(str(s['description']))}</small>"
+                steps_html += f"<br><small>{esc(str(s['description']))}</small>"
             steps_html += "</li>"
-        apis_html = ", ".join(f"<code>{_e(a)}</code>" for a in involved_apis) or "—"
-        html = f"""<!DOCTYPE html>
+        apis_html = ", ".join(f"<code>{esc(a)}</code>" for a in involved_apis) or "—"
+        body = f"""<!DOCTYPE html>
 <html>
-<head><title>{_e(name)} — Jentic Workflow</title>
+<head><title>{esc(name)} — Jentic Workflow</title>
 <style>body{{font-family:sans-serif;max-width:800px;margin:40px auto;padding:0 20px}}
 code{{background:#f4f4f4;padding:2px 6px;border-radius:3px}}
 pre{{background:#f4f4f4;padding:16px;border-radius:6px;overflow:auto}}
@@ -390,19 +388,19 @@ pre{{background:#f4f4f4;padding:16px;border-radius:6px;overflow:auto}}
 h1 span{{color:#888;font-weight:normal;font-size:.6em;margin-left:12px}}</style>
 </head>
 <body>
-<h1>{_e(name)} <span>workflow</span></h1>
-<p class="meta">Capability ID: <code>{_e(capability_id)}</code></p>
-<p>{_e(description or "")}</p>
+<h1>{esc(name)} <span>workflow</span></h1>
+<p class="meta">Capability ID: <code>{esc(capability_id)}</code></p>
+<p>{esc(description or "")}</p>
 <h2>Steps ({steps_count})</h2>
 <ol>{steps_html}</ol>
 <h2>APIs used</h2>
 <p>{apis_html}</p>
 <h2>Execute</h2>
-<p>POST to <code>https://{JENTIC_PUBLIC_HOSTNAME}/workflows/{_e(slug)}</code> with your inputs and <code>X-Jentic-API-Key</code> header.</p>
+<p>POST to <code>https://{JENTIC_PUBLIC_HOSTNAME}/workflows/{esc(slug)}</code> with your inputs and <code>X-Jentic-API-Key</code> header.</p>
 <h2>Arazzo source</h2>
-<pre>{_e(json.dumps(doc, indent=2)[:4000]) if doc else ""}</pre>
+<pre>{esc(json.dumps(doc, indent=2)[:4000]) if doc else ""}</pre>
 </body></html>"""
-        return HTMLResponse(html)
+        return HTMLResponse(body)
 
     if "text/markdown" in accept:
         steps_md = "\n".join(

--- a/src/startup.py
+++ b/src/startup.py
@@ -20,10 +20,10 @@ import traceback
 import uuid
 
 import httpx
-from fastapi.openapi.utils import get_openapi as _get_openapi
+from fastapi.openapi.utils import get_openapi
 
 from src.auth import default_allowed_ips
-from src.brokers.pipedream import _API_ID_TO_PD_SLUG as _PIPEDREAM_APP_SEEDS
+from src.brokers.pipedream import _API_ID_TO_PD_SLUG
 from src.config import DATA_DIR, JENTIC_PUBLIC_HOSTNAME, SPECS_DIR
 from src.db import DEFAULT_TOOLKIT_ID, get_db
 from src.routers.import_ import _register_openapi
@@ -152,7 +152,7 @@ async def _ensure_spec_imported(app=None) -> None:
         # We don't call app.openapi() to avoid caching issues during lifespan.
         if app is None:
             raise ValueError("app instance required for spec import")
-        spec = _get_openapi(
+        spec = get_openapi(
             title=app.title,
             version=app.version,
             description=app.description,
@@ -268,7 +268,7 @@ async def seed_broker_apps(broker_id: str = "pipedream") -> None:
             local_api_ids = {r[0] for r in await cur.fetchall()}
 
         inserted = updated = 0
-        for api_id, broker_app_id in _PIPEDREAM_APP_SEEDS.items():
+        for api_id, broker_app_id in _API_ID_TO_PD_SLUG.items():
             if api_id not in local_api_ids:
                 continue
             await db.execute(

--- a/src/vault.py
+++ b/src/vault.py
@@ -1,6 +1,6 @@
 """Fernet-encrypted credential vault."""
 
-import json as _json
+import json
 import logging
 import os
 import re
@@ -305,7 +305,7 @@ async def create_credential(
         if not env_var:
             env_var = re.sub(r"[^a-zA-Z0-9]+", "_", cid).strip("_").upper()
 
-        sv_json = _json.dumps(server_variables) if server_variables else None
+        sv_json = json.dumps(server_variables) if server_variables else None
 
         # Derive routes if not explicitly provided
         if routes is None:
@@ -325,7 +325,7 @@ async def create_credential(
         # Auto-derive scheme if not explicitly provided
         if scheme is None:
             scheme = await derive_scheme_for_credential(api_id, scheme_name, identity)
-        scheme_json = _json.dumps(scheme) if scheme else None
+        scheme_json = json.dumps(scheme) if scheme else None
 
         await db.execute(
             "INSERT INTO credentials (id, label, env_var, encrypted_value, api_id, auth_type, identity, server_variables, scheme) VALUES (?,?,?,?,?,?,?,?,?)",
@@ -415,7 +415,7 @@ async def patch_credential(
                 (identity, cid),
             )
         if server_variables is not None:
-            sv_json = _json.dumps(server_variables) if server_variables else None
+            sv_json = json.dumps(server_variables) if server_variables else None
             await db.execute(
                 "UPDATE credentials SET server_variables=?, updated_at=unixepoch() WHERE id=?",
                 (sv_json, cid),
@@ -425,7 +425,7 @@ async def patch_credential(
         if scheme is not None:
             await db.execute(
                 "UPDATE credentials SET scheme=?, updated_at=unixepoch() WHERE id=?",
-                (_json.dumps(scheme), cid),
+                (json.dumps(scheme), cid),
             )
         elif any(x is not None for x in [api_id, scheme_name, identity]):
             async with db.execute(
@@ -441,7 +441,7 @@ async def patch_credential(
                 if _derived:
                     await db.execute(
                         "UPDATE credentials SET scheme=?, updated_at=unixepoch() WHERE id=?",
-                        (_json.dumps(_derived), cid),
+                        (json.dumps(_derived), cid),
                     )
 
         # Update credential_routes
@@ -463,9 +463,9 @@ async def patch_credential(
             if _row:
                 _current_api_id = api_id if api_id is not None else _row[0]
                 _current_sv_raw = (
-                    _json.dumps(server_variables) if server_variables is not None else _row[1]
+                    json.dumps(server_variables) if server_variables is not None else _row[1]
                 )
-                _current_sv = _json.loads(_current_sv_raw) if _current_sv_raw else None
+                _current_sv = json.loads(_current_sv_raw) if _current_sv_raw else None
                 computed_host = await _resolve_server_url(_current_api_id, _current_sv)
                 new_route = computed_host or _current_api_id
                 if new_route:
@@ -571,7 +571,7 @@ async def get_credentials_for_route(toolkit_id: str, host: str, path: str) -> li
             continue
         cid, enc_val, auth_type, identity, sv_raw, scheme_raw, api_id = row
         try:
-            server_variables = _json.loads(sv_raw) if sv_raw else None
+            server_variables = json.loads(sv_raw) if sv_raw else None
         except Exception:
             server_variables = None
         result.append(
@@ -581,7 +581,7 @@ async def get_credentials_for_route(toolkit_id: str, host: str, path: str) -> li
                 "auth_type": auth_type,
                 "identity": identity,
                 "server_variables": server_variables,
-                "scheme": _json.loads(scheme_raw) if scheme_raw else None,
+                "scheme": json.loads(scheme_raw) if scheme_raw else None,
                 "api_id": api_id,
             }
         )
@@ -595,7 +595,7 @@ def _row_to_dict(row) -> dict:
     # routes is synthetic — appended by _fetch_credential_row as the last element
     sv_raw = row[7] if len(row) > 7 else None
     try:
-        server_variables = _json.loads(sv_raw) if sv_raw else None
+        server_variables = json.loads(sv_raw) if sv_raw else None
     except Exception:
         server_variables = None
     scheme_raw = row[8] if len(row) > 8 else None
@@ -610,6 +610,6 @@ def _row_to_dict(row) -> dict:
         "auth_type": row[5] if len(row) > 5 else None,
         "identity": row[6] if len(row) > 6 else None,
         "server_variables": server_variables,
-        "scheme": _json.loads(scheme_raw) if scheme_raw else None,
+        "scheme": json.loads(scheme_raw) if scheme_raw else None,
         "routes": routes,
     }

--- a/tests/test_html_rendering.py
+++ b/tests/test_html_rendering.py
@@ -1,0 +1,155 @@
+"""HTML rendering regression tests.
+
+Two endpoints render HTML inline with `html.escape()` — formerly via an
+`import html as _html` alias, now via plain `import html`. Reassigning a
+local variable named `html` in the same function would shadow the module
+and raise UnboundLocalError on the first `html.escape()` call.
+
+These tests exercise the HTML branches at the HTTP boundary to lock in
+the scoping behaviour.
+
+  - GET /toolkits/{id}/access-requests/approve/{req_id}/legacy
+  - GET /workflows/{slug} with Accept: text/html
+    (exercised against an isolated test app because the real app's SPA
+    middleware intercepts any request with text/html in Accept on
+    /workflows/* — see jentic/jentic-mini#255.)
+"""
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from src.routers import workflows as workflows_router
+from starlette.testclient import TestClient
+
+
+# ── Workflow HTML rendering ───────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def workflows_only_client(client):
+    """TestClient against a minimal app mounting only the workflows router.
+
+    The real app's SPA middleware intercepts GET requests with text/html in
+    Accept on /workflows/* and returns the React SPA instead of reaching the
+    route. A minimal app omits that middleware so the HTML branch is
+    reachable. The shared DB_PATH is still used (set by conftest), so the
+    workflow imported by the `imported_html_workflow` fixture via the main
+    client is visible here.
+
+    Depends on `client` to ensure the main app's lifespan (and therefore
+    run_migrations()) has executed before we query the DB.
+    """
+    mini_app = FastAPI()
+    mini_app.include_router(workflows_router.router)
+    with TestClient(mini_app, raise_server_exceptions=False) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def imported_html_workflow(client, admin_session):
+    """Import a workflow once for the module via the real app."""
+    workflow_path = Path(__file__).parent / "fixtures" / "test-workflow.arazzo.json"
+    assert workflow_path.exists(), f"Test workflow fixture not found: {workflow_path}"
+
+    resp = client.post(
+        "/import",
+        json={"sources": [{"type": "path", "path": str(workflow_path)}]},
+        cookies=admin_session,
+    )
+    assert resp.status_code == 200, f"Import failed: {resp.text}"
+    result = resp.json()
+    assert result["succeeded"] > 0
+
+
+def test_get_workflow_html_renders(workflows_only_client, imported_html_workflow):
+    """GET /workflows/{slug} with Accept: text/html returns rendered HTML.
+
+    Proves html.escape() in the HTML branch works without UnboundLocalError.
+    """
+    resp = workflows_only_client.get(
+        "/workflows/test-workflow",
+        headers={"Accept": "text/html"},
+    )
+    assert resp.status_code == 200, f"HTML workflow page failed: {resp.text}"
+    body = resp.text
+    # Escaped workflow name must be present — proves html.escape was called
+    assert "Test Workflow" in body
+    # Steps block must be rendered — proves the esc(...) loop completed
+    assert "<h2>Steps (2)</h2>" in body
+    assert "searchItems" in body or "getItem" in body
+    # Must be HTML content type
+    assert "text/html" in resp.headers["content-type"]
+
+
+# ── Access request legacy approval UI ─────────────────────────────────────────
+
+
+@pytest.fixture
+def access_request(client, agent_key_header):
+    """Create an access request and return (toolkit_id, req_id)."""
+    toolkit_id = "default"
+    resp = client.post(
+        f"/toolkits/{toolkit_id}/access-requests",
+        headers=agent_key_header,
+        json={
+            "type": "grant",
+            "credential_id": "some-credential",
+            "rules": [{"effect": "allow", "methods": ["GET"]}],
+            "reason": "Need read access <script>alert(1)</script>",
+        },
+    )
+    assert resp.status_code in (200, 201, 202), f"Create request failed: {resp.text}"
+    return toolkit_id, resp.json()["id"]
+
+
+def test_approval_ui_legacy_pending_renders(client, admin_session, access_request):
+    """Legacy HTML approval UI renders for a pending request."""
+    toolkit_id, req_id = access_request
+    resp = client.get(
+        f"/toolkits/{toolkit_id}/access-requests/approve/{req_id}/legacy",
+        cookies=admin_session,
+    )
+    assert resp.status_code == 200, f"Legacy UI failed: {resp.text}"
+    body = resp.text
+    # Request metadata escaped into the page
+    assert req_id in body
+    assert "grant" in body
+    # Reason is escaped — `<script>` must not appear literally
+    assert "<script>alert(1)</script>" not in body
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in body
+    # Pending branch: Approve/Deny buttons present
+    assert "Approve" in body
+    assert "Deny" in body
+    assert "text/html" in resp.headers["content-type"]
+
+
+def test_approval_ui_legacy_resolved_renders(client, admin_session, access_request):
+    """Legacy HTML approval UI renders the resolved branch after denial."""
+    toolkit_id, req_id = access_request
+    # Deny to leave the request in a non-pending state without side effects
+    resp = client.post(
+        f"/toolkits/{toolkit_id}/access-requests/{req_id}/deny",
+        cookies=admin_session,
+    )
+    assert resp.status_code in (200, 201), f"Deny failed: {resp.text}"
+
+    resp = client.get(
+        f"/toolkits/{toolkit_id}/access-requests/approve/{req_id}/legacy",
+        cookies=admin_session,
+    )
+    assert resp.status_code == 200, f"Legacy UI (resolved) failed: {resp.text}"
+    body = resp.text
+    # Resolved branch: no Approve/Deny buttons, just the "already resolved" line
+    assert "already been resolved" in body
+    assert "denied" in body
+
+
+def test_approval_ui_legacy_not_found(client, admin_session):
+    """Legacy HTML approval UI returns 404 HTML for unknown req_id."""
+    resp = client.get(
+        "/toolkits/default/access-requests/approve/areq_missing/legacy",
+        cookies=admin_session,
+    )
+    assert resp.status_code == 404
+    assert "Not found" in resp.text


### PR DESCRIPTION
## Summary
- Remove `as _name` aliases for module imports in `vault.py`, `startup.py`, `broker.py`, `user.py`, `access_requests.py`, `workflows.py`; update usages. Where a local variable would shadow the newly-unaliased module (both HTML-rendering paths had `html = f"..."` assignments), rename the local to `body` to avoid `UnboundLocalError` from Python's `LOAD_FAST` binding.
- Hoist `import yaml` to module top in `alembic/versions/0004_credential_routes.py`; drop the `try/except ImportError` fallback. `pyyaml` is a hard dep in `pyproject.toml`, and the old fallback silently produced wrong data during migration (fell through to `json.loads(yaml_content)` → raise → swallowed by outer `except Exception: return None`). Loud failure is strictly better.
- Add `tests/test_html_rendering.py` (4 tests) covering the HTML branches of `approval_ui_legacy` and `get_workflow` at the HTTP boundary, locking in the scoping fix. The workflow test uses a minimal FastAPI app because the main app's SPA middleware intercepts `text/html` on `/workflows/*` (see #255).

## Test plan
- [x] `pdm run lint` clean
- [x] `PYTHONPATH=. pdm run pytest tests/` — 95/95 pass (91 existing + 4 new)
- [x] Sanity import check of all touched modules

## Related
- #255 — SPA middleware shadows `/workflows/{slug}` HTML response branch (surfaced while testing this PR)