### PR TITLE
chore(ci): run pdm lint in husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+pdm run lint
 cd ui && npx lint-staged


### PR DESCRIPTION
## Summary
- Run `pdm run lint` (ruff check + format check) before the existing `lint-staged` step in `.husky/pre-commit`, so Python lint violations are caught before they reach CI.

## Test plan
- [x] `bash .husky/pre-commit` passes locally (ruff + lint-staged both green)
- [x] CI green on this PR