### PR TITLE
docs(conventional-commits): clarify ci type vs chore(ci) scope

### DIFF
--- a/.claude/rules/conventional-commits.md
+++ b/.claude/rules/conventional-commits.md
@@ -5,5 +5,6 @@ Format: `type(scope): description` — max 69 characters in the header.
 - Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `perf`, `build`, `ci`, `style`, `revert`
 - Scope: always include a scope. Use the primary subject of the change:
   - For `docs`: the doc file name without extension (e.g. `docs(DEVELOPMENT)`, `docs(README)`, `docs(TESTING)`)
+  - For `ci`: the workflow/config file name without extension (e.g. `ci(ci-backend)`, `ci(docker-publish)`, `ci(release)`). When the change IS the CI config, use type `ci` — not `chore(ci)`.
   - For code: the module, router, or component name (e.g. `fix(broker)`, `feat(search)`, `refactor(ui)`)
 - Description: lowercase, imperative mood, no trailing period


### PR DESCRIPTION
## Summary
- Clarify that when a change IS the CI config (workflow/pipeline files), the commit type should be `ci` with the workflow filename as the scope (e.g. `ci(ci-backend)`, `ci(docker-publish)`), not `chore(ci)`.
- Mirrors the existing `docs(<file>)` guidance so the rule is consistent across meta-types.

## Test plan
- [ ] commitlint (if configured for this rule) still accepts `ci(ci-backend): ...` style headers
- [ ] Future CI-config PRs follow the new convention