### PR TITLE
docs(roadmap): add phases 26, 27 — access-request safety

### DIFF
--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -380,6 +380,38 @@ Large upstream responses are fully buffered today, which spikes memory and block
 - Add tests covering unmounted (default) and mounted (`/foo`) modes — SPA load, asset paths, `/docs`, `/openapi.json`, internal routes
 - Close or cross-reference issue #356
 
+## Phase 26 — Incremental `modify_permissions` Access Requests
+
+**Goal:** Make `modify_permissions` access requests append to the agent's existing ruleset on approval instead of replacing it, removing the silent-privilege-loss footgun.
+**Depends on:** none (self-contained)
+**Priority:** High (blocker)
+
+Today, approving a `modify_permissions` access request silently replaces the agent's entire ruleset with the request's `rules`. An agent that asks for one new rule loses every rule it relied on — silently, on approval. This pushes agents toward over-broad initial asks (because narrowing later requires perfect recall of the current ruleset) and breaks the human reviewer's mental model of what they are approving. The behavior is `bug`+`security`-labelled and matches the early-access trust bar that other `(blocker)` phases (16, 17, 18, 19) target.
+
+- Change `modify_permissions` access-request semantics: on approval, append the request's rules to the agent's existing rules; never replace. The feature spec may introduce a parallel `add_permissions` request type as a fallback if a concrete backwards-compatibility blocker surfaces during design, but the primary direction is the in-place semantics change
+- Keep full-replace policy editing on the human-only `PUT /toolkits/{id}/credentials/{cred_id}/permissions` path for explicit admin rewrites
+- Document the change as logic-only — no schema migration expected (rule storage shape is unchanged)
+- Add integration tests: starting rules `A,B` + request `C` → `A,B,C` on approval; two sequential requests stack correctly; full-replace path on `PUT` still works
+- Audit `AGENTS.md` and `docs/auth.md` for wording that implies replace semantics; correct it
+- Close #325; cross-reference #324 (validation hardens the new shape)
+
+## Phase 27 — Validate Access Requests with Actionable Feedback
+
+**Goal:** Reject malformed `modify_permissions` access requests with structured 422 guidance an agent can self-correct against.
+**Depends on:** none (self-contained — see context)
+**Priority:** High
+
+The API currently accepts access requests with empty `rules`, no `reason`, rules that duplicate the always-appended system safety rules, or unconstrained `allow` rules — silently. Agents have no signal that the request is malformed, and human reviewers see "Modify permissions: 0 rule(s)" with no context. The result is wasted human review and a soft pressure toward broad asks. The four checks below stand under either current replace or post-Phase 26 append semantics; only the wording in the 422 `best_practice` payload (the example request and the prose around what "empty `rules`" means) revises when Phase 26 lands. Either order is shippable.
+
+- Reject `modify_permissions` requests with empty or missing `rules` (HTTP 422 with `type: "invalid_access_request"`)
+- Reject requests with no substantive `reason` (minimum length, e.g. 20 chars)
+- Reject rules that exact-match a system safety rule (same `effect` + `methods` + `path`) — they are redundant since system rules are always appended
+- Reject `allow` rules with no `path` and no `operations` constraint (effectively "allow everything")
+- Return 422 with a structured `issues` list (per-rule indices) and a `best_practice` payload containing summary, rules, and a minimal example, per the shape proposed in #324
+- Cover each rejection path with integration tests; cover happy-path acceptance with one representative request
+- Update `AGENTS.md` and any agent-facing examples to show a well-formed request
+- Close #324; cross-reference #325
+
 ---
 
 ## Later Phases (Not Yet Planned)


### PR DESCRIPTION
## Summary

Promotes two open issues into active phases on `specs/roadmap.md`:

- **Phase 26 — Incremental `modify_permissions` Access Requests** — `High (blocker)`, `Depends on: none (self-contained)`. Closes the silent-privilege-loss footgun where approving a `modify_permissions` request replaces the agent's entire ruleset. Refs #325.
- **Phase 27 — Validate Access Requests with Actionable Feedback** — `High`, `Depends on: none (self-contained — see context)`. Reject malformed requests (empty rules, no reason, redundant system rules, blanket `allow`) with structured 422 guidance the agent can self-correct against. Refs #324.

> Renumbered from 25/26 → 26/27 after [#357](https://github.com/jentic/jentic-mini/pull/357) (Phase 25 — Reverse-Proxy Path Prefix) merged to `main`. No existing phase is renumbered; the new phases take `max(active) + 1` per the lifecycle rule.

This PR is **roadmap-only** — no code changes. Once merged, each phase is materialized into a feature spec via `/sdd-new-spec <N>` (per `.claude/skills/sdd-new-spec/SKILL.md`), and implementation follows in a separate PR per phase.

## Why these priorities

`specs/roadmap.md`'s priority legend defines `(blocker)` as a trust/security gap that makes Mini unsafe for real agent usage today.

- **#325 → `High (blocker)`.** Silent replacement of an agent's ruleset on approval pushes agents toward over-broad asks and breaks the human reviewer's mental model of what was granted. Same bar as Phase 16 (hash toolkit keys), Phase 17 (scope traces), Phase 18 (control-plane audit), Phase 19 (legacy HTML XSS).
- **#324 → `High`.** Important hardening, but agents can recover today via trial-and-error and human guidance — does not independently gate early-access safety.

## Order and dependency (soft coupling)

The two phases are **independently shippable**. The four validation checks in Phase 27 all stand under either the current replace semantics or the post-Phase 26 append semantics — only the wording in the 422 `best_practice` payload (the example request and the prose around what "empty `rules`" means) revises when Phase 26 lands. If Phase 27 ships first, empty `rules` rejection actively prevents a silent wipe under today's replace behavior.

## Adjacent items already parked in `Later Phases`

Cross-checked for duplication; neither overlaps:

- **"Access request editing"** (#82) — patch/cancel **pending** requests. Distinct: lifecycle vs. approval semantics + validation.
- **"Operation scoping presets"** (#133, #122, #63) — preset policy templates and `pattern` grammar. Adjacent (rule shape) but distinct.

## Files

- `specs/roadmap.md`

## Review guidance

Reviewers should verify:
- Phase 26 and Phase 27 goals match the issue intent (#325, #324 respectively).
- The `(blocker)` tagging on #325 is appropriate per the legend in the file's preamble.
- Phase numbers continue from 25 (no renumber); the parking lot below the `---` is untouched.
- Bullets accurately capture "shippable" tasks without inventing scope.
- Phase 26 first bullet commits to changing `modify_permissions` semantics as the primary direction; `add_permissions` is an explicit fallback only if a concrete BC blocker surfaces during `/sdd-new-spec`.

Refs #324
Refs #325
