### PR TITLE
chore(harness): clarify chore vs feat for non-product changes

### DIFF
--- a/.claude/rules/conventional-commits.md
+++ b/.claude/rules/conventional-commits.md
@@ -3,10 +3,15 @@ Commit messages MUST follow Conventional Commits (https://www.conventionalcommit
 Format: `type(scope): description` — max 69 characters in the header.
 
 - Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `perf`, `build`, `ci`, `style`, `revert`
-- `feat` / `fix` apply only to changes an end user sees. Developer tooling (agent harness configs, editor configs, dev scripts, dependency bumps) uses `chore`. Litmus test: does an end user of Jentic Mini see this change? If no, it's `chore`.
+- If a change ships to users, it's `feat` (new capability) or `fix`
+  (bug). Internal developer tooling (agent harness configs, editor
+  configs, dev scripts, dependency bumps) uses `chore`. The other
+  types (`refactor`, `test`, `docs`, `perf`, `build`, `ci`, `style`,
+  `revert`) take precedence over `chore` when they fit.
 - Scope: always include a scope. Use the primary subject of the change:
   - For `docs`: the doc file name without extension (e.g. `docs(DEVELOPMENT)`, `docs(README)`, `docs(TESTING)`)
   - For `ci`: the workflow/config file name without extension (e.g. `ci(ci-backend)`, `ci(docker-publish)`, `ci(release)`). When the change IS the CI config, use type `ci` — not `chore(ci)`.
   - For code: the module, router, or component name (e.g. `fix(broker)`, `feat(search)`, `refactor(ui)`)
-  - For `chore`: prefer harness-agnostic scopes — `chore(harness)` covers anything under `.claude/`, `.cursor/`, `.codex/`, etc.
+  - For `chore`: prefer harness-agnostic scopes — `chore(harness)`
+    covers anything under `.claude/`, `.cursor/`, `.codex/`, etc.
 - Description: lowercase, imperative mood, no trailing period

--- a/.claude/rules/conventional-commits.md
+++ b/.claude/rules/conventional-commits.md
@@ -3,16 +3,10 @@ Commit messages MUST follow Conventional Commits (https://www.conventionalcommit
 Format: `type(scope): description` — max 69 characters in the header.
 
 - Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `perf`, `build`, `ci`, `style`, `revert`
-- `feat` / `fix` apply only to the **product** — code under `src/`, `ui/`, `alembic/`, or anything that ships to users. Tooling around the product (developer ergonomics, IDE/editor configs, agent harness configs, lint/format setup, scripts) uses `chore`. Examples:
-  - Adding or changing anything under `.claude/`, `.cursor/`, `.codex/`, or any agent harness config → `chore(harness)`. Not `feat`.
-  - Adding a pre-commit config or husky hook → `chore(hooks)`.
-  - Updating editor configs (`.editorconfig`, `.vscode/`) → `chore(editor)`.
-  - Adding a developer script under `scripts/` that no end user runs → `chore(scripts)`.
-  - Bumping a dependency → `chore(deps)`.
-  - The litmus test: does an end user of Jentic Mini see this change? If no, it's `chore`.
+- `feat` / `fix` apply only to changes an end user sees. Developer tooling (agent harness configs, editor configs, dev scripts, dependency bumps) uses `chore`. Litmus test: does an end user of Jentic Mini see this change? If no, it's `chore`.
 - Scope: always include a scope. Use the primary subject of the change:
   - For `docs`: the doc file name without extension (e.g. `docs(DEVELOPMENT)`, `docs(README)`, `docs(TESTING)`)
   - For `ci`: the workflow/config file name without extension (e.g. `ci(ci-backend)`, `ci(docker-publish)`, `ci(release)`). When the change IS the CI config, use type `ci` — not `chore(ci)`.
   - For code: the module, router, or component name (e.g. `fix(broker)`, `feat(search)`, `refactor(ui)`)
-  - For `chore`: the subsystem, harness-agnostic where possible (`harness`, `hooks`, `editor`, `scripts`, `deps`).
+  - For `chore`: prefer harness-agnostic scopes — `chore(harness)` covers anything under `.claude/`, `.cursor/`, `.codex/`, etc.
 - Description: lowercase, imperative mood, no trailing period

--- a/.claude/rules/conventional-commits.md
+++ b/.claude/rules/conventional-commits.md
@@ -3,8 +3,16 @@ Commit messages MUST follow Conventional Commits (https://www.conventionalcommit
 Format: `type(scope): description` — max 69 characters in the header.
 
 - Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `perf`, `build`, `ci`, `style`, `revert`
+- `feat` / `fix` apply only to the **product** — code under `src/`, `ui/`, `alembic/`, or anything that ships to users. Tooling around the product (developer ergonomics, IDE/editor configs, agent harness configs, lint/format setup, scripts) uses `chore`. Examples:
+  - Adding or changing anything under `.claude/`, `.cursor/`, `.codex/`, or any agent harness config → `chore(harness)`. Not `feat`.
+  - Adding a pre-commit config or husky hook → `chore(hooks)`.
+  - Updating editor configs (`.editorconfig`, `.vscode/`) → `chore(editor)`.
+  - Adding a developer script under `scripts/` that no end user runs → `chore(scripts)`.
+  - Bumping a dependency → `chore(deps)`.
+  - The litmus test: does an end user of Jentic Mini see this change? If no, it's `chore`.
 - Scope: always include a scope. Use the primary subject of the change:
   - For `docs`: the doc file name without extension (e.g. `docs(DEVELOPMENT)`, `docs(README)`, `docs(TESTING)`)
   - For `ci`: the workflow/config file name without extension (e.g. `ci(ci-backend)`, `ci(docker-publish)`, `ci(release)`). When the change IS the CI config, use type `ci` — not `chore(ci)`.
   - For code: the module, router, or component name (e.g. `fix(broker)`, `feat(search)`, `refactor(ui)`)
+  - For `chore`: the subsystem, harness-agnostic where possible (`harness`, `hooks`, `editor`, `scripts`, `deps`).
 - Description: lowercase, imperative mood, no trailing period


### PR DESCRIPTION
## Summary

- Adds a single bullet to `.claude/rules/conventional-commits.md` disambiguating `feat`/`fix` from `chore` for changes that don't ship to end users (agent harness configs, editor configs, dev scripts, dependency bumps).
- Notes that the other Conventional Commits types (`refactor`, `test`, `docs`, `perf`, `build`, `ci`, `style`, `revert`) take precedence over `chore` when they fit.
- Adds one scope hint: `chore(harness)` as the harness-agnostic scope for anything under `.claude/`, `.cursor/`, `.codex/`, etc.

## Motivation

Agent-driven workflows have repeatedly classified harness configuration additions as `feat`, which inflates the changelog with changes no end user sees. The rule previously gave examples for `docs`, `ci`, and code scopes but didn't address the `feat` vs `chore` distinction for non-product tooling.

## Test plan

- [x] The next harness-related PR uses `chore(harness):` (e.g. adding a Claude Code skill, Cursor rule, Codex setting)
- [x] Dependency bumps continue to use `chore(deps):`
- [x] CI config changes continue to use `ci(<workflow>):` per the existing rule (unchanged)
- [x] Test-only changes continue to use `test(...):`, not `chore`