### PR TITLE
ci(docker-publish-pr): add manual PR image publish workflow

### DIFF
--- a/.github/workflows/docker-publish-pr.yml
+++ b/.github/workflows/docker-publish-pr.yml
@@ -1,0 +1,49 @@
+# Manual-only: builds untrusted PR code with packages:write.
+# Dispatcher is expected to review the PR diff before triggering.
+
+name: Publish PR image
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to build and publish as ghcr.io/jentic/jentic-mini:pr-<N>'
+        required: true
+        type: number
+
+concurrency:
+  group: docker-publish-pr-${{ inputs.pr }}
+  cancel-in-progress: true
+
+jobs:
+  publish-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ inputs.pr }}/head
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          provenance: false
+          tags: ghcr.io/jentic/jentic-mini:pr-${{ inputs.pr }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/docker-publish-pr.yml` — a manual `workflow_dispatch` workflow that builds and pushes a Docker image for any open PR (own-repo or fork) to `ghcr.io/jentic/jentic-mini:pr-<N>`, so reviewers can pull and test PR builds without merging.
- Uses `refs/pull/<N>/head` so the same path covers own-repo and fork PRs (GitHub mirrors fork commits via the base repo's PR ref).
- GHCR-only push, single-arch `linux/amd64`, `provenance: false` to match `docker-publish.yml`. Scoped permissions: `contents: read` + `packages: write`.
- Trust model documented as a header comment in the file: dispatcher must review the PR diff before triggering, since fork code runs with `packages: write`.
- No automatic cleanup — delete tags manually via the GHCR UI when no longer needed. Intentional: keeps the workflow set minimal and visibility/cost is GHCR-only.

## Test plan
- [ ] Pre-merge smoke test from this branch:
  ```
  gh workflow run docker-publish-pr.yml --ref chore/docker-publish-pr-workflow -f pr=<any open PR number>
  ```
- [ ] Confirm image pulls cleanly: `docker pull ghcr.io/jentic/jentic-mini:pr-<N>`
- [ ] After merge, dispatch via Actions UI → "Publish PR image" → enter PR number → Run.
- [ ] Confirm `:pr-<N>` tag is visible at https://github.com/orgs/jentic/packages/container/jentic-mini.