### PR TITLE
chore(ai): add /sdd-new-phase skill and seed phases 13-15

### DIFF
--- a/.claude/rules/sdd-constitution.md
+++ b/.claude/rules/sdd-constitution.md
@@ -17,4 +17,5 @@ Supporting infrastructure:
 - `.claude/templates/sdd/constitution/*.example.md` — structural templates for each constitution section
 - `.claude/prompts/create-constitution.md` — constitution generator prompt
 - `.claude/templates/sdd/feature-spec/*.example.md` — structural templates for each feature-spec file
+- `.claude/skills/sdd-new-phase/SKILL.md` — `/sdd-new-phase` skill that appends a new active phase to `specs/roadmap.md`
 - `.claude/skills/sdd-new-spec/SKILL.md` — `/sdd-new-spec` skill that scaffolds a feature spec from a roadmap phase 

--- a/.claude/skills/sdd-new-phase/SKILL.md
+++ b/.claude/skills/sdd-new-phase/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: sdd-new-phase
+description: Append a new active phase to specs/roadmap.md. Parses existing phases to compute the next stable phase number (gaps preserved per the lifecycle rule), grounds the proposal against specs/mission.md and specs/tech-stack.md, groups structured questions (goal, dependencies, priority) via AskUserQuestion, then collects a freeform bullet list for the phase body. Edits specs/roadmap.md in place and stops — committing, pushing, and opening a PR are left to the user. Does not create a feature spec; that is /sdd-new-spec's job.
+argument-hint: "[short title or one-sentence intent] (optional)"
+---
+
+# /sdd-new-phase — add a new active phase to the roadmap
+
+You are operating within a Spec-Driven Development (SDD) workflow. See `.claude/rules/sdd-constitution.md`.
+
+The **constitution** (mission / tech-stack / roadmap) already exists in `specs/`. This skill adds a fresh active phase — a shippable, independently reviewable, testable vertical slice of work — to `specs/roadmap.md` as a new `## Phase N — Title` block. It stops after writing the edit. Reviewing the diff, branching, committing, and opening a PR are user actions. Once the roadmap change is merged, `/sdd-new-spec <N>` materializes the phase into a feature spec.
+
+## Inputs
+
+Argument in `$ARGUMENTS` (optional):
+
+- empty → prompt the user for a one-sentence description of the phase
+- short title or one-sentence intent → used as the starting point for title + goal derivation
+
+## Hard constraints
+
+- **Roadmap-only — zero code changes, zero git actions.** This skill never modifies anything outside `specs/roadmap.md`. It does not run `git`, `gh`, or any commit / branch / push / PR commands. The user handles git themselves after reviewing the edit.
+- **Do not renumber existing phases.** Phase numbers are stable identifiers; gaps mark shipped phases (per the lifecycle rule in `specs/roadmap.md`). The new phase number is always `max(existing active phase numbers) + 1` — never `len(active phases) + 1`.
+- **Do not create a feature spec.** That is `/sdd-new-spec`'s job.
+- **Do not touch the `## Later Phases (Not Yet Planned)` section** or the trailing `<!-- Only include items here if they are clearly out of current scope. -->` comment. Active phases and the parking lot are distinct.
+- **Do not write to disk before AskUserQuestion completes.** The structured questions lock in decisions that shape the entry; writing early wastes the call.
+- **Ground the phase against `specs/mission.md` and `specs/tech-stack.md`.** If the proposal obviously conflicts with the constitution (outside mission scope, violates a tech-stack invariant), stop and surface the conflict before asking the user to lock decisions.
+- **`Depends on:` must reference real active phases.** If the user names a dependency, it must match a current `## Phase N — Title` in `specs/roadmap.md` (case-insensitive contains match is fine). Typos get corrected; invented names get rejected.
+
+## Phase 0 — Load context
+
+Load in parallel:
+
+- @specs/mission.md
+- @specs/tech-stack.md
+- @specs/roadmap.md
+- @.claude/rules/sdd-constitution.md
+
+No git state checks — this skill doesn't touch git.
+
+## Phase 1 — Parse roadmap, propose phase identity
+
+Parse `specs/roadmap.md` to extract:
+
+- Every **active phase** block (`## Phase N — Title`): number, title, goal, `Depends on:`, `Priority:`. Ignore the `## Later Phases (Not Yet Planned)` section.
+- **Next phase number**: `max(active phase numbers) + 1`. Do NOT use `len(active phases) + 1` — gaps mark shipped phases.
+
+If `$ARGUMENTS` is empty, prompt the user for a one-sentence description of what the phase delivers.
+
+**Duplicate-overlap check:** if the proposal obviously overlaps with an existing active phase (strong keyword overlap with a phase title or goal), surface the overlap to the user and ask whether to proceed anyway, merge into the existing phase, or cancel. Do not silently proceed past an apparent duplicate.
+
+**Constitution-conflict check:** reason briefly about whether the proposal fits within the project's mission scope and tech-stack invariants. If there is an obvious conflict (proposes a capability outside the mission; proposes a runtime dependency the tech-stack forbids; violates a load-bearing constraint like the broker-last router rule), surface it and pause. If there is no obvious conflict, proceed silently — do not pad the response with "nothing conflicts" noise.
+
+Derive a candidate **title** in Title Case (e.g. "Local Service Routing", not "local service routing" or "LOCAL SERVICE ROUTING"). Show it to the user alongside the proposed phase number and confirm (or let them override) before Phase 2.
+
+## Phase 2 — AskUserQuestion (MANDATORY, before any disk write)
+
+Issue a single `AskUserQuestion` call containing three grouped questions. Each question offers 3–5 concrete options plus a freeform "other" write-in.
+
+**Question 1 — Goal** (shapes the `**Goal:**` line):
+  - Prompt: "One-sentence goal for this phase — what does shipping it mean?"
+  - Options: 3–4 goal phrasings derived from the user's initial description, grounded against mission/tech-stack, plus "other (write your own)". Each option is a single sentence starting with an action verb (e.g. "Allow…", "Replace…", "Add…", "Reduce…").
+
+**Question 2 — Dependencies** (shapes the `**Depends on:**` line):
+  - Prompt: "Which existing active phase must ship before this one?"
+  - Options: "none (self-contained)", each active phase title from `specs/roadmap.md` as a separate option, and "other (multiple — specify comma-separated)". If the user picks "other", validate the comma-separated names against active phase titles (case-insensitive contains match). Reject inventions with a one-line correction prompt.
+
+**Question 3 — Priority** (shapes the `**Priority:**` line):
+  - Prompt: "What priority level does this phase carry?"
+  - Options: `High`, `Medium–High`, `Medium`, plus "other (write your own)". Use the en-dash (`–`, U+2013) in `Medium–High`, not a hyphen — match existing roadmap formatting exactly.
+
+Only after the user answers all three do you proceed.
+
+## Phase 3 — Collect freeform phase body
+
+Ask the user a single freeform question:
+
+> Now describe the phase body — the concrete bullets that define "shippable". Each bullet should be one change (file, module, route, migration, test, doc, etc.). Freeform; I'll format them.
+
+Parse their response into bullets (one per line, `- ` prefix). Do not invent bullets; keep only what the user wrote. Light formatting is fine (normalize leading dashes, capitalization, trailing punctuation); content changes are not.
+
+If the response is fewer than three bullets, ask once: "A phase usually lists at least three concrete tasks — anything to add, or is this intentionally small?" Accept a short phase if the user confirms.
+
+If the user clearly typed a paragraph of prose rather than bullets, split it into a short **context paragraph** (kept as-is before the bullet list) and ask them for the concrete bullets. A phase may have both a context paragraph and a bullet list — see any active phase in `specs/roadmap.md` with prose between the `**Priority:**` line and the bullets for the shape.
+
+## Phase 4 — Edit the roadmap
+
+Edit `specs/roadmap.md` to insert the new phase. **Insertion rules:**
+
+- Active phase blocks are separated from the `## Later Phases (Not Yet Planned)` section by a `---` horizontal rule.
+- Insert the new block **immediately before the `---` that precedes `## Later Phases`** — after the last existing active phase.
+- Separate the new block from the previous active phase with a single blank line; match the existing file's spacing.
+- Do not renumber any existing phase.
+- Do not edit the `## Later Phases (Not Yet Planned)` section or the trailing HTML comment.
+
+**Block format** — match existing phases exactly:
+
+```
+## Phase <N> — <Title>
+
+**Goal:** <goal sentence ending with a period>.
+**Depends on:** <none (self-contained) | comma-separated phase titles, optional parenthetical rationale>
+**Priority:** <priority, optional parenthetical rationale>
+
+<optional 1–3 sentence context paragraph — include only if the user provided prose alongside bullets>
+
+- <bullet 1>
+- <bullet 2>
+- <bullet 3>
+```
+
+If `Depends on:` is `none`, follow an existing example like `none (self-contained broker change)` when the user provided a one-line reason; bare `none` is also fine. Do not invent a rationale.
+
+## Phase 5 — Report back
+
+Return to the user in a few lines:
+
+- Phase number and title that were added
+- File edited: `specs/roadmap.md`
+- Next steps (user-driven — this skill does not do them):
+  1. Review the diff (`git diff specs/roadmap.md`).
+  2. Branch + commit + PR per `.claude/rules/git-workflow.md` and `.claude/rules/conventional-commits.md` (suggested header: `docs(roadmap): add phase <N> — <short-slug>`).
+  3. Once merged, run `/sdd-new-spec <N>` to materialize the phase into a feature spec.

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -16,6 +16,10 @@ testable slice of work**. Phases are ordered by priority and dependency. Each ph
 vertical slice: it touches whatever layers are needed (backend, frontend, tests) to deliver a
 complete, observable capability.
 
+**Adding a phase:** run `/sdd-new-phase` in Claude Code to append a new active phase to this file
+via a review PR. The skill edits only `specs/roadmap.md`; once the PR is merged, materialize the
+phase with `/sdd-new-spec <N>`.
+
 **Starting a phase:** run `/sdd-new-spec <N>` in Claude Code to scaffold a feature-spec directory
 (`requirements.md`, `plan.md`, `validation.md`) and open it as a review PR. The skill touches only
 the spec files; implementation follows in a separate PR once the spec is approved.
@@ -176,6 +180,50 @@ Variables provide the native mechanism for this.
 - Add `GET /toolkits/{id}/summary` returning: which APIs are credentialed, what policy allows, which workflows are accessible, toolkit simulate mode status
 - Response must be LLM-consumable (compact, structured prose, no paginated sub-queries required)
 - Add unit tests verifying summary content against known toolkit/credential/policy fixtures
+
+## Phase 13 — Docs Accuracy Pass
+
+**Goal:** Align the twelve in-scope top-level `docs/` files with current codebase reality by removing stale content and verifying every factual claim against the code.
+**Depends on:** none (self-contained docs sweep)
+**Priority:** High (docs drift actively misleads users and agents; release-quality requirement)
+
+Scope covers these twelve top-level files only (subdirs `archive/`, `deploy/`, `tutorials/` are out of scope): `BROKER-CLI.md`, `CATALOG.md`, `credential-deeplink.md`, `CREDENTIALS.md`, `DECISIONS.md`, `oauth-broker.md`, `PIPEDREAM.md`, `README.md`, `SELF-REGISTRATION.md`, `server-variables.md`, `versioning.md`, `WORKFLOWS.md`. `ARCHITECTURE.md` and `AUTH.md` are explicitly excluded — already verified against current code.
+
+- Audit each of the twelve files against `src/` and correct stale endpoint paths, env var names, file paths, flag names, and flow descriptions
+- Remove references to retired features, deprecated schema shapes, and superseded flows; move wholly-superseded files to `docs/archive/` rather than editing them in place
+- Reconcile overlapping sections (credential injection, capability ID format, broker routing, two-actor auth) so the same claim reads identically wherever it appears
+- Refresh code snippets, curl examples, and sample payloads so they run against the current API surface
+- Verify internal cross-links between docs and to `CLAUDE.md` / `AGENTS.md` resolve to current targets; fix broken anchors
+- Update `docs/README.md` index to match the remaining file set (post-archive moves) with one-line summaries
+
+## Phase 14 — Resolve Open Security Advisories (Code Scanning)
+
+**Goal:** Resolve every open CodeQL / code-scanning advisory in the repo by fixing the root cause in code or image.
+**Depends on:** none (self-contained)
+**Priority:** High (security findings are release-quality concerns)
+
+Baseline (as of this phase entry): four open High-severity advisories at <https://github.com/jentic/jentic-mini/security/code-scanning> — one real code finding and three transitive dependency CVEs in the Docker image's Python install.
+
+- Investigate `py/path-injection` at `src/routers/catalog.py:319` — an existing `arazzo_file.relative_to(workflows_root)` guard (line 314) already enforces containment; determine whether the finding is a real escape or a pattern CodeQL can't prove effective, and either strengthen the guard (e.g. validate the untrusted input earlier, or use `os.path.commonpath`) or suppress it with a code comment + CodeQL annotation explaining why
+- Resolve `wheel` `CVE-2026-24049` (both top-level and the copy vendored inside `setuptools`) in the Docker image by bumping the Python base image or pinning a patched `wheel` version
+- Resolve `jaraco.context` `CVE-2026-23949` in the vendored `setuptools` copy by bumping `setuptools` to a version that vendors a patched release
+- Add regression tests for the path-injection fix (attempt to traverse outside the allowed root; expect rejection)
+- Re-run CodeQL and the Docker image scan after fixes; confirm the Security tab shows zero open High/Critical advisories
+
+## Phase 15 — Python Type Checking with Pyright
+
+**Goal:** Introduce proper Python type annotations across the backend and guard them with pyright.
+**Depends on:** none (self-contained)
+**Priority:** High
+
+Python code in `src/` has no static type checking today — type regressions only surface at runtime. Pyright will act as an additional quality guardrail for the agent alongside ruff and pytest, enforcing type annotations across the backend.
+
+- Add `pyright` to `[tool.pdm.dev-dependencies]` in `pyproject.toml` and create `pyrightconfig.json` at the repo root with `include: ["src"]`, `pythonVersion: "3.11"`, and `typeCheckingMode: "basic"` as the starting bar (ratchet to `standard`/`strict` later if helpful)
+- Add `typecheck = "pyright"` to `[tool.pdm.scripts]` so `pdm run typecheck` is the single invocation used locally, in the Claude hook, and in CI
+- Annotate all modules under `src/` until `pdm run typecheck` exits clean — cover function signatures, class attributes, and Pydantic model fields where inferred types are insufficient; handle dependencies without stubs (e.g. `arazzo-runner`, `rank-bm25`) via targeted `ignore` config rather than blanket `# type: ignore`
+- Add a `PostToolUse` hook in `.claude/settings.json` that runs `pdm run typecheck` on `Edit`/`Write`/`MultiEdit` matches under `src/**/*.py`, so agent-introduced type errors surface at edit time instead of PR time
+- Add a typecheck step to `.github/workflows/ci-backend.yml` alongside the existing lint/test steps so any pyright error fails the backend job
+- Update `specs/tech-stack.md`: rewrite the Python type-checking entry under the formatting/linting section (currently says Python has no static type checking) to reflect pyright adoption, and remove the "No mypy or pyright" bullet under "What We Are Not Using"
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `/sdd-new-phase`, a Claude Code skill that scaffolds a new active phase in `specs/roadmap.md`. Companion to `/sdd-new-spec` at the roadmap layer — where phases are proposed, not yet committed to implementation.

The skill:
- Parses `specs/roadmap.md` to compute the next stable phase number (`max(existing) + 1`; gaps preserved per the lifecycle rule — never renumbers).
- Grounds the proposal against `specs/mission.md` and `specs/tech-stack.md`; surfaces duplicate-overlap and constitution-conflict signals before locking decisions.
- Uses `AskUserQuestion` for goal / dependencies / priority (each with a freeform \"other\" write-in).
- Collects a freeform bullet list for the phase body.
- Writes to `specs/roadmap.md` and stops — committing, branching, and opening a PR are user actions.

Wires discovery into two places: a bullet in `.claude/rules/sdd-constitution.md`'s \"Supporting infrastructure\" list, and an \"Adding a phase\" operational note above the existing \"Starting a phase\" line in `specs/roadmap.md`.

## Seed phases

Three phases produced by the skill in a separate session. All self-contained, priority High:

- **Phase 13 — Docs Accuracy Pass**: sweep twelve top-level `docs/` files for drift against code (`ARCHITECTURE.md` and `AUTH.md` explicitly excluded — already verified).
- **Phase 14 — Resolve Open Security Advisories (Code Scanning)**: close four open High-severity CodeQL advisories (one code finding, three transitive dependency CVEs).
- **Phase 15 — Python Type Checking with Pyright**: introduce pyright as a backend type-check guardrail.

## Files

- `.claude/skills/sdd-new-phase/SKILL.md` (new)
- `.claude/rules/sdd-constitution.md` (+1 bullet in Supporting infrastructure list)
- `specs/roadmap.md` (+ \"Adding a phase\" operational note; + phases 13, 14, 15)

## Test plan

- [x] Phase numbering: 13, 14, 15 are the next three unused numbers after existing Phase 12.
- [x] No existing phase was renumbered.
- [x] \`## Later Phases (Not Yet Planned)\` section and trailing HTML comment are untouched.
- [x] Each new phase follows the existing \`## Phase N — Title\` + Goal / Depends on / Priority + optional context paragraph + bullets format.
- [x] Skill frontmatter valid; hard constraints non-contradictory; phase order sound.