### PR TITLE
chore(deps): bump urllib3 from 2.6.3 to 2.7.0

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -2195,13 +2195,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
-requires_python = ">=3.9"
+version = "2.7.0"
+requires_python = ">=3.10"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
 groups = ["default", "dev"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `urllib3` from 2.6.3 → 2.7.0 in `pdm.lock`
- Resolves two HIGH-severity CVEs flagged by Trivy in the Docker image security scan

## Security

| CVE | Severity | Fixed in |
|-----|----------|----------|
| CVE-2026-44431 | HIGH | 2.7.0 |
| CVE-2026-44432 | HIGH | 2.7.0 |

Closes https://github.com/jentic/jentic-mini/security/code-scanning/664
Closes https://github.com/jentic/jentic-mini/security/code-scanning/665

## Test plan

- [x] Docker security scan (Trivy) passes clean on this PR
- [x] Backend CI passes