### PR TITLE
fix(Dockerfile): upgrade system-wide pip/setuptools/wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,13 @@ RUN /root/.local/bin/pdm install --prod --no-editable --no-self --frozen-lockfil
 # Stage 3: Runtime
 FROM python:3.11-slim
 
+# Upgrade the base image's system-wide pip / setuptools / wheel to clear
+# transitive CVEs Trivy reports against /usr/local/lib/python3.11/site-packages
+# (wheel CVE-2026-24049, setuptools-vendored jaraco.context CVE-2026-23949).
+# These are bootstrap-only, not imported by the app; unpinned --upgrade is
+# self-healing against future CVEs.
+RUN python -m pip install --upgrade --no-cache-dir pip setuptools wheel
+
 ARG APP_VERSION=0.9.0
 ENV APP_VERSION=${APP_VERSION}
 


### PR DESCRIPTION
## Summary

Follow-up to #310. Phase 14 upgraded bootstrap tooling inside the venv, but Trivy was actually flagging the base image's system-wide Python install at `/usr/local/lib/python3.11/site-packages/` — which the venv upgrade never touched.

The three still-open Trivy advisories all point at that system path:
- #611 — `wheel-0.45.1` CVE-2026-24049 (system-wide top-level)
- #610 — `wheel-0.45.1` CVE-2026-24049 (setuptools vendored)
- #607 — `jaraco.context-5.3.0` CVE-2026-23949 (setuptools vendored)

## Change

Add `python -m pip install --upgrade pip setuptools wheel` to the runtime stage so the final image has patched packages in both locations. Same unpinned-upgrade rationale as #310 — bootstrap-only, not imported at runtime, self-healing against future CVEs.

## Verification (local)

Before:
- `wheel-0.45.1`, `setuptools-79.0.1` (vendoring vulnerable `jaraco.context-5.3.0`)

After (`docker build` locally):
- `wheel-0.47.0`, `setuptools-82.0.1` (vendoring `jaraco.context-6.1.0` + `wheel-0.46.3`)

All three CVE-tagged versions are gone. Post-merge Trivy scan should show zero High/Critical.