### PR TITLE
chore(harness): add review auto-apply rule

### DIFF
--- a/.claude/rules/review-auto-apply.md
+++ b/.claude/rules/review-auto-apply.md
@@ -1,15 +1,14 @@
-`/review` and `/security-review` always produce comments — that's the audit trail. Additionally, for each mechanical finding that remains clearly correct after re-reading the surrounding code in its current state, push a follow-up commit on the same PR (per `git-workflow.md` / `conventional-commits.md`) and, if the finding lived as a PR review thread, resolve it per `copilot-review-comments.md`.
+`/review` and `/security-review` always produce comments — that's the audit trail. For findings that pass the re-check (below), push a follow-up commit on the same PR (per `git-workflow.md` / `conventional-commits.md`). When auto-applying a bug fix, append an `## Auto-applied fixes` section to the PR review comment (or post a new comment if none exists). If the finding lived in a PR review thread, resolve it per `copilot-review-comments.md`.
 
-The re-check is per-finding: re-open the file(s) the finding points at, confirm the issue still applies (code may have shifted since the review was generated), and confirm the fix has no logic implications. If any of those is uncertain, leave it as a comment only.
-
-The comment is the record; the commit just closes the loop without bouncing through the user.
+The re-check is per-finding: re-open the file(s) the finding points at, confirm the issue still applies against current code, and confirm the fix fits the categories below. If uncertain, leave it as a comment directed to the PR author.
 
 If the follow-up commit breaks tests or hooks, revert it and convert the finding back to a comment — don't fix forward with more commits.
 
-### Follow-up commit only when *all* hold
+### Follow-up commit when *all* hold
 
-- PR author matches the harness user — verify with `gh pr view <num> --json author -q .author.login` against `gh api user -q .login`. Community PRs are review-only (`review-community` never pushes to a contributor's branch).
-- Fix is mechanical: lint, typo, dead import, missing type, formatting, narrow null-check.
-- No logic change. Judgment calls stay comment-only.
+- PR author is a jentic org member — verify with `gh api orgs/jentic/members/<author_login>` (204 = member, 404 = not). Non-member PRs are review-only; use `review-community`, which never pushes to a contributor's branch.
+- The finding is one of:
+  - **Mechanical**: lint, typo, dead import, missing type, formatting, narrow null-check.
+  - **Bug introduced by this PR**: a regression the PR's own diff caused, identifiable against the base branch.
+- No architectural or design change — those go to the PR author as a comment regardless of authorship.
 - Single-concern, small enough to verify at a glance.
-

--- a/.claude/rules/review-auto-apply.md
+++ b/.claude/rules/review-auto-apply.md
@@ -6,7 +6,7 @@ If the follow-up commit breaks tests or hooks, revert it and convert the finding
 
 ### Follow-up commit when *all* hold
 
-- PR author is a jentic org member — verify with `gh api orgs/jentic/members/<author_login>` (204 = member, 404 = not). Non-member PRs are review-only; use `review-community`, which never pushes to a contributor's branch.
+- PR author is a jentic org member — verify with `gh api orgs/jentic/members/<author_login>` (204 = member, 404 = not). Non-member PRs are review-only; use `review-community`, which never pushes to a contributor's branch. All findings on non-member PRs are comments only, regardless of category.
 - The finding is one of:
   - **Mechanical**: lint, typo, dead import, missing type, formatting, narrow null-check.
   - **Bug introduced by this PR**: a regression the PR's own diff caused, identifiable against the base branch.

--- a/.claude/rules/review-auto-apply.md
+++ b/.claude/rules/review-auto-apply.md
@@ -1,4 +1,4 @@
-`/review` and `/security-review` always produce comments — that's the audit trail. For findings that pass the re-check (below), push a follow-up commit on the same PR (per `git-workflow.md` / `conventional-commits.md`). When auto-applying a bug fix, append an `## Auto-applied fixes` section to the PR review comment (or post a new comment if none exists). If the finding lived in a PR review thread, resolve it per `copilot-review-comments.md`.
+`/review` and `/security-review` always produce comments — that's the audit trail. For findings that pass the re-check (below), push a follow-up commit on the same PR (per `git-workflow.md` / `conventional-commits.md`) and append an `## Auto-applied fixes` section to the PR review comment (or post a new comment if none exists), listing every auto-applied finding. If the finding lived in a PR review thread, resolve it per `copilot-review-comments.md`.
 
 The re-check is per-finding: re-open the file(s) the finding points at, confirm the issue still applies against current code, and confirm the fix fits the categories below. If uncertain, leave it as a comment directed to the PR author.
 

--- a/.claude/rules/review-auto-apply.md
+++ b/.claude/rules/review-auto-apply.md
@@ -1,0 +1,15 @@
+`/review` and `/security-review` always produce comments — that's the audit trail. Additionally, for each mechanical finding that remains clearly correct after re-reading the surrounding code in its current state, push a follow-up commit on the same PR (per `git-workflow.md` / `conventional-commits.md`) and, if the finding lived as a PR review thread, resolve it per `copilot-review-comments.md`.
+
+The re-check is per-finding: re-open the file(s) the finding points at, confirm the issue still applies (code may have shifted since the review was generated), and confirm the fix has no logic implications. If any of those is uncertain, leave it as a comment only.
+
+The comment is the record; the commit just closes the loop without bouncing through the user.
+
+If the follow-up commit breaks tests or hooks, revert it and convert the finding back to a comment — don't fix forward with more commits.
+
+### Follow-up commit only when *all* hold
+
+- PR author matches the harness user — verify with `gh pr view <num> --json author -q .author.login` against `gh api user -q .login`. Community PRs are review-only (`review-community` never pushes to a contributor's branch).
+- Fix is mechanical: lint, typo, dead import, missing type, formatting, narrow null-check.
+- No logic change. Judgment calls stay comment-only.
+- Single-concern, small enough to verify at a glance.
+


### PR DESCRIPTION
## Summary

Adds `.claude/rules/review-auto-apply.md` — a harness rule that lets `/review` and `/security-review` push follow-up commits for mechanical findings on your own PRs, while always keeping the review comments as the audit trail.

## Why

Comes from a team discussion (cc Manuel) about cutting the review→fix loop short: if the harness runs the same lint/test/hook config you do, an obvious mechanical fix would survive your hand-application anyway — so let the agent commit it directly instead of round-tripping through a comment-read-and-apply cycle.

## Guardrails baked in

- **Own PRs only** — PR author must match the harness user (verified via \`gh pr view\` vs \`gh api user\`). Community PRs stay on \`review-community\`, which never pushes to a contributor branch.
- **Mechanical fixes only** — lint, typo, dead import, missing type, formatting, narrow null-check. Judgment calls (architecture, design, "should this be cached?") stay comment-only.
- **Per-finding re-check** — agent must re-open the cited file(s), confirm the issue still applies against current code, and confirm no logic implications. Any uncertainty → comment-only.
- **No fix-forward** — if the follow-up commit breaks tests or hooks, it gets reverted and the finding is converted back to a comment, not patched with more commits.

## Test plan

- [x] Run \`/review\` on a PR with mixed mechanical + judgment findings; verify split (commits for the former, comments for the latter)
- [x] Run \`/review\` on a community PR; verify nothing is pushed and \`review-community\` flow takes over
- [x] Verify a deliberately-broken follow-up commit gets reverted, not patched over