### PR TITLE
chore(ai): add sdd constitution claude rule

### DIFF
--- a/.claude/rules/sdd-constitution.md
+++ b/.claude/rules/sdd-constitution.md
@@ -1,0 +1,16 @@
+**Spec-Driven Development** (SDD) is a workflow where feature specs, tasks, and implementation all derive from a stable project foundation — the **constitution**. Work is grounded in the constitution rather than re-invented each time.
+
+In this repo the constitution is one document split across three files in `specs/` — each a section, load-bearing together. None stands alone.
+
+- `specs/mission.md` — why the project exists, who it serves, what success looks like
+- `specs/tech-stack.md` — the stack that exists (not what is ideal), plus system-wide constraints and conventions
+- `specs/roadmap.md` — the next shippable phases, ordered and scoped small
+
+Each file is YAML-frontmatter-tagged with `type: constitution` and its `section:`, plus a `sources:` list of `@`-prefixed paths the content was derived from.
+
+The constitution captures **load-bearing invariants**, not operational detail. Endpoint catalogs, schemas, threat models, and similar reference material live in `docs/` — the constitution cross-references them from `tech-stack.md`. Mission / tech-stack / roadmap is the whole set; there is no fourth section.
+
+Supporting infrastructure:
+
+- `.claude/templates/sdd/constitution/*.example.md` — structural templates for each section
+- `.claude/prompts/create-constitution.md` — generator prompt 


### PR DESCRIPTION
## Summary

Adds `.claude/rules/sdd-constitution.md` — a short descriptive rule telling future Claude what Spec-Driven Development is in this repo and where the constitution lives.

The rule covers:
- What SDD is (work derives from a stable foundation — the constitution)
- That the constitution is **one document split across three files** in `specs/` (mission / tech-stack / roadmap), load-bearing together
- What each section contains
- Frontmatter tagging (`type: constitution`, `section:`, `sources:`)
- The boundary between constitution and `docs/` (invariants vs. operational detail; no fourth section)
- Pointers to `.claude/templates/sdd/constitution/` and `.claude/prompts/create-constitution.md`

Matches the style of the existing `.claude/rules/` entries (conventional-commits, karpathy-guidelines) — descriptive, not prescriptive.

## Test plan

- [x] Rule renders correctly in GitHub markdown view.
- [x] File paths in the rule still exist: `specs/mission.md`, `specs/tech-stack.md`, `specs/roadmap.md`, `.claude/templates/sdd/constitution/*.example.md`, `.claude/prompts/create-constitution.md`.
- [ ] Rule is picked up by Claude Code alongside the other `.claude/rules/*.md` files.