### PR TITLE
chore(ai): add copilot review auto-resolve rule

### DIFF
--- a/.claude/rules/copilot-review-comments.md
+++ b/.claude/rules/copilot-review-comments.md
@@ -1,0 +1,11 @@
+After pushing fixes for Copilot review comments, resolve the threads automatically — don't wait to be asked. Only resolve threads whose feedback the pushed commit actually addresses; skip the rest.
+
+Flow (via `gh api graphql`):
+
+1. Query `reviewThreads` on the PR.
+2. Filter to `isResolved=false` where the first comment's author is `copilot-pull-request-reviewer`.
+3. For each thread, decide whether the pushed commit addresses it. If not, skip.
+4. Reply with `addPullRequestReviewThreadReply` — `Addressed by <pushed-sha>`.
+5. Call `resolveReviewThread`.
+
+The reply is the audit trail, so the resolution isn't mistaken for a dismissal.


### PR DESCRIPTION
## Summary
- Adds `.claude/rules/copilot-review-comments.md` documenting the convention: after pushing fixes for Copilot review comments, reply with `Addressed by <sha>` and resolve the thread via GraphQL.
- Codifies the bot login (`copilot-pull-request-reviewer`) and the client-side `isResolved` filter, both verified against PRs #312 and #310.
- Flow requires a decision step on whether the pushed commit actually addresses each thread, so unaddressed feedback stays open.

## Test plan
- [ ] Docs-only change; no runtime impact.