### PR TITLE
docs(spec): scaffold phase 2 — backend-unit-test-coverage

### DIFF
--- a/.claude/rules/sdd-constitution.md
+++ b/.claude/rules/sdd-constitution.md
@@ -10,7 +10,11 @@ Each file is YAML-frontmatter-tagged with `type: constitution` and its `section:
 
 The constitution captures **load-bearing invariants**, not operational detail. Endpoint catalogs, schemas, threat models, and similar reference material live in `docs/` — the constitution cross-references them from `tech-stack.md`. Mission / tech-stack / roadmap is the whole set; there is no fourth section.
 
+Once the constitution exists, individual roadmap phases are materialized into **feature specs** — dated directories under `specs/` (`specs/YYYY-MM-DD-<slug>/`) containing `requirements.md` (what + why), `plan.md` (how), and `validation.md` (done). Unlike constitution files, feature-spec files are plain markdown with **no YAML frontmatter** — the H1 (`# Phase N <Requirements|Plan|Validation> — <Title>`) carries identity. When a phase ships, delete it from `specs/roadmap.md` (do not renumber); the feature-spec directory stays as history.
+
 Supporting infrastructure:
 
-- `.claude/templates/sdd/constitution/*.example.md` — structural templates for each section
-- `.claude/prompts/create-constitution.md` — generator prompt 
+- `.claude/templates/sdd/constitution/*.example.md` — structural templates for each constitution section
+- `.claude/prompts/create-constitution.md` — constitution generator prompt
+- `.claude/templates/sdd/feature-spec/*.example.md` — structural templates for each feature-spec file
+- `.claude/skills/sdd-new-spec/SKILL.md` — `/sdd-new-spec` skill that scaffolds a feature spec from a roadmap phase 

--- a/.claude/skills/sdd-new-spec/SKILL.md
+++ b/.claude/skills/sdd-new-spec/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: sdd-new-spec
+description: Scaffold a feature spec for a roadmap phase and open it as a PR for human review. Reads specs/roadmap.md, lets the user pick a phase (or accepts one as argument), runs preflight checks, cuts a feature branch, writes specs/YYYY-MM-DD-<slug>/ (requirements.md, plan.md, validation.md — grounded in specs/mission.md and specs/tech-stack.md), commits, pushes, and opens a PR. Makes zero code changes — the PR is for review of the spec itself; implementation follows in a separate PR once the spec is approved. Groups clarifying questions (one per output file) via AskUserQuestion before any disk write.
+argument-hint: "[phase-number | \"phase title fragment\"] (optional)"
+---
+
+# /sdd-new-spec — scaffold a feature spec for a roadmap phase
+
+You are operating within a Spec-Driven Development (SDD) workflow. See `.claude/rules/sdd-constitution.md`.
+
+The **constitution** (mission / tech-stack / roadmap) already exists in `specs/`. This skill takes one **phase** from `specs/roadmap.md` and turns it into a workable **feature spec** — a dated directory under `specs/` with three files: requirements (what + why), plan (how), validation (done).
+
+## Inputs
+
+Argument in `$ARGUMENTS` (optional):
+
+- empty → list candidate phases and ask the user to pick
+- integer (`1`, `7`) → use that phase number directly
+- title fragment (`"local service routing"`) → case-insensitive match against phase titles; if ambiguous, list matches and ask
+
+## Hard constraints
+
+- **Spec-only — zero code changes.** This skill never modifies `src/`, `ui/`, `tests/`, `alembic/`, `docs/`, `AGENTS.md`, `CLAUDE.md`, or any implementation/doc file outside `specs/<date>-<slug>/`. It does not run test suites or linters against code. The only files it touches are the three it scaffolds. The PR it opens is for review of the spec itself; the implementation that the spec describes happens in a follow-up PR.
+- **Do not write to disk before the Phase 4 AskUserQuestion step completes.** The grouped questions exist to lock in decisions that shape the files; writing early wastes the call.
+- **AskUserQuestion groups exactly three questions**, one per output file (requirements, plan, validation). Issue them in a single call.
+- **Do not create a new roadmap phase.** If the user wants one, tell them edits to `specs/roadmap.md` are a separate explicit action — this skill only materializes existing phases.
+- **Ground every requirement and constraint in `specs/mission.md`, `specs/tech-stack.md`, or the roadmap phase itself.** Do not invent scope the sources do not support.
+- **PR contains the spec, nothing else.** Staged set must be exactly the three files under `specs/<date>-<slug>/` before committing. If anything else appears, stop and surface it.
+
+## Phase 0 — Preflight
+
+Run these checks in parallel. Stop with a clear message on any failure — do not auto-fix, do not stash, do not force.
+
+- `git status --porcelain` is empty (working tree clean)
+- Current branch is `main`
+- `git fetch origin main` succeeds; local `main` is not behind `origin/main`. If behind and fast-forwardable, offer `git pull --ff-only` and wait for user confirmation. If diverged, stop.
+- `gh auth status` succeeds — fail fast here if `gh` is not installed or not authenticated; Phase 8 depends on it.
+
+Then load context in parallel:
+
+- @specs/mission.md
+- @specs/tech-stack.md
+- @specs/roadmap.md
+- @.claude/rules/git-workflow.md
+- @.claude/rules/conventional-commits.md
+- @.claude/rules/testing.md
+- @.claude/rules/karpathy-guidelines.md
+
+## Phase 1 — Pick a roadmap phase
+
+Parse active phases from `specs/roadmap.md` — the `## Phase N — <title>` blocks. Ignore the `Later Phases (Not Yet Planned)` section.
+
+For each phase extract: number, title, `**Goal:**`, `**Depends on:**`, `**Priority:**`.
+
+A phase is a **candidate** when every name in its `Depends on:` list is no longer present in `specs/roadmap.md` (i.e. that dependency has shipped and been removed per the lifecycle rule). Phases with still-pending dependencies are valid to pick but must be flagged.
+
+**If `$ARGUMENTS` identifies exactly one phase**, jump straight to showing that phase's full block and confirm with the user before continuing.
+
+**Otherwise** present candidates as a compact list:
+
+```
+N. <title> — priority: <High|Medium|Low> — deps: <satisfied|pending: <names>>
+   goal: <one-line goal>
+```
+
+Ask the user to pick one by number. Do not proceed until the user confirms.
+
+If the user wants to change the phase's scope at this step, route them to update `specs/roadmap.md` first and re-run the skill.
+
+## Phase 2 — Research in parallel (MANDATORY)
+
+Launch **three `Explore` subagents in parallel** — a single message with multiple `Agent` tool calls, `subagent_type: Explore`, one per output file. Do not proceed to Phase 3 until all three return.
+
+- **Thoroughness:** `very thorough` on every subagent. Feature specs are load-bearing; shallow grounding produces shallow specs.
+- **Model:** pass `model: "opus"` in every `Agent` tool call. Max capability for grounding.
+- **Briefs are self-contained.** Each subagent does not see this conversation. Include: phase number, phase title, the full roadmap-phase body copied verbatim from `specs/roadmap.md`, and a one-paragraph focus directive specific to its output file.
+
+**Subagent A — Requirements research** (grounds `requirements.md`):
+- Read `specs/mission.md` and `specs/tech-stack.md` for invariants / constraints this phase must preserve.
+- Scan `docs/` for documents the phase directly relates to (e.g. `ARCHITECTURE.md`, `AUTH.md`, `WORKFLOWS.md`, `DECISIONS.md`).
+- Scan recent git log for prior attempts at similar functionality or adjacent work.
+- Return: constraints that MUST be preserved (one-line rationale each), relevant `docs/*.md` links, stakeholder-context signals, and any prior-context that reframes the phase.
+
+**Subagent B — Plan research** (grounds `plan.md`):
+- Map the `src/` modules, routers, migrations, and UI pages the phase will touch (based on the roadmap-phase body).
+- Identify file-layout conventions (where new routers live, where tests live, where generated UI client code goes per `CLAUDE.md`).
+- Find similar-shape features that have already shipped (git log + `src/`) as implementation references.
+- Return: concrete file/module paths to touch or create, existing patterns to follow, the order in which layers depend on each other, and any gotchas (e.g. broker catch-all must remain last in `main.py`).
+
+**Subagent C — Validation research** (grounds `validation.md`):
+- Identify the test suites and CI workflows relevant to the areas touched (per `.claude/rules/testing.md` and `.github/workflows/`).
+- Find existing endpoints / UI flows / trace-log inspections that will demonstrate the phase works end-to-end.
+- Check whether `schemathesis` contract tests, `ui/openapi.json` regeneration, or Playwright E2E apply.
+- Return: concrete test targets (`pdm run test …`, `npm run test:run`, `npm run test:e2e`), curl / UI check commands with expected responses, and whether contract / E2E / migration gates apply.
+
+**Rules:**
+- Every brief must instruct the subagent to lead its summary with a `## Blockers` section (write `_none_` when there are none). Examples of blockers: the phase depends on an assumption that is false in the current code; prior work already landed and the phase is partly obsolete; a load-bearing file referenced by the phase body does not exist.
+- Subagents are read-only (`Explore` type; they cannot edit, write, or commit).
+- If any subagent surfaces a non-empty `## Blockers` section, stop and report to the user before Phase 3.
+- Summaries from all three subagents feed Phase 4 (AskUserQuestion options) and Phase 6 (file content).
+
+## Phase 3 — Derive slug, directory, and branch
+
+Derive identifiers in order, checking for conflicts at each step **before** asking the user anything they could not act on.
+
+1. **Slug** — kebab-case from the phase title, lowercase, alphanumerics and hyphens only. Drop leading `Phase N — `. Target ≤ 40 chars; strip filler words (`the`, `and`, `of`) only if over. Example: `Phase 1 — Local Service Routing` → `local-service-routing`.
+2. **Date** — today's date as `YYYY-MM-DD` from the current environment (do not ask).
+3. **Directory** — `specs/<date>-<slug>/`.
+4. **Directory idempotence check** — if `specs/<date>-<slug>/` already exists, stop, show what's there, ask whether to reuse / rename / abort. Do this **before** the issue-number question so the user does not waste effort on a scaffold that cannot proceed.
+5. **Branch prefix** — follow `.claude/rules/git-workflow.md`:
+   - `feature/` by default
+   - `fix/` if the phase goal describes a defect or starts with "Fix"
+   - `chore/` for tooling / maintenance / dependency phases
+   - `docs/` if the phase is purely documentation
+6. **Issue number** — ask the user once: "Is there a GitHub issue for this phase? (issue number or 'no')". If yes, branch is `<prefix>/<issue>-<slug>`; else `<prefix>/<slug>`.
+7. **Branch idempotence check** — if the target branch exists locally or on `origin`, stop, ask whether to switch to it / rename / abort.
+
+## Phase 4 — AskUserQuestion (MANDATORY, before any disk write)
+
+Issue a single `AskUserQuestion` call containing three questions, one per output file. Each question offers 3–5 concrete options plus a freeform "other" so the user can redirect. Frame each as a decision the scaffold needs locked-in.
+
+**Question 1 — Requirements** (shapes `requirements.md`):
+  - Prompt: "Any scope to explicitly exclude, external constraints, or up-front decisions to record?"
+  - Options should cover common shapes (e.g. "no exclusions, follow roadmap bullets exactly", "exclude UI changes for now", "lock a specific naming choice", "external deadline or dependent team", "other").
+
+**Question 2 — Plan** (shapes `plan.md`):
+  - Prompt: "How should the plan be structured — ordering and granularity?"
+  - Options should cover common shapes (e.g. "test-first", "skeleton-first then flesh out", "risky-bits-first to de-risk", "3–4 large groups", "6–10 small groups", "other").
+
+**Question 3 — Validation** (shapes `validation.md`):
+  - Prompt: "What is the primary acceptance signal, and are there merge gates beyond green CI?"
+  - Options should cover common shapes (e.g. "integration test passing", "contract test (`schemathesis`) passing", "UI flow verified manually", "endpoint reproducible via curl", "docs + AGENTS.md must update", "other").
+
+Only after the user answers do you proceed.
+
+## Phase 5 — Cut the branch
+
+```
+git checkout -b <branch>
+```
+
+Do not push yet — Phase 8 handles push after the commit.
+
+## Phase 6 — Write the three files
+
+Create `specs/<date>-<slug>/`. Write three files using these templates as structural scaffolds — fill in the placeholders from the phase content and the user's answers. **Use templates for structure only; do not copy text verbatim.** Files are plain markdown — no YAML frontmatter.
+
+- @.claude/templates/sdd/feature-spec/requirements.example.md
+- @.claude/templates/sdd/feature-spec/plan.example.md
+- @.claude/templates/sdd/feature-spec/validation.example.md
+
+All three share an H1 of `# Phase <N> <Requirements|Plan|Validation> — <Phase Title>` (the phase title is the human-readable title from `specs/roadmap.md`, not the kebab slug).
+
+### requirements.md
+
+Sections in this order:
+
+- **Scope** — one or two short paragraphs naming what this phase delivers. Written in plain language, informed by the user's Question 1 answer. Not a copy of the roadmap bullet list.
+- **Out of Scope** — explicit exclusions the user confirmed. Empty is allowed — do not invent exclusions.
+- **Decisions** — one `### <Decision Title>` subsection per decision from the user's answers. Body is a short paragraph: what was chosen, why, and any consequence for implementation (alternatives noted if weighed).
+- **Constraints** — load-bearing invariants from `specs/mission.md` and `specs/tech-stack.md` that this phase must preserve. Only what is actually relevant (e.g. "broker catch-all must be registered last" only if the work touches router registration). Do not copy every invariant.
+- **Context** — one to three short paragraphs: why this phase exists now, what it enables, how it fits the roadmap. Cross-reference any relevant `docs/*.md`.
+- **Stakeholder Notes** — `- **<Name or Role>** — <need; how satisfied>`. Omit the whole section if the user named no stakeholders.
+
+### plan.md
+
+Numbered task groups. Granularity per the user's Question 2 answer.
+
+**Task numbering is sequential across all groups** (1, 2, 3, … N), not reset per group:
+
+```
+## Group 1 — <Title>
+1. <Concrete task>
+2. <Concrete task>
+
+## Group 2 — <Title>
+3. <Concrete task>
+4. <Concrete task>
+```
+
+- Tasks are plain numbered items, **not checkboxes**. One concrete change each (file / function / test / route / migration / CLI command).
+- **The last group is always `Verify`**, listing the concrete checks that confirm the whole plan succeeded: command + expected result (e.g. `pdm run test tests/broker` exits 0; `curl localhost:8900/…` returns 200 with JSON containing `{ … }`).
+- **Do not include meta-workflow** in the plan (test-suite runs belong in `Verify`; squash/commit/PR/roadmap-delete are governed by `.claude/rules/git-workflow.md` and `.claude/rules/conventional-commits.md` — no need to repeat per phase).
+
+Do not pad. If three groups plus `Verify` cover the work, that is correct.
+
+### validation.md
+
+Structure:
+
+- **Definition of Done** — opening sentence: "All of the following must be true before this branch is merged."
+- Numbered subsections `### <N>. <Check Title>` — each contains either a fenced code-block command and an exact expectation (HTTP status, exit code, output substring, file contents), or a short description of a non-command check (e.g. `tsconfig.json` must contain `"strict": true`). Be concrete: "HTTP 200, body contains `<h1>Jentic</h1>`" — not "endpoint works".
+- **Not Required** — final section. Explicit list of what this phase does **not** need (no automated tests for this phase, no CI pipeline required, no browser check, etc.) — matches what the user flagged in Question 3. Prevents scope creep and reviewer confusion.
+
+## Phase 7 — Commit the spec files
+
+Atomic commit per `.claude/rules/git-workflow.md`.
+
+- Stage **only** the three files under `specs/<date>-<slug>/`. Do **not** use `git add -A` or `git add .` — name the three paths explicitly.
+- Safety check: `git diff --cached --name-only` must list exactly three paths, all inside `specs/<date>-<slug>/`. If anything else appears, abort and surface it — the skill does not commit code.
+- Commit with `git commit -s` (DCO sign-off) and a Conventional Commits header per `.claude/rules/conventional-commits.md`:
+  - Type `docs`, scope `spec`
+  - Header: `docs(spec): scaffold phase <N> — <short-slug>` (≤ 69 chars total; truncate the slug if needed)
+  - Body: one short paragraph naming what the spec covers and linking the roadmap phase. Include `Refs #<issue>` if the user provided an issue number. **Do not** use GitHub close-keywords (`Closes`, `Fixes`, `Resolves`) — this PR does not resolve the phase.
+
+## Phase 8 — Push and open the PR
+
+- `git push -u origin <branch>`
+- Open a PR with `gh pr create`. Pass the body via a HEREDOC to preserve formatting. Title is the commit header. Body shape:
+
+  ```
+  ## Summary
+
+  Spec scaffold for **Phase <N>: <title>** from `specs/roadmap.md`.
+
+  This PR adds **spec files only** — no code changes. Implementation follows in a separate PR once this spec is approved.
+
+  ### Scope
+  [one-paragraph summary pulled from the Scope section of requirements.md]
+
+  ### Out of Scope
+  - [bullets from requirements.md, or "none declared"]
+
+  ### Key decisions
+  - [one bullet per `###` decision title in requirements.md]
+
+  ## Files
+
+  - `specs/<date>-<slug>/requirements.md`
+  - `specs/<date>-<slug>/plan.md`
+  - `specs/<date>-<slug>/validation.md`
+
+  ## Review guidance
+
+  Reviewers should verify:
+  - The phase goal is captured faithfully (see `specs/roadmap.md` Phase <N>).
+  - Scope, constraints, and decisions match intent.
+  - The plan's task groups are appropriately granular and each has a concrete verification step.
+  - Validation gates are realistic for the phase.
+
+  Refs: `specs/roadmap.md` Phase <N>[; #<issue> if applicable].
+  ```
+
+- Do **not** include `Closes #<issue>` / `Fixes #<issue>` in the PR body — only `Refs`. The phase closes on the implementation PR, not this one.
+
+## Phase 9 — Report back
+
+Return to the user in a few lines:
+
+- Phase chosen (number + title)
+- Branch, commit SHA, PR URL
+- Files created (full paths)
+- Next step: human review on the PR. Once merged, the implementation work described in `plan.md` happens in a separate branch/PR — this skill does not execute it.

--- a/.claude/templates/sdd/feature-spec/plan.example.md
+++ b/.claude/templates/sdd/feature-spec/plan.example.md
@@ -1,0 +1,24 @@
+# Phase [PHASE_NUMBER] Plan — [PHASE_TITLE]
+
+## Group 1 — [FIRST_GROUP_TITLE]
+
+1. [CONCRETE_TASK — file / module / function / command]
+2. [CONCRETE_TASK]
+3. [CONCRETE_TASK]
+
+## Group 2 — [SECOND_GROUP_TITLE]
+
+4. [CONCRETE_TASK]
+5. [CONCRETE_TASK]
+
+## Group 3 — [THIRD_GROUP_TITLE]
+
+6. [CONCRETE_TASK]
+7. [CONCRETE_TASK]
+8. [CONCRETE_TASK]
+
+## Group N — Verify
+
+9. [CONCRETE_COMMAND_AND_EXPECTED_RESULT — e.g. `pdm run test tests/broker` exits 0]
+10. [CONCRETE_COMMAND_AND_EXPECTED_RESULT — e.g. `curl localhost:8900/search?q=...` returns 200 with JSON containing `{ "operations": [...] }`]
+11. [CONCRETE_COMMAND_AND_EXPECTED_RESULT]

--- a/.claude/templates/sdd/feature-spec/requirements.example.md
+++ b/.claude/templates/sdd/feature-spec/requirements.example.md
@@ -1,0 +1,37 @@
+# Phase [PHASE_NUMBER] Requirements — [PHASE_TITLE]
+
+## Scope
+
+[ONE_OR_TWO_SHORT_PARAGRAPHS describing what this phase delivers. Written in plain language, informed by the user's Question 1 answer. Not a copy of the roadmap bullet list.]
+
+## Out of Scope
+
+- [EXPLICIT_EXCLUSION_1 — deferred to a later phase / not needed now]
+- [EXPLICIT_EXCLUSION_2]
+- [EXPLICIT_EXCLUSION_3]
+
+## Decisions
+
+### [DECISION_1_TITLE]
+[RATIONALE_PARAGRAPH — what was chosen, why, and any consequence it imposes on implementation. Mention alternatives if the user weighed them.]
+
+### [DECISION_2_TITLE]
+[RATIONALE_PARAGRAPH.]
+
+## Constraints
+
+Load-bearing invariants from `specs/mission.md` and `specs/tech-stack.md` that this phase must preserve. List only what is relevant to the work — do not copy every invariant.
+
+- **[CONSTRAINT_1]** — [why it matters for this phase specifically]
+- **[CONSTRAINT_2]** — [why it matters]
+
+## Context
+
+[ONE_TO_THREE_SHORT_PARAGRAPHS explaining why this phase exists now, what it enables, and how it fits the roadmap's trajectory. Cross-reference any `docs/*.md` the phase touches.]
+
+## Stakeholder Notes
+
+- **[STAKEHOLDER_NAME_OR_ROLE]** — [what they need; how this phase satisfies them]
+- **[STAKEHOLDER_NAME_OR_ROLE]** — [optional]
+
+[Omit this whole section if the user named no stakeholders.]

--- a/.claude/templates/sdd/feature-spec/validation.example.md
+++ b/.claude/templates/sdd/feature-spec/validation.example.md
@@ -1,0 +1,31 @@
+# Phase [PHASE_NUMBER] Validation — [PHASE_TITLE]
+
+## Definition of Done
+
+All of the following must be true before this branch is merged.
+
+### 1. [CHECK_TITLE]
+
+```
+[CONCRETE_COMMAND]
+```
+
+[EXACT_EXPECTATION — HTTP status, exit code, output substring, file contents. Be concrete: "HTTP 200, body contains `<h1>Jentic</h1>`" — not "endpoint works".]
+
+### 2. [CHECK_TITLE]
+
+```
+[CONCRETE_COMMAND]
+```
+
+[EXACT_EXPECTATION.]
+
+### 3. [CHECK_TITLE]
+
+[DESCRIPTION_OF_CHECK — may or may not have a command. For file-contents assertions: "`package.json` must list `hono` without a `^` or `~` prefix".]
+
+## Not Required
+
+- [WHAT_IS_EXPLICITLY_DEFERRED_TO_A_LATER_PHASE]
+- [WHAT_NEED_NOT_BE_TESTED_IN_THIS_PHASE]
+- [WHAT_IS_OUT_OF_SCOPE_FOR_VALIDATION]

--- a/specs/2026-04-24-backend-unit-test-coverage/plan.md
+++ b/specs/2026-04-24-backend-unit-test-coverage/plan.md
@@ -1,0 +1,49 @@
+# Phase 2 Plan — Backend Unit Test Coverage (Vault, Auth, Policy, Broker)
+
+## Group 1 — Vault encryption tests
+
+1. Create `tests/test_vault.py`. Top-level imports only: `from src.vault import encrypt, decrypt, parse_route` plus `from cryptography.fernet import Fernet`.
+2. Add round-trip tests: generate a Fernet key, monkeypatch `JENTIC_VAULT_KEY`, assert `decrypt(encrypt(plaintext)) == plaintext` for several input shapes (ASCII, unicode, empty string, long blob); assert `encrypt(x) != x`.
+3. Add `InvalidToken` test: `decrypt("not-a-fernet-token")` raises `ValueError` whose message contains `"Failed to decrypt credential"` (pins the contract at `src/vault.py` `decrypt()`).
+4. Add wrong-key test: encrypt under key A, swap `JENTIC_VAULT_KEY` to key B, assert `decrypt(...)` raises `ValueError`. Locks the "vault-key-loss is terminal" invariant.
+5. Add `parse_route` tests covering the route shapes the module documents (simple path, path with variables, leading/trailing slash normalization).
+
+## Group 2 — Auth helper tests
+
+6. Create `tests/test_auth_middleware.py`. Top-level imports: `from src.auth import trusted_subnets, is_trusted_ip, default_allowed_ips, client_ip`.
+7. `trusted_subnets()` append-semantics tests: with `JENTIC_TRUSTED_SUBNETS` unset, the returned set equals the default RFC-1918 + loopback set (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8`, `::1/128`); with extras set, the returned set is the union (order-independent, deduped); defaults are never removed regardless of what `JENTIC_TRUSTED_SUBNETS` contains.
+8. `is_trusted_ip()` tests: loopback IPv4, loopback IPv6, each RFC-1918 range, a public IPv4, a public IPv6; with and without extras env var.
+9. `default_allowed_ips()` returns a JSON-encoded list matching `trusted_subnets()` at call time (per-call read, not import-time).
+10. Middleware IP-rejection test via the existing `client` + `agent_key_header` fixtures: issue a key with `allowed_ips = ["203.0.113.0/24"]`, call any authed endpoint from the default test IP, assert HTTP 403.
+11. Revoked-key test: issue a key, revoke it, call an authed endpoint with that key, assert HTTP 401 (covers the `ck.revoked_at IS NULL` filter in `APIKeyMiddleware.dispatch`).
+
+## Group 3 — Broker credential injection tests
+
+12. Create `tests/test_broker_injection.py`. Reuse the simulate-mode pattern from `tests/test_credential_injection.py` — set `X-Jentic-Simulate: true` to short-circuit the broker before any upstream HTTP call.
+13. Seed a toolkit + credential for each scheme shape using the existing conftest factories (as `test_credential_injection.py` does): bearer, apiKey-in-header, basic, and compound (Secret + Identity, multi-header).
+14. For each scheme, issue a simulated broker request and assert the simulated echo response reports the injected headers exactly — including the `Authorization: Basic <base64(user:pass)>` shape for basic auth.
+15. Query-param apiKey: seed a credential whose scheme declares `in: query`, issue a simulated request, assert the broker logs/returns the unsupported-query-param warning (pins the behavior at the injection helper's unsupported branch).
+16. `auth_type` fallback test: seed a credential with no explicit scheme blob and `auth_type = 'basic'`, assert the broker still produces the base64 Basic header via the fallback path (pins the fallback branch).
+
+## Group 4 — Policy engine tests (extend existing)
+
+17. Extend `tests/test_policy_engine.py` — do not create a new file; it already uses the module-level unit-test shape (`from src.routers.toolkits import check_policy`, plain pytest classes).
+18. Add engine-level default-action cases: with `agent_rules = []` and *no* `SYSTEM_SAFETY_RULES` appended, `check_policy(..., "GET", "/x")` returns `(True, "Default action: allow")`. Locks the literal default in `check_policy`.
+19. Add effective-default cases using `SYSTEM_SAFETY_RULES` appended: writes on arbitrary paths denied; sensitive regex paths (`admin|pay|billing|webhook|secret|token`) denied for any method; non-sensitive reads allowed.
+20. Add `operations` regex-list matching cases: a rule whose `operations` list contains multiple regexes is first-match-wins across the list; a non-matching regex falls through to the next rule.
+21. Add invalid-regex fallback case: a rule with a malformed regex does not crash policy evaluation; it is skipped and evaluation continues (pins the invalid-regex guard).
+
+## Group 5 — BM25 ranking tests
+
+22. Create `tests/test_bm25.py`. Top-level imports: `from src.bm25 import build, search`.
+23. Build a hand-crafted fixture: ~6 operation dicts and ~2 workflow dicts. Operations use the `METHOD/host/path` capability-ID shape with the required fields (`summary`, `description`, `path`, `method`, `_vendor`); workflows use `name`, `involved_apis`.
+24. Assertions: exact-match query against an operation summary returns that operation first; synonym/partial query returns relevant docs with `score > 0`; irrelevant query returns `[]` (the `score > 0` filter excludes zero-score results); workflows and operations both appear in mixed-result queries.
+25. Determinism test: `build(ops)` then two `search(q)` calls return identical result ordering.
+
+## Group 6 — Verify
+
+26. `pdm run test tests/test_vault.py tests/test_auth_middleware.py tests/test_broker_injection.py tests/test_policy_engine.py tests/test_bm25.py` exits 0.
+27. `pdm run test` exits 0 (full suite, zero regressions on existing integration/contract tests).
+28. `pdm run lint` exits 0. New files comply with top-level-imports-only (`PLC0415`) and no-private-cross-module-imports (`PLC2701`).
+29. `ci-backend.yml` is green on the PR (triggered by `tests/**` path filter).
+30. Audit new test files: no `httpx`, `requests`, `aiohttp`, or `urllib` call escapes simulate mode; no catalog manifest fetch; no Pipedream API call.

--- a/specs/2026-04-24-backend-unit-test-coverage/requirements.md
+++ b/specs/2026-04-24-backend-unit-test-coverage/requirements.md
@@ -1,0 +1,59 @@
+# Phase 2 Requirements — Backend Unit Test Coverage (Vault, Auth, Policy, Broker)
+
+## Scope
+
+Add module-level unit tests for the highest-risk backend modules — vault encryption, auth middleware helpers, broker credential injection, policy-engine evaluation, and BM25 ranking — alongside the existing integration/contract suite in `tests/`. Tests are additive: one new file per module (`tests/test_<module>.py`), plus an extension of the already-unit-shaped `tests/test_policy_engine.py`. No `src/` code changes; every target is exercised through its existing public surface.
+
+The phase closes an explicit early-access risk named in `specs/mission.md` (`## Current State`) and called out again in `specs/tech-stack.md` (`## Testing`): the backend has integration and contract tests but no module-level unit tests over the credential-handling, perimeter-auth, and access-control code paths that define the system's security posture.
+
+## Out of Scope
+
+- `src/` refactors — no helper promotions (e.g. `_ip_allowed` → `ip_allowed`), no extraction of the broker injection loop into `src/brokers/injection.py`, no relocation of `check_policy` out of `src/routers/toolkits.py`
+- OAuth broker credential paths through `src/brokers/pipedream.py` — the phase covers native bearer / apiKey / basic / multi-header schemes only
+- Coverage-percentage thresholds — `pytest-cov` is not configured, and wiring it is explicitly deferred
+- New integration tests — the existing integration/contract suite is the baseline this phase is *additive to*
+- Any UI / E2E / Playwright / docs changes
+
+## Decisions
+
+### Test-only, no src/ changes
+Every target is reached through its public surface: `encrypt`/`decrypt` in `src/vault.py`; `trusted_subnets`, `is_trusted_ip`, `default_allowed_ips`, `client_ip` in `src/auth.py`; `check_policy` in `src/routers/toolkits.py`; `build`/`search` in `src/bm25.py`; broker credential injection via the existing simulate-mode code path (`X-Jentic-Simulate: true`) that short-circuits before any aiohttp call. Private helpers (`_ip_allowed`, `_fernet`, `_find_credential_for_host`'s inline header loop) are tested indirectly through their public callers. Rationale: the phase is framed as test coverage; mixing test work with structural refactors increases review surface and fights the ruff `PLC2701` rule on private cross-module imports.
+
+### Flat file layout under `tests/`
+New files follow the existing flat naming convention (`tests/test_<module>.py`). No new subdirectory (`tests/unit/`), no separate light-weight conftest. New files skip the heavy session fixtures from `tests/conftest.py` (`client`, `admin_session`, `agent_key`, `agent_only_client`) and only use them where a TestClient-shaped test is unavoidable (the auth middleware IP/revoked-key cases, which must go through the full app lifespan to exercise middleware ordering).
+
+### Hand-built BM25 fixture
+Use a small in-test dict fixture (~6 operations, ~2 workflows) matching the `METHOD/host/path` capability-ID shape and the field contract declared in `src/bm25.py` (`summary`, `description`, `path`, `method`, `_vendor` for operations; `name`, `involved_apis` for workflows). Rejected alternative: snapshotting `data/catalog_manifest.json` — would bind tests to external catalog churn and defeat the "no network in CI" constraint.
+
+### Behavior-focused, invariant-per-test
+Every load-bearing invariant listed under *Constraints* below gets at least one direct assertion. Coverage is measured by the explicit invariant checklist, not a line-coverage percentage.
+
+### Policy engine tested in place
+`check_policy` lives in `src/routers/toolkits.py` today. `tests/test_policy_engine.py` already imports it directly and uses the correct unit-test shape (plain pytest classes, no fixtures) — the phase extends that file instead of creating a new one or moving the engine.
+
+## Constraints
+
+Load-bearing invariants from `specs/mission.md` and `specs/tech-stack.md` that this phase must preserve and — where relevant — witness with an assertion.
+
+- **Secrets never touch the agent** (mission.md `Core Invariants`) — Vault tests assert encrypt/decrypt round-trip, `InvalidToken` → `ValueError("Failed to decrypt credential")`, and wrong-key decryption failure. Credential loss is terminal (there is no recovery path), so pinning Fernet behavior is directly load-bearing.
+- **Trusted-subnet append semantics** (tech-stack.md `Constraints and Conventions`) — `trusted_subnets()` must always include the default RFC-1918 + loopback set and *append* `JENTIC_TRUSTED_SUBNETS` extras. Self-hosters rely on this perimeter; a silent replace would open unintended remote access.
+- **Two-actor authentication** (mission.md `Core Invariants`) — Agent keys are revocable and IP-restricted; a compromised agent key cannot self-escalate. Tests assert revoked keys (`revoked_at IS NULL` filter) and IP-allowlist enforcement.
+- **Policy engine default action** (tech-stack.md `Constraints and Conventions`) — First-match-wins; engine-level default is allow, but `SYSTEM_SAFETY_RULES` are appended by the runtime, making the effective default deny-writes-and-sensitive-paths. Tests pin both the engine-level default and the effective default so the semantics cannot drift silently.
+- **Capability ID format `METHOD/host/path`** (mission.md `Core Invariants`) — BM25 fixtures use this exact shape so the tests stay honest to the API contract that agents persist.
+- **`conftest.py` DB_PATH ordering** (tech-stack.md `Testing`) — New test files must not break the rule that `DB_PATH` is set in `tests/conftest.py` before any `src.*` import. New files add no import-time side effects; they rely on the existing conftest.
+- **Top-level imports only; no private cross-module imports** (tech-stack.md `Constraints and Conventions`) — Ruff `PLC0415` / `PLC2701`. Tests import only public symbols; private helpers are exercised through their public callers, not imported directly.
+- **CI passes without external network access** (phase body) — No outbound HTTP from new tests. Broker injection exclusively uses `X-Jentic-Simulate: true`; BM25 uses in-memory fixtures; vault and policy tests are pure.
+
+## Context
+
+This phase exists now because the backend is explicitly flagged as incomplete on module-level unit coverage — `specs/mission.md` lists "incomplete backend unit test coverage (integration and contract tests exist; module-level unit tests are a gap)" as a known early-access risk. For a credential-handling proxy whose whole value proposition is "secrets never touch the agent," the fact that the Fernet vault, the perimeter auth middleware, the broker's credential-injection dispatch, and the policy engine have no direct unit tests is a reliability and security concern in its own right.
+
+The phase also sits on the critical path to Phase 3 (TypeScript Arazzo Runner Migration), which explicitly depends on it: `specs/roadmap.md` notes "test coverage needed before a risky runtime swap." The invariants this phase locks down become regression fences for the runner swap — a workflow that routes every step through the broker must behave identically on the TS runner, and we need tests that catch divergence at the module level, not only at the HTTP boundary.
+
+Cross-references for reviewers: `docs/AUTH.md` (endpoint-level auth model), `docs/CREDENTIALS.md` (Fernet vault contract), `docs/ARCHITECTURE.md` (broker + injection flow), `.claude/rules/testing.md` (test organization and commands).
+
+## Stakeholder Notes
+
+- **Security-conscious teams** — Directly served. The phase tests the single-chokepoint credential injection and perimeter auth — exactly the surfaces this audience relies on. Trusted-subnet append semantics and revoked-key handling are the two tests they would write first.
+- **Self-hosters** — Directly served. Fernet vault integrity + trusted-subnet perimeter lock down the self-hosted threat model; a wrong-key decryption test makes the "losing the vault key means losing access" invariant enforceable, not just documented.
+- **Phase 3 implementers (TypeScript Arazzo Runner Migration)** — Served indirectly. Broker injection + policy evaluation become a testable contract before the Python → TypeScript runner swap, so a behavioral regression during that work surfaces as a failing module-level test rather than an integration flake.

--- a/specs/2026-04-24-backend-unit-test-coverage/validation.md
+++ b/specs/2026-04-24-backend-unit-test-coverage/validation.md
@@ -1,0 +1,71 @@
+# Phase 2 Validation — Backend Unit Test Coverage (Vault, Auth, Policy, Broker)
+
+## Definition of Done
+
+All of the following must be true before this branch is merged.
+
+### 1. Full backend suite passes
+
+```
+pdm run test
+```
+
+Exits 0. Output includes all new unit-test files (`test_vault.py`, `test_auth_middleware.py`, `test_broker_injection.py`, `test_bm25.py`) and the extended `test_policy_engine.py` alongside the pre-existing integration/contract suite. Zero regressions on the existing tests.
+
+### 2. New unit-test files run individually
+
+```
+pdm run test tests/test_vault.py tests/test_auth_middleware.py tests/test_broker_injection.py tests/test_policy_engine.py tests/test_bm25.py
+```
+
+Exits 0. Each new/extended file contributes at least one passing test per invariant listed in `requirements.md` *Constraints*.
+
+### 3. Lint passes
+
+```
+pdm run lint
+```
+
+Exits 0. New test files comply with top-level-imports-only (ruff `PLC0415`) and no-private-cross-module-imports (ruff `PLC2701`). No new per-file-ignores are added in `pyproject.toml`.
+
+### 4. CI backend workflow green
+
+`.github/workflows/ci-backend.yml` passes on the PR. Both jobs — `lint` and `backend-tests` — must be green. The workflow is triggered automatically by changes under `tests/**`.
+
+### 5. Each target module has a dedicated unit-test file
+
+The following files exist and collectively cover the invariants listed in `requirements.md`:
+
+- `tests/test_vault.py` — encrypt/decrypt round-trip; `InvalidToken` → `ValueError`; wrong-key decryption fails; `parse_route`
+- `tests/test_auth_middleware.py` — `trusted_subnets()` append semantics; `is_trusted_ip()`; revoked-key rejection (401); IP-allowlist enforcement (403)
+- `tests/test_broker_injection.py` — bearer; apiKey-in-header; basic; compound multi-header; unsupported query-param apiKey warning; `auth_type` fallback
+- `tests/test_policy_engine.py` (extended) — engine-level default; effective default with `SYSTEM_SAFETY_RULES`; `operations` regex-list matching; invalid-regex fallback
+- `tests/test_bm25.py` — exact-match ordering; partial-match `score > 0`; irrelevant-query empty result; mixed op + workflow results; determinism
+
+### 6. No outbound network access in new tests
+
+New test files contain no `httpx`, `requests`, `aiohttp`, or `urllib` call that escapes simulate mode. Broker-injection tests use `X-Jentic-Simulate: true` exclusively; no real upstream URL is contacted. The `_test_lifespan` skip set in `tests/conftest.py` (BM25 rebuild, self-registration, catalog refresh, OAuth broker loading) is unchanged — new tests do not re-enable any of those startup side-effects.
+
+### 7. No src/ changes on the branch
+
+```
+git diff --name-only main...HEAD -- src/
+```
+
+Returns empty. The phase is test-only; any `src/` diff is a scope violation per `requirements.md` *Decisions*.
+
+### 8. Human reviewer approval
+
+PR approved by a human reviewer. This repo has no `CODEOWNERS` or `CONTRIBUTING.md` review policy; the gate is a standard GitHub review approval on a green CI.
+
+## Not Required
+
+- No UI tests — phase is backend-only; `ci-ui.yml` stays path-filtered off.
+- No Playwright / E2E run.
+- No `schemathesis` CLI run — the contract surface exercised today is `tests/test_openapi_contract.py`, which runs as part of `pdm run test`.
+- No `ui/openapi.json` regeneration — no endpoint changes in this phase.
+- No Alembic migration gates — no schema changes.
+- No coverage-percentage threshold — `pytest-cov` is not configured and is explicitly out of scope for this phase.
+- No manual curl or browser smoke — CI is the signal.
+- No performance benchmarks.
+- No `src/` refactors — helper promotions, broker-injection extraction, and policy-engine relocation are all explicitly deferred.


### PR DESCRIPTION
## Summary

Spec scaffold for **Phase 2: Backend Unit Test Coverage (Vault, Auth, Policy, Broker)** from `specs/roadmap.md`.

This PR adds **spec files only** — no code changes. Implementation follows in a separate PR once this spec is approved.

### Scope

Add module-level unit tests for the highest-risk backend modules — vault encryption, auth middleware helpers, broker credential injection, policy-engine evaluation, and BM25 ranking — alongside the existing integration/contract suite in `tests/`. Tests are additive: one new file per module (`tests/test_<module>.py`), plus an extension of the already-unit-shaped `tests/test_policy_engine.py`. No `src/` code changes; every target is exercised through its existing public surface.

### Out of Scope

- `src/` refactors (no helper promotions, no broker-injection extraction, no policy-engine relocation)
- OAuth broker credential paths through `src/brokers/pipedream.py`
- Coverage-percentage thresholds (`pytest-cov` wiring deferred)
- New integration tests (additive only)
- UI / E2E / Playwright / docs changes

### Key decisions

- Test-only, no src/ changes — exercise existing public surfaces; private helpers reached via their public callers
- Flat file layout under `tests/` (no `tests/unit/` subdirectory, no sibling conftest)
- Hand-built BM25 fixture (not a snapshot of `data/catalog_manifest.json`)
- Behavior-focused, invariant-per-test (no line-coverage target)
- Policy engine tested in place (extends `tests/test_policy_engine.py`, no relocation)

## Files

- `specs/2026-04-24-backend-unit-test-coverage/requirements.md`
- `specs/2026-04-24-backend-unit-test-coverage/plan.md`
- `specs/2026-04-24-backend-unit-test-coverage/validation.md`

## Review guidance

Reviewers should verify:

- The phase goal is captured faithfully (see `specs/roadmap.md` Phase 2).
- Scope, constraints, and decisions match intent — in particular the test-only boundary and the decision to keep `check_policy` in place.
- The plan's five per-module task groups are appropriately granular and the Verify group has concrete commands with expected results.
- Validation gates are realistic — no coverage threshold, CI green + reviewer approval + no `src/` diff.

Refs: `specs/roadmap.md` Phase 2.