### PR TITLE
chore(settings): enable skill-creator plugin repo-wide

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,5 +17,8 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "skill-creator@claude-plugins-official": true
   }
 }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,6 +59,16 @@ npm run dev
 
 The Vite dev server runs on `http://localhost:5173` and proxies API calls to the backend on port 8900.
 
+### 6. Claude Code plugins (optional)
+
+If you use Claude Code, this repo expects the `skill-creator` plugin (listed under `enabledPlugins` in `.claude/settings.json`). The marketplace is built-in, so one command installs it:
+
+```
+/plugin install skill-creator@claude-plugins-official
+```
+
+`enabledPlugins` only activates an already-installed plugin — it does not install it. Skip this step if you don't use Claude Code.
+
 ## Day-to-day Development
 
 - **Python changes**: `src/` is volume-mounted into the container. Uvicorn auto-reloads on any `.py` file change — no container restart needed.


### PR DESCRIPTION
## Summary
- Enables `skill-creator@claude-plugins-official` in the checked-in `.claude/settings.json` so it auto-activates once installed.
- Adds a setup step to `DEVELOPMENT.md` telling contributors how to install it (`/plugin install skill-creator@claude-plugins-official` — the marketplace is built-in to Claude Code).
- Note: `enabledPlugins` alone does nothing for contributors who haven't installed the plugin. The doc note is what closes that gap.
- Also fixes the missing trailing newline on `settings.json`.

## Test plan
- [x] Confirm team wants this as a shared convention vs. personal `settings.local.json`.