### PR TITLE
ci(docker-publish): bump publish job timeout to 30 minutes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,7 @@ jobs:
   publish:
     needs: [ci-backend, ci]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

- The `publish` job has been hitting its 15-minute `timeout-minutes` limit on main — the most recent two pushes (#327, #292) were both killed mid-cleanup, even though the image had already been pushed successfully.
- Root cause: the multi-arch build (`linux/amd64` + `linux/arm64`) routinely takes 16–34 min because `arm64` runs under QEMU emulation on the `amd64` runner. Recent successful runs landed in the 16–27 min range; current 15-min cap is below that floor.
- Bump `timeout-minutes: 15 → 30` as a stopgap so main stops red-flagging.

The real fix (native arm64 runner + per-arch parallel jobs, which should bring publish back under 15 min) is tracked in #328.

## Test plan

- [x] Merge and confirm the next push to `main` lands a successful Publish run within the 30-min budget.
- [x] `:unstable` tag on `ghcr.io/jentic/jentic-mini` and `jentic/jentic-mini` updates to the merge SHA.