### PR TITLE
fix(docker): dev compose venv binaries + vite node_modules permissions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,6 +46,8 @@ docker compose up -d                                  # base only
 docker compose -f compose.yml -f compose.dev.yml up   # with UI dev server
 ```
 
+Export `JENTIC_UID=$(id -u)` and `JENTIC_GID=$(id -g)` (same shell line as `docker compose ...`) whenever your workstation UID/GID differs from Compose’s defaults (**1000:1000**) — notably on Linux, so `./ui`, `./src`, and `./data` stay owned by your user for both **jentic-mini** and **vite** (`compose.dev.yml` passes the same values through).
+
 The API is available at `http://localhost:8900` and the Swagger UI at `http://localhost:8900/docs`.
 
 ### 5. UI development (optional)

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ For UI development, use the dev compose override which runs Vite in a container 
 docker compose -f compose.yml -f compose.dev.yml up
 ```
 
-This starts a Vite dev server on `http://localhost:5173` with hot module replacement, proxying API calls to the backend on port 8900. Edit files in `ui/` and changes appear instantly.
+This starts a Vite dev server on `http://localhost:5173` with hot module replacement, proxying API calls to the backend on port 8900. Edit files in `ui/` and changes appear instantly. The Vite service uses the same `JENTIC_UID` / `JENTIC_GID` as `compose.yml` (defaults **1000:1000**), including for the bind-mounted `ui/` directory and for `npm`’s cache — **on Linux**, if your workstation user isn’t UID 1000, export matching values before spinning up compose (same snippet as below) so `./ui` is not littered with root- or mismatched-owner files from the container.
 
 Alternatively, run Vite directly on the host (requires Node.js 24):
 
@@ -206,9 +206,14 @@ See `ui/TESTING.md` for the full contributor guide.
 
 To rebuild the production UI bundle: `cd ui && npm run build`, then `docker compose up -d --build`.
 
-> **Note:** The container runs as a non-root user. `compose.yml` defaults to uid/gid 1000 for bind mount compatibility.
-> If your host user has a different uid, set `JENTIC_UID` and `JENTIC_GID` before starting:
-> `JENTIC_UID=$(id -u) JENTIC_GID=$(id -g) docker compose up -d`
+> **Note:** The backend container runs as a non-root user. `compose.yml` defaults to uid/gid 1000 for bind mount compatibility.
+> If your host user has a different UID/GID (common on Linux), set `JENTIC_UID` and `JENTIC_GID` before starting — applies to **`compose.yml`** and to **`compose.dev.yml`** so the bundled Vite service matches too:
+>
+> ```bash
+> JENTIC_UID=$(id -u) JENTIC_GID=$(id -g) docker compose up -d
+> # or with UI dev server:
+> JENTIC_UID=$(id -u) JENTIC_GID=$(id -g) docker compose -f compose.yml -f compose.dev.yml up
+> ```
 
 Swagger UI is available at `http://localhost:8900/docs` for interactive API exploration.
 

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -13,7 +13,6 @@
 services:
   vite:
     image: node:24-slim
-    user: "${JENTIC_UID:-1000}:${JENTIC_GID:-1000}"
     restart: unless-stopped
     working_dir: /app/ui
     command: sh -c "npm install --ignore-scripts && npm run dev"

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -35,11 +35,15 @@ services:
       - |
         set -eu
         mkdir -p "$$JENTIC_NPM_HOME"
-        chown -R "$$JENTIC_UID:$$JENTIC_GID" /app/ui/node_modules "$$JENTIC_NPM_HOME"
-        HOME="$$JENTIC_NPM_HOME"
-        export HOME
-        exec setpriv --reuid="$$JENTIC_UID" --regid="$$JENTIC_GID" --clear-groups \
-          sh -c 'cd /app/ui && npm install --ignore-scripts && npm run dev'
+        chown "$$JENTIC_UID:$$JENTIC_GID" "$$JENTIC_NPM_HOME"
+        NM_DIR=/app/ui/node_modules
+        if [ "$$(stat -c %u "$$NM_DIR")" != "$$JENTIC_UID" ] \
+           || [ "$$(stat -c %g "$$NM_DIR")" != "$$JENTIC_GID" ]; then
+          chown -R "$$JENTIC_UID:$$JENTIC_GID" "$$NM_DIR"
+        fi
+        export HOME="$$JENTIC_NPM_HOME"
+        exec setpriv --no-new-privs --reuid="$$JENTIC_UID" --regid="$$JENTIC_GID" --clear-groups \
+          sh -c 'npm install --ignore-scripts && npm run dev'
     volumes:
       - ${JENTIC_HOST_PATH:-.}/ui:/app/ui
       - ui_node_modules:/app/ui/node_modules

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -9,28 +9,42 @@
 #
 # node_modules is stored in a named volume so subsequent restarts are instant.
 # On first start, npm install runs — takes ~30s.
+#
+# The vite service bind-mounts ./ui under /app/ui. On Linux hosts where your
+# UID ≠ 1000, export JENTIC_UID / JENTIC_GID alongside the backend (typically
+# `JENTIC_UID=$(id -u) JENTIC_GID=$(id -g)`) so file ownership under ./ui matches
+# your user rather than falling back to 1000:1000 inside the container.
 
 services:
   vite:
     image: node:24-slim
     restart: unless-stopped
     working_dir: /app/ui
-    # Start as root so we can chown the named volume on first run (Docker
-    # initialises empty named volumes as root-owned), then drop to the bundled
-    # `node` user (UID 1000) via `su -` before running npm/vite. Using `su -`
-    # also sets HOME=/home/node so npm's cache (~/.npm) lands in a writable
-    # directory — running as a non-root UID with HOME=/root would EACCES on
-    # the npm cache regardless of the named-volume permissions.
-    command: >
-      sh -c "chown -R node:node /app/ui/node_modules &&
-      exec su - node -s /bin/sh -c 'cd /app/ui && npm install --ignore-scripts && npm run dev'"
+    environment:
+      VITE_API_HOST: http://jentic-mini:8900
+      # Same UID/GID as compose.yml (jentic-mini service) so frontend + backend
+      # mounts stay coherent on Linux. Export JENTIC_UID=$(id -u) … when needed.
+      JENTIC_UID: "${JENTIC_UID:-1000}"
+      JENTIC_GID: "${JENTIC_GID:-1000}"
+      # Writable HOME prefix for npm (setpriv cannot keep HOME=/root when we
+      # drop privileges). Resolved at Compose parse time from the same UID/GID.
+      JENTIC_NPM_HOME: "/tmp/jentic-mini-npm-home-${JENTIC_UID:-1000}-${JENTIC_GID:-1000}"
+    command:
+      - sh
+      - -c
+      - |
+        set -eu
+        mkdir -p "$$JENTIC_NPM_HOME"
+        chown -R "$$JENTIC_UID:$$JENTIC_GID" /app/ui/node_modules "$$JENTIC_NPM_HOME"
+        HOME="$$JENTIC_NPM_HOME"
+        export HOME
+        exec setpriv --reuid="$$JENTIC_UID" --regid="$$JENTIC_GID" --clear-groups \
+          sh -c 'cd /app/ui && npm install --ignore-scripts && npm run dev'
     volumes:
       - ${JENTIC_HOST_PATH:-.}/ui:/app/ui
       - ui_node_modules:/app/ui/node_modules
     ports:
       - "5173:5173"
-    environment:
-      VITE_API_HOST: http://jentic-mini:8900
 
 volumes:
   ui_node_modules:

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -15,7 +15,16 @@ services:
     image: node:24-slim
     restart: unless-stopped
     working_dir: /app/ui
-    command: sh -c "npm install --ignore-scripts && npm run dev"
+    # Start as root so we can chown the named volume on first run (Docker
+    # initialises empty named volumes as root-owned), then drop to the host
+    # UID/GID via setpriv before running npm/vite. This keeps writes to the
+    # bind-mounted ui/ directory owned by the developer's host user instead of
+    # root — matters on Linux hosts where docker-compose volume ownership is
+    # not virtualised.
+    command: >
+      sh -c "chown -R ${JENTIC_UID:-1000}:${JENTIC_GID:-1000} /app/ui/node_modules &&
+      exec setpriv --reuid=${JENTIC_UID:-1000} --regid=${JENTIC_GID:-1000} --clear-groups
+      sh -c 'npm install --ignore-scripts && npm run dev'"
     volumes:
       - ${JENTIC_HOST_PATH:-.}/ui:/app/ui
       - ui_node_modules:/app/ui/node_modules

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -16,15 +16,14 @@ services:
     restart: unless-stopped
     working_dir: /app/ui
     # Start as root so we can chown the named volume on first run (Docker
-    # initialises empty named volumes as root-owned), then drop to the host
-    # UID/GID via setpriv before running npm/vite. This keeps writes to the
-    # bind-mounted ui/ directory owned by the developer's host user instead of
-    # root — matters on Linux hosts where docker-compose volume ownership is
-    # not virtualised.
+    # initialises empty named volumes as root-owned), then drop to the bundled
+    # `node` user (UID 1000) via `su -` before running npm/vite. Using `su -`
+    # also sets HOME=/home/node so npm's cache (~/.npm) lands in a writable
+    # directory — running as a non-root UID with HOME=/root would EACCES on
+    # the npm cache regardless of the named-volume permissions.
     command: >
-      sh -c "chown -R ${JENTIC_UID:-1000}:${JENTIC_GID:-1000} /app/ui/node_modules &&
-      exec setpriv --reuid=${JENTIC_UID:-1000} --regid=${JENTIC_GID:-1000} --clear-groups
-      sh -c 'npm install --ignore-scripts && npm run dev'"
+      sh -c "chown -R node:node /app/ui/node_modules &&
+      exec su - node -s /bin/sh -c 'cd /app/ui && npm install --ignore-scripts && npm run dev'"
     volumes:
       - ${JENTIC_HOST_PATH:-.}/ui:/app/ui
       - ui_node_modules:/app/ui/node_modules

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,13 +6,13 @@ set -e
 export PYTHONPATH=/app
 
 echo "[entrypoint] Running database migrations..."
-python3 -m alembic upgrade head
+/app/.venv/bin/python -m alembic upgrade head
 
 echo "[entrypoint] Seeding broker app mappings..."
-python3 -c "import asyncio; from src.startup import seed_broker_apps; asyncio.run(seed_broker_apps())"
+/app/.venv/bin/python -c "import asyncio; from src.startup import seed_broker_apps; asyncio.run(seed_broker_apps())"
 
 echo "[entrypoint] Starting server..."
-exec uvicorn src.main:app \
+exec /app/.venv/bin/uvicorn src.main:app \
     --host 0.0.0.0 \
     --port 8900 \
     --log-level "${LOG_LEVEL:-info}" \

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -98,7 +98,7 @@ Core modules live in `src/` and routers in `src/routers/`; see `CLAUDE.md` and
 
 - **Deployment target:** Docker container; published to DockerHub (`jentic/jentic-mini`) and GHCR (`ghcr.io/jentic/jentic-mini`); multi-arch (`amd64`, `arm64`)
 - **Port:** 8900 (exposed in Dockerfile; configurable via compose)
-- **User:** Non-root `jentic` system user; UID/GID configurable via `JENTIC_UID` / `JENTIC_GID`
+- **User:** Non-root `jentic` system user; UID/GID configurable via `JENTIC_UID` / `JENTIC_GID` (`compose.yml`). The bundled Vite stack in `compose.dev.yml` reuses those values for `npm` / Vite against the `./ui` bind mount (`HOME` is under `/tmp` inside the Node image after a brief root `chown` on the named `node_modules` volume).
 - **Environment management:** Optional `.env` file or Docker env vars. Key vars: `JENTIC_VAULT_KEY`, `JENTIC_PUBLIC_HOSTNAME`, `JENTIC_TRUSTED_SUBNETS`, `LOG_LEVEL`, `JENTIC_TELEMETRY`, `JENTIC_UID`, `JENTIC_GID`, `DB_PATH`
 - **Observability:** Python stdlib `logging` (configurable with `LOG_LEVEL`); execution traces stored in SQLite and queryable via `GET /traces`; `GET /version` (6-hour cache; see `docs/versioning.md`); anonymous install telemetry (opt-out via `JENTIC_TELEMETRY=off`)
 - **Error handling:** FastAPI exception handlers; broker propagates upstream HTTP status and `failed_step` detail on workflow errors; no rate limiting or audit trail currently

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -98,7 +98,7 @@ Core modules live in `src/` and routers in `src/routers/`; see `CLAUDE.md` and
 
 - **Deployment target:** Docker container; published to DockerHub (`jentic/jentic-mini`) and GHCR (`ghcr.io/jentic/jentic-mini`); multi-arch (`amd64`, `arm64`)
 - **Port:** 8900 (exposed in Dockerfile; configurable via compose)
-- **User:** Non-root `jentic` system user; UID/GID configurable via `JENTIC_UID` / `JENTIC_GID` (`compose.yml`). The bundled Vite stack in `compose.dev.yml` reuses those values for `npm` / Vite against the `./ui` bind mount (`HOME` is under `/tmp` inside the Node image after a brief root `chown` on the named `node_modules` volume).
+- **User:** Non-root `jentic` system user; UID/GID configurable via `JENTIC_UID` / `JENTIC_GID`; `compose.dev.yml`'s Vite service honours the same values.
 - **Environment management:** Optional `.env` file or Docker env vars. Key vars: `JENTIC_VAULT_KEY`, `JENTIC_PUBLIC_HOSTNAME`, `JENTIC_TRUSTED_SUBNETS`, `LOG_LEVEL`, `JENTIC_TELEMETRY`, `JENTIC_UID`, `JENTIC_GID`, `DB_PATH`
 - **Observability:** Python stdlib `logging` (configurable with `LOG_LEVEL`); execution traces stored in SQLite and queryable via `GET /traces`; `GET /version` (6-hour cache; see `docs/versioning.md`); anonymous install telemetry (opt-out via `JENTIC_TELEMETRY=off`)
 - **Error handling:** FastAPI exception handlers; broker propagates upstream HTTP status and `failed_step` detail on workflow errors; no rate limiting or audit trail currently


### PR DESCRIPTION
## Summary

Fixes local development when using `docker compose -f compose.yml -f compose.dev.yml up`.

## Changes

### 1) `docker-entrypoint.sh` — always execute via venv binaries

Run Alembic, broker-app seed, and Uvicorn via `/app/.venv/bin/python` and `/app/.venv/bin/uvicorn` instead of relying on `python3` / `uvicorn` PATH resolution.

This removes ambiguity around interpreter resolution and prevents the class of "wrong Python binary" failures in environments where PATH resolution differs.

### 2) `compose.dev.yml` — fix `ui_node_modules` EACCES and keep Linux UID/GID mapping

The Vite service now:

- uses the same `JENTIC_UID` / `JENTIC_GID` pattern as `compose.yml` (defaults `1000:1000`)
- creates a writable npm HOME per uid/gid at `/tmp/jentic-mini-npm-home-<uid>-<gid>`
- `chown`s both `/app/ui/node_modules` and that npm HOME to `JENTIC_UID:JENTIC_GID`
- drops privileges with `setpriv` before running `npm install` and `npm run dev`

This fixes both permission paths:

- named-volume ownership issue on `/app/ui/node_modules`
- npm cache writes that would fail if HOME remained `/root`

Result: Vite/npm/esbuild run non-root with the configured UID/GID, including non-1000 Linux users.

## Docs updates

Updated:

- `README.md`
- `DEVELOPMENT.md`
- `specs/tech-stack.md`

to clarify that `compose.dev.yml` now honors `JENTIC_UID`/`JENTIC_GID` as well, and to recommend exporting them on Linux when host UID/GID differs from `1000:1000`.

## How to verify

```bash
# Optional cleanup if old root-owned volume state exists
docker compose -f compose.yml -f compose.dev.yml down -v

# Default uid/gid flow
docker compose -f compose.yml -f compose.dev.yml up --build

# Non-1000 Linux-style simulation
JENTIC_UID=1337 JENTIC_GID=1441 docker compose -f compose.yml -f compose.dev.yml up --build

# Vite reachable
curl -sSf -o /dev/null -w '%{http_code}\n' http://localhost:5173/

# Process uid/gid inside vite container
# (expect 1000:1000 by default, or provided JENTIC_UID:JENTIC_GID when overridden)
docker exec jentic-mini-vite-1 sh -c 'for p in /proc/[0-9]*; do n=$(cat "$p/comm" 2>/dev/null || true); case "$n" in MainThread|esbuild|npm|sh) awk "/^Uid:|^Gid:/{print}" "$p/status" 2>/dev/null; break;; esac; done'
```

Made with [Cursor](https://cursor.com)