### PR TITLE
docs: add gh prerequisite and backend lint commands

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,6 +9,7 @@
   ```
 - **Node.js 24+** and **npm** (for the UI)
 - **Docker** and **Docker Compose** (for running the server)
+- **GitHub CLI** (`gh`) — https://cli.github.com/
 
 ## Getting Started
 
@@ -83,6 +84,13 @@ npm run test:e2e:docker  # Docker E2E (real backend)
 ```
 
 ## Linting
+
+### Backend
+
+```bash
+pdm run lint          # Ruff check + format check
+pdm run lint:fix      # Auto-fix
+```
 
 ### UI
 


### PR DESCRIPTION
## Summary
- Add GitHub CLI (`gh`) to the prerequisites list in DEVELOPMENT.md
- Document backend linting commands (`pdm run lint` / `pdm run lint:fix`) alongside the existing UI section

## Test plan
- [x] Rendered DEVELOPMENT.md locally to verify formatting