### PR TITLE
fix(catalog): resolve phase 14 security advisories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY pyproject.toml pdm.lock ./
 # transitive CVEs in wheel and the setuptools-vendored copies of
 # wheel / jaraco.context reported by Trivy against the final image.
 RUN /root/.local/bin/pdm install --prod --no-editable --no-self --frozen-lockfile \
- && /app/.venv/bin/pip install --upgrade --no-cache-dir pip setuptools wheel
+ && /app/.venv/bin/python -m pip install --upgrade --no-cache-dir pip setuptools wheel
 
 # Stage 3: Runtime
 FROM python:3.11-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,13 @@ RUN curl -sSL https://pdm-project.org/install-pdm.py | python3 - --version 2.25.
 
 COPY pyproject.toml pdm.lock ./
 # Install locked project deps, then upgrade bootstrap tooling inside the venv.
+# PDM-managed venvs don't bundle pip, so bootstrap it with ensurepip first.
 # pip / setuptools / wheel are not in pdm.lock (bootstrap-only), so upgrading
 # them post-install does not conflict with the frozen lockfile. This clears
 # transitive CVEs in wheel and the setuptools-vendored copies of
 # wheel / jaraco.context reported by Trivy against the final image.
 RUN /root/.local/bin/pdm install --prod --no-editable --no-self --frozen-lockfile \
+ && /app/.venv/bin/python -m ensurepip --upgrade \
  && /app/.venv/bin/python -m pip install --upgrade --no-cache-dir pip setuptools wheel
 
 # Stage 3: Runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,12 @@ RUN curl -sSL https://pdm-project.org/install-pdm.py | python3 - --version 2.25.
 COPY pyproject.toml pdm.lock ./
 # Install locked project deps, then upgrade bootstrap tooling inside the venv.
 # PDM-managed venvs don't bundle pip, so bootstrap it with ensurepip first.
-# pip / setuptools / wheel are not in pdm.lock (bootstrap-only), so upgrading
-# them post-install does not conflict with the frozen lockfile. This clears
-# transitive CVEs in wheel and the setuptools-vendored copies of
-# wheel / jaraco.context reported by Trivy against the final image.
+# pip / setuptools / wheel are not in pdm.lock (bootstrap-only) and are not
+# imported at runtime — they only exist so the venv can install things. We
+# intentionally don't pin versions here: unpinned --upgrade is self-healing
+# against future CVEs and avoids manual-bump toil; Trivy gates regressions.
+# This clears transitive CVEs in wheel and the setuptools-vendored copies
+# of wheel / jaraco.context reported by Trivy against the final image.
 RUN /root/.local/bin/pdm install --prod --no-editable --no-self --frozen-lockfile \
  && /app/.venv/bin/python -m ensurepip --upgrade \
  && /app/.venv/bin/python -m pip install --upgrade --no-cache-dir pip setuptools wheel

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,13 @@ WORKDIR /app
 RUN curl -sSL https://pdm-project.org/install-pdm.py | python3 - --version 2.25.5
 
 COPY pyproject.toml pdm.lock ./
-RUN /root/.local/bin/pdm install --prod --no-editable --no-self --frozen-lockfile
+# Install locked project deps, then upgrade bootstrap tooling inside the venv.
+# pip / setuptools / wheel are not in pdm.lock (bootstrap-only), so upgrading
+# them post-install does not conflict with the frozen lockfile. This clears
+# transitive CVEs in wheel and the setuptools-vendored copies of
+# wheel / jaraco.context reported by Trivy against the final image.
+RUN /root/.local/bin/pdm install --prod --no-editable --no-self --frozen-lockfile \
+ && /app/.venv/bin/pip install --upgrade --no-cache-dir pip setuptools wheel
 
 # Stage 3: Runtime
 FROM python:3.11-slim

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -181,20 +181,6 @@ Variables provide the native mechanism for this.
 - Response must be LLM-consumable (compact, structured prose, no paginated sub-queries required)
 - Add unit tests verifying summary content against known toolkit/credential/policy fixtures
 
-## Phase 14 — Resolve Open Security Advisories (Code Scanning)
-
-**Goal:** Resolve every open CodeQL / code-scanning advisory in the repo by fixing the root cause in code or image.
-**Depends on:** none (self-contained)
-**Priority:** High (security findings are release-quality concerns)
-
-Baseline (as of this phase entry): four open High-severity advisories at <https://github.com/jentic/jentic-mini/security/code-scanning> — one real code finding and three transitive dependency CVEs in the Docker image's Python install.
-
-- Investigate `py/path-injection` at `src/routers/catalog.py:319` — an existing `arazzo_file.relative_to(workflows_root)` guard (line 314) already enforces containment; determine whether the finding is a real escape or a pattern CodeQL can't prove effective, and either strengthen the guard (e.g. validate the untrusted input earlier, or use `os.path.commonpath`) or suppress it with a code comment + CodeQL annotation explaining why
-- Resolve `wheel` `CVE-2026-24049` (both top-level and the copy vendored inside `setuptools`) in the Docker image by bumping the Python base image or pinning a patched `wheel` version
-- Resolve `jaraco.context` `CVE-2026-23949` in the vendored `setuptools` copy by bumping `setuptools` to a version that vendors a patched release
-- Add regression tests for the path-injection fix (attempt to traverse outside the allowed root; expect rejection)
-- Re-run CodeQL and the Docker image scan after fixes; confirm the Security tab shows zero open High/Critical advisories
-
 ## Phase 15 — Python Type Checking with Pyright
 
 **Goal:** Introduce proper Python type annotations across the backend and guard them with pyright.

--- a/src/routers/catalog.py
+++ b/src/routers/catalog.py
@@ -310,20 +310,13 @@ async def lazy_import_catalog_workflows(api_id: str) -> list[str]:
         # Save as a single-workflow arazzo file so execution always picks the right one
         single_doc = {**doc, "workflows": [wf]}
         arazzo_file = (WORKFLOWS_DIR / f"catalog_{safe_id}_{slug}.json").resolve()
-        # Path traversal is prevented by three layers:
-        #   1. safe_id is whitelist-sanitized to [a-z0-9_-] above.
-        #   2. slug is whitelist-sanitized to [a-z0-9-] above.
-        #   3. The resolve() + relative_to() guard below blocks any residual escape
-        #      (both sides are resolved, so `..` and symlinks are normalised first).
-        # CodeQL does not model Path.relative_to() as a sanitiser, so the
-        # py/path-injection alert on the open() below is a false positive.
         try:
             arazzo_file.relative_to(workflows_root)
         except ValueError:
             log.warning("Path traversal blocked for workflow '%s'", workflow_id)
             continue
         arazzo_path = str(arazzo_file)
-        with open(arazzo_path, "w") as f:  # codeql[py/path-injection]
+        with open(arazzo_path, "w") as f:
             json.dump(single_doc, f, indent=2)
 
         try:

--- a/src/routers/catalog.py
+++ b/src/routers/catalog.py
@@ -310,13 +310,20 @@ async def lazy_import_catalog_workflows(api_id: str) -> list[str]:
         # Save as a single-workflow arazzo file so execution always picks the right one
         single_doc = {**doc, "workflows": [wf]}
         arazzo_file = (WORKFLOWS_DIR / f"catalog_{safe_id}_{slug}.json").resolve()
+        # Path traversal is prevented by three layers:
+        #   1. safe_id is whitelist-sanitized to [a-z0-9_-] above.
+        #   2. slug is whitelist-sanitized to [a-z0-9-] above.
+        #   3. The resolve() + relative_to() guard below blocks any residual escape
+        #      (both sides are resolved, so `..` and symlinks are normalised first).
+        # CodeQL does not model Path.relative_to() as a sanitiser, so the
+        # py/path-injection alert on the open() below is a false positive.
         try:
             arazzo_file.relative_to(workflows_root)
         except ValueError:
             log.warning("Path traversal blocked for workflow '%s'", workflow_id)
             continue
         arazzo_path = str(arazzo_file)
-        with open(arazzo_path, "w") as f:
+        with open(arazzo_path, "w") as f:  # codeql[py/path-injection]
             json.dump(single_doc, f, indent=2)
 
         try:

--- a/tests/test_catalog_path_traversal.py
+++ b/tests/test_catalog_path_traversal.py
@@ -2,8 +2,8 @@
 
 Feeds `lazy_import_catalog_workflows` a crafted Arazzo document whose
 `workflowId` contains path-traversal sequences. Asserts that no file is
-written outside `WORKFLOWS_DIR` and the function returns no imported
-slugs for the malicious entries.
+written outside `WORKFLOWS_DIR` and the traversal branch actually runs
+(so the assertion is not a false negative from an early error).
 """
 
 import asyncio
@@ -20,26 +20,11 @@ from src.routers.catalog import WORKFLOW_MANIFEST_PATH, lazy_import_catalog_work
 API_ID = "api.traversal-test.example"
 
 
-class _FakeResponse(BytesIO):
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *exc):
-        return False
-
-
 def _fake_urlopen_factory(doc: dict):
     def _fake(*_args, **_kwargs):
-        return _FakeResponse(json.dumps(doc).encode())
+        return BytesIO(json.dumps(doc).encode())
 
     return _fake
-
-
-def _seed_workflow_manifest(tmp_entry: dict) -> None:
-    """Write a workflow manifest pointing at our synthetic source_id."""
-
-    WORKFLOW_MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
-    WORKFLOW_MANIFEST_PATH.write_text(json.dumps([tmp_entry]))
 
 
 async def _insert_api_row() -> None:
@@ -61,67 +46,94 @@ async def _cleanup_api_row() -> None:
 def test_malicious_workflow_id_cannot_escape_workflows_dir(client):
     """A traversal-laden workflowId must not create files outside WORKFLOWS_DIR.
 
-    The `client` fixture is requested to ensure the app lifespan has run and
-    the schema exists, even though we hit the function directly.
+    The `client` fixture ensures the app lifespan has run and the schema
+    exists, even though we hit the function directly.
     """
     WORKFLOWS_DIR.mkdir(parents=True, exist_ok=True)
     workflows_root = WORKFLOWS_DIR.resolve()
     before = set(workflows_root.rglob("*"))
 
-    # Seed the manifest entry this api_id will resolve to.
+    # Snapshot the workflow manifest so we can restore it — some earlier
+    # tests may have written entries we must not destroy.
+    prior_manifest = WORKFLOW_MANIFEST_PATH.read_text() if WORKFLOW_MANIFEST_PATH.exists() else None
+
     source_id = API_ID.replace("/", "~", 1)
-    _seed_workflow_manifest(
-        {"source_id": source_id, "path": f"workflows/{source_id}", "api_id": API_ID}
+    WORKFLOW_MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    WORKFLOW_MANIFEST_PATH.write_text(
+        json.dumps([{"source_id": source_id, "path": f"workflows/{source_id}", "api_id": API_ID}])
     )
 
+    # A benign workflowId alongside the malicious ones proves the traversal
+    # branch actually executes end-to-end (rather than erroring out early and
+    # silently passing the containment assertion).
     arazzo_doc = {
         "arazzo": "1.0.0",
         "info": {"title": "Traversal", "version": "1.0"},
         "sourceDescriptions": [{"name": "self", "url": "./openapi.json", "type": "openapi"}],
         "workflows": [
-            {
-                "workflowId": "../../../../etc/passwd",
-                "steps": [],
-            },
-            {
-                "workflowId": "..%2F..%2Fescaped",
-                "steps": [],
-            },
+            {"workflowId": "benign-canary", "steps": []},
+            {"workflowId": "../../../../etc/passwd", "steps": []},
+            {"workflowId": "..%2F..%2Fescaped", "steps": []},
         ],
     }
 
+    new_files: set = set()
+    slugs: list[str] = []
     try:
         asyncio.run(_insert_api_row())
         with patch("urllib.request.urlopen", _fake_urlopen_factory(arazzo_doc)):
             slugs = asyncio.run(lazy_import_catalog_workflows(API_ID))
+
+        after = set(workflows_root.rglob("*"))
+        new_files = after - before
+
+        # Sanity: the benign workflow must have produced at least one file,
+        # proving the code actually reached the open() sink.
+        assert len(new_files) >= 1, "expected at least the benign workflow to be written"
+
+        # Every new artefact must be contained inside WORKFLOWS_DIR.
+        for p in new_files:
+            resolved = p.resolve()
+            assert resolved.is_relative_to(workflows_root), (
+                f"Path escaped WORKFLOWS_DIR: {resolved} (root={workflows_root})"
+            )
+
+        # Filenames must match the sanitised pattern — no raw traversal tokens.
+        for p in new_files:
+            assert ".." not in p.name
+            assert "/" not in p.name
+            assert "\\" not in p.name
+
+        # The benign slug must be present (proves the code path ran). Any
+        # slugs derived from the malicious inputs must be fully sanitised —
+        # no traversal tokens surviving.
+        assert "benign-canary" in slugs, f"benign slug missing, got: {slugs}"
+        for s in slugs:
+            assert ".." not in s
+            assert "/" not in s
+            assert "\\" not in s
     finally:
+        # Restore (or remove) the manifest so other tests aren't affected.
+        if prior_manifest is None:
+            WORKFLOW_MANIFEST_PATH.unlink(missing_ok=True)
+        else:
+            WORKFLOW_MANIFEST_PATH.write_text(prior_manifest)
+
+        # Clean up anything written so repeated runs don't accumulate files
+        # or poison the shared workflow index.
+        for p in sorted(new_files, reverse=True):
+            if p.is_file():
+                p.unlink(missing_ok=True)
+            elif p.is_dir():
+                shutil.rmtree(p, ignore_errors=True)
+
         asyncio.run(_cleanup_api_row())
+        asyncio.run(_cleanup_workflow_rows(slugs))
 
-    after = set(workflows_root.rglob("*"))
-    new_files = after - before
 
-    # Every new artefact must be contained inside WORKFLOWS_DIR.
-    for p in new_files:
-        resolved = p.resolve()
-        assert resolved.is_relative_to(workflows_root), (
-            f"Path escaped WORKFLOWS_DIR: {resolved} (root={workflows_root})"
-        )
-
-    # Filenames must match the sanitised pattern — no raw traversal tokens.
-    for p in new_files:
-        assert ".." not in p.name
-        assert "/" not in p.name
-        assert "\\" not in p.name
-
-    # Cleanup: drop anything we created so we don't pollute the shared
-    # test DB workflow index on subsequent runs.
-    for p in sorted(new_files, reverse=True):
-        if p.is_file():
-            p.unlink(missing_ok=True)
-        elif p.is_dir():
-            shutil.rmtree(p, ignore_errors=True)
-
-    # Defence-in-depth — even if a slug came back, it must be whitelist-clean.
-    for s in slugs:
-        assert ".." not in s
-        assert "/" not in s
+async def _cleanup_workflow_rows(slugs: list[str]) -> None:
+    """Remove workflow rows we registered during the test."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        for s in slugs:
+            await db.execute("DELETE FROM workflows WHERE slug=?", (s,))
+        await db.commit()

--- a/tests/test_catalog_path_traversal.py
+++ b/tests/test_catalog_path_traversal.py
@@ -1,0 +1,127 @@
+"""Regression test for the py/path-injection finding at catalog.py.
+
+Feeds `lazy_import_catalog_workflows` a crafted Arazzo document whose
+`workflowId` contains path-traversal sequences. Asserts that no file is
+written outside `WORKFLOWS_DIR` and the function returns no imported
+slugs for the malicious entries.
+"""
+
+import asyncio
+import json
+import shutil
+from io import BytesIO
+from unittest.mock import patch
+
+import aiosqlite
+from src.config import DB_PATH, WORKFLOWS_DIR
+from src.routers.catalog import WORKFLOW_MANIFEST_PATH, lazy_import_catalog_workflows
+
+
+API_ID = "api.traversal-test.example"
+
+
+class _FakeResponse(BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _fake_urlopen_factory(doc: dict):
+    def _fake(*_args, **_kwargs):
+        return _FakeResponse(json.dumps(doc).encode())
+
+    return _fake
+
+
+def _seed_workflow_manifest(tmp_entry: dict) -> None:
+    """Write a workflow manifest pointing at our synthetic source_id."""
+
+    WORKFLOW_MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    WORKFLOW_MANIFEST_PATH.write_text(json.dumps([tmp_entry]))
+
+
+async def _insert_api_row() -> None:
+    """Insert a row in `apis` so sourceDescriptions rewriting branch runs."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT OR REPLACE INTO apis (id, name, spec_path) VALUES (?, ?, ?)",
+            (API_ID, "Traversal Test", "/tmp/fake-spec.json"),
+        )
+        await db.commit()
+
+
+async def _cleanup_api_row() -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("DELETE FROM apis WHERE id=?", (API_ID,))
+        await db.commit()
+
+
+def test_malicious_workflow_id_cannot_escape_workflows_dir(client):
+    """A traversal-laden workflowId must not create files outside WORKFLOWS_DIR.
+
+    The `client` fixture is requested to ensure the app lifespan has run and
+    the schema exists, even though we hit the function directly.
+    """
+    WORKFLOWS_DIR.mkdir(parents=True, exist_ok=True)
+    workflows_root = WORKFLOWS_DIR.resolve()
+    before = set(workflows_root.rglob("*"))
+
+    # Seed the manifest entry this api_id will resolve to.
+    source_id = API_ID.replace("/", "~", 1)
+    _seed_workflow_manifest(
+        {"source_id": source_id, "path": f"workflows/{source_id}", "api_id": API_ID}
+    )
+
+    arazzo_doc = {
+        "arazzo": "1.0.0",
+        "info": {"title": "Traversal", "version": "1.0"},
+        "sourceDescriptions": [{"name": "self", "url": "./openapi.json", "type": "openapi"}],
+        "workflows": [
+            {
+                "workflowId": "../../../../etc/passwd",
+                "steps": [],
+            },
+            {
+                "workflowId": "..%2F..%2Fescaped",
+                "steps": [],
+            },
+        ],
+    }
+
+    try:
+        asyncio.run(_insert_api_row())
+        with patch("urllib.request.urlopen", _fake_urlopen_factory(arazzo_doc)):
+            slugs = asyncio.run(lazy_import_catalog_workflows(API_ID))
+    finally:
+        asyncio.run(_cleanup_api_row())
+
+    after = set(workflows_root.rglob("*"))
+    new_files = after - before
+
+    # Every new artefact must be contained inside WORKFLOWS_DIR.
+    for p in new_files:
+        resolved = p.resolve()
+        assert resolved.is_relative_to(workflows_root), (
+            f"Path escaped WORKFLOWS_DIR: {resolved} (root={workflows_root})"
+        )
+
+    # Filenames must match the sanitised pattern — no raw traversal tokens.
+    for p in new_files:
+        assert ".." not in p.name
+        assert "/" not in p.name
+        assert "\\" not in p.name
+
+    # Cleanup: drop anything we created so we don't pollute the shared
+    # test DB workflow index on subsequent runs.
+    for p in sorted(new_files, reverse=True):
+        if p.is_file():
+            p.unlink(missing_ok=True)
+        elif p.is_dir():
+            shutil.rmtree(p, ignore_errors=True)
+
+    # Defence-in-depth — even if a slug came back, it must be whitelist-clean.
+    for s in slugs:
+        assert ".." not in s
+        assert "/" not in s


### PR DESCRIPTION
## Summary

Resolves all four open High-severity advisories from the Security tab per `specs/roadmap.md` Phase 14.

- **`py/path-injection`** at `src/routers/catalog.py` — determined to be a false positive. Traversal is already blocked by three independent layers (whitelist-sanitized `safe_id`, whitelist-sanitized `slug`, and a `resolve()` + `relative_to()` containment guard). CodeQL does not model `Path.relative_to()` as a sanitizer. Annotated the sink with `# codeql[py/path-injection]` and an inline comment explaining the defenses.
- **`wheel` `CVE-2026-24049`** (top-level + vendored inside setuptools) and **`jaraco.context` `CVE-2026-23949`** (vendored inside setuptools) — upgraded `pip`, `setuptools`, and `wheel` inside the final venv at Docker build time. Bootstrap tooling is not in `pdm.lock`, so the upgrade doesn't conflict with the frozen lockfile.

## Changes

- `src/routers/catalog.py` — inline sanitizer comment + `codeql[py/path-injection]` suppression on the `open()` sink
- `tests/test_catalog_path_traversal.py` — regression test: crafted Arazzo doc with traversal-laden `workflowId` must not produce any file outside `WORKFLOWS_DIR`
- `Dockerfile` — chain `pip install --upgrade pip setuptools wheel` to the `pdm install` step in the `py-deps` stage
- `specs/roadmap.md` — remove the shipped Phase 14 entry per the SDD lifecycle rule (numbers are stable; gaps preserved)

## Verification

- `pdm run lint` — clean
- `pdm run test tests` — 96/96 passing (including the new regression test)
- Post-merge: CodeQL and `docker-security.yml` workflows re-run against the new image; Security tab should show zero open High/Critical advisories

Refs: `specs/roadmap.md` Phase 14.