### PR TITLE
chore(commitlint): enforce conventional commits via husky + hook

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -149,6 +149,7 @@ See @DEVELOPMENT.md for commands.
 
 - **UI**: ESLint 9 (flat config) with Prettier as plugin. Config: `ui/eslint.config.js`, `ui/prettier.config.js`, `ui/.editorconfig`
 - **Husky + lint-staged**: pre-commit hook lints staged files automatically
+- **commitlint**: commit-msg hook validates Conventional Commits (config: `ui/.commitlintrc.json`). A Claude PreToolUse hook (`.claude/hooks/commitlint-before-commit.py`) runs the same check before `git commit` is fired so failures surface inside the agent loop.
 
 ## Data directory (all gitignored)
 - `data/jentic-mini.db` — SQLite database

--- a/.claude/hooks/commitlint-before-commit.py
+++ b/.claude/hooks/commitlint-before-commit.py
@@ -31,17 +31,19 @@ def emit_deny(reason: str) -> None:
 
 def extract_message(command: str) -> str | None:
     # Pattern: -m "$(cat <<'DELIM' ... DELIM)" — what Claude's CLAUDE.md prescribes.
+    # Terminator anchored to start of line (MULTILINE); `<<-` form allows leading tabs/spaces.
     m = re.search(
-        r"-m\s+\"?\$\(\s*cat\s+<<-?\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n\s*\1\s*\n",
+        r"-m\s+\"?\$\(\s*cat\s+<<(-?)\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n[\t ]*\2\s*$",
         command,
-        re.DOTALL,
+        re.DOTALL | re.MULTILINE,
     )
     if m:
-        return textwrap.dedent(m.group(2))
-    # Pattern: -m "..." with escapes
+        body = m.group(3)
+        return textwrap.dedent(body) if m.group(1) == "-" else body
+    # Pattern: -m "..." — bash double-quotes only escape \$ \" \\ \` (NOT \n, \t, \uNNNN).
     m = re.search(r'-m\s+"((?:[^"\\]|\\.)*)"', command)
     if m:
-        return m.group(1).encode("utf-8").decode("unicode_escape")
+        return re.sub(r'\\([$"\\`])', r"\1", m.group(1))
     # Pattern: -m '...' (single quotes — no escapes in shell)
     m = re.search(r"-m\s+'([^']*)'", command)
     if m:
@@ -57,9 +59,13 @@ def main() -> int:
 
     command = data.get("tool_input", {}).get("command", "") or ""
 
-    if not re.search(r"(^|[\s&;|])git\s+commit(\s|$)", command):
+    # Match `git commit` allowing flags between (e.g., `git -C /path commit`, `git -c k=v commit`).
+    if not re.search(r"(^|[\s&;|])git(\s+\S+)*?\s+commit(\s|$)", command):
         return 0
-    if "--no-edit" in command:
+    # Check for `--no-edit` only in the args before -m / --message — avoid false-matching
+    # the literal string inside a message body.
+    args_prefix = re.split(r"\s-m\b|\s--message\b", command, maxsplit=1)[0]
+    if "--no-edit" in args_prefix:
         return 0
     if not COMMITLINT_BIN.exists():
         # Fresh checkout before `npm install` — defer to husky.

--- a/.claude/hooks/commitlint-before-commit.py
+++ b/.claude/hooks/commitlint-before-commit.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# PreToolUse hook: validate Conventional Commits before Claude fires `git commit`.
+# Reads Claude Code's tool-input JSON from stdin. On a malformed message, emits
+# a `permissionDecision: deny` JSON so the bash command never runs.
+# Mirrors what .husky/commit-msg enforces for human/CI commits.
+import json
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMMITLINT_BIN = REPO_ROOT / "ui" / "node_modules" / ".bin" / "commitlint"
+
+
+def emit_deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
+        )
+    )
+
+
+def extract_message(command: str) -> str | None:
+    # Pattern: -m "$(cat <<'DELIM' ... DELIM)" — what Claude's CLAUDE.md prescribes.
+    m = re.search(
+        r"-m\s+\"?\$\(\s*cat\s+<<-?\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n\s*\1\s*\n",
+        command,
+        re.DOTALL,
+    )
+    if m:
+        return textwrap.dedent(m.group(2))
+    # Pattern: -m "..." with escapes
+    m = re.search(r'-m\s+"((?:[^"\\]|\\.)*)"', command)
+    if m:
+        return m.group(1).encode("utf-8").decode("unicode_escape")
+    # Pattern: -m '...' (single quotes — no escapes in shell)
+    m = re.search(r"-m\s+'([^']*)'", command)
+    if m:
+        return m.group(1)
+    return None
+
+
+def main() -> int:
+    try:
+        data = json.loads(sys.stdin.read())
+    except Exception:
+        return 0
+
+    command = data.get("tool_input", {}).get("command", "") or ""
+
+    if not re.search(r"(^|[\s&;|])git\s+commit(\s|$)", command):
+        return 0
+    if "--no-edit" in command:
+        return 0
+    if not COMMITLINT_BIN.exists():
+        # Fresh checkout before `npm install` — defer to husky.
+        return 0
+
+    msg = extract_message(command)
+    if not msg:
+        # Couldn't extract (e.g., -F file or interactive editor); husky covers it.
+        return 0
+
+    try:
+        proc = subprocess.run(
+            [str(COMMITLINT_BIN)],
+            input=msg,
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT / "ui"),
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return 0
+
+    if proc.returncode == 0:
+        return 0
+
+    output = (proc.stdout + proc.stderr).strip() or "commitlint reported errors."
+    emit_deny(
+        "Commit message fails Conventional Commits validation "
+        "(see .claude/rules/conventional-commits.md):\n\n" + output
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/rules/conventional-commits.md
+++ b/.claude/rules/conventional-commits.md
@@ -1,5 +1,7 @@
 Commit messages MUST follow Conventional Commits (https://www.conventionalcommits.org/en/v1.0.0/).
 
+*Enforced by `.husky/commit-msg` (commitlint, config: `ui/.commitlintrc.json`) and a Claude PreToolUse hook (`.claude/hooks/commitlint-before-commit.py`) that runs the same check before `git commit` is fired.*
+
 Format: `type(scope): description` — max 69 characters in the header.
 
 - Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `perf`, `build`, `ci`, `style`, `revert`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/commitlint-before-commit.py",
+            "statusMessage": "Validating Conventional Commit format"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,7 @@
-cd ui && npx --no -- commitlint --edit "$1"
+set -e
+case "$1" in
+  /*) MSG_FILE="$1" ;;
+  *)  MSG_FILE="$(pwd)/$1" ;;
+esac
+cd ui
+exec npx --no -- commitlint --edit "$MSG_FILE"

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+cd ui && npx --no -- commitlint --edit "$1"

--- a/ui/.commitlintrc.json
+++ b/ui/.commitlintrc.json
@@ -1,0 +1,22 @@
+{
+	"extends": ["@commitlint/config-conventional"],
+	"rules": {
+		"header-max-length": [2, "always", 69],
+		"scope-empty": [2, "never"],
+		"scope-case": [
+			2,
+			"always",
+			[
+				"camel-case",
+				"kebab-case",
+				"upper-case",
+				"lower-case",
+				"pascal-case",
+				"sentence-case",
+				"snake-case",
+				"start-case"
+			]
+		]
+	},
+	"helpUrl": "https://github.com/jentic/jentic-mini/blob/main/.claude/rules/conventional-commits.md"
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -19,6 +19,8 @@
 				"tailwind-merge": "^3.5.0"
 			},
 			"devDependencies": {
+				"@commitlint/cli": "^20.5.3",
+				"@commitlint/config-conventional": "^20.5.3",
 				"@eslint/js": "^9.39.4",
 				"@playwright/test": "^1.59.1",
 				"@tailwindcss/vite": "^4.2.4",
@@ -107,6 +109,7 @@
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -432,6 +435,345 @@
 			"integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
 			"license": "Apache-2.0"
 		},
+		"node_modules/@commitlint/cli": {
+			"version": "20.5.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.3.tgz",
+			"integrity": "sha512-OJdL0EXWD5y9LPa0nr/geOwzaS8BsdaybKkcloB0JgsguGxNv2R+hC2FTPqrAcprg35zF33KOQerY0x8W1aesA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@commitlint/format": "^20.5.0",
+				"@commitlint/lint": "^20.5.3",
+				"@commitlint/load": "^20.5.3",
+				"@commitlint/read": "^20.5.0",
+				"@commitlint/types": "^20.5.0",
+				"tinyexec": "^1.0.0",
+				"yargs": "^17.0.0"
+			},
+			"bin": {
+				"commitlint": "cli.js"
+			},
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/config-conventional": {
+			"version": "20.5.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.5.3.tgz",
+			"integrity": "sha512-j34Qqeaa152chJgz2ysyk0BCpHenJn1lV0Rx0VXf8k3ccQcED+48EZrzMvo9jLmJUyBrrBwvu89I+2er4gW7QQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@commitlint/types": "^20.5.0",
+				"conventional-changelog-conventionalcommits": "^9.2.0"
+			},
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/config-validator": {
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.5.0.tgz",
+			"integrity": "sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@commitlint/types": "^20.5.0",
+				"ajv": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/config-validator/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@commitlint/config-validator/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@commitlint/ensure": {
+			"version": "20.5.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.3.tgz",
+			"integrity": "sha512-4i4AgNvH62owG9MwSiWKrle7HGNpBHHdLnWFIp5fTsHUYe5kRuh15t08L/0pdbbrRk8JKXQxxN4hZQcn+szkrw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@commitlint/types": "^20.5.0",
+				"es-toolkit": "^1.46.0"
+			},
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/execute-rule": {
+			"version": "20.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-20.0.0.tgz",
+			"integrity": "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/format": {
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.5.0.tgz",
+			"integrity": "sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@commitlint/types": "^20.5.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/is-ignored": {
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.5.0.tgz",
+			"integrity": "sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@commitlint/types": "^20.5.0",
+				"semver": "^7.6.0"
+			},
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/is-ignored/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@commitlint/lint": {
+			"version": "20.5.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.3.tgz",
+			"integrity": "sha512-M7JbWBNr2gXKaPc4i/KipsuW1gkDHpj35KPjWtKy3Z+2AQw5wu1gBi1LIO0uoaij67CqY4K8PxPZSGens4evCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@commitlint/is-ignored": "^20.5.0",
+				"@commitlint/parse": "^20.5.0",
+				"@commitlint/rules": "^20.5.3",
+				"@commitlint/types": "^20.5.0"
+			},
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/load": {
+			"version": "20.5.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.3.tgz",
+			"integrity": "sha512-1FDZWuKyu98Myb8i7Tp31jPU2rZpOwAdYRyJcy2KoGg7Xk2A+bgHN8smhMaaNSNkmE8fwt53BokywZq8Gv/5XQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@commitlint/config-validator": "^20.5.0",
+				"@commitlint/execute-rule": "^20.0.0",
+				"@commitlint/resolve-extends": "^20.5.3",
+				"@commitlint/types": "^20.5.0",
+				"cosmiconfig": "^9.0.1",
+				"cosmiconfig-typescript-loader": "^6.1.0",
+				"es-toolkit": "^1.46.0",
+				"is-plain-obj": "^4.1.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/message": {
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.4.3.tgz",
+			"integrity": "sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/parse": {
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.5.0.tgz",
+			"integrity": "sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@commitlint/types": "^20.5.0",
+				"conventional-changelog-angular": "^8.2.0",
+				"conventional-commits-parser": "^6.3.0"
+			},
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/read": {
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.5.0.tgz",
+			"integrity": "sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@commitlint/top-level": "^20.4.3",
+				"@commitlint/types": "^20.5.0",
+				"git-raw-commits": "^5.0.0",
+				"minimist": "^1.2.8",
+				"tinyexec": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/resolve-extends": {
+			"version": "20.5.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.3.tgz",
+			"integrity": "sha512-+ogW9v/u9JqpvAgTrLra/YTFo0KkjU6iNblF89pPsj4NebNc+DAWctsludwezI8YnsjBmfHpApSwcXprN/f/ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@commitlint/config-validator": "^20.5.0",
+				"@commitlint/types": "^20.5.0",
+				"es-toolkit": "^1.46.0",
+				"global-directory": "^5.0.0",
+				"import-meta-resolve": "^4.0.0",
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@commitlint/rules": {
+			"version": "20.5.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.3.tgz",
+			"integrity": "sha512-MPlMnb9D3wbszYMp+1hPtuhtPJndRo6I6yfkZVA4+jR8w7Kqp0u2u/Y+gzbaItx5Lltq5rw7FSZQWJMoXUC4NQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@commitlint/ensure": "^20.5.3",
+				"@commitlint/message": "^20.4.3",
+				"@commitlint/to-lines": "^20.0.0",
+				"@commitlint/types": "^20.5.0"
+			},
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/to-lines": {
+			"version": "20.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-20.0.0.tgz",
+			"integrity": "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/top-level": {
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.4.3.tgz",
+			"integrity": "sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"escalade": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@commitlint/types": {
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.5.0.tgz",
+			"integrity": "sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"conventional-commits-parser": "^6.3.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=v18"
+			}
+		},
+		"node_modules/@conventional-changelog/git-client": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+			"integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-libs/child-process-utils": "^1.0.0",
+				"@simple-libs/stream-utils": "^1.2.0",
+				"semver": "^7.5.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"conventional-commits-filter": "^5.0.0",
+				"conventional-commits-parser": "^6.4.0"
+			},
+			"peerDependenciesMeta": {
+				"conventional-commits-filter": {
+					"optional": true
+				},
+				"conventional-commits-parser": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@conventional-changelog/git-client/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/@emnapi/core": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
@@ -472,7 +814,6 @@
 			"integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@emotion/memoize": "^0.9.0"
 			}
@@ -482,16 +823,14 @@
 			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
 			"integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@emotion/unitless": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
 			"integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.27.4",
@@ -2060,6 +2399,35 @@
 			"hasInstallScript": true,
 			"license": "Apache-2.0"
 		},
+		"node_modules/@simple-libs/child-process-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
+			"integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-libs/stream-utils": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/dangreen"
+			}
+		},
+		"node_modules/@simple-libs/stream-utils": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+			"integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/dangreen"
+			}
+		},
 		"node_modules/@speclynx/apidom-core": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@speclynx/apidom-core/-/apidom-core-4.2.0.tgz",
@@ -3034,8 +3402,7 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -3420,6 +3787,7 @@
 			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.19.0"
 			}
@@ -3435,6 +3803,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
 			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -3446,6 +3815,7 @@
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
 			}
@@ -3472,8 +3842,7 @@
 			"resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
 			"integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
@@ -3494,6 +3863,7 @@
 			"integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
 				"@typescript-eslint/scope-manager": "8.59.2",
@@ -3533,6 +3903,7 @@
 			"integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.59.2",
 				"@typescript-eslint/types": "8.59.2",
@@ -3734,6 +4105,7 @@
 			"integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
 				"@typescript-eslint/scope-manager": "8.59.2",
@@ -4118,6 +4490,7 @@
 			"integrity": "sha512-CWy0lBQJq97nionyJJdnaU4961IXTl43a7UCu5nHy51IoKxAt6PVIJLo+76rVl7KOOgcWHNkG4kbJu/pW7knvA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/browser": "4.1.5",
 				"@vitest/mocker": "4.1.5",
@@ -4142,6 +4515,7 @@
 			"integrity": "sha512-X4kQMDEWh9mA0IiLuigtdYv4kXe+W8KLTbucoz15lbyZRPAxT5l+hu0JizI7Am050+G9vQnB7QJNgYi2LnwV4w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.29.0",
 				"@istanbuljs/schema": "^0.1.3",
@@ -4279,6 +4653,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -4404,6 +4779,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/array-ify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/array-includes": {
 			"version": "3.1.9",
@@ -4667,6 +5049,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.12",
 				"caniuse-lite": "^1.0.30001782",
@@ -4753,7 +5136,6 @@
 			"integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -4861,6 +5243,7 @@
 			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
 			"integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@chevrotain/cst-dts-gen": "11.1.2",
 				"@chevrotain/gast": "11.1.2",
@@ -5077,6 +5460,17 @@
 				"node": ">= 12.0.0"
 			}
 		},
+		"node_modules/compare-func": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+			"integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array-ify": "^1.0.0",
+				"dot-prop": "^5.1.0"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5089,6 +5483,49 @@
 			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
 			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
 			"license": "MIT"
+		},
+		"node_modules/conventional-changelog-angular": {
+			"version": "8.3.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+			"integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"compare-func": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/conventional-changelog-conventionalcommits": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+			"integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"compare-func": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/conventional-commits-parser": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+			"integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@simple-libs/stream-utils": "^1.2.0",
+				"meow": "^13.0.0"
+			},
+			"bin": {
+				"conventional-commits-parser": "dist/cli/index.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
@@ -5144,6 +5581,52 @@
 				"layout-base": "^1.0.0"
 			}
 		},
+		"node_modules/cosmiconfig": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"env-paths": "^2.2.1",
+				"import-fresh": "^3.3.0",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/cosmiconfig-typescript-loader": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+			"integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jiti": "2.6.1"
+			},
+			"engines": {
+				"node": ">=v18"
+			},
+			"peerDependencies": {
+				"@types/node": "*",
+				"cosmiconfig": ">=9",
+				"typescript": ">=5"
+			}
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5165,7 +5648,6 @@
 			"integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -5176,7 +5658,6 @@
 			"integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"camelize": "^1.0.0",
 				"css-color-keywords": "^1.0.0",
@@ -5201,6 +5682,7 @@
 			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
 			"integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10"
 			}
@@ -5610,6 +6092,7 @@
 			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
 			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
 			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -5918,8 +6401,7 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/dompurify": {
 			"version": "3.4.0",
@@ -5928,6 +6410,19 @@
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
+			}
+		},
+		"node_modules/dot-prop": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-obj": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/dunder-proto": {
@@ -5984,6 +6479,16 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/environment": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -5995,6 +6500,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/error-ex": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+			"integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"node_modules/es-abstract": {
@@ -6178,6 +6693,17 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/es-toolkit": {
+			"version": "1.46.1",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+			"integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"docs",
+				"benchmarks"
+			]
+		},
 		"node_modules/es6-promise": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
@@ -6256,6 +6782,7 @@
 			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -6316,6 +6843,7 @@
 			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -6770,6 +7298,23 @@
 				"fast-string-truncated-width": "^3.0.2"
 			}
 		},
+		"node_modules/fast-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/fast-wrap-ansi": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
@@ -7112,6 +7657,23 @@
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
+		"node_modules/git-raw-commits": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
+			"integrity": "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@conventional-changelog/git-client": "^2.6.0",
+				"meow": "^13.0.0"
+			},
+			"bin": {
+				"git-raw-commits": "src/cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -7123,6 +7685,22 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/global-directory": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
+			"integrity": "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ini": "6.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/globals": {
@@ -7584,6 +8162,17 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/import-meta-resolve": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+			"integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -7602,6 +8191,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/ini": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+			"integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/inline-style-parser": {
@@ -7675,6 +8274,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/is-async-function": {
 			"version": "2.1.1",
@@ -7936,6 +8542,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-obj": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/is-plain-obj": {
@@ -8222,6 +8838,13 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -8636,6 +9259,13 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/lines-and-columns": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/lint-staged": {
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.2.tgz",
@@ -8869,7 +9499,6 @@
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -9243,6 +9872,19 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/meow": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/mermaid": {
@@ -9894,6 +10536,16 @@
 				"node": "*"
 			}
 		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/mlly": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -10531,6 +11183,25 @@
 			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
 			"license": "MIT"
 		},
+		"node_modules/parse-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/parse5": {
 			"version": "7.3.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -10655,6 +11326,7 @@
 			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"playwright-core": "1.59.1"
 			},
@@ -10760,7 +11432,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.7",
 				"picocolors": "^1.1.1",
@@ -10775,8 +11446,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -10794,6 +11464,7 @@
 			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -10902,7 +11573,6 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -10918,7 +11588,6 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -10998,6 +11667,7 @@
 			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
 			"integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/ramda"
@@ -11024,6 +11694,7 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -11036,6 +11707,7 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -11049,8 +11721,7 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/react-markdown": {
 			"version": "10.1.0",
@@ -11678,8 +12349,7 @@
 			"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
 			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -12680,6 +13350,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -12858,6 +13529,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"napi-postinstall": "^0.3.0"
 			},
@@ -13021,6 +13693,7 @@
 			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -13140,6 +13813,7 @@
 			"integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.1.5",
 				"@vitest/mocker": "4.1.5",
@@ -13624,6 +14298,7 @@
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/ui/package.json
+++ b/ui/package.json
@@ -31,6 +31,8 @@
 		"lodash-es": ">=4.18.0"
 	},
 	"devDependencies": {
+		"@commitlint/cli": "^20.5.3",
+		"@commitlint/config-conventional": "^20.5.3",
 		"@eslint/js": "^9.39.4",
 		"@playwright/test": "^1.59.1",
 		"@tailwindcss/vite": "^4.2.4",


### PR DESCRIPTION
## Summary

- Adds **commitlint** (with `@commitlint/config-conventional`) and a `.husky/commit-msg` hook so every commit is validated against the project's CC rules (`.claude/rules/conventional-commits.md`) — `header-max-length: 69`, scope required, project-wide scope-case allowlist; everything else inherited from `config-conventional`.
- Adds a Claude Code **PreToolUse** hook (`.claude/hooks/commitlint-before-commit.py`) that runs the same commitlint check before Claude fires `git commit`. On a malformed message, it emits `permissionDecision: deny` so the bash command never runs and Claude gets a structured reason instead of a wasted retry turn.
- Pattern modelled on [speclynx/apidom](https://github.com/speclynx/apidom)'s `.claude/hooks/*-before-commit.sh` + husky/commitlint setup.

### Layers (deliberate overlap)

| | `.husky/commit-msg` | `.claude/hooks/commitlint-before-commit.py` |
|---|---|---|
| Fires for | every commit (humans, IDE, CI, agents) | only Claude-initiated `git commit` Bash calls |
| Failure UX | bash exit non-zero → Claude has to parse stderr | structured deny JSON → Claude sees the reason directly |

### Layout note

`.commitlintrc.json` lives at `ui/.commitlintrc.json` (not repo root) because commitlint resolves `extends: ["@commitlint/config-conventional"]` relative to the config's directory, and the project's `node_modules` lives only in `ui/`.

## Test plan

- [x] `commitlint` rejects: bad format, missing scope, header > 69 chars, trailing-period subject
- [x] husky `commit-msg` aborts a real `git commit -m "totally bad message"` with `husky - commit-msg script failed (code 1)`
- [x] Claude hook returns deny JSON for: bad heredoc, bad simple `-m`, missing scope; exits 0 for: valid heredoc, non-commit Bash (`ls -la`), `git commit --amend --no-edit`
- [x] `ruff check` + `ruff format --check` pass on the Python hook
- [x] This very PR's first commit (`chore(commitlint): …`) was validated by the new layers — self-consistency check