### PR TITLE
chore(harness): add issue rules and refine PR linking

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -11,9 +11,17 @@
 - Do NOT use GitHub magic close-keywords (`Closes`, `Fixes`, `Resolves`) in commit messages — those belong in the PR body so they close issues on merge, not on every push.
 - Sign off every commit per the Developer Certificate of Origin: `git commit -s` (adds a `Signed-off-by:` trailer).
 
+## Issues
+
+If you spot something worth tracking outside the current task, surface it and offer to file a GitHub issue — don't let findings get buried in chat. Never create one yourself unless the user explicitly asks. Before creating any issue:
+
+- Verify the claim (re-read the code, run the relevant test, reproduce if possible).
+- Search existing issues (`gh issue list --search "..."`) to avoid duplicates. If a match exists, comment on it with new findings instead of opening a new one.
+
 ## Pull requests
 
 - Keep PRs **small and focused**. Split unrelated changes into separate PRs.
-- Magic close-keywords (`Closes #123`, `Fixes #123`) go in the PR **body**, not the title.
+- Before opening a PR, search existing issues (`gh issue list --search "..."`) and link the ones the change touches in the PR **body** (never the title).
+- Use `Closes #N` / `Fixes #N` for issues the PR fully resolves — they auto-close on merge. Use `Refs #N` for partial relation.
 - PRs are **squash-merged**. The squash commit message must follow Conventional Commits (see `conventional-commits.md`).
 - When a PR adds or changes a feature, update the relevant documentation in the same PR.


### PR DESCRIPTION
## Summary

- Add `## Issues` section to `.claude/rules/git-workflow.md`: surface out-of-scope findings and offer an issue (don't bury in chat), but never create one autonomously — only when the user explicitly asks. Verify the claim and search existing issues before any creation, preferring a comment on a matching issue over a duplicate.
- Refine `## Pull requests`: replace the lone "close-keywords go in body" bullet with two — search existing issues and link the ones the change touches, and choose between `Closes #N` / `Fixes #N` (auto-close on merge) and `Refs #N` (partial relation).

## Test plan

- [x] N/A — rules-doc only change. No code, tests, or build affected.