### PR TITLE
chore(ai): scope tech-stack rule to dependency files

### DIFF
--- a/.claude/rules/update-tech-stack-on-deps.md
+++ b/.claude/rules/update-tech-stack-on-deps.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "pyproject.toml"
+  - "ui/package.json"
+  - "Dockerfile"
+---
+
 When a change touches `pyproject.toml`, `ui/package.json`, or `Dockerfile` and either **adds a library, removes a library, or changes its role in the architecture**, update `specs/tech-stack.md` in the same commit.
 
 Version bumps do NOT require a constitution update — `pyproject.toml` and `ui/package.json` are the version source of truth. Do not re-add version numbers to `specs/tech-stack.md`.


### PR DESCRIPTION
## Summary
- Add `paths:` frontmatter to `.claude/rules/update-tech-stack-on-deps.md` so the rule loads only when `pyproject.toml`, `ui/package.json`, or `Dockerfile` is in context, instead of every session.

## Test plan
- [x] Confirm rule still triggers when editing `pyproject.toml` / `ui/package.json` / `Dockerfile`
- [x] Confirm rule is not injected for unrelated sessions