### PR TITLE
fix(deps): bump python-multipart to 0.0.27 and mako to 1.3.12

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:adc35beb5113ccdd1a93390754962df987f4c8d8ab2417beaecb2ba3cdc5710e"
+content_hash = "sha256:f65eac92fe21c5138f2f688201dc3956426c82b2d8a7562f1369fa98ff60dfa4"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
@@ -1062,7 +1062,7 @@ files = [
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 requires_python = ">=3.8"
 summary = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 groups = ["default"]
@@ -1070,8 +1070,8 @@ dependencies = [
     "MarkupSafe>=0.9.2",
 ]
 files = [
-    {file = "mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77"},
-    {file = "mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069"},
+    {file = "mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9"},
+    {file = "mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a"},
 ]
 
 [[package]]
@@ -1740,13 +1740,13 @@ files = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 requires_python = ">=3.10"
 summary = "A streaming multipart parser for Python"
 groups = ["default"]
 files = [
-    {file = "python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185"},
-    {file = "python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17"},
+    {file = "python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645"},
+    {file = "python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "aiosqlite==0.22.1",
   "bcrypt==5.0.0",
   "python-jose[cryptography]==3.5.0",
-  "python-multipart>=0.0.26",
+  "python-multipart>=0.0.27",
   "alembic>=1.18.4,<2",
   "jentic-openapi-common>=1.0.0a51",
   "arazzo-runner>=0.9.5",


### PR DESCRIPTION
## Summary

Address two open code-scanning advisories on the runtime container.

| Alert | Package | Bump | Notes |
|---|---|---|---|
| [#661 CVE-2026-42561](https://github.com/jentic/jentic-mini/security/code-scanning/661) | `python-multipart` (direct dep) | 0.0.26 → 0.0.27 | DoS via unbounded multipart part headers — exercised on FastAPI's form-parsing path. Real fix. |
| [#660 CVE-2026-44307](https://github.com/jentic/jentic-mini/security/code-scanning/660) | `Mako` (transitive via `alembic`) | 1.3.11 → 1.3.12 | Path traversal **on Windows only** in `TemplateLookup`. We run Linux containers and don't pass user input to `TemplateLookup`, so practical exposure is zero — bumped for a clean Trivy scan. |

Pin update on `python-multipart`; Mako moves transitively via `pdm update`.

## Test plan

- [x] `pdm install` — both packages updated cleanly
- [x] `pdm run test` — 101/101 passed
- [x] CI green
- [x] Trivy scan on rebuilt image clears both alerts