### PR TITLE
ci: run pdm lint in CI and gate CD on backend checks

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -9,6 +9,7 @@ on:
       - 'alembic/**'
       - 'pyproject.toml'
       - 'pdm.lock'
+      - '.github/workflows/ci-backend.yml'
   pull_request:
     branches: [main]
     paths:
@@ -17,6 +18,7 @@ on:
       - 'alembic/**'
       - 'pyproject.toml'
       - 'pdm.lock'
+      - '.github/workflows/ci-backend.yml'
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1,16 +1,6 @@
-name: Backend Tests
+name: Backend CI
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'alembic/**'
-      - 'pyproject.toml'
-      - 'pdm.lock'
-      # Self-reference: ensures edits to this workflow are validated on the PR that makes them.
-      - '.github/workflows/ci-backend.yml'
   pull_request:
     branches: [main]
     paths:
@@ -39,6 +29,7 @@ jobs:
         with:
           python-version: '3.11'
           version: '2.25.5'
+          cache: true
 
       - name: Install dependencies
         run: pdm install --dev --frozen-lockfile
@@ -56,6 +47,7 @@ jobs:
         with:
           python-version: '3.11'
           version: '2.25.5'
+          cache: true
 
       - name: Install dependencies
         run: pdm install --dev --frozen-lockfile

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -9,6 +9,7 @@ on:
       - 'alembic/**'
       - 'pyproject.toml'
       - 'pdm.lock'
+      # Self-reference: ensures edits to this workflow are validated on the PR that makes them.
       - '.github/workflows/ci-backend.yml'
   pull_request:
     branches: [main]
@@ -18,6 +19,7 @@ on:
       - 'alembic/**'
       - 'pyproject.toml'
       - 'pdm.lock'
+      # Self-reference: ensures edits to this workflow are validated on the PR that makes them.
       - '.github/workflows/ci-backend.yml'
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -25,6 +25,23 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pdm-project/setup-pdm@v4
+        with:
+          python-version: '3.11'
+          version: '2.25.5'
+
+      - name: Install dependencies
+        run: pdm install --dev --frozen-lockfile
+
+      - name: Run lint
+        run: pdm run lint
+
   backend-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,11 +21,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  ci-backend:
+    uses: ./.github/workflows/ci-backend.yml
+
   ci:
     uses: ./.github/workflows/ci-docker.yml
 
   publish:
-    needs: ci
+    needs: [ci-backend, ci]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
## Summary
- Add a `lint` job to `ci-backend.yml` that runs `pdm run lint` in parallel with `backend-tests`.
- Make `docker-publish.yml` call `ci-backend.yml` alongside `ci-docker.yml`, so both lint and backend tests must pass before publish. This also gates the `release.yml` path, which calls `docker-publish.yml`.

Note: `ci-backend.yml`'s `paths:` filters only apply to `push`/`pull_request` triggers — `workflow_call` from `docker-publish.yml` runs it unconditionally.

## Test plan
- [x] PR CI runs both `lint` and `backend-tests` jobs in `ci-backend.yml`
- [x] `docker-publish` on push to main waits on `ci-backend` + `ci` before publishing