### PR TITLE
chore(gitignore): ignore .pdm-python interpreter marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ node_modules
 *.db
 .hypothesis/
 __pypackages__/
+.pdm-python


### PR DESCRIPTION
## Summary
- Add `.pdm-python` to `.gitignore`. PDM writes an absolute path to the project's chosen Python interpreter into this file on every `pdm install` / `pdm use`, so it's machine-specific and shouldn't be tracked.

## Test plan
- [x] `git status` no longer reports `.pdm-python` as untracked