### PR TITLE
chore(ai): add claude hook to run ruff on edited python files

### DIFF
--- a/.claude/hooks/ruff-fix.sh
+++ b/.claude/hooks/ruff-fix.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# PostToolUse hook: run ruff check --fix and ruff format on an edited .py file.
+# Reads Claude Code's hook JSON from stdin and no-ops for non-Python paths.
+set -u
+f=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty')
+[ -n "$f" ] && [ "${f##*.}" = "py" ] || exit 0
+ruff check --fix "$f" && ruff format "$f"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/ruff-fix.sh",
+            "statusMessage": "Running ruff on edited file"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` with a `PostToolUse` hook on `Write|Edit` that invokes `.claude/hooks/ruff-fix.sh`
- Script reads the hook JSON from stdin, filters to `.py` paths, and runs `ruff check --fix` + `ruff format` on the edited file only (no `pdm` wrapper overhead, no full-project scan)
- Non-Python edits are a silent no-op

## Test plan
- [x] Pipe-test: feed synthetic hook JSON for a `.py` path → ruff runs; for a `.md` path → no-op, exit 0
- [x] End-to-end: add an unused `import json` to `src/config.py` via Edit → hook fires → ruff strips it, file returns to original state