### PR TITLE
chore(ai): add claude hook to run eslint on edited ts/tsx files

### DIFF
--- a/.claude/hooks/eslint-fix.sh
+++ b/.claude/hooks/eslint-fix.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# PostToolUse hook: run eslint --fix on an edited .ts/.tsx file inside ui/.
+# Prettier runs via eslint-plugin-prettier, so this also reformats.
+# Reads Claude Code's hook JSON from stdin and no-ops for other paths.
+set -u
+f=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty')
+[ -n "$f" ] || exit 0
+case "$f" in
+  *.ts|*.tsx) ;;
+  *) exit 0 ;;
+esac
+ui_dir=$(git rev-parse --show-toplevel 2>/dev/null)/ui
+case "$f" in
+  "$ui_dir"/*) ;;
+  *) exit 0 ;;
+esac
+eslint_bin="$ui_dir/node_modules/.bin/eslint"
+[ -x "$eslint_bin" ] || exit 0
+cd "$ui_dir" && "$eslint_bin" --fix "$f"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": ".claude/hooks/ruff-fix.sh",
             "statusMessage": "Running ruff on edited file"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/eslint-fix.sh",
+            "statusMessage": "Running eslint on edited file"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- New `.claude/hooks/eslint-fix.sh` PostToolUse hook that runs `eslint --fix` on `.ts`/`.tsx` files edited under `ui/`. Since `eslint-plugin-prettier/recommended` is wired into `ui/eslint.config.js`, this also applies prettier formatting.
- Registered alongside the existing `ruff-fix.sh` under the `Write|Edit` matcher in `.claude/settings.json`.
- Script self-filters (extension + path inside `<repo>/ui/`) and silently no-ops if `ui/node_modules/.bin/eslint` isn't installed, matching the pattern established by `ruff-fix.sh`.

## Test plan
- [x] Hook exits 0 on a clean UI file (`ui/src/App.tsx`) without modifying it
- [x] Hook no-ops on `.py` and `.md` paths
- [x] End-to-end: `Edit` adding an unused `import { useState } from 'react'` to `ui/src/App.tsx` triggered the hook, which stripped the import (`git diff` empty afterwards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)