### PR TITLE
docs(CLAUDE): reference AGENTS.md and flag overlapping sections

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Jentic Mini is the open-source, self-hosted implementation of the Jentic API. It gives AI agents a local execution layer: search APIs via BM25, broker authenticated requests (credential injection without exposing secrets to the agent), enforce access policies, and observe execution traces. Built with FastAPI + SQLite + Fernet encryption.
 
+See @AGENTS.md for the agent-facing runtime guide (search, inspect, execute workflow; endpoint reference; credential-injection contract from the agent's perspective). Keep the overlapping sections in both files (Jentic Mini overview, credential-injection flow, capability ID format, `X-Jentic-API-Key` header) in sync when changing either.
+
 ## Development Setup
 
 See @DEVELOPMENT.md for prerequisites, installation, and running the server.


### PR DESCRIPTION
## Summary
- Add a link from `.claude/CLAUDE.md` to `AGENTS.md` so contributor guidance points at the agent-facing runtime guide.
- Flag the overlapping sections between the two files (Jentic Mini overview, credential-injection flow, capability ID format, `X-Jentic-API-Key` header) so future edits keep them in sync.

Content was already aligned — no factual changes were needed, only the cross-reference and the sync reminder.

## Test plan
- [x] Docs-only change; no backend or UI tests affected.
- [x] Verified `@AGENTS.md` reference resolves (file exists at repo root).