### PR TITLE
docs(roadmap): add phase 24 — google oauth broker (token mode)

### DIFF
--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -318,6 +318,24 @@ Large upstream responses are fully buffered today, which spikes memory and block
 - Add integration tests: large upstream body returned to the client in full, trace body truncated at the cap
 - Close or cross-reference issue #225
 
+## Phase 24 — Google OAuth Broker (Token Mode)
+
+**Goal:** Implement the first token-mode OAuth broker in Mini's broker library — Google — with code-exchange and refresh, alongside Pipedream's untouched proxy-mode broker.
+**Depends on:** none (additive — Pipedream untouched, schema additions NULLable)
+**Priority:** High
+
+`PipedreamOAuthBroker` is Mini's only OAuth broker today and it's proxy-mode. The `OAuthBroker` Protocol already defines a token-mode path, but no implementation exists. This phase ships `GoogleOAuthBroker` as the first token-mode broker; follow-up brokers (GitHub, Microsoft) become URL/scope-format swaps.
+
+- Add `GoogleOAuthBroker` in `src/brokers/google.py` with `get_token` (refresh + cache), `exchange_code`, `has_scopes`, plus a scope→api_host map for Gmail/Calendar/Drive/Sheets/Docs
+- Add the optional `has_scopes()` method to the `OAuthBroker` Protocol with an async default of `True`; Pipedream inherits unchanged
+- Introduce `auth_type='broker_oauth'`, parallel to `'pipedream_oauth'`, to keep the two broker paths visibly distinct in `broker.py`
+- Add an Alembic migration with seven NULLable columns on `oauth_brokers` and `oauth_broker_accounts` for redirect URI, scopes, refresh/access tokens, token expiry, and provider user ID
+- Wire the broker into `src/routers/broker.py` (`_maybe_inject_broker_oauth` branch) and `src/main.py` lifespan registration; Pipedream's path is untouched
+- Add `POST /oauth-brokers/{broker_id}/exchange-code` plus `body.type` dispatch in `POST /oauth-brokers`
+- Add `POST /admin/api-keys` for programmatic toolkit-key minting (independently shippable per the issue)
+- Add backend tests against a mocked `oauth2.googleapis.com`; existing Pipedream tests must continue to pass
+- Close #336 on implementation; cross-reference #104 (overlapping design, not a duplicate)
+
 ---
 
 ## Later Phases (Not Yet Planned)


### PR DESCRIPTION
## Summary

- Adds **Phase 24 — Google OAuth Broker (Token Mode)** to `specs/roadmap.md`.
- Materializes the planning slot for issue #336: first token-mode `OAuthBroker` implementation, sibling to the existing proxy-mode `PipedreamOAuthBroker`. Pipedream code path untouched; schema additions all NULLable; no data migration.
- Cross-references issue #104 (overlapping but not a duplicate — see below). Roadmap edit only — no code, no parking-lot edits, no renumbering.

## #104 vs #336 — overlapping, not a duplicate

| Aspect | #104 | #336 (this phase) |
|---|---|---|
| Scope | Generic OAuth, any provider, BYO client_id/secret/URLs | Google-specific, hardcoded URLs, generalizable later |
| Tables | New `oauth_native_apps` / `oauth_native_tokens` (parallel) | Extends existing `oauth_brokers` / `oauth_broker_accounts` |
| Code delivery | Mini-side `GET /oauth/callback` | External control plane → `POST /oauth-brokers/{id}/exchange-code` |
| Provider URLs | User-supplied at registration | Hardcoded per-provider class |

#336 supersedes the design uncertainties #104 was waiting on (storage and token-refresh scheduling), but does **not** implement #104's in-Mini callback flow. Cross-referenced rather than closed.

## Test plan

- [x] `git diff main...HEAD -- specs/roadmap.md` shows only the new Phase 24 block (no renumbering, no parking-lot edits).
- [x] Phase number is 24 (= max(active phase numbers=23) + 1).
- [x] Insertion is between Phase 23 and the `---` separator.
- [ ] After merge, `/sdd-new-spec 24` will materialize the phase into a feature spec directory (separate PR).

Refs #336, #104.