### PR TITLE
feat(main): support reverse-proxy path prefix mounting

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -15,6 +15,7 @@ See @DEVELOPMENT.md for prerequisites, installation, and running the server.
 ### Key environment variables
 - `JENTIC_VAULT_KEY` — Fernet key for credentials vault (auto-generated from `data/vault.key` if unset)
 - `JENTIC_PUBLIC_HOSTNAME` — public hostname for self-links and workflow dispatch
+- `JENTIC_ROOT_PATH` — path prefix when Mini is mounted under a reverse proxy (e.g. `/jentic`); falls back to the per-request `X-Forwarded-Prefix` header when unset
 - `DB_PATH` — SQLite database path (default: `/app/data/jentic-mini.db`)
 - `LOG_LEVEL` — `debug | info | warning | error`
 - `JENTIC_HOST_PATH` — project root path for Docker mounts (defaults to `.`)

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,16 @@
 # Public hostname (used in self-links and arazzo callbacks)
 # JENTIC_PUBLIC_HOSTNAME=mini.jentic.com
 
+# Optional path prefix when Mini is mounted under a reverse proxy
+# (e.g. example.com/jentic). Empty / unset / "/" all mean "no mount".
+# Opt-in: when set, the SPA bundle, hand-rolled /docs and /redoc, and
+# self-links resolve under the prefix. When unset, Mini falls back to the
+# per-request X-Forwarded-Prefix header (Traefik / nginx Ingress style).
+# Pair with JENTIC_PUBLIC_BASE_URL when mounting — that env var must include
+# the prefix (e.g. https://example.com/jentic) so OAuth issuer / token aud
+# values are correct.
+# JENTIC_ROOT_PATH=/jentic
+
 # Log level: debug | info | warning | error
 LOG_LEVEL=info
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,12 @@ Open `http://localhost:8900` to complete setup.
 
 Optional environment variables (set in `.env` or pass to `docker compose`):
 
-| Variable                 | Default        | Description                                                                       |
-| ------------------------ | -------------- | --------------------------------------------------------------------------------- |
-| `JENTIC_VAULT_KEY`       | auto-generated | [Fernet](https://cryptography.io/en/latest/fernet/) key for the credentials vault |
-| `JENTIC_PUBLIC_HOSTNAME` | `localhost`    | Public hostname for self-links and workflow IDs, e.g. `jentic.example.com`        |
-| `LOG_LEVEL`              | `info`         | `debug`, `info`, `warning`, `error`                                               |
+| Variable                 | Default        | Description                                                                                                                                                                                                    |
+| ------------------------ | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `JENTIC_VAULT_KEY`       | auto-generated | [Fernet](https://cryptography.io/en/latest/fernet/) key for the credentials vault                                                                                                                              |
+| `JENTIC_PUBLIC_HOSTNAME` | `localhost`    | Public hostname for self-links and workflow IDs, e.g. `jentic.example.com`                                                                                                                                     |
+| `JENTIC_ROOT_PATH`       | _(unset)_      | Path prefix to mount the app under, e.g. `/jentic`. Pair with `JENTIC_PUBLIC_BASE_URL` (which must include the prefix) for OAuth issuer correctness. If unset, falls back to `X-Forwarded-Prefix` per request. |
+| `LOG_LEVEL`              | `info`         | `debug`, `info`, `warning`, `error`                                                                                                                                                                            |
 
 ### Authentication
 

--- a/compose.yml
+++ b/compose.yml
@@ -15,6 +15,11 @@ services:
       - ${JENTIC_DATA_PATH:-${JENTIC_HOST_PATH:-.}/data}:/app/data
     environment:
       JENTIC_PUBLIC_HOSTNAME: ${JENTIC_PUBLIC_HOSTNAME}
+      # Optional path prefix when Mini is mounted under a reverse proxy
+      # (e.g. example.com/jentic). Empty / unset / "/" all mean "no mount".
+      # When unset, Mini honours the per-request X-Forwarded-Prefix header.
+      # Pair with JENTIC_PUBLIC_BASE_URL (which must include the prefix).
+      JENTIC_ROOT_PATH: ${JENTIC_ROOT_PATH:-}
       # Pin the canonical base URL used to derive the OAuth issuer / token aud /
       # registration_client_uri. Required for any deployment where the inbound
       # Host: header is not strictly trustworthy (internet-facing or shared

--- a/docs/deploy/digitalocean/README.md
+++ b/docs/deploy/digitalocean/README.md
@@ -71,6 +71,33 @@ sed -i 's/JENTIC_PUBLIC_HOSTNAME=.*/JENTIC_PUBLIC_HOSTNAME=your-domain.com/' /op
 docker restart jentic-mini
 ```
 
+### Step 5b (optional) - Mounting under a path prefix
+
+Want Jentic Mini to share a domain with other apps (e.g. `your-domain.com/jentic`)?
+Use Caddy's `handle_path` directive to strip the prefix before forwarding, and pin
+the prefix on the container so the SPA bundle, hand-rolled docs, and self-links
+resolve under the mount.
+
+```caddyfile
+your-domain.com {
+    handle_path /jentic/* {
+        reverse_proxy localhost:8900
+    }
+    # other apps on the same domain go here
+}
+```
+
+```bash
+cat >> /opt/jentic-mini/jentic-mini.env <<EOF
+JENTIC_ROOT_PATH=/jentic
+JENTIC_PUBLIC_BASE_URL=https://your-domain.com/jentic
+EOF
+docker restart jentic-mini
+```
+
+`JENTIC_PUBLIC_BASE_URL` must include the prefix — the OAuth issuer is pinned to
+this value and is security-critical. Operators must set both env vars when mounting.
+
 ### Updating
 
 SSH into the droplet and run:

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -336,18 +336,6 @@ Large upstream responses are fully buffered today, which spikes memory and block
 - Add backend tests against a mocked `oauth2.googleapis.com`; existing Pipedream tests must continue to pass
 - Close #336 on implementation; cross-reference #104 (overlapping design, not a duplicate)
 
-## Phase 25 — Reverse-Proxy Path Prefix Support
-
-**Goal:** Allow Jentic Mini to be mounted at any path prefix behind a reverse proxy, not only the subdomain root.
-**Depends on:** none (self-contained)
-**Priority:** High (unblocks self-hosted reverse-proxy deploys)
-
-- Set Vite `base: './'` so bundled assets resolve relative to the served `index.html`
-- Initialize `FastAPI(root_path=...)` from `JENTIC_ROOT_PATH` env (fallback: `X-Forwarded-Prefix` header)
-- Render the served `index.html` with a dynamic `<base href="{root_path}/">` from `request.scope["root_path"]`
-- Add tests covering unmounted (default) and mounted (`/foo`) modes — SPA load, asset paths, `/docs`, `/openapi.json`, internal routes
-- Close or cross-reference issue #356
-
 ---
 
 ## Later Phases (Not Yet Planned)

--- a/src/auth.py
+++ b/src/auth.py
@@ -318,6 +318,7 @@ async def _human_session_response(request: Request, call_next, jwt_token: str | 
             httponly=True,
             samesite="strict",
             max_age=JWT_TTL_SECONDS,
+            path=request.scope.get("root_path") or "/",
         )
     return response
 

--- a/src/auth.py
+++ b/src/auth.py
@@ -43,6 +43,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from src.agent_identity_gate import verify_registration_access_token
 from src.agent_identity_util import hash_token
 from src.db import DB_PATH, DEFAULT_TOOLKIT_ID, setup_state
+from src.utils import route_path
 
 
 logger = logging.getLogger("jentic.auth")
@@ -325,7 +326,7 @@ async def _human_session_response(request: Request, call_next, jwt_token: str | 
 
 class APIKeyMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
-        path = request.url.path
+        path = route_path(request.scope)
         method = request.method
 
         # ── Default state ─────────────────────────────────────────────────────

--- a/src/config.py
+++ b/src/config.py
@@ -28,7 +28,7 @@ JENTIC_PUBLIC_HOSTNAME = os.getenv("JENTIC_PUBLIC_HOSTNAME") or "localhost"
 # the SPA bundle, hand-rolled docs, and self-links resolve under the prefix; if
 # unset, the per-request X-Forwarded-Prefix header is honoured. Pair with
 # JENTIC_PUBLIC_BASE_URL (which must include the prefix) when mounting.
-def _normalise_root_path(value: str) -> str:
+def normalise_root_path(value: str) -> str:
     """Normalise and validate a path-prefix value.
 
     Empty string and "/" both mean "no mount" → "". Other values must start
@@ -52,7 +52,7 @@ def _normalise_root_path(value: str) -> str:
     return value[:-1] if value.endswith("/") and len(value) > 1 else value
 
 
-JENTIC_ROOT_PATH = _normalise_root_path(os.getenv("JENTIC_ROOT_PATH", ""))
+JENTIC_ROOT_PATH = normalise_root_path(os.getenv("JENTIC_ROOT_PATH", ""))
 
 # ── Public base URL ───────────────────────────────────────────────────────────
 # Operator-pinned canonical base URL (no trailing slash) — e.g.

--- a/src/config.py
+++ b/src/config.py
@@ -21,6 +21,39 @@ WORKFLOWS_DIR = DATA_DIR / "workflows"
 # ── Public hostname ───────────────────────────────────────────────────────────
 JENTIC_PUBLIC_HOSTNAME = os.getenv("JENTIC_PUBLIC_HOSTNAME") or "localhost"
 
+
+# ── Reverse-proxy path prefix ─────────────────────────────────────────────────
+# Optional path at which Mini is mounted behind a reverse proxy (Caddy, Traefik,
+# nginx Ingress, etc.). Empty / unset / "/" all mean "no mount" → "". When set,
+# the SPA bundle, hand-rolled docs, and self-links resolve under the prefix; if
+# unset, the per-request X-Forwarded-Prefix header is honoured. Pair with
+# JENTIC_PUBLIC_BASE_URL (which must include the prefix) when mounting.
+def _normalise_root_path(value: str) -> str:
+    """Normalise and validate a path-prefix value.
+
+    Empty string and "/" both mean "no mount" → "". Other values must start
+    with "/" and contain no whitespace, "?", "#", "..", or consecutive "//".
+    A single trailing slash is stripped ("/foo/" → "/foo"); "/foo" is returned
+    unchanged. Validation runs against the raw value so "//" surfaces here
+    rather than collapsing silently.
+    """
+    if value in ("", "/"):
+        return ""
+    if (
+        not value.startswith("/")
+        or any(ch.isspace() or ch in "?#" for ch in value)
+        or ".." in value
+        or "//" in value
+    ):
+        raise RuntimeError(
+            "JENTIC_ROOT_PATH must start with '/' and contain no whitespace, "
+            "query, fragment, '..', or '//'"
+        )
+    return value[:-1] if value.endswith("/") and len(value) > 1 else value
+
+
+JENTIC_ROOT_PATH = _normalise_root_path(os.getenv("JENTIC_ROOT_PATH", ""))
+
 # ── Public base URL ───────────────────────────────────────────────────────────
 # Operator-pinned canonical base URL (no trailing slash) — e.g.
 # "https://jentic.example.com". When set, the issuer / token aud /

--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, Field
 
 from src.auth import APIKeyMiddleware
 from src.brokers.pipedream import PipedreamOAuthBroker
-from src.config import APP_VERSION
+from src.config import APP_VERSION, JENTIC_ROOT_PATH, normalise_root_path
 from src.db import run_migrations, setup_state
 from src.negotiate import negotiate_middleware
 from src.oauth_broker import registry as oauth_broker_registry
@@ -83,6 +83,56 @@ async def lifespan(app: FastAPI):
     log.info("Jentic shutting down")
 
 
+class ForwardedPrefixMiddleware:
+    """Resolve and strip the active root_path from each ASGI scope.
+
+    Sources, in precedence order:
+    1. ``JENTIC_ROOT_PATH`` env var — already on ``scope["root_path"]`` from the
+       FastAPI constructor.
+    2. ``X-Forwarded-Prefix`` header — read per request when the env var is
+       unset; invalid values are silently ignored (treated as no mount).
+
+    After resolving, the middleware strips the prefix from ``scope["path"]``
+    and ``scope["raw_path"]`` so downstream middleware comparing
+    ``request.url.path`` against unprefixed constants (``_SPA_PATHS``,
+    ``_is_public``) keeps working under any mount. Idempotent.
+
+    Registered last so it ends up Starlette's outermost middleware and runs
+    first on the way in.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        if not scope.get("root_path"):
+            for key, value in scope.get("headers", []):
+                if key == b"x-forwarded-prefix":
+                    try:
+                        scope["root_path"] = normalise_root_path(value.decode("latin-1"))
+                    except RuntimeError:
+                        # Hostile / malformed header → treat as no mount.
+                        pass
+                    break
+
+        root_path = scope.get("root_path", "")
+        if root_path:
+            path = scope.get("path", "")
+            if path.startswith(root_path):
+                scope["path"] = path[len(root_path) :] or "/"
+            raw_path = scope.get("raw_path")
+            if raw_path is not None:
+                root_path_bytes = root_path.encode("latin-1")
+                if raw_path.startswith(root_path_bytes):
+                    scope["raw_path"] = raw_path[len(root_path_bytes) :] or b"/"
+
+        await self.app(scope, receive, send)
+
+
 # Tag order controls Swagger UI section order.
 # Within each section, operations appear in router-registration order.
 _TAGS_METADATA = [
@@ -127,6 +177,7 @@ _TAGS_METADATA = [
 
 app = FastAPI(
     title="Jentic Mini",
+    root_path=JENTIC_ROOT_PATH,
     openapi_tags=_TAGS_METADATA,
     description=(
         "**Jentic Mini** is the open-source, self-hosted implementation of the Jentic API — "
@@ -499,6 +550,13 @@ async def spa_middleware(request: Request, call_next):
                 return resp
             return Response(content="UI not built", status_code=404, media_type="text/plain")
     return await call_next(request)
+
+
+# ── Reverse-proxy prefix middleware — registered last so it ends up Starlette's
+#    outermost middleware. Resolves scope["root_path"] from JENTIC_ROOT_PATH or
+#    X-Forwarded-Prefix and strips it from scope["path"] before any downstream
+#    middleware reads request.url.path.
+app.add_middleware(ForwardedPrefixMiddleware)
 
 
 # ── Broker catch-all — MUST be registered last ────────────────────────────────

--- a/src/main.py
+++ b/src/main.py
@@ -48,7 +48,7 @@ from src.routers.apis import rebuild_index_on_startup
 from src.routers.catalog import refresh_catalog_if_stale
 from src.routers.toolkits import policy_router as toolkits_policy_router
 from src.startup import backfill_credential_routes, seed_broker_apps, self_register
-from src.utils import build_absolute_url, build_canonical_url
+from src.utils import build_absolute_url, build_canonical_url, route_path
 
 
 logging.basicConfig(level=(os.getenv("LOG_LEVEL") or "info").upper())
@@ -84,21 +84,20 @@ async def lifespan(app: FastAPI):
 
 
 class ForwardedPrefixMiddleware:
-    """Resolve and strip the active root_path from each ASGI scope.
+    """Resolve the active root_path on each ASGI scope.
 
     Sources, in precedence order:
-    1. ``JENTIC_ROOT_PATH`` env var — already on ``scope["root_path"]`` from the
-       FastAPI constructor.
+    1. ``JENTIC_ROOT_PATH`` env var — already on ``scope["root_path"]`` from
+       the FastAPI constructor.
     2. ``X-Forwarded-Prefix`` header — read per request when the env var is
        unset; invalid values are silently ignored (treated as no mount).
 
-    After resolving, the middleware strips the prefix from ``scope["path"]``
-    and ``scope["raw_path"]`` so downstream middleware comparing
-    ``request.url.path`` against unprefixed constants (``_SPA_PATHS``,
-    ``_is_public``) keeps working under any mount. Idempotent.
-
-    Registered last so it ends up Starlette's outermost middleware and runs
-    first on the way in.
+    Path stripping is intentionally left to Starlette's routing machinery
+    (``get_route_path``) so ``Mount`` / ``StaticFiles`` cooperation stays
+    intact — pre-stripping here causes ``StaticFiles`` to look in the wrong
+    directory because ``Mount.matches`` recomputes ``root_path`` assuming
+    the prefix is still on ``scope["path"]``. Custom middleware that compare
+    against unprefixed constants use :func:`src.utils.route_path` instead.
     """
 
     def __init__(self, app):
@@ -118,17 +117,6 @@ class ForwardedPrefixMiddleware:
                         # Hostile / malformed header → treat as no mount.
                         pass
                     break
-
-        root_path = scope.get("root_path", "")
-        if root_path:
-            path = scope.get("path", "")
-            if path.startswith(root_path):
-                scope["path"] = path[len(root_path) :] or "/"
-            raw_path = scope.get("raw_path")
-            if raw_path is not None:
-                root_path_bytes = root_path.encode("latin-1")
-                if raw_path.startswith(root_path_bytes):
-                    scope["raw_path"] = raw_path[len(root_path_bytes) :] or b"/"
 
         await self.app(scope, receive, send)
 
@@ -566,7 +554,7 @@ _SPA_PATHS = {
 @app.middleware("http")
 async def spa_middleware(request: Request, call_next):
     if request.method == "GET":
-        path = request.url.path
+        path = route_path(request.scope)
         accept = request.headers.get("accept", "")
         wants_html = any(part.strip().startswith("text/html") for part in accept.split(","))
         # Exclude connect-callback from SPA interception (real GET endpoint, browser redirect)

--- a/src/main.py
+++ b/src/main.py
@@ -254,6 +254,35 @@ app.middleware("http")(negotiate_middleware)
 # ── Static dir — defined early so route handlers can reference it ──────────────
 STATIC_DIR = Path(__file__).resolve().parent.parent / "static"
 
+
+# Tolerant regex: matches <base ...> with any href, with-or-without self-close,
+# with-or-without extra spaces. Substitutes only the first occurrence.
+_BASE_TAG_RE = re.compile(rb'<base\s+href="[^"]*"\s*/?\s*>')
+
+
+def _inject_base_href(html: bytes, root_path: str) -> bytes:
+    """Substitute the SPA's <base href="..."> with one that includes root_path.
+
+    When ``root_path`` is empty, the bytes are returned unchanged. Otherwise the
+    first ``<base ...>`` tag is replaced with ``<base href="{root_path}/" />``
+    (trailing slash intentional — browsers resolve relative URLs against
+    ``<base href>`` differently with vs. without it). HTML without any
+    ``<base>`` tag is returned unchanged.
+    """
+    if not root_path:
+        return html
+    return _BASE_TAG_RE.sub(f'<base href="{root_path}/" />'.encode(), html, count=1)
+
+
+def _render_index(request: Request) -> HTMLResponse:
+    """Read SPA index.html, inject the per-request base href, return HTML."""
+    body = _inject_base_href(
+        (STATIC_DIR / "index.html").read_bytes(),
+        request.scope.get("root_path", ""),
+    )
+    return HTMLResponse(body, media_type="text/html")
+
+
 app.include_router(capability_router.router, tags=["inspect"])
 app.include_router(workflows_router.router)
 app.include_router(import_router.router, tags=["catalog"])
@@ -434,32 +463,36 @@ async def llms_txt():
 
 
 @app.get("/", tags=["meta"], include_in_schema=False)
-async def root():
+async def root(request: Request):
     index_path = STATIC_DIR / "index.html"
     if index_path.exists():
-        return FileResponse(index_path)
+        return _render_index(request)
     return {"message": "Jentic API is running. See /docs for API documentation."}
 
 
 # ── Docs served locally (no CDN, works offline / on patchy connections) ───────
 @app.get("/docs", include_in_schema=False)
-async def swagger_ui():
-    # Custom Swagger UI with persistAuthorization + auth banner
-    html = """<!DOCTYPE html>
+async def swagger_ui(request: Request):
+    rp = request.scope.get("root_path", "")
+    # Custom Swagger UI with persistAuthorization + auth banner. Every absolute
+    # path the browser resolves (CSS / JS asset URLs, the login link, the
+    # OpenAPI URL) is prefixed with the active root_path so the page works
+    # under any mount.
+    html = f"""<!DOCTYPE html>
 <html>
 <head>
   <title>Jentic — Swagger UI</title>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" type="text/css" href="/static/swagger-ui.css" >
+  <link rel="stylesheet" type="text/css" href="{rp}/static/swagger-ui.css" >
   <style>
-    .auth-banner {
+    .auth-banner {{
       background: #1a1a2e; border-left: 4px solid #667eea;
       color: #e0e0e0; padding: 12px 20px; font-family: monospace;
       font-size: 14px; margin: 0;
-    }
-    .auth-banner strong { color: #667eea; }
-    .auth-banner code { background: #2d2d2d; padding: 2px 6px; border-radius: 3px; }
+    }}
+    .auth-banner strong {{ color: #667eea; }}
+    .auth-banner code {{ background: #2d2d2d; padding: 2px 6px; border-radius: 3px; }}
   </style>
 </head>
 <body>
@@ -467,23 +500,23 @@ async def swagger_ui():
   🔑 <strong>Authentication.</strong>
   <strong>Agents (toolkit):</strong> <em>JenticApiKey</em> — your <code>tk_xxx</code> in <code>X-Jentic-API-Key</code>.
   <strong>Agents (OAuth):</strong> <em>AgentOauthAccessToken</em> — <code>Authorization: Bearer</code> with <code>at_…</code>; <em>AgentOauthRegistrationToken</em> — <code>Authorization: Bearer</code> with <code>rat_…</code> where applicable.
-  <strong>Humans:</strong> <em>HumanLogin</em> (username + password) — or <a href="/login" style="color:#a5b4fc">log in here</a> for a browser session.
+  <strong>Humans:</strong> <em>HumanLogin</em> (username + password) — or <a href="{rp}/login" style="color:#a5b4fc">log in here</a> for a browser session.
   OAuth agents: <code>GET /.well-known/oauth-authorization-server</code> then <code>POST /register</code>. Toolkit keys are issued from the UI.
 </div>
 <div id="swagger-ui"></div>
-<script src="/static/swagger-ui-bundle.js"> </script>
+<script src="{rp}/static/swagger-ui-bundle.js"> </script>
 <script>
-  window.onload = function() {
-    SwaggerUIBundle({
-      url: "/openapi.json",
+  window.onload = function() {{
+    SwaggerUIBundle({{
+      url: "{rp}/openapi.json",
       dom_id: '#swagger-ui',
       presets: [ SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset ],
       layout: "BaseLayout",
       persistAuthorization: true,
       tryItOutEnabled: true,
-      requestInterceptor: function(req) { return req; },
-    })
-  }
+      requestInterceptor: function(req) {{ return req; }},
+    }})
+  }}
 </script>
 </body>
 </html>"""
@@ -491,11 +524,12 @@ async def swagger_ui():
 
 
 @app.get("/redoc", include_in_schema=False)
-async def redoc():
+async def redoc(request: Request):
+    rp = request.scope.get("root_path", "")
     return get_redoc_html(
-        openapi_url="/openapi.json",
+        openapi_url=f"{rp}/openapi.json",
         title="Jentic — Redoc",
-        redoc_js_url="/static/redoc.standalone.js",
+        redoc_js_url=f"{rp}/static/redoc.standalone.js",
     )
 
 
@@ -544,7 +578,7 @@ async def spa_middleware(request: Request, call_next):
         ):
             index_path = STATIC_DIR / "index.html"
             if index_path.exists():
-                resp = FileResponse(index_path)
+                resp = _render_index(request)
                 resp.headers["Vary"] = "Accept"
                 resp.headers["Cache-Control"] = "no-store"
                 return resp

--- a/src/routers/user.py
+++ b/src/routers/user.py
@@ -115,6 +115,7 @@ async def create_user(body: UserCreate, request: Request, response: Response):
         httponly=True,
         samesite="strict",
         max_age=JWT_TTL_SECONDS,
+        path=request.scope.get("root_path") or "/",
     )
 
     audit_log.info("ACCOUNT_CREATED user=%s ip=%s", body.username.strip(), client_ip(request))
@@ -207,7 +208,12 @@ async def login(
             redirect_to = "/"
         redir = RedirectResponse(url=redirect_to, status_code=303)
         redir.set_cookie(
-            "jentic_session", token, httponly=True, samesite="strict", max_age=JWT_TTL_SECONDS
+            "jentic_session",
+            token,
+            httponly=True,
+            samesite="strict",
+            max_age=JWT_TTL_SECONDS,
+            path=request.scope.get("root_path") or "/",
         )
         return redir
 
@@ -217,6 +223,7 @@ async def login(
         httponly=True,
         samesite="strict",
         max_age=JWT_TTL_SECONDS,
+        path=request.scope.get("root_path") or "/",
     )
 
     return {"message": "Logged in.", "username": row["username"]}
@@ -297,7 +304,7 @@ async def logout(request: Request, response: Response):
     except Exception:
         pass
     audit_log.info("LOGOUT user=%s ip=%s", username, client_ip(request))
-    response.delete_cookie("jentic_session")
+    response.delete_cookie("jentic_session", path=request.scope.get("root_path") or "/")
     return {"message": "Logged out."}
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -5,6 +5,27 @@ import re
 from src.config import JENTIC_PUBLIC_BASE_URL, JENTIC_PUBLIC_HOSTNAME
 
 
+def route_path(scope) -> str:
+    """Return ``scope["path"]`` with ``scope["root_path"]`` stripped if applicable.
+
+    Mirrors Starlette's internal ``get_route_path`` so middleware that compares
+    against unprefixed constants (``_SPA_PATHS``, ``_is_public``) keeps working
+    when Mini is mounted under a path prefix. Path stripping is left to
+    Starlette's routing machinery for ``Mount`` / ``StaticFiles`` cooperation;
+    custom middleware call this helper to read the same view of the path that
+    decorator-style routes see.
+    """
+    path = scope.get("path", "")
+    root_path = scope.get("root_path", "")
+    if not root_path or not path.startswith(root_path):
+        return path
+    if path == root_path:
+        return ""
+    if path[len(root_path)] == "/":
+        return path[len(root_path) :]
+    return path
+
+
 def build_absolute_url(request, path: str) -> str:
     """Build an absolute URL from a request and a path.
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,7 +8,9 @@ from src.config import JENTIC_PUBLIC_BASE_URL, JENTIC_PUBLIC_HOSTNAME
 def build_absolute_url(request, path: str) -> str:
     """Build an absolute URL from a request and a path.
 
-    Respects X-Forwarded-Proto behind reverse proxies.
+    Respects X-Forwarded-Proto behind reverse proxies and prepends the active
+    ``root_path`` (from ``JENTIC_ROOT_PATH`` or ``X-Forwarded-Prefix``) so
+    self-links resolve under the mount.
     Handles comma-separated values from chained proxies.
     """
     host = (
@@ -23,7 +25,8 @@ def build_absolute_url(request, path: str) -> str:
     scheme = request.headers.get("x-forwarded-proto", request.url.scheme).split(",")[0].strip()
     if scheme not in ("http", "https"):
         scheme = "http"
-    return f"{scheme}://{host}{path}"
+    root_path = request.scope.get("root_path", "") if hasattr(request, "scope") else ""
+    return f"{scheme}://{host}{root_path}{path}"
 
 
 def build_canonical_url(request, path: str) -> str:

--- a/tests/fixtures/index.html
+++ b/tests/fixtures/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><base href="/" /></head><body></body></html>

--- a/tests/test_root_path.py
+++ b/tests/test_root_path.py
@@ -1,0 +1,204 @@
+"""Three-mode integration tests for reverse-proxy path prefix support.
+
+Mode A — JENTIC_ROOT_PATH unset, no X-Forwarded-Prefix → no mount (regression).
+Mode B — JENTIC_ROOT_PATH=/foo simulated by setting app.root_path; FastAPI's
+        per-request scope filling propagates this into scope["root_path"].
+Mode C — X-Forwarded-Prefix: /foo header; ForwardedPrefixMiddleware reads it
+        per-request and writes scope["root_path"].
+
+All three modes are exercised against the same session-scoped `app` fixture.
+A function-scoped fixture monkeypatches src.main.STATIC_DIR to point at
+tests/fixtures/ so _render_index has an index.html to read regardless of
+whether the UI build artefact is present.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def static_fixtures(monkeypatch):
+    """Point STATIC_DIR at tests/fixtures/ for the duration of one test."""
+    fixtures_dir = Path(__file__).parent / "fixtures"
+    monkeypatch.setattr("src.main.STATIC_DIR", fixtures_dir)
+    return fixtures_dir
+
+
+@pytest.fixture
+def app_with_prefix(app, monkeypatch):
+    """Mode B fixture — pin app.root_path so FastAPI fills scope["root_path"]."""
+    monkeypatch.setattr(app, "root_path", "/foo")
+    return app
+
+
+# ── Mode A — unset, regression ──────────────────────────────────────────────
+
+
+def test_mode_a_root_serves_unprefixed_base(client, static_fixtures):
+    resp = client.get("/", headers={"Accept": "text/html"})
+    assert resp.status_code == 200
+    assert b'href="/"' in resp.content
+    assert b'href="/foo/"' not in resp.content
+
+
+def test_mode_a_openapi_reachable(client, static_fixtures):
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 200
+    assert "openapi" in resp.json()
+
+
+def test_mode_a_docs_reachable(client, static_fixtures):
+    resp = client.get("/docs")
+    assert resp.status_code == 200
+    assert b"swagger-ui-bundle.js" in resp.content
+    # Without a mount, asset URLs are bare (start with /static).
+    assert b'src="/static/swagger-ui-bundle.js"' in resp.content
+
+
+def test_mode_a_health_reachable(client, static_fixtures):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+
+
+def test_mode_a_spa_fallback_for_credentials(client, static_fixtures):
+    resp = client.get("/credentials", headers={"Accept": "text/html"})
+    assert resp.status_code == 200
+    assert b'href="/"' in resp.content
+
+
+def test_mode_a_login_cookie_path_unprefixed(admin_client, static_fixtures):
+    """Login Set-Cookie carries Path=/ (no mount → origin-root cookie)."""
+    resp = admin_client.post(
+        "/user/login",
+        json={"username": "testadmin", "password": "testpassword123"},
+    )
+    assert resp.status_code == 200
+    cookie_header = resp.headers.get("set-cookie", "")
+    assert "Path=/" in cookie_header
+    assert "Path=/foo" not in cookie_header
+
+
+# ── Mode B — env-pinned (app.root_path) ─────────────────────────────────────
+
+
+def test_mode_b_root_serves_prefixed_base(client, app_with_prefix, static_fixtures):
+    resp = client.get("/foo/", headers={"Accept": "text/html"})
+    assert resp.status_code == 200
+    assert b'href="/foo/"' in resp.content
+
+
+def test_mode_b_openapi_reachable(client, app_with_prefix, static_fixtures):
+    """Proves task 6's path-strip propagates through APIKeyMiddleware._is_public."""
+    resp = client.get("/foo/openapi.json")
+    assert resp.status_code == 200
+    assert "openapi" in resp.json()
+
+
+def test_mode_b_docs_assets_prefixed(client, app_with_prefix, static_fixtures):
+    """Hand-rolled /docs HTML embeds prefixed asset URLs."""
+    resp = client.get("/foo/docs")
+    assert resp.status_code == 200
+    assert b"/foo/static/swagger-ui-bundle.js" in resp.content
+    assert b"/foo/static/swagger-ui.css" in resp.content
+    assert b'"/foo/openapi.json"' in resp.content
+    assert b'href="/foo/login"' in resp.content
+
+
+def test_mode_b_redoc_assets_prefixed(client, app_with_prefix, static_fixtures):
+    resp = client.get("/foo/redoc")
+    assert resp.status_code == 200
+    assert b"/foo/static/redoc.standalone.js" in resp.content
+    assert b"/foo/openapi.json" in resp.content
+
+
+def test_mode_b_health_reachable(client, app_with_prefix, static_fixtures):
+    resp = client.get("/foo/health")
+    assert resp.status_code == 200
+
+
+def test_mode_b_spa_fallback_for_credentials(client, app_with_prefix, static_fixtures):
+    """Proves both task 6's path-strip AND task 9's <base> injection fire."""
+    resp = client.get("/foo/credentials", headers={"Accept": "text/html"})
+    assert resp.status_code == 200
+    assert b'href="/foo/"' in resp.content
+
+
+def test_mode_b_login_cookie_path_prefixed(admin_client, app_with_prefix, static_fixtures):
+    """Login Set-Cookie carries Path=/foo (cookie scoped to the mount)."""
+    resp = admin_client.post(
+        "/foo/user/login",
+        json={"username": "testadmin", "password": "testpassword123"},
+    )
+    assert resp.status_code == 200
+    cookie_header = resp.headers.get("set-cookie", "")
+    assert "Path=/foo" in cookie_header
+
+
+# ── Mode C — header-driven (X-Forwarded-Prefix) ─────────────────────────────
+
+
+_PREFIX_HEADERS = {"X-Forwarded-Prefix": "/foo"}
+
+
+def test_mode_c_root_serves_prefixed_base(client, static_fixtures):
+    resp = client.get(
+        "/foo/",
+        headers={"Accept": "text/html", **_PREFIX_HEADERS},
+    )
+    assert resp.status_code == 200
+    assert b'href="/foo/"' in resp.content
+
+
+def test_mode_c_openapi_reachable(client, static_fixtures):
+    resp = client.get("/foo/openapi.json", headers=_PREFIX_HEADERS)
+    assert resp.status_code == 200
+    assert "openapi" in resp.json()
+
+
+def test_mode_c_docs_assets_prefixed(client, static_fixtures):
+    resp = client.get("/foo/docs", headers=_PREFIX_HEADERS)
+    assert resp.status_code == 200
+    assert b"/foo/static/swagger-ui-bundle.js" in resp.content
+
+
+def test_mode_c_health_reachable(client, static_fixtures):
+    resp = client.get("/foo/health", headers=_PREFIX_HEADERS)
+    assert resp.status_code == 200
+
+
+def test_mode_c_spa_fallback_for_credentials(client, static_fixtures):
+    resp = client.get(
+        "/foo/credentials",
+        headers={"Accept": "text/html", **_PREFIX_HEADERS},
+    )
+    assert resp.status_code == 200
+    assert b'href="/foo/"' in resp.content
+
+
+def test_mode_c_login_cookie_path_prefixed(admin_client, static_fixtures):
+    """Mode C's load-bearing check: cookie Path is read from per-request scope.
+
+    Proves the cookie-path lookup uses scope["root_path"] (set by the
+    middleware from X-Forwarded-Prefix) rather than the static config value.
+    """
+    resp = admin_client.post(
+        "/foo/user/login",
+        json={"username": "testadmin", "password": "testpassword123"},
+        headers=_PREFIX_HEADERS,
+    )
+    assert resp.status_code == 200
+    cookie_header = resp.headers.get("set-cookie", "")
+    assert "Path=/foo" in cookie_header
+
+
+# ── Hostile X-Forwarded-Prefix is silently ignored ──────────────────────────
+
+
+def test_hostile_forwarded_prefix_is_ignored(client, static_fixtures):
+    """Invalid X-Forwarded-Prefix values must not crash; treated as no mount."""
+    for bad in ("/foo bar", "/foo?x=1", "/foo/../bar", "//", "no-leading-slash"):
+        resp = client.get("/", headers={"Accept": "text/html", "X-Forwarded-Prefix": bad})
+        assert resp.status_code == 200
+        # Body has unprefixed base since the bad header was rejected.
+        assert b'href="/"' in resp.content

--- a/tests/test_root_path_unit.py
+++ b/tests/test_root_path_unit.py
@@ -1,0 +1,107 @@
+"""Unit tests for the path-prefix helpers — pure functions, no app fixture."""
+
+import pytest
+from src.config import normalise_root_path
+from src.main import _inject_base_href  # noqa: PLC2701
+from src.utils import build_absolute_url
+
+
+# ── _inject_base_href ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "html,root_path,expected",
+    [
+        # No mount → bytes pass through unchanged.
+        (b'<base href="/" />', "", b'<base href="/" />'),
+        # Single-segment prefix.
+        (b'<base href="/" />', "/foo", b'<base href="/foo/" />'),
+        # Multi-segment prefix.
+        (b'<base href="/" />', "/foo/bar", b'<base href="/foo/bar/" />'),
+    ],
+)
+def test_inject_base_href_basic(html, root_path, expected):
+    assert _inject_base_href(html, root_path) == expected
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        b'<base href="/">',  # no self-close
+        b'<base href="/"/>',  # self-close, no space
+        b'<base href="/" >',  # trailing space inside
+        b'<base  href="/"  />',  # double internal whitespace
+    ],
+)
+def test_inject_base_href_formatting_drift(html):
+    """Regex must absorb common formatting variants Vite emits."""
+    out = _inject_base_href(html, "/foo")
+    assert out == b'<base href="/foo/" />'
+
+
+def test_inject_base_href_no_base_tag_returns_unchanged():
+    """HTML without any <base> tag is returned unchanged — substitution is a no-op."""
+    html = b"<!doctype html><html><head></head><body></body></html>"
+    assert _inject_base_href(html, "/foo") == html
+
+
+# ── normalise_root_path ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "foo",  # no leading slash
+        "/foo bar",  # whitespace
+        "/foo?q=1",  # query
+        "/foo#frag",  # fragment
+        "/foo/../bar",  # parent traversal
+        "//",  # double slash
+    ],
+)
+def test_normalise_root_path_invalid(value):
+    with pytest.raises(RuntimeError, match="JENTIC_ROOT_PATH"):
+        normalise_root_path(value)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("", ""),
+        ("/", ""),
+        ("/foo", "/foo"),
+        ("/foo/", "/foo"),
+        ("/foo/bar", "/foo/bar"),
+    ],
+)
+def test_normalise_root_path_valid(value, expected):
+    assert normalise_root_path(value) == expected
+
+
+# ── build_absolute_url ───────────────────────────────────────────────────────
+
+
+class _FakeURL:
+    scheme = "http"
+
+
+class _FakeRequest:
+    """Minimal request shape for build_absolute_url unit tests."""
+
+    def __init__(self, root_path: str = ""):
+        self.headers = {"host": "example.com"}
+        self.scope = {"root_path": root_path}
+        self.url = _FakeURL()
+
+
+def test_build_absolute_url_no_root_path():
+    """Without a mount, the URL is host + path verbatim."""
+    assert build_absolute_url(_FakeRequest(""), "/user/create") == "http://example.com/user/create"
+
+
+def test_build_absolute_url_with_root_path():
+    """Self-links emitted via build_absolute_url include scope['root_path']."""
+    assert (
+        build_absolute_url(_FakeRequest("/foo"), "/user/create")
+        == "http://example.com/foo/user/create"
+    )

--- a/ui/e2e/docker/prefix-mount.spec.ts
+++ b/ui/e2e/docker/prefix-mount.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+// Hits the prefix container started by the webServer block in
+// playwright.docker.config.ts. Uses absolute URLs so the spec is unaffected
+// by the default baseURL (which points at the unprefixed main container).
+const PREFIX_BASE = 'http://localhost:8901/foo';
+const ADMIN_USER = 'admin';
+const ADMIN_PASS = 'admin123';
+
+test.describe('Reverse-proxy prefix mount', () => {
+	test('serves the SPA shell with a prefixed <base href>', async ({ request }) => {
+		const res = await request.get(`${PREFIX_BASE}/`, {
+			headers: { Accept: 'text/html' },
+		});
+		expect(res.ok()).toBeTruthy();
+		const body = await res.text();
+		expect(body).toContain('<base href="/foo/"');
+	});
+
+	test('navigates to credentials and survives a reload', async ({ page }) => {
+		// 1. Bootstrap auth state — fresh container needs admin creation;
+		//    a reused container needs login. Both paths leave us logged in.
+		await page.goto(`${PREFIX_BASE}/`);
+
+		const setupVisible = await page
+			.getByText(/create admin account/i)
+			.isVisible({ timeout: 5_000 })
+			.catch(() => false);
+
+		if (setupVisible) {
+			await page.getByLabel('Username').fill(ADMIN_USER);
+			await page.getByRole('textbox', { name: 'Password' }).fill(ADMIN_PASS);
+			await page.getByRole('button', { name: /create account/i }).click();
+			await expect(page.getByText(/setup complete/i)).toBeVisible({ timeout: 30_000 });
+			// Continue from setup wizard's completion state to the dashboard.
+			await page.goto(`${PREFIX_BASE}/`);
+		} else {
+			const loginVisible = await page
+				.getByRole('button', { name: /^log in$/i })
+				.isVisible({ timeout: 5_000 })
+				.catch(() => false);
+			if (loginVisible) {
+				await page.getByLabel('Username').fill(ADMIN_USER);
+				await page.getByRole('textbox', { name: 'Password' }).fill(ADMIN_PASS);
+				await page.getByRole('button', { name: /^log in$/i }).click();
+			}
+		}
+
+		// 2. Click the Credentials nav link — proves React Router's basename
+		//    is reading the backend-injected <base href>.
+		await page
+			.getByRole('link', { name: /credentials/i })
+			.first()
+			.click();
+		await expect(page).toHaveURL(`${PREFIX_BASE}/credentials`);
+		await expect(page.getByRole('heading', { name: /credentials/i })).toBeVisible({
+			timeout: 15_000,
+		});
+
+		// 3. Cold-boot deep-link path — reloading must keep the URL and re-render.
+		await page.reload();
+		await expect(page).toHaveURL(`${PREFIX_BASE}/credentials`);
+		await expect(page.getByRole('heading', { name: /credentials/i })).toBeVisible({
+			timeout: 15_000,
+		});
+	});
+});

--- a/ui/playwright.docker.config.ts
+++ b/ui/playwright.docker.config.ts
@@ -9,14 +9,28 @@ export default defineConfig({
 		baseURL: 'http://localhost:8900',
 		trace: 'on-first-retry',
 	},
+	// Spawn a second container at /foo for the prefix-mount spec. Playwright
+	// keeps it alive for the test run and tears it down afterwards (--rm).
+	// Locally, set reuseExistingServer to skip the spawn when the container
+	// is already up; in CI we always start fresh.
+	webServer: {
+		command:
+			'docker rm -f jentic-mini-prefix-e2e 2>/dev/null; docker run --rm --name jentic-mini-prefix-e2e -p 8901:8900 -e JENTIC_TELEMETRY=off -e JENTIC_ROOT_PATH=/foo jentic-mini:latest',
+		url: 'http://localhost:8901/foo/health',
+		timeout: 90_000,
+		reuseExistingServer: !process.env.CI,
+	},
 	projects: [
 		{ name: 'setup', testMatch: 'setup.spec.ts' },
 		{
 			name: 'e2e',
 			testMatch: '*.spec.ts',
-			testIgnore: 'setup.spec.ts',
+			testIgnore: ['setup.spec.ts', 'prefix-mount.spec.ts'],
 			dependencies: ['setup'],
 		},
+		// The prefix-mount project hits the second container directly via absolute
+		// URLs and runs its own setup, so it has no dependency on the main setup.
+		{ name: 'prefix-mount', testMatch: 'prefix-mount.spec.ts' },
 	],
 	reporter: [['html', { open: 'never' }]],
 });

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -19,39 +19,47 @@ import TraceDetailPage from '@/pages/TraceDetailPage';
 import ApprovalPage from '@/pages/ApprovalPage';
 import AgentsPage from '@/pages/AgentsPage';
 
-const router = createBrowserRouter([
-	{
-		element: <AuthGuard />,
-		children: [
-			{ path: '/setup', element: <SetupPage /> },
-			{ path: '/login', element: <LoginPage /> },
-			// Approval page has minimal chrome — outside Layout
-			{ path: '/approve/:toolkit_id/:req_id', element: <ApprovalPage /> },
-			{
-				element: <Layout />,
-				children: [
-					{ path: '/', element: <DashboardPage /> },
-					{ path: '/search', element: <SearchPage /> },
-					{ path: '/catalog', element: <CatalogPage /> },
-					{ path: '/workflows', element: <WorkflowsPage /> },
-					{ path: '/workflows/:slug', element: <WorkflowDetailPage /> },
-					{ path: '/toolkits', element: <ToolkitsPage /> },
-					{ path: '/toolkits/new', element: <ToolkitsPage createNew /> },
-					{ path: '/toolkits/:id', element: <ToolkitDetailPage /> },
-					{ path: '/agents', element: <AgentsPage /> },
-					{ path: '/credentials', element: <CredentialsPage /> },
-					{ path: '/credentials/new', element: <CredentialFormPage /> },
-					{ path: '/credentials/:id/edit', element: <CredentialFormPage /> },
-					{ path: '/oauth-brokers', element: <Navigate to="/credentials" replace /> },
-					{ path: '/traces', element: <TracesPage /> },
-					{ path: '/traces/:id', element: <TraceDetailPage /> },
-					{ path: '/jobs', element: <JobsPage /> },
-					{ path: '/jobs/:id', element: <JobDetailPage /> },
-				],
-			},
-		],
-	},
-]);
+// Read the basename from the backend-injected <base href> so the SPA bundle
+// stays prefix-agnostic — works at "/" or any "/foo" mount the operator
+// configures via JENTIC_ROOT_PATH / X-Forwarded-Prefix.
+const basename = new URL(document.baseURI).pathname.replace(/\/$/, '') || undefined;
+
+const router = createBrowserRouter(
+	[
+		{
+			element: <AuthGuard />,
+			children: [
+				{ path: '/setup', element: <SetupPage /> },
+				{ path: '/login', element: <LoginPage /> },
+				// Approval page has minimal chrome — outside Layout
+				{ path: '/approve/:toolkit_id/:req_id', element: <ApprovalPage /> },
+				{
+					element: <Layout />,
+					children: [
+						{ path: '/', element: <DashboardPage /> },
+						{ path: '/search', element: <SearchPage /> },
+						{ path: '/catalog', element: <CatalogPage /> },
+						{ path: '/workflows', element: <WorkflowsPage /> },
+						{ path: '/workflows/:slug', element: <WorkflowDetailPage /> },
+						{ path: '/toolkits', element: <ToolkitsPage /> },
+						{ path: '/toolkits/new', element: <ToolkitsPage createNew /> },
+						{ path: '/toolkits/:id', element: <ToolkitDetailPage /> },
+						{ path: '/agents', element: <AgentsPage /> },
+						{ path: '/credentials', element: <CredentialsPage /> },
+						{ path: '/credentials/new', element: <CredentialFormPage /> },
+						{ path: '/credentials/:id/edit', element: <CredentialFormPage /> },
+						{ path: '/oauth-brokers', element: <Navigate to="/credentials" replace /> },
+						{ path: '/traces', element: <TracesPage /> },
+						{ path: '/traces/:id', element: <TraceDetailPage /> },
+						{ path: '/jobs', element: <JobsPage /> },
+						{ path: '/jobs/:id', element: <JobDetailPage /> },
+					],
+				},
+			],
+		},
+	],
+	{ basename },
+);
 
 export default function App() {
 	return <RouterProvider router={router} />;

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -6,8 +6,11 @@ import '@/index.css';
 import { OpenAPI } from '@/api/generated';
 import { ApiError } from '@/api/generated/core/ApiError';
 
-// Configure OpenAPI client before any services are used
-OpenAPI.BASE = ''; // Use relative URLs (same origin as UI) — works in dev (Vite proxy) and prod (same port)
+// Configure OpenAPI client before any services are used.
+// BASE is the path component of the active mount (from <base href>) so the
+// generated client emits prefixed absolute paths under any reverse-proxy
+// path prefix while staying same-origin.
+OpenAPI.BASE = new URL(document.baseURI).pathname.replace(/\/$/, '');
 OpenAPI.WITH_CREDENTIALS = true;
 
 function isNonTransientError(error: unknown): boolean {

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -51,7 +51,9 @@ export default defineConfig({
 		},
 	},
 	plugins: [react(), tailwindcss(), copyApiDocsAssets()],
-	base: '/',
+	// Relative base — bundled assets resolve against the served index.html's
+	// <base href>, so the same build can be served at any path prefix.
+	base: './',
 	build: { outDir: '../static', emptyOutDir: true },
 	server: {
 		host: '0.0.0.0',


### PR DESCRIPTION
## Summary

Implements **Phase 25: Reverse-Proxy Path Prefix Support** from the SDD roadmap.

Spec: `specs/2026-05-08-reverse-proxy-path-prefix-support/`

### What changed

- **Config plumbing.** `JENTIC_ROOT_PATH` env var with strict validation (no whitespace, query, fragment, `..`, or `//`); wired into `.env.example` and `compose.yml`.
- **Backend `root_path` wiring.** `FastAPI(root_path=...)` from the env, an outermost `ForwardedPrefixMiddleware` that resolves `scope["root_path"]` from `X-Forwarded-Prefix` per request when the env is unset, prefixed self-links via `build_absolute_url`, and `jentic_session` cookies scoped to the mount path so shared-tenant deploys cannot leak across siblings.
- **Index.html, `/docs`, `/redoc` prefix-aware.** Pure `_inject_base_href` helper substitutes the served `<base href>` per request; the hand-rolled Swagger HTML and ReDoc handler embed prefixed asset URLs.
- **SPA bundle prefix-agnostic.** Vite `base: './'`; React Router `basename` and the generated client `OpenAPI.BASE` read from `document.baseURI` at app load — same build serves at any mount.
- **Tests.** Pure-function coverage for `_inject_base_href`, `normalise_root_path`, and `build_absolute_url`; three-mode integration tests against the same FastAPI app (A unset, B env-pinned, C `X-Forwarded-Prefix`); a new Playwright Docker E2E spec spawns a second container at `/foo` via the `playwright.docker.config` `webServer` block and validates `createBrowserRouter`'s `basename` plus a cold-boot deep-link reload.
- **Docs + roadmap retired.** `JENTIC_ROOT_PATH` row in `README.md`, bullet in `.claude/CLAUDE.md`, path-prefix mounting recipe in `docs/deploy/digitalocean/README.md`. Phase 25 block removed from `specs/roadmap.md` (gap preserved per the lifecycle rule).

### Deviation from the spec

`plan.md` task 6 originally called for stripping `scope["path"]` and `scope["raw_path"]` in the prefix middleware so downstream consumers see the unprefixed form. That approach broke Starlette's `Mount`/`StaticFiles` cooperation under a non-empty `root_path`: `Mount.matches` recomputes `root_path` to `original_root_path + matched_path`, but `StaticFiles.get_route_path` then runs against the already-stripped `scope["path"]`, so every `/foo/static/*` and `/foo/assets/*` request 404'd because the lookup path picked up the mount segment a second time.

The fix-up commit `fix(broker): keep scope path intact for Mount cooperation` drops the path strip and adds a `route_path()` helper to `src.utils` that `spa_middleware` and `APIKeyMiddleware` now use to keep their unprefixed-path comparisons working — the standard ASGI behind-a-proxy pattern. The behavioural contract from the spec is preserved.

## Validation

All gates from `specs/2026-05-08-reverse-proxy-path-prefix-support/validation.md` passed:

- Backend lint clean — pass
- New tests pass (unit + integration, 41 cases) — pass
- Full backend suite (284 tests) — pass
- OpenAPI schema content unchanged — pass
- UI lint clean — pass
- UI typecheck clean — pass
- UI Vitest suite (49 files / 327 tests) — pass
- Docker E2E with prefix mount (7 tests including 2 new prefix-mount specs) — pass
- Mode A curl smoke (regression — unset) — pass
- Mode B curl smoke (env-driven) — pass (`Set-Cookie ... Path=/foo`)
- Mode C curl smoke (header-driven) — pass (`Set-Cookie ... Path=/foo`)
- `README.md` Configuration table lists `JENTIC_ROOT_PATH` — pass
- `.claude/CLAUDE.md` lists `JENTIC_ROOT_PATH` — pass
- `specs/roadmap.md` no longer contains the Phase 25 entry — pass

### Out of scope (from `validation.md` "Not Required")

- Real reverse-proxy round-trip in CI (nginx/Caddy/Traefik instance)
- Schemathesis CLI gate (existing `test_ui_openapi_matches_served_spec` is the contract enforcement)
- Mocked Playwright suite coverage of prefix behaviour (Docker E2E covers it)
- Pipedream OAuth `connect-callback` URL prefix coverage (per-broker dashboard config)
- WebSocket / streaming endpoints under prefix (Phase 23)
- Generated TypeScript client regeneration (no schema change)
- A dedicated `docs/reverse-proxy.md` (README + env-var entry covers it)
- `JENTIC_PUBLIC_BASE_URL` auto-derivation (operator must set both when mounting)
- Multi-mount validation (single `JENTIC_ROOT_PATH` value supported)

## Test plan

- [x] CI green
- [x] Manual smoke per `validation.md` gates 9–11 against a built container

Closes #356
Refs: `specs/2026-05-08-reverse-proxy-path-prefix-support/`