### PR TITLE
chore(harness): ignore .claude/scheduled_tasks*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 !/.claude
 /.claude/settings.local.json
 /.claude/worktrees/*
+/.claude/scheduled_tasks*
 !/.claude/worktrees/.gitkeep
 *.pyc
 *.pyo


### PR DESCRIPTION
## Summary
- Ignore `.claude/scheduled_tasks*` so per-checkout scheduler state stays local.

## Test plan
- [x] `.gitignore` matches `.claude/scheduled_tasks` and `.claude/scheduled_tasks.json`