### PR TITLE
fix: use default_external_user_id from config in discover_accounts on broker creation (#158)

### DIFF
--- a/src/routers/oauth_brokers.py
+++ b/src/routers/oauth_brokers.py
@@ -132,7 +132,8 @@ class OAuthBrokerCreate(NormModel):
             "For `pipedream`: `client_id`, `client_secret`, `project_id` "
             "(all from Pipedream workspace → API settings → OAuth clients). "
             "Optional: `environment` (`production` or `development`, default `production`), "
-            "`support_email`."
+            "`support_email`, "
+            "`default_external_user_id` (user identity for initial account sync, default `\"default\"`)."
         ),
         examples=[_PIPEDREAM_CONFIG_EXAMPLE],
     )
@@ -201,10 +202,10 @@ def _make_broker_id(broker_type: str, existing_ids: list[str]) -> str:
     return f"{base}-{n}"
 
 
-def _extract_pipedream_config(config: dict) -> tuple[str, str, str, str | None, str]:
+def _extract_pipedream_config(config: dict) -> tuple[str, str, str, str | None, str, str]:
     """Extract and validate Pipedream config fields.
 
-    Returns (client_id, client_secret, project_id, support_email, environment).
+    Returns (client_id, client_secret, project_id, support_email, environment, default_external_user_id).
     app_name and logo_url are set by the backend — not exposed in the API.
     """
     missing = [f for f in ("client_id", "client_secret", "project_id") if not config.get(f)]
@@ -301,7 +302,7 @@ async def create_oauth_broker(body: OAuthBrokerCreate):
 
     accounts_discovered = 0
     try:
-        accounts_discovered = await broker.discover_accounts("default")
+        accounts_discovered = await broker.discover_accounts(default_external_user_id)
     except Exception as exc:
         log.warning("Account sync failed for broker %s: %s", broker_id, exc)
 

--- a/src/routers/oauth_brokers.py
+++ b/src/routers/oauth_brokers.py
@@ -133,7 +133,7 @@ class OAuthBrokerCreate(NormModel):
             "(all from Pipedream workspace → API settings → OAuth clients). "
             "Optional: `environment` (`production` or `development`, default `production`), "
             "`support_email`, "
-            "`default_external_user_id` (user identity for initial account sync, default `\"default\"`)."
+            '`default_external_user_id` (user identity for initial account sync, default `"default"`).'
         ),
         examples=[_PIPEDREAM_CONFIG_EXAMPLE],
     )

--- a/tests/test_oauth_broker_default_user.py
+++ b/tests/test_oauth_broker_default_user.py
@@ -1,0 +1,100 @@
+"""OAuth broker default_external_user_id tests.
+
+Verifies that POST /oauth-brokers correctly persists and returns the
+default_external_user_id from config, and that the value is passed
+to discover_accounts on creation rather than being silently overridden
+with the hardcoded string "default".
+"""
+
+import pytest
+
+from src.brokers.pipedream import PipedreamOAuthBroker
+
+
+BROKER_CUSTOM_USER = "test-oauth-broker-custom-user"
+BROKER_DEFAULT_USER = "test-oauth-broker-default-user"
+
+_BASE_CONFIG = {
+    "client_id": "test-client-id",
+    "client_secret": "test-client-secret",
+    "project_id": "proj_test123",
+}
+
+
+@pytest.fixture(scope="module")
+def broker_with_custom_user(admin_client):
+    resp = admin_client.post(
+        "/oauth-brokers",
+        json={
+            "id": BROKER_CUSTOM_USER,
+            "type": "pipedream",
+            "config": {**_BASE_CONFIG, "default_external_user_id": "alice"},
+        },
+    )
+    assert resp.status_code in (200, 201), f"Create failed: {resp.text}"
+    yield BROKER_CUSTOM_USER
+    admin_client.delete(f"/oauth-brokers/{BROKER_CUSTOM_USER}")
+
+
+@pytest.fixture(scope="module")
+def broker_with_default_user(admin_client):
+    resp = admin_client.post(
+        "/oauth-brokers",
+        json={
+            "id": BROKER_DEFAULT_USER,
+            "type": "pipedream",
+            "config": _BASE_CONFIG,
+        },
+    )
+    assert resp.status_code in (200, 201), f"Create failed: {resp.text}"
+    yield BROKER_DEFAULT_USER
+    admin_client.delete(f"/oauth-brokers/{BROKER_DEFAULT_USER}")
+
+
+def test_custom_default_external_user_id_is_persisted(admin_client, broker_with_custom_user):
+    """default_external_user_id from config must be stored and returned, not overridden with 'default'."""
+    resp = admin_client.get(f"/oauth-brokers/{broker_with_custom_user}")
+    assert resp.status_code == 200, f"GET failed: {resp.text}"
+    data = resp.json()
+    assert data["config"]["default_external_user_id"] == "alice", (
+        f"Expected 'alice', got {data['config'].get('default_external_user_id')!r} -- "
+        "backend is overriding the provided value with 'default'"
+    )
+
+
+def test_omitted_default_external_user_id_falls_back_to_default(admin_client, broker_with_default_user):
+    """When default_external_user_id is omitted from config, it should fall back to 'default'."""
+    resp = admin_client.get(f"/oauth-brokers/{broker_with_default_user}")
+    assert resp.status_code == 200, f"GET failed: {resp.text}"
+    data = resp.json()
+    assert data["config"]["default_external_user_id"] == "default", (
+        f"Expected 'default' fallback, got {data['config'].get('default_external_user_id')!r}"
+    )
+
+
+def test_discover_accounts_called_with_configured_user_id(admin_client, monkeypatch):
+    """discover_accounts on create must receive the caller-supplied value, not 'default'."""
+    broker_id = "test-oauth-broker-discover-spy"
+    calls = []
+
+    async def spy(self, external_user_id: str) -> int:
+        calls.append(external_user_id)
+        return 0
+
+    monkeypatch.setattr(PipedreamOAuthBroker, "discover_accounts", spy)
+
+    resp = admin_client.post(
+        "/oauth-brokers",
+        json={
+            "id": broker_id,
+            "type": "pipedream",
+            "config": {**_BASE_CONFIG, "default_external_user_id": "alice"},
+        },
+    )
+    assert resp.status_code in (200, 201), f"Create failed: {resp.text}"
+    admin_client.delete(f"/oauth-brokers/{broker_id}")
+
+    assert calls == ["alice"], (
+        f"discover_accounts was called with {calls!r}; expected ['alice'] -- "
+        "the configured default_external_user_id is not being forwarded to the initial sync"
+    )

--- a/tests/test_oauth_broker_default_user.py
+++ b/tests/test_oauth_broker_default_user.py
@@ -7,7 +7,6 @@ with the hardcoded string "default".
 """
 
 import pytest
-
 from src.brokers.pipedream import PipedreamOAuthBroker
 
 
@@ -62,7 +61,9 @@ def test_custom_default_external_user_id_is_persisted(admin_client, broker_with_
     )
 
 
-def test_omitted_default_external_user_id_falls_back_to_default(admin_client, broker_with_default_user):
+def test_omitted_default_external_user_id_falls_back_to_default(
+    admin_client, broker_with_default_user
+):
     """When default_external_user_id is omitted from config, it should fall back to 'default'."""
     resp = admin_client.get(f"/oauth-brokers/{broker_with_default_user}")
     assert resp.status_code == 200, f"GET failed: {resp.text}"

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -5496,7 +5496,7 @@
 						"additionalProperties": true,
 						"type": "object",
 						"title": "Config",
-						"description": "Provider-specific configuration. For `pipedream`: `client_id`, `client_secret`, `project_id` (all from Pipedream workspace → API settings → OAuth clients). Optional: `environment` (`production` or `development`, default `production`), `support_email`.",
+						"description": "Provider-specific configuration. For `pipedream`: `client_id`, `client_secret`, `project_id` (all from Pipedream workspace → API settings → OAuth clients). Optional: `environment` (`production` or `development`, default `production`), `support_email`, `default_external_user_id` (user identity for initial account sync, default `\"default\"`).",
 						"examples": [
 							{
 								"client_id": "oa_abc123",


### PR DESCRIPTION
## Summary

- `POST /oauth-brokers` accepts `default_external_user_id` inside the `config` dict and persists it correctly — but the `broker.discover_accounts(...)` call immediately after creation always passed the hardcoded string `"default"`, ignoring the caller-supplied value.
- In multi-user deployments this means the initial account sync runs under the wrong user identity, returning 0 discovered accounts even when the custom user has connected apps in Pipedream.

## Changes

- **`src/routers/oauth_brokers.py`**
  - `create_oauth_broker`: pass `default_external_user_id` instead of `"default"` to `broker.discover_accounts(...)`.
  - `_extract_pipedream_config`: fix return type annotation (`tuple[str, str, str, str|None, str]` → `tuple[str, str, str, str|None, str, str]`) and update docstring to include `default_external_user_id`.
  - `OAuthBrokerCreate.config` field description: document `default_external_user_id` as an accepted optional key.
- **`ui/openapi.json`**: regenerated to match updated `OAuthBrokerCreate.config` description (required by `test_ui_openapi_matches_served_spec`).
- **`tests/test_oauth_broker_default_user.py`**: two new tests — one asserts a custom `default_external_user_id` is persisted and returned by `GET /oauth-brokers/{id}`; one asserts omitting it falls back to `"default"`.

## Test plan

- [x] `test_custom_default_external_user_id_is_persisted` — passes
- [x] `test_omitted_default_external_user_id_falls_back_to_default` — passes
- [x] `test_ui_openapi_matches_served_spec` — passes with updated `ui/openapi.json`
- [x] All existing broker lifecycle tests pass

Closes #158