### PR TITLE
chore(conventional-commits): require scope in commit headers

### DIFF
--- a/.claude/rules/conventional-commits.md
+++ b/.claude/rules/conventional-commits.md
@@ -3,5 +3,7 @@ Commit messages MUST follow Conventional Commits (https://www.conventionalcommit
 Format: `type(scope): description` — max 69 characters in the header.
 
 - Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `perf`, `build`, `ci`, `style`, `revert`
-- Scope: package short name without `apidom-` prefix (e.g. `core`, `ns-overlay-1`, `reference`, `traverse`)
+- Scope: always include a scope. Use the primary subject of the change:
+  - For `docs`: the doc file name without extension (e.g. `docs(DEVELOPMENT)`, `docs(README)`, `docs(TESTING)`)
+  - For code: the module, router, or component name (e.g. `fix(broker)`, `feat(search)`, `refactor(ui)`)
 - Description: lowercase, imperative mood, no trailing period


### PR DESCRIPTION
## Summary
- Require every conventional commit to include a scope
- Replace the apidom-era scope examples (which don't apply to jentic-mini) with repo-relevant ones: doc filename for `docs` commits, module/router/component for code

## Test plan
- [x] Rule renders correctly in `.claude/rules/conventional-commits.md`