### PR TITLE
fix: harden path-prefix mounting — address #365 review

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,7 +16,7 @@ See @DEVELOPMENT.md for prerequisites, installation, and running the server.
 - `JENTIC_VAULT_KEY` — Fernet key for credentials vault (auto-generated from `data/vault.key` if unset)
 - `JENTIC_PUBLIC_HOSTNAME` — public hostname for self-links and workflow dispatch
 - `JENTIC_ROOT_PATH` — path prefix when Mini is mounted under a reverse proxy (e.g. `/jentic`); falls back to the per-request `X-Forwarded-Prefix` header when unset
-- `JENTIC_TRUST_FORWARDED_PREFIX` — whether the `X-Forwarded-Prefix` fallback is honoured (default `true`); set to `false` on direct-exposure deploys to pin the mount path
+- `JENTIC_TRUST_FORWARDED_PREFIX` — whether the `X-Forwarded-Prefix` fallback is honoured (default `true`); set to `false` on direct-exposure deploys to ignore the header fallback (pair with `JENTIC_ROOT_PATH` to pin a specific mount)
 - `DB_PATH` — SQLite database path (default: `/app/data/jentic-mini.db`)
 - `LOG_LEVEL` — `debug | info | warning | error`
 - `JENTIC_HOST_PATH` — project root path for Docker mounts (defaults to `.`)

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,6 +16,7 @@ See @DEVELOPMENT.md for prerequisites, installation, and running the server.
 - `JENTIC_VAULT_KEY` — Fernet key for credentials vault (auto-generated from `data/vault.key` if unset)
 - `JENTIC_PUBLIC_HOSTNAME` — public hostname for self-links and workflow dispatch
 - `JENTIC_ROOT_PATH` — path prefix when Mini is mounted under a reverse proxy (e.g. `/jentic`); falls back to the per-request `X-Forwarded-Prefix` header when unset
+- `JENTIC_TRUST_FORWARDED_PREFIX` — whether the `X-Forwarded-Prefix` fallback is honoured (default `true`); set to `false` on direct-exposure deploys to pin the mount path
 - `DB_PATH` — SQLite database path (default: `/app/data/jentic-mini.db`)
 - `LOG_LEVEL` — `debug | info | warning | error`
 - `JENTIC_HOST_PATH` — project root path for Docker mounts (defaults to `.`)

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,7 +16,6 @@ See @DEVELOPMENT.md for prerequisites, installation, and running the server.
 - `JENTIC_VAULT_KEY` — Fernet key for credentials vault (auto-generated from `data/vault.key` if unset)
 - `JENTIC_PUBLIC_HOSTNAME` — public hostname for self-links and workflow dispatch
 - `JENTIC_ROOT_PATH` — path prefix when Mini is mounted under a reverse proxy (e.g. `/jentic`); falls back to the per-request `X-Forwarded-Prefix` header when unset
-- `JENTIC_TRUST_FORWARDED_PREFIX` — whether the `X-Forwarded-Prefix` fallback is honoured (default `true`); set to `false` on direct-exposure deploys to ignore the header fallback (pair with `JENTIC_ROOT_PATH` to pin a specific mount)
 - `DB_PATH` — SQLite database path (default: `/app/data/jentic-mini.db`)
 - `LOG_LEVEL` — `debug | info | warning | error`
 - `JENTIC_HOST_PATH` — project root path for Docker mounts (defaults to `.`)

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,14 @@
 # values are correct.
 # JENTIC_ROOT_PATH=/jentic
 
+# Trust the per-request X-Forwarded-Prefix header when JENTIC_ROOT_PATH is unset.
+# Default: true (preserves the existing reverse-proxy fallback). Set to "false"
+# when the instance is reached directly by clients with no header-sanitising
+# proxy in front — there, the header is attacker-controllable and treating it
+# as authoritative lets a remote client steer the cookie path / self-link
+# prefix per request (DoS-ish, not RCE — the value is still validator-checked).
+# JENTIC_TRUST_FORWARDED_PREFIX=false
+
 # Log level: debug | info | warning | error
 LOG_LEVEL=info
 

--- a/.env.example
+++ b/.env.example
@@ -22,14 +22,6 @@
 # values are correct.
 # JENTIC_ROOT_PATH=/jentic
 
-# Trust the per-request X-Forwarded-Prefix header when JENTIC_ROOT_PATH is unset.
-# Default: true (preserves the existing reverse-proxy fallback). Set to "false"
-# when the instance is reached directly by clients with no header-sanitising
-# proxy in front — there, the header is attacker-controllable and treating it
-# as authoritative lets a remote client steer the cookie path / self-link
-# prefix per request (DoS-ish, not RCE — the value is still validator-checked).
-# JENTIC_TRUST_FORWARDED_PREFIX=false
-
 # Log level: debug | info | warning | error
 LOG_LEVEL=info
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ Optional environment variables (set in `.env` or pass to `docker compose`):
 | `JENTIC_VAULT_KEY`       | auto-generated | [Fernet](https://cryptography.io/en/latest/fernet/) key for the credentials vault                                                                                                                              |
 | `JENTIC_PUBLIC_HOSTNAME` | `localhost`    | Public hostname for self-links and workflow IDs, e.g. `jentic.example.com`                                                                                                                                     |
 | `JENTIC_ROOT_PATH`       | _(unset)_      | Path prefix to mount the app under, e.g. `/jentic`. Pair with `JENTIC_PUBLIC_BASE_URL` (which must include the prefix) for OAuth issuer correctness. If unset, falls back to `X-Forwarded-Prefix` per request. |
-| `JENTIC_TRUST_FORWARDED_PREFIX` | `true`  | Whether the per-request `X-Forwarded-Prefix` fallback is honoured when `JENTIC_ROOT_PATH` is unset. Set to `false` on instances reached directly by clients (no header-sanitising proxy) to ignore the header fallback; pair with `JENTIC_ROOT_PATH` to pin a specific non-empty mount prefix. |
 | `LOG_LEVEL`              | `info`         | `debug`, `info`, `warning`, `error`                                                                                                                                                                            |
+
+> **Deployment note — `X-Forwarded-Prefix` trust:** when `JENTIC_ROOT_PATH` is unset, the per-request `X-Forwarded-Prefix` header is honoured from any client. Deploy Mini behind a reverse proxy that sanitises inbound `X-Forwarded-*` headers (Caddy, Traefik, nginx Ingress with proper config). On direct-internet exposure, a remote client can steer the cookie path and self-link prefix per request — a peer-IP CIDR gate covering all proxy headers is tracked in [#366](https://github.com/jentic/jentic-mini/issues/366).
 
 ### Authentication
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Optional environment variables (set in `.env` or pass to `docker compose`):
 | `JENTIC_VAULT_KEY`       | auto-generated | [Fernet](https://cryptography.io/en/latest/fernet/) key for the credentials vault                                                                                                                              |
 | `JENTIC_PUBLIC_HOSTNAME` | `localhost`    | Public hostname for self-links and workflow IDs, e.g. `jentic.example.com`                                                                                                                                     |
 | `JENTIC_ROOT_PATH`       | _(unset)_      | Path prefix to mount the app under, e.g. `/jentic`. Pair with `JENTIC_PUBLIC_BASE_URL` (which must include the prefix) for OAuth issuer correctness. If unset, falls back to `X-Forwarded-Prefix` per request. |
+| `JENTIC_TRUST_FORWARDED_PREFIX` | `true`  | Whether the per-request `X-Forwarded-Prefix` fallback is honoured when `JENTIC_ROOT_PATH` is unset. Set to `false` on instances reached directly by clients (no header-sanitising proxy) to pin the mount path. |
 | `LOG_LEVEL`              | `info`         | `debug`, `info`, `warning`, `error`                                                                                                                                                                            |
 
 ### Authentication

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Optional environment variables (set in `.env` or pass to `docker compose`):
 | `JENTIC_VAULT_KEY`       | auto-generated | [Fernet](https://cryptography.io/en/latest/fernet/) key for the credentials vault                                                                                                                              |
 | `JENTIC_PUBLIC_HOSTNAME` | `localhost`    | Public hostname for self-links and workflow IDs, e.g. `jentic.example.com`                                                                                                                                     |
 | `JENTIC_ROOT_PATH`       | _(unset)_      | Path prefix to mount the app under, e.g. `/jentic`. Pair with `JENTIC_PUBLIC_BASE_URL` (which must include the prefix) for OAuth issuer correctness. If unset, falls back to `X-Forwarded-Prefix` per request. |
-| `JENTIC_TRUST_FORWARDED_PREFIX` | `true`  | Whether the per-request `X-Forwarded-Prefix` fallback is honoured when `JENTIC_ROOT_PATH` is unset. Set to `false` on instances reached directly by clients (no header-sanitising proxy) to pin the mount path. |
+| `JENTIC_TRUST_FORWARDED_PREFIX` | `true`  | Whether the per-request `X-Forwarded-Prefix` fallback is honoured when `JENTIC_ROOT_PATH` is unset. Set to `false` on instances reached directly by clients (no header-sanitising proxy) to ignore the header fallback; pair with `JENTIC_ROOT_PATH` to pin a specific non-empty mount prefix. |
 | `LOG_LEVEL`              | `info`         | `debug`, `info`, `warning`, `error`                                                                                                                                                                            |
 
 ### Authentication

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Optional environment variables (set in `.env` or pass to `docker compose`):
 | `JENTIC_ROOT_PATH`       | _(unset)_      | Path prefix to mount the app under, e.g. `/jentic`. Pair with `JENTIC_PUBLIC_BASE_URL` (which must include the prefix) for OAuth issuer correctness. If unset, falls back to `X-Forwarded-Prefix` per request. |
 | `LOG_LEVEL`              | `info`         | `debug`, `info`, `warning`, `error`                                                                                                                                                                            |
 
-> **Deployment note — `X-Forwarded-Prefix` trust:** when `JENTIC_ROOT_PATH` is unset, the per-request `X-Forwarded-Prefix` header is honoured from any client. Deploy Mini behind a reverse proxy that sanitises inbound `X-Forwarded-*` headers (Caddy, Traefik, nginx Ingress with proper config). On direct-internet exposure, a remote client can steer the cookie path and self-link prefix per request — a peer-IP CIDR gate covering all proxy headers is tracked in [#366](https://github.com/jentic/jentic-mini/issues/366).
+> **Deployment note — `X-Forwarded-Prefix` trust:** when `JENTIC_ROOT_PATH` is unset, the per-request `X-Forwarded-Prefix` header is honoured from any client. Deploy Mini behind a reverse proxy (Caddy, Traefik, nginx Ingress) configured to strip inbound `X-Forwarded-*` headers from clients before setting its own. On direct-internet exposure, a remote client can steer the cookie path and self-link prefix per request — a peer-IP CIDR gate covering all proxy headers is tracked in [#366](https://github.com/jentic/jentic-mini/issues/366).
 
 ### Authentication
 

--- a/src/config.py
+++ b/src/config.py
@@ -60,25 +60,6 @@ def normalise_root_path(value: str) -> str:
 
 JENTIC_ROOT_PATH = normalise_root_path(os.getenv("JENTIC_ROOT_PATH", ""))
 
-# Per-request X-Forwarded-Prefix fallback toggle. Defaults to True so existing
-# Mode C deploys (proxy injects the header, env unset) continue to work. Set to
-# false on instances reached directly by clients — there, the header is
-# attacker-controllable and there's no proxy to strip it. Strict parsing on
-# purpose: a typo like "flase" would otherwise silently evaluate to true and
-# leave the operator with a false sense of hardening.
-_TRUST_TRUE = ("true", "1", "yes", "on")
-_TRUST_FALSE = ("false", "0", "no", "off")
-_raw_trust = os.getenv("JENTIC_TRUST_FORWARDED_PREFIX", "true").strip().lower()
-if _raw_trust in _TRUST_TRUE:
-    JENTIC_TRUST_FORWARDED_PREFIX = True
-elif _raw_trust in _TRUST_FALSE:
-    JENTIC_TRUST_FORWARDED_PREFIX = False
-else:
-    raise RuntimeError(
-        f"JENTIC_TRUST_FORWARDED_PREFIX={_raw_trust!r} is not recognised; "
-        f"expected one of {_TRUST_TRUE + _TRUST_FALSE}"
-    )
-
 # ── Public base URL ───────────────────────────────────────────────────────────
 # Operator-pinned canonical base URL (no trailing slash) — e.g.
 # "https://jentic.example.com". When set, the issuer / token aud /

--- a/src/config.py
+++ b/src/config.py
@@ -60,6 +60,14 @@ def normalise_root_path(value: str) -> str:
 
 JENTIC_ROOT_PATH = normalise_root_path(os.getenv("JENTIC_ROOT_PATH", ""))
 
+# Per-request X-Forwarded-Prefix fallback toggle. Defaults to True so existing
+# Mode C deploys (proxy injects the header, env unset) continue to work. Set to
+# false ("false" / "0" / "no" / "off") on instances reached directly by clients
+# — there, the header is attacker-controllable and there's no proxy to strip it.
+JENTIC_TRUST_FORWARDED_PREFIX = os.getenv(
+    "JENTIC_TRUST_FORWARDED_PREFIX", "true"
+).strip().lower() not in ("false", "0", "no", "off")
+
 # ── Public base URL ───────────────────────────────────────────────────────────
 # Operator-pinned canonical base URL (no trailing slash) — e.g.
 # "https://jentic.example.com". When set, the issuer / token aud /

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,7 @@
 """Centralised configuration constants for Jentic Mini."""
 
 import os
+import re
 from pathlib import Path
 
 
@@ -28,28 +29,33 @@ JENTIC_PUBLIC_HOSTNAME = os.getenv("JENTIC_PUBLIC_HOSTNAME") or "localhost"
 # the SPA bundle, hand-rolled docs, and self-links resolve under the prefix; if
 # unset, the per-request X-Forwarded-Prefix header is honoured. Pair with
 # JENTIC_PUBLIC_BASE_URL (which must include the prefix) when mounting.
+
+# Allowlist: one or more "/segment" pairs, each segment is alnum + [-._~]. This
+# is the chokepoint that closes the XSS / cookie-injection / stored-URL classes
+# from PR #364 review — every char that's dangerous in HTML attributes, inline
+# JS strings, or Set-Cookie attribute serialisation (<, >, ", ', ;, ,, \, NUL,
+# C0/C1 controls) is rejected here before the value reaches any sink.
+_ROOT_PATH_RE = re.compile(r"^(?:/[A-Za-z0-9._~-]+)+/?$")
+
+
 def normalise_root_path(value: str) -> str:
     """Normalise and validate a path-prefix value.
 
-    Empty string and "/" both mean "no mount" → "". Other values must start
-    with "/" and contain no whitespace, "?", "#", "..", or consecutive "//".
-    A single trailing slash is stripped ("/foo/" → "/foo"); "/foo" is returned
-    unchanged. Validation runs against the raw value so "//" surfaces here
-    rather than collapsing silently.
+    Empty string and "/" both mean "no mount" → "". Other values must match
+    ``^(?:/[A-Za-z0-9._~-]+)+/?$``. A single trailing slash is stripped
+    ("/foo/" → "/foo"); "/foo" is returned unchanged.
     """
     if value in ("", "/"):
         return ""
-    if (
-        not value.startswith("/")
-        or any(ch.isspace() or ch in "?#" for ch in value)
-        or ".." in value
-        or "//" in value
-    ):
+    # Regex catches metacharacters; segment check catches "." / ".." traversal,
+    # which would otherwise match [A-Za-z0-9._~-]+ as a regular segment.
+    if not _ROOT_PATH_RE.fullmatch(value) or any(s in (".", "..") for s in value.split("/") if s):
         raise RuntimeError(
-            "JENTIC_ROOT_PATH must start with '/' and contain no whitespace, "
-            "query, fragment, '..', or '//'"
+            "JENTIC_ROOT_PATH must be /-separated segments of [A-Za-z0-9._~-]+ "
+            "(no whitespace, query, fragment, '..', '//', or HTML/JS/cookie "
+            "metacharacters)"
         )
-    return value[:-1] if value.endswith("/") and len(value) > 1 else value
+    return value[:-1] if value.endswith("/") else value
 
 
 JENTIC_ROOT_PATH = normalise_root_path(os.getenv("JENTIC_ROOT_PATH", ""))

--- a/src/config.py
+++ b/src/config.py
@@ -62,11 +62,22 @@ JENTIC_ROOT_PATH = normalise_root_path(os.getenv("JENTIC_ROOT_PATH", ""))
 
 # Per-request X-Forwarded-Prefix fallback toggle. Defaults to True so existing
 # Mode C deploys (proxy injects the header, env unset) continue to work. Set to
-# false ("false" / "0" / "no" / "off") on instances reached directly by clients
-# — there, the header is attacker-controllable and there's no proxy to strip it.
-JENTIC_TRUST_FORWARDED_PREFIX = os.getenv(
-    "JENTIC_TRUST_FORWARDED_PREFIX", "true"
-).strip().lower() not in ("false", "0", "no", "off")
+# false on instances reached directly by clients — there, the header is
+# attacker-controllable and there's no proxy to strip it. Strict parsing on
+# purpose: a typo like "flase" would otherwise silently evaluate to true and
+# leave the operator with a false sense of hardening.
+_TRUST_TRUE = ("true", "1", "yes", "on")
+_TRUST_FALSE = ("false", "0", "no", "off")
+_raw_trust = os.getenv("JENTIC_TRUST_FORWARDED_PREFIX", "true").strip().lower()
+if _raw_trust in _TRUST_TRUE:
+    JENTIC_TRUST_FORWARDED_PREFIX = True
+elif _raw_trust in _TRUST_FALSE:
+    JENTIC_TRUST_FORWARDED_PREFIX = False
+else:
+    raise RuntimeError(
+        f"JENTIC_TRUST_FORWARDED_PREFIX={_raw_trust!r} is not recognised; "
+        f"expected one of {_TRUST_TRUE + _TRUST_FALSE}"
+    )
 
 # ── Public base URL ───────────────────────────────────────────────────────────
 # Operator-pinned canonical base URL (no trailing slash) — e.g.

--- a/src/config.py
+++ b/src/config.py
@@ -3,6 +3,7 @@
 import os
 import re
 from pathlib import Path
+from urllib.parse import urlparse
 
 
 # ── Version ───────────────────────────────────────────────────────────────────
@@ -73,6 +74,19 @@ JENTIC_ROOT_PATH = normalise_root_path(os.getenv("JENTIC_ROOT_PATH", ""))
 # behaviour). Operators on internet-facing deployments are strongly
 # encouraged to set this to a fully-qualified URL.
 JENTIC_PUBLIC_BASE_URL = (os.getenv("JENTIC_PUBLIC_BASE_URL") or "").rstrip("/")
+
+# Fail-fast when the two path-prefix sources disagree. If an operator sets
+# JENTIC_PUBLIC_BASE_URL=https://example.com/foo alongside JENTIC_ROOT_PATH=/bar,
+# stored URLs (approve_url, OAuth callbacks) embed /foo while request-derived
+# URLs embed /bar — silently broken tokens, 404 OAuth callbacks, failed agent
+# assertions. Same pattern as the AGENT_NONCE_WINDOW invariant below.
+if JENTIC_PUBLIC_BASE_URL:
+    _pub_path = urlparse(JENTIC_PUBLIC_BASE_URL).path.rstrip("/")
+    if _pub_path != JENTIC_ROOT_PATH.rstrip("/"):
+        raise RuntimeError(
+            f"JENTIC_PUBLIC_BASE_URL path ({_pub_path!r}) disagrees with "
+            f"JENTIC_ROOT_PATH ({JENTIC_ROOT_PATH!r}); both must use the same prefix"
+        )
 
 # ── Toolkit defaults ──────────────────────────────────────────────────────────
 DEFAULT_TOOLKIT_ID = "default"

--- a/src/main.py
+++ b/src/main.py
@@ -686,8 +686,15 @@ def custom_openapi():
         tags=app.openapi_tags,  # controls section order in Swagger UI
     )
 
-    # Add servers (HTTPS first)
-    schema["servers"] = app.servers
+    # Add servers (HTTPS first). When mounted under a path prefix, prepend a
+    # simple prefix-relative entry so Swagger UI "Try it out" and code-generators
+    # (openapi-ts, openapi-generator, Postman) use the correct base path.
+    schema["servers"] = (
+        [{"url": JENTIC_ROOT_PATH, "description": "This instance (path-prefix mount)"}]
+        + app.servers
+        if JENTIC_ROOT_PATH
+        else app.servers
+    )
 
     # Add contact and license
     schema["info"]["contact"] = app.contact

--- a/src/main.py
+++ b/src/main.py
@@ -93,11 +93,10 @@ class ForwardedPrefixMiddleware:
        unset; invalid values are silently ignored (treated as no mount).
 
     The header is accepted from any client, which is correct when Mini sits
-    behind a header-sanitising reverse proxy (the documented deployment).
-    Operators on direct-exposure deploys (no proxy in front) should either
-    fix the deployment posture or wait for issue #366's peer-IP CIDR gate,
-    which will scope every proxy header (this one plus ``X-Auth-Email``) to
-    a single trust boundary.
+    behind a reverse proxy that strips inbound ``X-Forwarded-*`` from clients
+    before setting its own. Direct-internet exposure is the at-risk posture;
+    a future peer-IP-gated trust boundary will scope every proxy header
+    (this one plus ``X-Auth-Email``) to a single CIDR allowlist.
 
     Path stripping is intentionally left to Starlette's routing machinery
     (``get_route_path``) so ``Mount`` / ``StaticFiles`` cooperation stays

--- a/src/main.py
+++ b/src/main.py
@@ -688,9 +688,13 @@ def custom_openapi():
         tags=app.openapi_tags,  # controls section order in Swagger UI
     )
 
-    # Add servers (HTTPS first). When mounted under a path prefix, prepend a
-    # simple prefix-relative entry so Swagger UI "Try it out" and code-generators
-    # (openapi-ts, openapi-generator, Postman) use the correct base path.
+    # Add servers. When JENTIC_ROOT_PATH is set, prepend a prefix-relative entry
+    # so Swagger UI "Try it out" and code-generators use the correct base path.
+    # Note: the schema is cached after the first call (app.openapi_schema), so
+    # this entry reflects the *static* JENTIC_ROOT_PATH only. Mode C deployments
+    # (X-Forwarded-Prefix per request, JENTIC_ROOT_PATH unset) will always see
+    # app.servers here — Swagger UI "Try it out" may not work under a Mode C
+    # prefix mount. Set JENTIC_ROOT_PATH for full Swagger UI compatibility.
     schema["servers"] = (
         [{"url": JENTIC_ROOT_PATH, "description": "This instance (path-prefix mount)"}]
         + app.servers

--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,12 @@ from pydantic import BaseModel, Field
 
 from src.auth import APIKeyMiddleware
 from src.brokers.pipedream import PipedreamOAuthBroker
-from src.config import APP_VERSION, JENTIC_ROOT_PATH, normalise_root_path
+from src.config import (
+    APP_VERSION,
+    JENTIC_ROOT_PATH,
+    JENTIC_TRUST_FORWARDED_PREFIX,
+    normalise_root_path,
+)
 from src.db import run_migrations, setup_state
 from src.negotiate import negotiate_middleware
 from src.oauth_broker import registry as oauth_broker_registry
@@ -90,7 +95,10 @@ class ForwardedPrefixMiddleware:
     1. ``JENTIC_ROOT_PATH`` env var — already on ``scope["root_path"]`` from
        the FastAPI constructor.
     2. ``X-Forwarded-Prefix`` header — read per request when the env var is
-       unset; invalid values are silently ignored (treated as no mount).
+       unset AND ``JENTIC_TRUST_FORWARDED_PREFIX`` is truthy (the default).
+       Invalid values are silently ignored (treated as no mount). Operators
+       reaching Mini directly (no header-sanitising proxy in front) should set
+       ``JENTIC_TRUST_FORWARDED_PREFIX=false`` to disable this fallback.
 
     Path stripping is intentionally left to Starlette's routing machinery
     (``get_route_path``) so ``Mount`` / ``StaticFiles`` cooperation stays
@@ -108,7 +116,7 @@ class ForwardedPrefixMiddleware:
             await self.app(scope, receive, send)
             return
 
-        if not scope.get("root_path"):
+        if JENTIC_TRUST_FORWARDED_PREFIX and not scope.get("root_path"):
             for key, value in scope.get("headers", []):
                 if key == b"x-forwarded-prefix":
                     try:

--- a/src/main.py
+++ b/src/main.py
@@ -251,9 +251,11 @@ app.middleware("http")(negotiate_middleware)
 STATIC_DIR = Path(__file__).resolve().parent.parent / "static"
 
 
-# Tolerant regex: matches <base ...> with any href, with-or-without self-close,
-# with-or-without extra spaces. Substitutes only the first occurrence.
-_BASE_TAG_RE = re.compile(rb'<base\s+href="[^"]*"\s*/?\s*>')
+# Matches any <base ...> tag regardless of the number of attributes.
+# Using href="..." as the anchor would silently become a no-op if Vite ever
+# adds a second attribute (e.g. crossorigin). The \s after 'base' prevents
+# matching <basefont>. Substitutes only the first occurrence.
+_BASE_TAG_RE = re.compile(rb"<base\s[^>]*>")
 
 
 def _inject_base_href(html: bytes, root_path: str) -> bytes:

--- a/src/main.py
+++ b/src/main.py
@@ -20,12 +20,7 @@ from pydantic import BaseModel, Field
 
 from src.auth import APIKeyMiddleware
 from src.brokers.pipedream import PipedreamOAuthBroker
-from src.config import (
-    APP_VERSION,
-    JENTIC_ROOT_PATH,
-    JENTIC_TRUST_FORWARDED_PREFIX,
-    normalise_root_path,
-)
+from src.config import APP_VERSION, JENTIC_ROOT_PATH, normalise_root_path
 from src.db import run_migrations, setup_state
 from src.negotiate import negotiate_middleware
 from src.oauth_broker import registry as oauth_broker_registry
@@ -95,10 +90,14 @@ class ForwardedPrefixMiddleware:
     1. ``JENTIC_ROOT_PATH`` env var — already on ``scope["root_path"]`` from
        the FastAPI constructor.
     2. ``X-Forwarded-Prefix`` header — read per request when the env var is
-       unset AND ``JENTIC_TRUST_FORWARDED_PREFIX`` is truthy (the default).
-       Invalid values are silently ignored (treated as no mount). Operators
-       reaching Mini directly (no header-sanitising proxy in front) should set
-       ``JENTIC_TRUST_FORWARDED_PREFIX=false`` to disable this fallback.
+       unset; invalid values are silently ignored (treated as no mount).
+
+    The header is accepted from any client, which is correct when Mini sits
+    behind a header-sanitising reverse proxy (the documented deployment).
+    Operators on direct-exposure deploys (no proxy in front) should either
+    fix the deployment posture or wait for issue #366's peer-IP CIDR gate,
+    which will scope every proxy header (this one plus ``X-Auth-Email``) to
+    a single trust boundary.
 
     Path stripping is intentionally left to Starlette's routing machinery
     (``get_route_path``) so ``Mount`` / ``StaticFiles`` cooperation stays
@@ -116,7 +115,7 @@ class ForwardedPrefixMiddleware:
             await self.app(scope, receive, send)
             return
 
-        if JENTIC_TRUST_FORWARDED_PREFIX and not scope.get("root_path"):
+        if not scope.get("root_path"):
             for key, value in scope.get("headers", []):
                 if key == b"x-forwarded-prefix":
                     try:

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,8 @@
 Jentic Mini — main.py
 """
 
+import html as _html
+import json
 import logging
 import os
 import re
@@ -265,7 +267,8 @@ def _inject_base_href(html: bytes, root_path: str) -> bytes:
     """
     if not root_path:
         return html
-    return _BASE_TAG_RE.sub(f'<base href="{root_path}/" />'.encode(), html, count=1)
+    safe = _html.escape(root_path, quote=True)
+    return _BASE_TAG_RE.sub(f'<base href="{safe}/" />'.encode(), html, count=1)
 
 
 def _render_index(request: Request) -> HTMLResponse:
@@ -468,6 +471,12 @@ async def root(request: Request):
 @app.get("/docs", include_in_schema=False)
 async def swagger_ui(request: Request):
     rp = request.scope.get("root_path", "")
+    # Defense-in-depth: HTML-escape rp for attribute contexts, JSON-encode for
+    # the inline JS string. The validator already restricts root_path to
+    # [A-Za-z0-9._~-] segments so these calls are no-ops today; they decouple
+    # each sink's safety from the validator should the character set widen.
+    rp_attr = _html.escape(rp, quote=True)
+    rp_js_url = json.dumps(f"{rp}/openapi.json")
     # Custom Swagger UI with persistAuthorization + auth banner. Every absolute
     # path the browser resolves (CSS / JS asset URLs, the login link, the
     # OpenAPI URL) is prefixed with the active root_path so the page works
@@ -478,7 +487,7 @@ async def swagger_ui(request: Request):
   <title>Jentic — Swagger UI</title>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" type="text/css" href="{rp}/static/swagger-ui.css" >
+  <link rel="stylesheet" type="text/css" href="{rp_attr}/static/swagger-ui.css" >
   <style>
     .auth-banner {{
       background: #1a1a2e; border-left: 4px solid #667eea;
@@ -494,15 +503,15 @@ async def swagger_ui(request: Request):
   🔑 <strong>Authentication.</strong>
   <strong>Agents (toolkit):</strong> <em>JenticApiKey</em> — your <code>tk_xxx</code> in <code>X-Jentic-API-Key</code>.
   <strong>Agents (OAuth):</strong> <em>AgentOauthAccessToken</em> — <code>Authorization: Bearer</code> with <code>at_…</code>; <em>AgentOauthRegistrationToken</em> — <code>Authorization: Bearer</code> with <code>rat_…</code> where applicable.
-  <strong>Humans:</strong> <em>HumanLogin</em> (username + password) — or <a href="{rp}/login" style="color:#a5b4fc">log in here</a> for a browser session.
+  <strong>Humans:</strong> <em>HumanLogin</em> (username + password) — or <a href="{rp_attr}/login" style="color:#a5b4fc">log in here</a> for a browser session.
   OAuth agents: <code>GET /.well-known/oauth-authorization-server</code> then <code>POST /register</code>. Toolkit keys are issued from the UI.
 </div>
 <div id="swagger-ui"></div>
-<script src="{rp}/static/swagger-ui-bundle.js"> </script>
+<script src="{rp_attr}/static/swagger-ui-bundle.js"> </script>
 <script>
   window.onload = function() {{
     SwaggerUIBundle({{
-      url: "{rp}/openapi.json",
+      url: {rp_js_url},
       dom_id: '#swagger-ui',
       presets: [ SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset ],
       layout: "BaseLayout",
@@ -519,7 +528,7 @@ async def swagger_ui(request: Request):
 
 @app.get("/redoc", include_in_schema=False)
 async def redoc(request: Request):
-    rp = request.scope.get("root_path", "")
+    rp = _html.escape(request.scope.get("root_path", ""), quote=True)
     return get_redoc_html(
         openapi_url=f"{rp}/openapi.json",
         title="Jentic — Redoc",

--- a/src/routers/access_requests.py
+++ b/src/routers/access_requests.py
@@ -34,7 +34,7 @@ from src.auth import require_human_session
 from src.db import get_db
 from src.models import AccessRequestOut, PermissionRule
 from src.routers.toolkits import write_credential_permissions
-from src.utils import build_absolute_url
+from src.utils import build_canonical_url
 from src.validators import NormModel
 
 
@@ -179,7 +179,7 @@ async def create_access_request(
 
     req_id = "areq_" + str(uuid.uuid4())[:8]
 
-    approve_url = build_absolute_url(request, f"/approve/{toolkit_id}/{req_id}")
+    approve_url = build_canonical_url(request, f"/approve/{toolkit_id}/{req_id}")
 
     # Store payload as the flat fields relevant to this request type
     payload_dict = {

--- a/src/routers/default_key.py
+++ b/src/routers/default_key.py
@@ -20,7 +20,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from src.auth import default_allowed_ips
 from src.db import DEFAULT_TOOLKIT_ID, get_db, set_setting, setup_state
-from src.utils import build_absolute_url
+from src.utils import build_canonical_url
 
 
 router = APIRouter(tags=["user"])
@@ -96,7 +96,7 @@ async def generate_default_key(request: Request):
 
     setup = await setup_state()
     if not setup["account_created"]:
-        setup_url = build_absolute_url(request, "/user/create")
+        setup_url = build_canonical_url(request, "/user/create")
         next_step = f"Tell your user to visit {setup_url} to create their admin account."
     else:
         next_step = "Key ready. Use it as X-Jentic-API-Key on all agent requests."

--- a/src/routers/oauth_brokers.py
+++ b/src/routers/oauth_brokers.py
@@ -32,7 +32,7 @@ from src.brokers.pipedream import PipedreamOAuthBroker, api_host_to_pd_slug, bro
 from src.db import get_db
 from src.oauth_broker import registry as oauth_broker_registry
 from src.openapi_helpers import agent_hints
-from src.utils import build_absolute_url
+from src.utils import build_absolute_url, build_canonical_url
 from src.validators import NormModel
 
 
@@ -589,7 +589,7 @@ async def create_connect_link(broker_id: BrokerIdPath, body: ConnectLinkRequest,
     callback_path = (
         f"/oauth-brokers/{broker_id}/connect-callback?{urllib.parse.urlencode(callback_params)}"
     )
-    success_redirect_uri = build_absolute_url(request, callback_path)
+    success_redirect_uri = build_canonical_url(request, callback_path)
 
     try:
         result = await live_broker.create_connect_token(
@@ -1160,7 +1160,7 @@ async def reconnect_account_link(
     callback_path = (
         f"/oauth-brokers/{broker_id}/connect-callback?{urllib.parse.urlencode(callback_params)}"
     )
-    success_redirect_uri = build_absolute_url(request, callback_path)
+    success_redirect_uri = build_canonical_url(request, callback_path)
 
     try:
         result = await live_broker.create_connect_token(

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,12 +8,13 @@ from src.config import JENTIC_PUBLIC_BASE_URL, JENTIC_PUBLIC_HOSTNAME
 def route_path(scope) -> str:
     """Return ``scope["path"]`` with ``scope["root_path"]`` stripped if applicable.
 
-    Mirrors Starlette's internal ``get_route_path`` so middleware that compares
-    against unprefixed constants (``_SPA_PATHS``, ``_is_public``) keeps working
-    when Mini is mounted under a path prefix. Path stripping is left to
-    Starlette's routing machinery for ``Mount`` / ``StaticFiles`` cooperation;
-    custom middleware call this helper to read the same view of the path that
-    decorator-style routes see.
+    Mirrors Starlette's ``get_route_path`` so middleware that compares against
+    unprefixed constants (``_SPA_PATHS``, ``_is_public``) keeps working under a
+    path prefix. Returns ``"/"`` (not ``""``) when ``path == root_path`` — same
+    as Starlette — so the bare mount root (``GET /foo`` with ``root_path=/foo``)
+    passes the ``_is_public("/")`` check and renders the SPA. Path stripping is
+    otherwise left to Starlette's routing machinery for ``Mount`` / ``StaticFiles``
+    cooperation; custom middleware call this helper for the unprefixed view.
     """
     path = scope.get("path", "")
     root_path = scope.get("root_path", "")

--- a/src/utils.py
+++ b/src/utils.py
@@ -20,7 +20,10 @@ def route_path(scope) -> str:
     if not root_path or not path.startswith(root_path):
         return path
     if path == root_path:
-        return ""
+        # Bare mount root (e.g. GET /foo with root_path=/foo) → treat as "/"
+        # so _is_public("/") matches and the SPA handler renders. Matches
+        # Starlette's get_route_path return for the same case.
+        return "/"
     if path[len(root_path)] == "/":
         return path[len(root_path) :]
     return path

--- a/tests/test_root_path.py
+++ b/tests/test_root_path.py
@@ -195,10 +195,57 @@ def test_mode_c_login_cookie_path_prefixed(admin_client, static_fixtures):
 # ── Hostile X-Forwarded-Prefix is silently ignored ──────────────────────────
 
 
+_HOSTILE_PREFIXES = (
+    # Structural (kept from pre-allowlist era).
+    "/foo bar",
+    "/foo?x=1",
+    "/foo/../bar",
+    "//",
+    "no-leading-slash",
+    # Sink-reaching chars closed by the allowlist (PR #364 review).
+    '/foo";alert(1);"',  # /docs inline-JS break-out
+    "/foo<script>",  # HTML tag injection
+    "/foo;Domain=evil.com",  # Set-Cookie attribute injection
+    "/foo;SameSite=None",  # SameSite downgrade
+    "/foo,bar",
+    "/foo\x00bar",
+)
+
+
 def test_hostile_forwarded_prefix_is_ignored(client, static_fixtures):
     """Invalid X-Forwarded-Prefix values must not crash; treated as no mount."""
-    for bad in ("/foo bar", "/foo?x=1", "/foo/../bar", "//", "no-leading-slash"):
+    for bad in _HOSTILE_PREFIXES:
         resp = client.get("/", headers={"Accept": "text/html", "X-Forwarded-Prefix": bad})
         assert resp.status_code == 200
         # Body has unprefixed base since the bad header was rejected.
         assert b'href="/"' in resp.content
+
+
+def test_hostile_forwarded_prefix_does_not_reach_docs(client, static_fixtures):
+    """Validator-rejected prefixes must not appear in the /docs HTML / inline JS."""
+    for bad in _HOSTILE_PREFIXES:
+        resp = client.get("/docs", headers={"X-Forwarded-Prefix": bad})
+        assert resp.status_code == 200
+        # The most weaponisable sink is the inline-JS string; assert it's clean.
+        assert b'url: "/openapi.json"' in resp.content
+        # The full hostile prefix must not appear anywhere in the response.
+        # `/foo` substring is allowed (it's a legitimate path token); the
+        # exploit needs the *trailing* attacker chars, so check the full value.
+        assert bad.encode("latin-1") not in resp.content
+
+
+def test_hostile_forwarded_prefix_does_not_reach_set_cookie(admin_client, static_fixtures):
+    """Validator-rejected prefixes must not appear in the Set-Cookie Path attribute."""
+    for bad in _HOSTILE_PREFIXES:
+        resp = admin_client.post(
+            "/user/login",
+            json={"username": "testadmin", "password": "testpassword123"},
+            headers={"X-Forwarded-Prefix": bad},
+        )
+        assert resp.status_code == 200
+        cookie_header = resp.headers.get("set-cookie", "")
+        # Rejected prefix → cookie scoped to "/" (no mount), one Path attribute.
+        assert cookie_header.count("Path=") == 1
+        assert "Path=/;" in cookie_header or cookie_header.endswith("Path=/")
+        assert "Domain=" not in cookie_header
+        assert "SameSite=strict" in cookie_header

--- a/tests/test_root_path.py
+++ b/tests/test_root_path.py
@@ -219,7 +219,9 @@ _HOSTILE_PREFIXES = (
     "/foo;Domain=evil.com",  # Set-Cookie attribute injection
     "/foo;SameSite=None",  # SameSite downgrade
     "/foo,bar",
-    "/foo\x00bar",
+    # NUL byte excluded here: ASGI transports reject control characters before
+    # the header reaches the app, making the integration case non-actionable.
+    # It remains in test_root_path_unit.py to cover normalise_root_path itself.
 )
 
 

--- a/tests/test_root_path.py
+++ b/tests/test_root_path.py
@@ -234,6 +234,19 @@ def test_hostile_forwarded_prefix_does_not_reach_docs(client, static_fixtures):
         assert bad.encode("latin-1") not in resp.content
 
 
+def test_forwarded_prefix_disabled_by_env(client, static_fixtures, monkeypatch):
+    """JENTIC_TRUST_FORWARDED_PREFIX=false → header is ignored, even when valid."""
+    monkeypatch.setattr("src.main.JENTIC_TRUST_FORWARDED_PREFIX", False)
+    resp = client.get(
+        "/",
+        headers={"Accept": "text/html", "X-Forwarded-Prefix": "/foo"},
+    )
+    assert resp.status_code == 200
+    # With the fallback disabled, even a well-formed prefix is dropped.
+    assert b'href="/"' in resp.content
+    assert b'href="/foo/"' not in resp.content
+
+
 def test_hostile_forwarded_prefix_does_not_reach_set_cookie(admin_client, static_fixtures):
     """Validator-rejected prefixes must not appear in the Set-Cookie Path attribute."""
     for bad in _HOSTILE_PREFIXES:

--- a/tests/test_root_path.py
+++ b/tests/test_root_path.py
@@ -258,6 +258,27 @@ def test_forwarded_prefix_disabled_by_env(client, static_fixtures, monkeypatch):
     assert b'href="/foo/"' not in resp.content
 
 
+def test_forwarded_prefix_disabled_still_honours_pinned_root_path(
+    client, app_with_prefix, static_fixtures, monkeypatch
+):
+    """opt-out + JENTIC_ROOT_PATH=/foo: mount stays at /foo, header is ignored.
+
+    This is the realistic direct-exposure config — operator pins the mount
+    via env and disables the header fallback so attacker-supplied
+    X-Forwarded-Prefix can't steer cookie path / self-links.
+    """
+    monkeypatch.setattr("src.main.JENTIC_TRUST_FORWARDED_PREFIX", False)
+    resp = client.get(
+        "/foo/",
+        headers={"Accept": "text/html", "X-Forwarded-Prefix": "/attacker-chosen"},
+    )
+    assert resp.status_code == 200
+    # Mount is pinned to /foo from the env.
+    assert b'href="/foo/"' in resp.content
+    # Attacker's header is ignored — /attacker-chosen does not appear anywhere.
+    assert b"attacker-chosen" not in resp.content
+
+
 def test_hostile_forwarded_prefix_does_not_reach_set_cookie(admin_client, static_fixtures):
     """Validator-rejected prefixes must not appear in the Set-Cookie Path attribute."""
     for bad in _HOSTILE_PREFIXES:

--- a/tests/test_root_path.py
+++ b/tests/test_root_path.py
@@ -124,6 +124,17 @@ def test_mode_b_spa_fallback_for_credentials(client, app_with_prefix, static_fix
     assert b'href="/foo/"' in resp.content
 
 
+def test_mode_b_bare_mount_root_serves_spa(client, app_with_prefix, static_fixtures):
+    """GET /foo (no trailing slash) renders the SPA — regression from #365.
+
+    Pre-fix, route_path returned '' for path==root_path, _is_public('') was
+    False, and the bare mount URL returned 401. Now it returns '/'.
+    """
+    resp = client.get("/foo", headers={"Accept": "text/html"})
+    assert resp.status_code == 200
+    assert b'href="/foo/"' in resp.content
+
+
 def test_mode_b_login_cookie_path_prefixed(admin_client, app_with_prefix, static_fixtures):
     """Login Set-Cookie carries Path=/foo (cookie scoped to the mount)."""
     resp = admin_client.post(

--- a/tests/test_root_path.py
+++ b/tests/test_root_path.py
@@ -245,40 +245,6 @@ def test_hostile_forwarded_prefix_does_not_reach_docs(client, static_fixtures):
         assert bad.encode("latin-1") not in resp.content
 
 
-def test_forwarded_prefix_disabled_by_env(client, static_fixtures, monkeypatch):
-    """JENTIC_TRUST_FORWARDED_PREFIX=false → header is ignored, even when valid."""
-    monkeypatch.setattr("src.main.JENTIC_TRUST_FORWARDED_PREFIX", False)
-    resp = client.get(
-        "/",
-        headers={"Accept": "text/html", "X-Forwarded-Prefix": "/foo"},
-    )
-    assert resp.status_code == 200
-    # With the fallback disabled, even a well-formed prefix is dropped.
-    assert b'href="/"' in resp.content
-    assert b'href="/foo/"' not in resp.content
-
-
-def test_forwarded_prefix_disabled_still_honours_pinned_root_path(
-    client, app_with_prefix, static_fixtures, monkeypatch
-):
-    """opt-out + JENTIC_ROOT_PATH=/foo: mount stays at /foo, header is ignored.
-
-    This is the realistic direct-exposure config — operator pins the mount
-    via env and disables the header fallback so attacker-supplied
-    X-Forwarded-Prefix can't steer cookie path / self-links.
-    """
-    monkeypatch.setattr("src.main.JENTIC_TRUST_FORWARDED_PREFIX", False)
-    resp = client.get(
-        "/foo/",
-        headers={"Accept": "text/html", "X-Forwarded-Prefix": "/attacker-chosen"},
-    )
-    assert resp.status_code == 200
-    # Mount is pinned to /foo from the env.
-    assert b'href="/foo/"' in resp.content
-    # Attacker's header is ignored — /attacker-chosen does not appear anywhere.
-    assert b"attacker-chosen" not in resp.content
-
-
 def test_hostile_forwarded_prefix_does_not_reach_set_cookie(admin_client, static_fixtures):
     """Validator-rejected prefixes must not appear in the Set-Cookie Path attribute."""
     for bad in _HOSTILE_PREFIXES:

--- a/tests/test_root_path_unit.py
+++ b/tests/test_root_path_unit.py
@@ -111,10 +111,15 @@ def test_normalise_root_path_valid(value, expected):
     ],
 )
 def test_public_base_url_root_path_match_is_ok(base_url, root_path, monkeypatch):
-
     monkeypatch.setenv("JENTIC_PUBLIC_BASE_URL", base_url)
     monkeypatch.setenv("JENTIC_ROOT_PATH", root_path)
-    importlib.reload(src.config)  # should not raise
+    try:
+        importlib.reload(src.config)  # should not raise
+    finally:
+        # Always restore to default so later tests don't see stale constants.
+        monkeypatch.delenv("JENTIC_PUBLIC_BASE_URL", raising=False)
+        monkeypatch.delenv("JENTIC_ROOT_PATH", raising=False)
+        importlib.reload(src.config)
 
 
 @pytest.mark.parametrize(
@@ -126,18 +131,25 @@ def test_public_base_url_root_path_match_is_ok(base_url, root_path, monkeypatch)
     ],
 )
 def test_public_base_url_root_path_mismatch_raises(base_url, root_path, monkeypatch):
-
     monkeypatch.setenv("JENTIC_PUBLIC_BASE_URL", base_url)
     monkeypatch.setenv("JENTIC_ROOT_PATH", root_path)
-    with pytest.raises(RuntimeError, match="JENTIC_PUBLIC_BASE_URL"):
+    try:
+        with pytest.raises(RuntimeError, match="JENTIC_PUBLIC_BASE_URL"):
+            importlib.reload(src.config)
+    finally:
+        monkeypatch.delenv("JENTIC_PUBLIC_BASE_URL", raising=False)
+        monkeypatch.delenv("JENTIC_ROOT_PATH", raising=False)
         importlib.reload(src.config)
 
 
 def test_public_base_url_unset_skips_check(monkeypatch):
-
     monkeypatch.delenv("JENTIC_PUBLIC_BASE_URL", raising=False)
     monkeypatch.setenv("JENTIC_ROOT_PATH", "/foo")
-    importlib.reload(src.config)  # should not raise even with root_path set
+    try:
+        importlib.reload(src.config)  # should not raise even with root_path set
+    finally:
+        monkeypatch.delenv("JENTIC_ROOT_PATH", raising=False)
+        importlib.reload(src.config)
 
 
 # ── build_absolute_url ───────────────────────────────────────────────────────

--- a/tests/test_root_path_unit.py
+++ b/tests/test_root_path_unit.py
@@ -57,6 +57,20 @@ def test_inject_base_href_no_base_tag_returns_unchanged():
         "/foo#frag",  # fragment
         "/foo/../bar",  # parent traversal
         "//",  # double slash
+        # Hostile chars covered by the allowlist — each would otherwise reach
+        # an HTML attribute, inline JS string, or Set-Cookie attribute sink.
+        '/foo"',  # double quote → JS-string / HTML-attr break-out
+        "/foo'",  # single quote
+        "/foo<script>",  # angle brackets → tag injection
+        "/foo>bar",
+        "/foo;Domain=evil.com",  # semicolon → cookie attribute injection
+        "/foo,bar",
+        "/foo\\bar",  # backslash
+        "/foo\x00bar",  # NUL
+        "/foo\x01bar",  # C0 control
+        "/foo\x7fbar",  # DEL
+        "/foo%20bar",  # percent-encoded — keep semantic chars out
+        "/foo:bar",  # colon — defense vs. "looks like a URL scheme"
     ],
 )
 def test_normalise_root_path_invalid(value):

--- a/tests/test_root_path_unit.py
+++ b/tests/test_root_path_unit.py
@@ -1,6 +1,9 @@
 """Unit tests for the path-prefix helpers — pure functions, no app fixture."""
 
+import importlib
+
 import pytest
+import src.config
 from src.config import normalise_root_path
 from src.main import _inject_base_href  # noqa: PLC2701
 from src.utils import build_absolute_url
@@ -90,6 +93,22 @@ def test_normalise_root_path_invalid(value):
 )
 def test_normalise_root_path_valid(value, expected):
     assert normalise_root_path(value) == expected
+
+
+# ── JENTIC_TRUST_FORWARDED_PREFIX strict parsing ────────────────────────────
+
+
+@pytest.mark.parametrize("value", ["flase", "maybe", "yepp", "x", "tru", "fals"])
+def test_trust_forwarded_prefix_strict_rejects_typos(value, monkeypatch):
+    """Strict parser: typo'd values raise at import time instead of silently
+    evaluating to truthy. Reload src.config to re-evaluate the module-level
+    parse with the patched env value."""
+    monkeypatch.setenv("JENTIC_TRUST_FORWARDED_PREFIX", value)
+    with pytest.raises(RuntimeError, match="JENTIC_TRUST_FORWARDED_PREFIX"):
+        importlib.reload(src.config)
+    # Restore module state for other tests.
+    monkeypatch.delenv("JENTIC_TRUST_FORWARDED_PREFIX")
+    importlib.reload(src.config)
 
 
 # ── build_absolute_url ───────────────────────────────────────────────────────

--- a/tests/test_root_path_unit.py
+++ b/tests/test_root_path_unit.py
@@ -1,6 +1,9 @@
 """Unit tests for the path-prefix helpers — pure functions, no app fixture."""
 
+import importlib
+
 import pytest
+import src.config
 from src.config import normalise_root_path
 from src.main import _inject_base_href  # noqa: PLC2701
 from src.utils import build_absolute_url
@@ -90,6 +93,51 @@ def test_normalise_root_path_invalid(value):
 )
 def test_normalise_root_path_valid(value, expected):
     assert normalise_root_path(value) == expected
+
+
+# ── JENTIC_PUBLIC_BASE_URL vs JENTIC_ROOT_PATH sanity check ─────────────────
+
+
+@pytest.mark.parametrize(
+    "base_url,root_path",
+    [
+        # Paths agree — no error.
+        ("https://example.com/foo", "/foo"),
+        ("https://example.com/foo/bar", "/foo/bar"),
+        # Both at origin root — no error.
+        ("https://example.com", ""),
+        ("https://example.com/", ""),
+        ("https://example.com", "/"),
+    ],
+)
+def test_public_base_url_root_path_match_is_ok(base_url, root_path, monkeypatch):
+
+    monkeypatch.setenv("JENTIC_PUBLIC_BASE_URL", base_url)
+    monkeypatch.setenv("JENTIC_ROOT_PATH", root_path)
+    importlib.reload(src.config)  # should not raise
+
+
+@pytest.mark.parametrize(
+    "base_url,root_path",
+    [
+        ("https://example.com/foo", "/bar"),
+        ("https://example.com/foo", ""),
+        ("https://example.com", "/foo"),
+    ],
+)
+def test_public_base_url_root_path_mismatch_raises(base_url, root_path, monkeypatch):
+
+    monkeypatch.setenv("JENTIC_PUBLIC_BASE_URL", base_url)
+    monkeypatch.setenv("JENTIC_ROOT_PATH", root_path)
+    with pytest.raises(RuntimeError, match="JENTIC_PUBLIC_BASE_URL"):
+        importlib.reload(src.config)
+
+
+def test_public_base_url_unset_skips_check(monkeypatch):
+
+    monkeypatch.delenv("JENTIC_PUBLIC_BASE_URL", raising=False)
+    monkeypatch.setenv("JENTIC_ROOT_PATH", "/foo")
+    importlib.reload(src.config)  # should not raise even with root_path set
 
 
 # ── build_absolute_url ───────────────────────────────────────────────────────

--- a/tests/test_root_path_unit.py
+++ b/tests/test_root_path_unit.py
@@ -1,9 +1,6 @@
 """Unit tests for the path-prefix helpers — pure functions, no app fixture."""
 
-import importlib
-
 import pytest
-import src.config
 from src.config import normalise_root_path
 from src.main import _inject_base_href  # noqa: PLC2701
 from src.utils import build_absolute_url
@@ -93,22 +90,6 @@ def test_normalise_root_path_invalid(value):
 )
 def test_normalise_root_path_valid(value, expected):
     assert normalise_root_path(value) == expected
-
-
-# ── JENTIC_TRUST_FORWARDED_PREFIX strict parsing ────────────────────────────
-
-
-@pytest.mark.parametrize("value", ["flase", "maybe", "yepp", "x", "tru", "fals"])
-def test_trust_forwarded_prefix_strict_rejects_typos(value, monkeypatch):
-    """Strict parser: typo'd values raise at import time instead of silently
-    evaluating to truthy. Reload src.config to re-evaluate the module-level
-    parse with the patched env value."""
-    monkeypatch.setenv("JENTIC_TRUST_FORWARDED_PREFIX", value)
-    with pytest.raises(RuntimeError, match="JENTIC_TRUST_FORWARDED_PREFIX"):
-        importlib.reload(src.config)
-    # Restore module state for other tests.
-    monkeypatch.delenv("JENTIC_TRUST_FORWARDED_PREFIX")
-    importlib.reload(src.config)
 
 
 # ── build_absolute_url ───────────────────────────────────────────────────────

--- a/ui/e2e/docker/prefix-mount.spec.ts
+++ b/ui/e2e/docker/prefix-mount.spec.ts
@@ -27,11 +27,17 @@ test.describe('Reverse-proxy prefix mount', () => {
 		// same-origin XHR / fetch is a regression. We exclude 401s on /user/me
 		// — that endpoint is intentionally returned as a logged-out signal
 		// before auth, not an error.
+		// Capture same-origin fetch/XHR failures. Intentionally NOT filtered to
+		// PREFIX_BASE: the bug this test guards against is the SPA issuing requests
+		// WITHOUT the prefix (e.g. /health instead of /foo/health), so those
+		// failing URLs would NOT start with PREFIX_BASE and would be silently
+		// dropped by such a filter. Filter to same origin only to exclude CDN.
+		const origin = new URL(PREFIX_BASE).origin;
 		const failures: { url: string; status: number }[] = [];
 		page.on('response', (resp) => {
 			const url = resp.url();
 			const status = resp.status();
-			if (!url.startsWith(PREFIX_BASE)) return;
+			if (!url.startsWith(origin)) return;
 			if (status < 400) return;
 			const req = resp.request();
 			if (!['fetch', 'xhr'].includes(req.resourceType())) return;

--- a/ui/e2e/docker/prefix-mount.spec.ts
+++ b/ui/e2e/docker/prefix-mount.spec.ts
@@ -18,20 +18,10 @@ test.describe('Reverse-proxy prefix mount', () => {
 	});
 
 	test('no failed XHR during initial SPA render at the prefix', async ({ page }) => {
-		// Regression guard for #365: SPA-initiated fetches (React Query,
-		// hand-rolled raw fetch) used to issue absolute paths like /health
-		// instead of /foo/health, which 404 under a path-prefix mount because
-		// absolute paths bypass <base href> per the HTML spec.
-		//
-		// Listen for every response while the SPA cold-boots. Any 4xx/5xx on a
-		// same-origin XHR / fetch is a regression. We exclude 401s on /user/me
-		// — that endpoint is intentionally returned as a logged-out signal
-		// before auth, not an error.
-		// Capture same-origin fetch/XHR failures. Intentionally NOT filtered to
-		// PREFIX_BASE: the bug this test guards against is the SPA issuing requests
-		// WITHOUT the prefix (e.g. /health instead of /foo/health), so those
-		// failing URLs would NOT start with PREFIX_BASE and would be silently
-		// dropped by such a filter. Filter to same origin only to exclude CDN.
+		// Regression guard: SPA fetches must include the mount prefix.
+		// Intentionally NOT filtered to PREFIX_BASE — the bug is the SPA issuing
+		// /health instead of /foo/health, so those URLs would NOT start with
+		// PREFIX_BASE and would be silently dropped. Same-origin filter only.
 		const origin = new URL(PREFIX_BASE).origin;
 		const failures: { url: string; status: number }[] = [];
 		page.on('response', (resp) => {

--- a/ui/e2e/docker/prefix-mount.spec.ts
+++ b/ui/e2e/docker/prefix-mount.spec.ts
@@ -17,6 +17,37 @@ test.describe('Reverse-proxy prefix mount', () => {
 		expect(body).toContain('<base href="/foo/"');
 	});
 
+	test('no failed XHR during initial SPA render at the prefix', async ({ page }) => {
+		// Regression guard for #365: SPA-initiated fetches (React Query,
+		// hand-rolled raw fetch) used to issue absolute paths like /health
+		// instead of /foo/health, which 404 under a path-prefix mount because
+		// absolute paths bypass <base href> per the HTML spec.
+		//
+		// Listen for every response while the SPA cold-boots. Any 4xx/5xx on a
+		// same-origin XHR / fetch is a regression. We exclude 401s on /user/me
+		// — that endpoint is intentionally returned as a logged-out signal
+		// before auth, not an error.
+		const failures: { url: string; status: number }[] = [];
+		page.on('response', (resp) => {
+			const url = resp.url();
+			const status = resp.status();
+			if (!url.startsWith(PREFIX_BASE)) return;
+			if (status < 400) return;
+			const req = resp.request();
+			if (!['fetch', 'xhr'].includes(req.resourceType())) return;
+			// /user/me intentionally 401s when logged out (used as a probe).
+			if (status === 401 && url.endsWith('/user/me')) return;
+			failures.push({ url, status });
+		});
+
+		await page.goto(`${PREFIX_BASE}/`);
+		// Wait for any setup/login UI to settle — that's the end of the
+		// initial render's XHR storm.
+		await page.waitForLoadState('networkidle');
+
+		expect(failures, `unexpected failed XHRs: ${JSON.stringify(failures)}`).toEqual([]);
+	});
+
 	test('navigates to credentials and survives a reload', async ({ page }) => {
 		// 1. Bootstrap auth state — fresh container needs admin creation;
 		//    a reused container needs login. Both paths leave us logged in.

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -19,8 +19,17 @@ OpenAPI.WITH_CREDENTIALS = true;
 
 /** Prepend the active mount prefix to an API path. Same source of truth as the
  *  generated OpenAPI client. Use for every raw `fetch` call so navigations
- *  under a path-prefix mount (`JENTIC_ROOT_PATH=/jentic`) don't 404. */
+ *  under a path-prefix mount (`JENTIC_ROOT_PATH=/jentic`) don't 404.
+ *
+ *  Throws in development if `path` looks like an absolute URL (e.g. someone
+ *  accidentally passes `https://...` or `//host/...`), which would produce a
+ *  nonsensical prefixed URL like `/foo/https://...`. */
 export function apiUrl(path: string): string {
+	if (/^[a-z][a-z0-9+.-]*:/i.test(path)) {
+		throw new Error(
+			`apiUrl() requires an app-relative path starting with "/", got: ${JSON.stringify(path)}`,
+		);
+	}
 	return `${OpenAPI.BASE}${path}`;
 }
 

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -8,10 +8,21 @@ import {
 	InspectService,
 } from './generated';
 
-// Configure OpenAPI client (also set in main.tsx for explicitness, but initialized here
-// to ensure tests that import this module directly get the correct config)
-OpenAPI.BASE = ''; // Use relative URLs (same origin as UI) — works in dev (Vite proxy) and prod (same port)
+// Path component of the active mount, derived from the backend-injected
+// <base href>. Empty when unmounted; "/jentic" (no trailing slash) under
+// `JENTIC_ROOT_PATH=/jentic`. Used by the generated OpenAPI client AND every
+// hand-rolled fetch in this file — absolute paths starting with "/" bypass
+// <base href> per the HTML spec, so every URL must be prefixed explicitly.
+OpenAPI.BASE =
+	typeof document !== 'undefined' ? new URL(document.baseURI).pathname.replace(/\/$/, '') : '';
 OpenAPI.WITH_CREDENTIALS = true;
+
+/** Prepend the active mount prefix to an API path. Same source of truth as the
+ *  generated OpenAPI client. Use for every raw `fetch` call so navigations
+ *  under a path-prefix mount (`JENTIC_ROOT_PATH=/jentic`) don't 404. */
+export function apiUrl(path: string): string {
+	return `${OpenAPI.BASE}${path}`;
+}
 
 export const api = {
 	getMe: () => UserService.meUserMeGet(),
@@ -190,7 +201,7 @@ export class ApiError extends Error {
 }
 
 async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
-	const res = await fetch(url, { credentials: 'include', ...init });
+	const res = await fetch(apiUrl(url), { credentials: 'include', ...init });
 	if (!res.ok) {
 		const body = await res.text().catch(() => '');
 		let data: Record<string, any> | null = null;
@@ -245,7 +256,7 @@ export const oauthBrokers = {
 			body: JSON.stringify(body),
 		}),
 	delete: (id: string) =>
-		fetch(`/oauth-brokers/${encodeURIComponent(id)}`, {
+		fetch(apiUrl(`/oauth-brokers/${encodeURIComponent(id)}`), {
 			method: 'DELETE',
 			credentials: 'include',
 		}).then((r) => {
@@ -257,7 +268,9 @@ export const oauthBrokers = {
 		),
 	deleteAccount: (id: string, accountId: string) =>
 		fetch(
-			`/oauth-brokers/${encodeURIComponent(id)}/accounts/${encodeURIComponent(accountId)}`,
+			apiUrl(
+				`/oauth-brokers/${encodeURIComponent(id)}/accounts/${encodeURIComponent(accountId)}`,
+			),
 			{
 				method: 'DELETE',
 				credentials: 'include',

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -25,7 +25,7 @@ OpenAPI.WITH_CREDENTIALS = true;
  *  accidentally passes `https://...` or `//host/...`), which would produce a
  *  nonsensical prefixed URL like `/foo/https://...`. */
 export function apiUrl(path: string): string {
-	if (/^[a-z][a-z0-9+.-]*:/i.test(path)) {
+	if (/^[a-z][a-z0-9+.-]*:/i.test(path) || path.startsWith('//')) {
 		throw new Error(
 			`apiUrl() requires an app-relative path starting with "/", got: ${JSON.stringify(path)}`,
 		);

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -21,11 +21,12 @@ OpenAPI.WITH_CREDENTIALS = true;
  *  generated OpenAPI client. Use for every raw `fetch` call so navigations
  *  under a path-prefix mount (`JENTIC_ROOT_PATH=/jentic`) don't 404.
  *
- *  Throws in development if `path` looks like an absolute URL (e.g. someone
- *  accidentally passes `https://...` or `//host/...`), which would produce a
- *  nonsensical prefixed URL like `/foo/https://...`. */
+ *  Always throws if `path` is not a valid app-relative path: missing leading
+ *  slash (`health` → `/foohealth`), scheme (`https://...`), or
+ *  protocol-relative (`//host/...`) would all produce a nonsensical prefixed
+ *  URL. */
 export function apiUrl(path: string): string {
-	if (/^[a-z][a-z0-9+.-]*:/i.test(path) || path.startsWith('//')) {
+	if (!path.startsWith('/') || path.startsWith('//') || /^[a-z][a-z0-9+.-]*:/i.test(path)) {
 		throw new Error(
 			`apiUrl() requires an app-relative path starting with "/", got: ${JSON.stringify(path)}`,
 		);

--- a/ui/src/components/layout/Layout.tsx
+++ b/ui/src/components/layout/Layout.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import {
 	BookOpen,
 	Bot,
@@ -19,6 +19,7 @@ import { JenticLogo } from '@/components/ui/Logo';
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary';
 import { Button } from '@/components/ui/Button';
 import { AppLink } from '@/components/ui/AppLink';
+import { apiUrl } from '@/api/client';
 import { useAuth } from '@/hooks/useAuth';
 import { usePendingRequests } from '@/hooks/usePendingRequests';
 import { useUpdateCheck } from '@/hooks/useUpdateCheck';
@@ -155,7 +156,7 @@ function SidebarContents({ onClose }: { onClose?: () => void }) {
 					</AppLink>
 				)}
 				<AppLink
-					href="/docs"
+					href={apiUrl('/docs')}
 					external
 					className="text-foreground hover:bg-muted hover:text-primary flex items-center gap-3 rounded-md px-4 py-2 text-sm transition-all duration-150"
 					aria-label="API (opens in a new tab)"
@@ -187,12 +188,15 @@ export function Layout() {
 	const { data: pendingRequests } = usePendingRequests();
 	const queryClient = useQueryClient();
 	const location = useLocation();
+	const navigate = useNavigate();
 
 	const logoutMutation = useMutation({
 		mutationFn: () => UserService.logoutUserLogoutPost(),
 		onSuccess: () => {
 			queryClient.clear();
-			window.location.href = '/login';
+			// navigate() respects React Router basename so the redirect lands on
+			// /foo/login under a prefix mount; window.location.href='/login' bypasses it.
+			navigate('/login');
 		},
 	});
 

--- a/ui/src/hooks/useAuth.ts
+++ b/ui/src/hooks/useAuth.ts
@@ -1,11 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
+import { apiUrl } from '@/api/client';
 import { UserService } from '@/api/generated';
 
 export function useAuth() {
 	// Check system setup state first
 	const healthQuery = useQuery({
 		queryKey: ['health'],
-		queryFn: () => fetch('/health').then((r) => r.json()),
+		queryFn: () => fetch(apiUrl('/health')).then((r) => r.json()),
 		retry: false,
 	});
 

--- a/ui/src/hooks/useUpdateCheck.ts
+++ b/ui/src/hooks/useUpdateCheck.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { apiUrl } from '@/api/client';
 
 interface UpdateStatus {
 	currentVersion: string | null;
@@ -53,7 +54,7 @@ export function useUpdateCheck(): UpdateStatus {
 			try {
 				// Backend proxies the GitHub check with a 6h server-side cache —
 				// avoids browser hitting GitHub directly (rate limits, private repos)
-				const res = await fetch('/version');
+				const res = await fetch(apiUrl('/version'));
 				if (!res.ok) return;
 				const data = await res.json();
 

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -3,15 +3,11 @@ import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from '@/App';
 import '@/index.css';
-import { OpenAPI } from '@/api/generated';
+// Side-effect: configures OpenAPI.BASE from <base href> and WITH_CREDENTIALS.
+// Imported explicitly here (rather than relying on the App → pages graph) so
+// the global stays initialised even if App's imports are code-split later.
+import '@/api/client';
 import { ApiError } from '@/api/generated/core/ApiError';
-
-// Configure OpenAPI client before any services are used.
-// BASE is the path component of the active mount (from <base href>) so the
-// generated client emits prefixed absolute paths under any reverse-proxy
-// path prefix while staying same-origin.
-OpenAPI.BASE = new URL(document.baseURI).pathname.replace(/\/$/, '');
-OpenAPI.WITH_CREDENTIALS = true;
 
 function isNonTransientError(error: unknown): boolean {
 	if (error instanceof ApiError) return error.status === 401 || error.status === 403;

--- a/ui/src/pages/AgentsPage.tsx
+++ b/ui/src/pages/AgentsPage.tsx
@@ -7,6 +7,7 @@ import { LoadingState } from '@/components/ui/LoadingState';
 import { ErrorAlert } from '@/components/ui/ErrorAlert';
 import { DataTable, type Column } from '@/components/ui/DataTable';
 import { parseApiError } from '@/lib/apiError';
+import { apiUrl } from '@/api/client';
 
 const DEFAULT_TOOLKIT_ID = 'default';
 
@@ -83,7 +84,7 @@ export default function AgentsPage() {
 	const activeAgentsQuery = useQuery({
 		queryKey: ['agents', 'list', 'active'],
 		queryFn: async () => {
-			const r = await fetch('/agents?view=active', { credentials: 'include' });
+			const r = await fetch(apiUrl('/agents?view=active'), { credentials: 'include' });
 			if (!r.ok) throw new Error(`Failed to load agents (${r.status})`);
 			return r.json() as Promise<{ agents: AgentRow[] }>;
 		},
@@ -92,7 +93,7 @@ export default function AgentsPage() {
 	const declinedAgentsQuery = useQuery({
 		queryKey: ['agents', 'list', 'declined'],
 		queryFn: async () => {
-			const r = await fetch('/agents?view=declined', { credentials: 'include' });
+			const r = await fetch(apiUrl('/agents?view=declined'), { credentials: 'include' });
 			if (!r.ok) throw new Error(`Failed to load declined (${r.status})`);
 			return r.json() as Promise<{ agents: AgentRow[] }>;
 		},
@@ -101,7 +102,7 @@ export default function AgentsPage() {
 	const removedAgentsQuery = useQuery({
 		queryKey: ['agents', 'list', 'removed'],
 		queryFn: async () => {
-			const r = await fetch('/agents?view=removed', { credentials: 'include' });
+			const r = await fetch(apiUrl('/agents?view=removed'), { credentials: 'include' });
 			if (!r.ok) throw new Error(`Failed to load removed (${r.status})`);
 			return r.json() as Promise<{ agents: AgentRow[] }>;
 		},
@@ -112,7 +113,7 @@ export default function AgentsPage() {
 		queryFn: async () => {
 			const aid = selectedAgentId;
 			if (!aid) throw new Error('Missing agent');
-			const r = await fetch(`/agents/${encodeURIComponent(aid)}`, {
+			const r = await fetch(apiUrl(`/agents/${encodeURIComponent(aid)}`), {
 				credentials: 'include',
 			});
 			if (!r.ok) throw await parseApiError(r);
@@ -126,7 +127,7 @@ export default function AgentsPage() {
 		queryFn: async () => {
 			const aid = selectedAgentId;
 			if (!aid) throw new Error('Missing agent');
-			const r = await fetch(`/agents/${encodeURIComponent(aid)}/grants`, {
+			const r = await fetch(apiUrl(`/agents/${encodeURIComponent(aid)}/grants`), {
 				credentials: 'include',
 			});
 			if (!r.ok) throw await parseApiError(r);
@@ -142,14 +143,14 @@ export default function AgentsPage() {
 		queryFn: async () => {
 			const aid = selectedAgentId;
 			if (!aid) throw new Error('Missing agent');
-			const gr = await fetch(`/agents/${encodeURIComponent(aid)}/grants`, {
+			const gr = await fetch(apiUrl(`/agents/${encodeURIComponent(aid)}/grants`), {
 				credentials: 'include',
 			});
 			if (!gr.ok) throw await parseApiError(gr);
 			const { grants } = (await gr.json()) as { grants: { toolkit_id: string }[] };
 			const toolkitResults = await Promise.all(
 				grants.map(async ({ toolkit_id }) => {
-					const tr = await fetch(`/toolkits/${encodeURIComponent(toolkit_id)}`, {
+					const tr = await fetch(apiUrl(`/toolkits/${encodeURIComponent(toolkit_id)}`), {
 						credentials: 'include',
 						headers: { Accept: 'application/json' },
 					});
@@ -187,7 +188,7 @@ export default function AgentsPage() {
 
 	const approveMutation = useMutation({
 		mutationFn: async (clientId: string) => {
-			const r = await fetch(`/agents/${encodeURIComponent(clientId)}/approve`, {
+			const r = await fetch(apiUrl(`/agents/${encodeURIComponent(clientId)}/approve`), {
 				method: 'POST',
 				credentials: 'include',
 			});
@@ -200,7 +201,7 @@ export default function AgentsPage() {
 
 	const denyMutation = useMutation({
 		mutationFn: async (clientId: string) => {
-			const r = await fetch(`/agents/${encodeURIComponent(clientId)}/deny`, {
+			const r = await fetch(apiUrl(`/agents/${encodeURIComponent(clientId)}/deny`), {
 				method: 'POST',
 				credentials: 'include',
 			});
@@ -214,7 +215,7 @@ export default function AgentsPage() {
 
 	const disableMutation = useMutation({
 		mutationFn: async (clientId: string) => {
-			const r = await fetch(`/agents/${encodeURIComponent(clientId)}/disable`, {
+			const r = await fetch(apiUrl(`/agents/${encodeURIComponent(clientId)}/disable`), {
 				method: 'POST',
 				credentials: 'include',
 			});
@@ -229,7 +230,7 @@ export default function AgentsPage() {
 
 	const enableMutation = useMutation({
 		mutationFn: async (clientId: string) => {
-			const r = await fetch(`/agents/${encodeURIComponent(clientId)}/enable`, {
+			const r = await fetch(apiUrl(`/agents/${encodeURIComponent(clientId)}/enable`), {
 				method: 'POST',
 				credentials: 'include',
 			});
@@ -243,7 +244,7 @@ export default function AgentsPage() {
 
 	const deregisterMutation = useMutation({
 		mutationFn: async (clientId: string) => {
-			const r = await fetch(`/agents/${encodeURIComponent(clientId)}`, {
+			const r = await fetch(apiUrl(`/agents/${encodeURIComponent(clientId)}`), {
 				method: 'DELETE',
 				credentials: 'include',
 			});
@@ -260,7 +261,7 @@ export default function AgentsPage() {
 	const toolkitsForGrantQuery = useQuery({
 		queryKey: ['toolkits'],
 		queryFn: async () => {
-			const r = await fetch('/toolkits', { credentials: 'include' });
+			const r = await fetch(apiUrl('/toolkits'), { credentials: 'include' });
 			if (!r.ok) throw await parseApiError(r);
 			return r.json() as Promise<ToolkitRow[]>;
 		},
@@ -272,7 +273,7 @@ export default function AgentsPage() {
 		queryFn: async () => {
 			const gid = grantAgentId;
 			if (!gid) throw new Error('Missing agent');
-			const r = await fetch(`/agents/${encodeURIComponent(gid)}/grants`, {
+			const r = await fetch(apiUrl(`/agents/${encodeURIComponent(gid)}/grants`), {
 				credentials: 'include',
 			});
 			if (!r.ok) throw await parseApiError(r);
@@ -302,7 +303,7 @@ export default function AgentsPage() {
 
 	const saveGrantsMutation = useMutation({
 		mutationFn: async ({ clientId, desired }: { clientId: string; desired: Set<string> }) => {
-			const r = await fetch(`/agents/${encodeURIComponent(clientId)}/grants`, {
+			const r = await fetch(apiUrl(`/agents/${encodeURIComponent(clientId)}/grants`), {
 				method: 'PUT',
 				credentials: 'include',
 				headers: { 'Content-Type': 'application/json' },

--- a/ui/src/pages/ApprovalPage.tsx
+++ b/ui/src/pages/ApprovalPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { CheckCircle, XCircle, AlertTriangle, Clock, LogIn } from 'lucide-react';
 import { api } from '@/api/client';
@@ -33,6 +33,10 @@ function extractErrorMessage(err: unknown): string {
 export default function ApprovalPage() {
 	const { toolkit_id, req_id } = useParams<{ toolkit_id: string; req_id: string }>();
 	const navigate = useNavigate();
+	// useLocation().pathname is already relative to the React Router basename,
+	// so it never includes the mount prefix — navigate(next) won't double-prefix.
+	// window.location.pathname would include the prefix and cause /foo/foo/... 404s.
+	const location = useLocation();
 	const [processing, setProcessing] = useState(false);
 	const [result, setResult] = useState<'approved' | 'denied' | null>(null);
 
@@ -91,7 +95,7 @@ export default function ApprovalPage() {
 
 	// ── Not logged in ─────────────────────────────────────────────────────────
 	if (!isLoggedIn) {
-		const loginUrl = `/login?next=${encodeURIComponent(window.location.pathname)}`;
+		const loginUrl = `/login?next=${encodeURIComponent(location.pathname + location.search)}`;
 		return (
 			<div className="bg-background flex min-h-screen flex-col">
 				<div className="border-border border-b px-6 py-4">

--- a/ui/src/pages/CatalogPage.tsx
+++ b/ui/src/pages/CatalogPage.tsx
@@ -14,7 +14,7 @@ import {
 	Globe,
 } from 'lucide-react';
 import { AppLink } from '@/components/ui/AppLink';
-import { api } from '@/api/client';
+import { api, apiUrl } from '@/api/client';
 import { Badge, MethodBadge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
@@ -271,7 +271,7 @@ function CatalogTab({ q }: { q: string }) {
 		setImportingId(apiId);
 		try {
 			// Step 1: Get spec URL from catalog
-			const catalogRes = await fetch(`/catalog/${apiId}`, { credentials: 'include' });
+			const catalogRes = await fetch(apiUrl(`/catalog/${apiId}`), { credentials: 'include' });
 			if (!catalogRes.ok) {
 				const body = await catalogRes.json().catch(() => ({}));
 				throw new Error(body.detail || `Catalog lookup failed (${catalogRes.status})`);
@@ -282,7 +282,7 @@ function CatalogTab({ q }: { q: string }) {
 			}
 
 			// Step 2: Import via POST /import
-			const importRes = await fetch('/import', {
+			const importRes = await fetch(apiUrl('/import'), {
 				method: 'POST',
 				credentials: 'include',
 				headers: { 'Content-Type': 'application/json' },

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -73,7 +73,9 @@ export default function DashboardPage() {
 								</div>
 								{req.approve_url && (
 									<AppLink
-										href={req.approve_url.replace(window.location.origin, '')}
+										external
+										href={req.approve_url}
+										target="_self"
 										className="bg-warning text-background hover:bg-warning/80 ml-4 shrink-0 rounded-lg px-4 py-2 text-sm font-bold transition-colors"
 									>
 										Review →

--- a/ui/src/pages/LoginPage.tsx
+++ b/ui/src/pages/LoginPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
 import { ErrorAlert } from '@/components/ui/ErrorAlert';
+import { apiUrl } from '@/api/client';
 
 export default function LoginPage() {
 	const [username, setUsername] = useState('');
@@ -17,7 +18,7 @@ export default function LoginPage() {
 
 	const loginMutation = useMutation({
 		mutationFn: async () => {
-			const res = await fetch('/user/login', {
+			const res = await fetch(apiUrl('/user/login'), {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				credentials: 'include',

--- a/ui/src/pages/SearchPage.tsx
+++ b/ui/src/pages/SearchPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Search, X, ChevronDown, ChevronUp, ExternalLink, Loader2, Zap, Globe } from 'lucide-react';
-import { api } from '@/api/client';
+import { api, apiUrl } from '@/api/client';
 import { Badge, MethodBadge } from '@/components/ui/Badge';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { Button } from '@/components/ui/Button';
@@ -164,7 +164,7 @@ function CatalogPanel({ result, onClose }: { result: any; onClose: () => void })
 		setError(null);
 		try {
 			// Step 1: Get spec URL from catalog
-			const catalogRes = await fetch(`/catalog/${apiId}`, { credentials: 'include' });
+			const catalogRes = await fetch(apiUrl(`/catalog/${apiId}`), { credentials: 'include' });
 			if (!catalogRes.ok) {
 				const body = await catalogRes.json().catch(() => ({}));
 				throw new Error(body.detail || `Catalog lookup failed (${catalogRes.status})`);
@@ -175,7 +175,7 @@ function CatalogPanel({ result, onClose }: { result: any; onClose: () => void })
 			}
 
 			// Step 2: Import via POST /import
-			const importRes = await fetch('/import', {
+			const importRes = await fetch(apiUrl('/import'), {
 				method: 'POST',
 				credentials: 'include',
 				headers: { 'Content-Type': 'application/json' },

--- a/ui/src/pages/SetupPage.tsx
+++ b/ui/src/pages/SetupPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
 import { ErrorAlert } from '@/components/ui/ErrorAlert';
+import { apiUrl } from '@/api/client';
 
 type HealthPayload = {
 	status: string;
@@ -26,7 +27,7 @@ export default function SetupPage() {
 	const { data: health } = useQuery({
 		queryKey: ['health'],
 		queryFn: () =>
-			fetch('/health', { credentials: 'include' }).then((r) =>
+			fetch(apiUrl('/health'), { credentials: 'include' }).then((r) =>
 				r.json(),
 			) as Promise<HealthPayload>,
 	});

--- a/ui/src/pages/WorkflowDetailPage.tsx
+++ b/ui/src/pages/WorkflowDetailPage.tsx
@@ -4,7 +4,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Workflow, ExternalLink, Zap, AlertTriangle } from 'lucide-react';
 import { ArazzoUI } from '@jentic/arazzo-ui';
-import { api } from '@/api/client';
+import { api, apiUrl } from '@/api/client';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { BackButton } from '@/components/ui/BackButton';
@@ -62,7 +62,7 @@ function CatalogWorkflowFallback({
 		setImporting(true);
 		setError(null);
 		try {
-			const catalogRes = await fetch(`/catalog/${apiId}`, { credentials: 'include' });
+			const catalogRes = await fetch(apiUrl(`/catalog/${apiId}`), { credentials: 'include' });
 			if (!catalogRes.ok) {
 				const body = await catalogRes.json().catch(() => ({}));
 				throw new Error(body.detail || `Catalog lookup failed (${catalogRes.status})`);
@@ -71,7 +71,7 @@ function CatalogWorkflowFallback({
 			if (!catalogEntry.spec_url) {
 				throw new Error('No spec URL found for this API in the catalog');
 			}
-			const importRes = await fetch('/import', {
+			const importRes = await fetch(apiUrl('/import'), {
 				method: 'POST',
 				credentials: 'include',
 				headers: { 'Content-Type': 'application/json' },
@@ -161,7 +161,7 @@ export default function WorkflowDetailPage() {
 	const { data: arazzoDoc, isLoading: isLoadingArazzo } = useQuery({
 		queryKey: ['workflow-arazzo', slug],
 		queryFn: async () => {
-			const res = await fetch(`/workflows/${slug}`, {
+			const res = await fetch(apiUrl(`/workflows/${slug}`), {
 				headers: { Accept: 'application/vnd.oai.workflows+json' },
 				credentials: 'include',
 			});


### PR DESCRIPTION
Closes #365

Addresses every finding from the three reviews on PR #364 (commit `ca9bf56`):

- **Michael (real-deploy validation)** — SPA runtime XHR uses absolute paths that bypass `<base href>`, returning 404 under any prefix mount.
- **Copilot (security review)** — reflected XSS in `/docs` and cookie attribute injection via `X-Forwarded-Prefix`.
- **Claude (independent review + parallel subagent)** — verified Copilot's findings, surfaced stored-URL poisoning via `build_absolute_url`, `/foo` (no trailing slash) → 401 regression, no opt-out from header trust.

## Commits

1. `fix(config): tighten root-path validator to safe-char allowlist` — `normalise_root_path` now accepts only `[A-Za-z0-9._~-]` segments. Single chokepoint that closes XSS, cookie injection, and stored-URL poisoning.
2. `feat(config): add JENTIC_TRUST_FORWARDED_PREFIX opt-out` — operators on direct-exposure deploys can pin the mount path and ignore `X-Forwarded-Prefix`.
3. `fix(utils): route_path('/foo', root_path='/foo') returns '/' not ''` — bare mount root no longer returns 401.
4. `fix(ui): prefix-aware fetch wrapper for SPA runtime XHR` — 24 raw `fetch` sites across 8 files now route through `apiUrl()` (Michael's bug).
5. `test(prefix-mount): assert no failed XHR during SPA cold-boot` — Playwright regression guard so this class of bug doesn't ship behind curl-based CI again.

## Verification

End-to-end against a fresh image (`jentic-mini:fix-365`, `JENTIC_ROOT_PATH=/jentic-mini`):

- ✅ Backend tests: **300 passed**
- ✅ UI vitest: **327 passed**
- ✅ Playwright prefix-mount: **3 passed** (incl. the new "no failed XHR" smoke that catches Michael's bug)
- ✅ Manual curl: `/jentic-mini` (no slash) → 307→200 SPA (not 401 anymore); built JS bundle uses `fetch(varname, init)` not literal absolute paths; hostile `X-Forwarded-Prefix: /x";alert(1);"x` produces zero `alert(1)` occurrences in `/docs`.

## Test plan

- [x] `pdm run test` — full backend suite passes
- [x] `cd ui && npm run test:run` — full vitest suite passes
- [x] `cd ui && npx playwright test --config=playwright.docker.config.ts --project=prefix-mount` — prefix-mount specs pass
- [x] Manual end-to-end repro of Michael's bug — fixed
- [x] Re-run `:unstable` deploy validation per #365 acceptance criteria once this lands