### PR TITLE
docs(roadmap): add phase 25 — reverse-proxy path prefix

### DIFF
--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -336,6 +336,18 @@ Large upstream responses are fully buffered today, which spikes memory and block
 - Add backend tests against a mocked `oauth2.googleapis.com`; existing Pipedream tests must continue to pass
 - Close #336 on implementation; cross-reference #104 (overlapping design, not a duplicate)
 
+## Phase 25 — Reverse-Proxy Path Prefix Support
+
+**Goal:** Allow Jentic Mini to be mounted at any path prefix behind a reverse proxy, not only the subdomain root.
+**Depends on:** none (self-contained)
+**Priority:** High (unblocks self-hosted reverse-proxy deploys)
+
+- Set Vite `base: './'` so bundled assets resolve relative to the served `index.html`
+- Initialize `FastAPI(root_path=...)` from `JENTIC_ROOT_PATH` env (fallback: `X-Forwarded-Prefix` header)
+- Render the served `index.html` with a dynamic `<base href="{root_path}/">` from `request.scope["root_path"]`
+- Add tests covering unmounted (default) and mounted (`/foo`) modes — SPA load, asset paths, `/docs`, `/openapi.json`, internal routes
+- Close or cross-reference issue #356
+
 ---
 
 ## Later Phases (Not Yet Planned)


### PR DESCRIPTION
## Summary
- Adds **Phase 25 — Reverse-Proxy Path Prefix Support** to `specs/roadmap.md`
- High priority, self-contained; unblocks self-hosted deploys behind a reverse proxy at a sub-path

## Notes for `/sdd-new-spec 25`
Three implementation gotchas the bullets gloss over (intentionally — operational detail belongs in the feature spec, not the roadmap):
- `<base href>` alone won't fix SPA routing — `react-router-dom`'s `createBrowserRouter` needs `basename` passed explicitly
- `X-Forwarded-Prefix` is per-request; needs Starlette middleware mutating `scope["root_path"]`, not the static `FastAPI(root_path=...)` constructor
- Tests should split into three cases — unmounted (default), env-driven (`JENTIC_ROOT_PATH=/foo`), header-driven (`X-Forwarded-Prefix: /foo`)

## Test plan
- [x] Phase 25 block format matches existing entries (Goal / Depends on / Priority + bullets)
- [x] Phase number is `max(active) + 1 = 25` (gaps at 13/14 preserved per the lifecycle rule)
- [x] No existing phase renumbered, `## Later Phases` section untouched

Refs #356