### PR TITLE
fix(utils): canonical URL falls back to JENTIC_PUBLIC_HOSTNAME

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -98,7 +98,7 @@ elif JENTIC_PUBLIC_HOSTNAME != "localhost":
     warnings.warn(
         "JENTIC_PUBLIC_HOSTNAME is set but JENTIC_PUBLIC_BASE_URL is not. "
         "Canonical URLs (OAuth callbacks, approve links) will use "
-        f"https://{JENTIC_PUBLIC_HOSTNAME}. "
+        f"https://{JENTIC_PUBLIC_HOSTNAME}{JENTIC_ROOT_PATH}. "
         "Set JENTIC_PUBLIC_BASE_URL for explicit control over scheme and path prefix.",
         UserWarning,
         stacklevel=2,

--- a/src/config.py
+++ b/src/config.py
@@ -101,7 +101,7 @@ elif JENTIC_PUBLIC_HOSTNAME != "localhost":
         f"https://{JENTIC_PUBLIC_HOSTNAME}. "
         "Set JENTIC_PUBLIC_BASE_URL for explicit control over scheme and path prefix.",
         UserWarning,
-        stacklevel=1,
+        stacklevel=2,
     )
 
 # ── Toolkit defaults ──────────────────────────────────────────────────────────

--- a/src/config.py
+++ b/src/config.py
@@ -7,21 +7,14 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 
-# ── Version ───────────────────────────────────────────────────────────────────
-# In Docker, APP_VERSION is set via Dockerfile ARG/ENV (CI overrides with
-# --build-arg APP_VERSION from the git tag).
-APP_VERSION = os.getenv("APP_VERSION", "unknown")
+# ── Helpers ───────────────────────────────────────────────────────────────────
 
-# ── Database ──────────────────────────────────────────────────────────────────
-DB_PATH = os.getenv("DB_PATH", "/app/data/jentic-mini.db")
-
-# ── Data directories ──────────────────────────────────────────────────────────
-_db_path = Path(DB_PATH)
-DATA_DIR = _db_path if _db_path.is_dir() else _db_path.parent
-SPECS_DIR = DATA_DIR / "specs"
-WORKFLOWS_DIR = DATA_DIR / "workflows"
-
-# ── Public hostname ───────────────────────────────────────────────────────────
+# Allowlist: one or more "/segment" pairs, each segment is alnum + [-._~]. This
+# is the chokepoint that closes the XSS / cookie-injection / stored-URL classes
+# from PR #364 review — every char that's dangerous in HTML attributes, inline
+# JS strings, or Set-Cookie attribute serialisation (<, >, ", ', ;, ,, \, NUL,
+# C0/C1 controls) is rejected here before the value reaches any sink.
+_ROOT_PATH_RE = re.compile(r"^(?:/[A-Za-z0-9._~-]+)+/?$")
 
 
 def normalise_public_hostname(value: str) -> str:
@@ -44,30 +37,6 @@ def normalise_public_hostname(value: str) -> str:
     return urlparse(f"//{value}").netloc
 
 
-JENTIC_PUBLIC_HOSTNAME = normalise_public_hostname(os.getenv("JENTIC_PUBLIC_HOSTNAME") or "")
-
-# ── Trusted-proxy forwarded identity ─────────────────────────────────────────
-# Both vars must be non-empty to activate the trusted-proxy auth path.
-# Either unset → today's JWT-cookie / agent-key behaviour is preserved.
-JENTIC_TRUSTED_PROXY_HEADER = os.getenv("JENTIC_TRUSTED_PROXY_HEADER", "")
-JENTIC_TRUSTED_PROXY_NETS = os.getenv("JENTIC_TRUSTED_PROXY_NETS", "")
-
-
-# ── Reverse-proxy path prefix ─────────────────────────────────────────────────
-# Optional path at which Mini is mounted behind a reverse proxy (Caddy, Traefik,
-# nginx Ingress, etc.). Empty / unset / "/" all mean "no mount" → "". When set,
-# the SPA bundle, hand-rolled docs, and self-links resolve under the prefix; if
-# unset, the per-request X-Forwarded-Prefix header is honoured. Pair with
-# JENTIC_PUBLIC_BASE_URL (which must include the prefix) when mounting.
-
-# Allowlist: one or more "/segment" pairs, each segment is alnum + [-._~]. This
-# is the chokepoint that closes the XSS / cookie-injection / stored-URL classes
-# from PR #364 review — every char that's dangerous in HTML attributes, inline
-# JS strings, or Set-Cookie attribute serialisation (<, >, ", ', ;, ,, \, NUL,
-# C0/C1 controls) is rejected here before the value reaches any sink.
-_ROOT_PATH_RE = re.compile(r"^(?:/[A-Za-z0-9._~-]+)+/?$")
-
-
 def normalise_root_path(value: str) -> str:
     """Normalise and validate a path-prefix value.
 
@@ -88,9 +57,47 @@ def normalise_root_path(value: str) -> str:
     return value[:-1] if value.endswith("/") else value
 
 
+def _int_env(name: str, default: int) -> int:
+    """Read an int env var, treating unset/empty as the default.
+
+    compose.yml forwards env vars through ``${VAR:-}``, which means an unset
+    operator value still arrives as the empty string. ``int("")`` raises, so
+    we treat empty-or-unset uniformly here — the operator override is
+    unambiguous and a stray blank line in ``.env`` doesn't crash startup.
+    """
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    return int(raw)
+
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+# In Docker, APP_VERSION is set via Dockerfile ARG/ENV (CI overrides with
+# --build-arg APP_VERSION from the git tag).
+APP_VERSION = os.getenv("APP_VERSION", "unknown")
+
+DB_PATH = os.getenv("DB_PATH", "/app/data/jentic-mini.db")
+
+_db_path = Path(DB_PATH)
+DATA_DIR = _db_path if _db_path.is_dir() else _db_path.parent
+SPECS_DIR = DATA_DIR / "specs"
+WORKFLOWS_DIR = DATA_DIR / "workflows"
+
+JENTIC_PUBLIC_HOSTNAME = normalise_public_hostname(os.getenv("JENTIC_PUBLIC_HOSTNAME") or "")
+
+# Both vars must be non-empty to activate the trusted-proxy auth path.
+# Either unset → today's JWT-cookie / agent-key behaviour is preserved.
+JENTIC_TRUSTED_PROXY_HEADER = os.getenv("JENTIC_TRUSTED_PROXY_HEADER", "")
+JENTIC_TRUSTED_PROXY_NETS = os.getenv("JENTIC_TRUSTED_PROXY_NETS", "")
+
+# Optional path at which Mini is mounted behind a reverse proxy (Caddy, Traefik,
+# nginx Ingress, etc.). Empty / unset / "/" all mean "no mount" → "". When set,
+# the SPA bundle, hand-rolled docs, and self-links resolve under the prefix; if
+# unset, the per-request X-Forwarded-Prefix header is honoured. Pair with
+# JENTIC_PUBLIC_BASE_URL (which must include the prefix) when mounting.
 JENTIC_ROOT_PATH = normalise_root_path(os.getenv("JENTIC_ROOT_PATH", ""))
 
-# ── Public base URL ───────────────────────────────────────────────────────────
 # Operator-pinned canonical base URL (no trailing slash) — e.g.
 # "https://jentic.example.com". When set, the issuer / token aud /
 # registration_client_uri values used by the agent-identity (OAuth) routes are
@@ -104,11 +111,22 @@ JENTIC_ROOT_PATH = normalise_root_path(os.getenv("JENTIC_ROOT_PATH", ""))
 # encouraged to set this to a fully-qualified URL.
 JENTIC_PUBLIC_BASE_URL = (os.getenv("JENTIC_PUBLIC_BASE_URL") or "").rstrip("/")
 
+DEFAULT_TOOLKIT_ID = "default"
+
+AGENT_ACCESS_TTL = _int_env("AGENT_ACCESS_TTL", 3600)
+AGENT_REFRESH_TTL = _int_env("AGENT_REFRESH_TTL", 7 * 24 * 3600)
+AGENT_REGISTRATION_TOKEN_TTL = _int_env("AGENT_REGISTRATION_TOKEN_TTL", 900)
+AGENT_ASSERTION_MAX_AGE = _int_env("AGENT_ASSERTION_MAX_AGE", 300)
+AGENT_NONCE_WINDOW = _int_env("AGENT_NONCE_WINDOW", 600)
+
+
+# ── Invariant checks ──────────────────────────────────────────────────────────
+
 # Fail-fast when the two path-prefix sources disagree. If an operator sets
 # JENTIC_PUBLIC_BASE_URL=https://example.com/foo alongside JENTIC_ROOT_PATH=/bar,
 # stored URLs (approve_url, OAuth callbacks) embed /foo while request-derived
 # URLs embed /bar — silently broken tokens, 404 OAuth callbacks, failed agent
-# assertions. Same pattern as the AGENT_NONCE_WINDOW invariant below.
+# assertions.
 if JENTIC_PUBLIC_BASE_URL:
     _pub_path = urlparse(JENTIC_PUBLIC_BASE_URL).path.rstrip("/")
     if _pub_path != JENTIC_ROOT_PATH.rstrip("/"):
@@ -126,35 +144,9 @@ elif JENTIC_PUBLIC_HOSTNAME != "localhost":
         stacklevel=2,
     )
 
-# ── Toolkit defaults ──────────────────────────────────────────────────────────
-DEFAULT_TOOLKIT_ID = "default"
-
-
-# ── Agent identity (OAuth) ────────────────────────────────────────────────────
-def _int_env(name: str, default: int) -> int:
-    """Read an int env var, treating unset/empty as the default.
-
-    compose.yml forwards env vars through ``${VAR:-}``, which means an unset
-    operator value still arrives as the empty string. ``int("")`` raises, so
-    we treat empty-or-unset uniformly here — the operator override is
-    unambiguous and a stray blank line in ``.env`` doesn't crash startup.
-    """
-    raw = os.getenv(name, "").strip()
-    if not raw:
-        return default
-    return int(raw)
-
-
-AGENT_ACCESS_TTL = _int_env("AGENT_ACCESS_TTL", 3600)
-AGENT_REFRESH_TTL = _int_env("AGENT_REFRESH_TTL", 7 * 24 * 3600)
-AGENT_REGISTRATION_TOKEN_TTL = _int_env("AGENT_REGISTRATION_TOKEN_TTL", 900)
-AGENT_ASSERTION_MAX_AGE = _int_env("AGENT_ASSERTION_MAX_AGE", 300)
-AGENT_NONCE_WINDOW = _int_env("AGENT_NONCE_WINDOW", 600)
-
-# Replay protection invariant: the nonce-cache window must outlive the assertion's
-# acceptance window, otherwise a replayed JWT could land after its jti has been
-# pruned but before iat falls outside the max-age — silently bypassing the
-# replay check. Fail fast at import time so misconfiguration can't ship.
+# The nonce-cache window must outlive the assertion's acceptance window, otherwise
+# a replayed JWT could land after its jti has been pruned but before iat falls
+# outside the max-age — silently bypassing the replay check.
 if AGENT_NONCE_WINDOW <= AGENT_ASSERTION_MAX_AGE:
     raise RuntimeError(
         f"AGENT_NONCE_WINDOW ({AGENT_NONCE_WINDOW}s) must be greater than "

--- a/src/config.py
+++ b/src/config.py
@@ -40,6 +40,18 @@ def normalise_public_hostname(value: str) -> str:
     return result or "localhost"
 
 
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def is_loopback_hostname(host_with_port: str) -> bool:
+    """Return True when *host_with_port* refers to a loopback address.
+
+    Accepts bare hostnames and host:port strings; strips the port via
+    urlparse so ``localhost:8900`` and ``[::1]:8900`` are handled correctly.
+    """
+    return urlparse(f"//{host_with_port}").hostname in _LOOPBACK_HOSTS
+
+
 def normalise_root_path(value: str) -> str:
     """Normalise and validate a path-prefix value.
 
@@ -137,7 +149,7 @@ if JENTIC_PUBLIC_BASE_URL:
             f"JENTIC_PUBLIC_BASE_URL path ({_pub_path!r}) disagrees with "
             f"JENTIC_ROOT_PATH ({JENTIC_ROOT_PATH!r}); both must use the same prefix"
         )
-elif JENTIC_PUBLIC_HOSTNAME.split(":")[0] != "localhost":
+elif not is_loopback_hostname(JENTIC_PUBLIC_HOSTNAME):
     warnings.warn(
         "JENTIC_PUBLIC_HOSTNAME is set but JENTIC_PUBLIC_BASE_URL is not. "
         "Canonical URLs (OAuth callbacks, approve links) will use "

--- a/src/config.py
+++ b/src/config.py
@@ -22,7 +22,29 @@ SPECS_DIR = DATA_DIR / "specs"
 WORKFLOWS_DIR = DATA_DIR / "workflows"
 
 # ── Public hostname ───────────────────────────────────────────────────────────
-JENTIC_PUBLIC_HOSTNAME = os.getenv("JENTIC_PUBLIC_HOSTNAME") or "localhost"
+
+
+def normalise_public_hostname(value: str) -> str:
+    """Extract a bare ``host[:port]`` from whatever the operator typed.
+
+    Accepts a bare hostname (``example.com``), a scheme-prefixed URL
+    (``https://example.com``), or either with a trailing slash or path.
+    Port is preserved (``example.com:8900`` → ``example.com:8900``).
+    Paths are silently stripped — ``JENTIC_PUBLIC_HOSTNAME`` is a host,
+    not a URL; any path component is meaningless here.
+    """
+    if not value:
+        return "localhost"
+    if "://" in value:
+        # Scheme-prefixed URL: https://example.com[:port][/path] → netloc only.
+        return urlparse(value).netloc
+    # Bare host[:port][/path]: prefix "//" so urlparse populates netloc correctly.
+    # Without this, urlparse("example.com:8900") treats "example.com" as the
+    # scheme and "8900" as the path, losing the hostname entirely.
+    return urlparse(f"//{value}").netloc
+
+
+JENTIC_PUBLIC_HOSTNAME = normalise_public_hostname(os.getenv("JENTIC_PUBLIC_HOSTNAME") or "")
 
 # ── Trusted-proxy forwarded identity ─────────────────────────────────────────
 # Both vars must be non-empty to activate the trusted-proxy auth path.

--- a/src/config.py
+++ b/src/config.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import warnings
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -93,6 +94,15 @@ if JENTIC_PUBLIC_BASE_URL:
             f"JENTIC_PUBLIC_BASE_URL path ({_pub_path!r}) disagrees with "
             f"JENTIC_ROOT_PATH ({JENTIC_ROOT_PATH!r}); both must use the same prefix"
         )
+elif JENTIC_PUBLIC_HOSTNAME != "localhost":
+    warnings.warn(
+        "JENTIC_PUBLIC_HOSTNAME is set but JENTIC_PUBLIC_BASE_URL is not. "
+        "Canonical URLs (OAuth callbacks, approve links) will use "
+        f"https://{JENTIC_PUBLIC_HOSTNAME}. "
+        "Set JENTIC_PUBLIC_BASE_URL for explicit control over scheme and path prefix.",
+        UserWarning,
+        stacklevel=1,
+    )
 
 # ── Toolkit defaults ──────────────────────────────────────────────────────────
 DEFAULT_TOOLKIT_ID = "default"

--- a/src/config.py
+++ b/src/config.py
@@ -26,15 +26,18 @@ def normalise_public_hostname(value: str) -> str:
     Paths are silently stripped — ``JENTIC_PUBLIC_HOSTNAME`` is a host,
     not a URL; any path component is meaningless here.
     """
+    value = value.strip()
     if not value:
         return "localhost"
     if "://" in value:
         # Scheme-prefixed URL: https://example.com[:port][/path] → netloc only.
-        return urlparse(value).netloc
-    # Bare host[:port][/path]: prefix "//" so urlparse populates netloc correctly.
-    # Without this, urlparse("example.com:8900") treats "example.com" as the
-    # scheme and "8900" as the path, losing the hostname entirely.
-    return urlparse(f"//{value}").netloc
+        result = urlparse(value).netloc
+    else:
+        # Bare host[:port][/path]: prefix "//" so urlparse populates netloc correctly.
+        # Without this, urlparse("example.com:8900") treats "example.com" as the
+        # scheme and "8900" as the path, losing the hostname entirely.
+        result = urlparse(f"//{value}").netloc
+    return result or "localhost"
 
 
 def normalise_root_path(value: str) -> str:
@@ -134,7 +137,7 @@ if JENTIC_PUBLIC_BASE_URL:
             f"JENTIC_PUBLIC_BASE_URL path ({_pub_path!r}) disagrees with "
             f"JENTIC_ROOT_PATH ({JENTIC_ROOT_PATH!r}); both must use the same prefix"
         )
-elif JENTIC_PUBLIC_HOSTNAME != "localhost":
+elif JENTIC_PUBLIC_HOSTNAME.split(":")[0] != "localhost":
     warnings.warn(
         "JENTIC_PUBLIC_HOSTNAME is set but JENTIC_PUBLIC_BASE_URL is not. "
         "Canonical URLs (OAuth callbacks, approve links) will use "

--- a/src/utils.py
+++ b/src/utils.py
@@ -71,7 +71,7 @@ def build_canonical_url(request, path: str) -> str:
     """
     if JENTIC_PUBLIC_BASE_URL:
         return f"{JENTIC_PUBLIC_BASE_URL}{path}"
-    if JENTIC_PUBLIC_HOSTNAME and JENTIC_PUBLIC_HOSTNAME != "localhost":
+    if JENTIC_PUBLIC_HOSTNAME != "localhost":
         return f"https://{JENTIC_PUBLIC_HOSTNAME}{JENTIC_ROOT_PATH}{path}"
     return build_absolute_url(request, path)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -55,19 +55,26 @@ def build_absolute_url(request, path: str) -> str:
 
 
 def build_canonical_url(request, path: str) -> str:
-    """Build an absolute URL pinned to the operator-configured public base URL.
+    """Build an absolute URL pinned to operator-configured public base.
+
+    Unlike ``build_absolute_url``, this helper is intentionally immune to
+    Host:/X-Forwarded-Host: spoofing: an attacker who can set those headers
+    cannot redirect the OAuth issuer, token audience, or Pipedream callback
+    to a URL they control.  Tiers 1 and 2 both derive the base from static
+    config, not from the incoming request.
 
     Priority:
     1. ``JENTIC_PUBLIC_BASE_URL`` — fully-qualified canonical base (scheme + host + prefix).
     2. ``JENTIC_PUBLIC_HOSTNAME`` when non-default (not ``"localhost"``) — synthesises
-       ``https://<hostname><JENTIC_ROOT_PATH><path>``. Covers deployments that set the
-       hostname knob but not the full base-URL knob; assumes ``https`` which is correct
-       for any internet-facing host.
-    3. ``build_absolute_url`` — request-header-derived, correct for local dev where
+       ``https://<hostname><JENTIC_ROOT_PATH><path>``.  Uses the static
+       ``JENTIC_ROOT_PATH`` env var, not ``scope["root_path"]``, so the URL
+       stays deterministic even when ``X-Forwarded-Prefix`` varies per request.
+       Assumes ``https`` — correct for any internet-facing host.
+    3. ``build_absolute_url`` — request-header-derived; safe for local dev where
        ``JENTIC_PUBLIC_HOSTNAME`` is the default ``"localhost"``.
 
-    Used wherever a URL will be consumed outside this process (OAuth callbacks sent to
-    Pipedream, approve-links stored in the DB, agent-identity issuer/aud values).
+    Use this wherever a URL escapes the process: OAuth callbacks sent to
+    Pipedream, approve-links stored in the DB, agent-identity issuer/aud values.
     """
     if JENTIC_PUBLIC_BASE_URL:
         return f"{JENTIC_PUBLIC_BASE_URL}{path}"

--- a/src/utils.py
+++ b/src/utils.py
@@ -78,7 +78,7 @@ def build_canonical_url(request, path: str) -> str:
     """
     if JENTIC_PUBLIC_BASE_URL:
         return f"{JENTIC_PUBLIC_BASE_URL}{path}"
-    if JENTIC_PUBLIC_HOSTNAME != "localhost":
+    if JENTIC_PUBLIC_HOSTNAME.split(":")[0] != "localhost":
         return f"https://{JENTIC_PUBLIC_HOSTNAME}{JENTIC_ROOT_PATH}{path}"
     return build_absolute_url(request, path)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,7 +2,7 @@
 
 import re
 
-from src.config import JENTIC_PUBLIC_BASE_URL, JENTIC_PUBLIC_HOSTNAME
+from src.config import JENTIC_PUBLIC_BASE_URL, JENTIC_PUBLIC_HOSTNAME, JENTIC_ROOT_PATH
 
 
 def route_path(scope) -> str:
@@ -57,15 +57,22 @@ def build_absolute_url(request, path: str) -> str:
 def build_canonical_url(request, path: str) -> str:
     """Build an absolute URL pinned to the operator-configured public base URL.
 
-    Used by agent-identity routes (issuer, token aud, registration_client_uri)
-    so an attacker who can spoof Host:/X-Forwarded-Host: cannot mint or verify
-    assertions against an issuer that doesn't match the canonical deployment.
+    Priority:
+    1. ``JENTIC_PUBLIC_BASE_URL`` — fully-qualified canonical base (scheme + host + prefix).
+    2. ``JENTIC_PUBLIC_HOSTNAME`` when non-default (not ``"localhost"``) — synthesises
+       ``https://<hostname><JENTIC_ROOT_PATH><path>``. Covers deployments that set the
+       hostname knob but not the full base-URL knob; assumes ``https`` which is correct
+       for any internet-facing host.
+    3. ``build_absolute_url`` — request-header-derived, correct for local dev where
+       ``JENTIC_PUBLIC_HOSTNAME`` is the default ``"localhost"``.
 
-    Falls back to ``build_absolute_url`` when ``JENTIC_PUBLIC_BASE_URL`` is
-    unset, preserving the existing dev / on-localhost ergonomics.
+    Used wherever a URL will be consumed outside this process (OAuth callbacks sent to
+    Pipedream, approve-links stored in the DB, agent-identity issuer/aud values).
     """
     if JENTIC_PUBLIC_BASE_URL:
         return f"{JENTIC_PUBLIC_BASE_URL}{path}"
+    if JENTIC_PUBLIC_HOSTNAME and JENTIC_PUBLIC_HOSTNAME != "localhost":
+        return f"https://{JENTIC_PUBLIC_HOSTNAME}{JENTIC_ROOT_PATH}{path}"
     return build_absolute_url(request, path)
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,7 +2,12 @@
 
 import re
 
-from src.config import JENTIC_PUBLIC_BASE_URL, JENTIC_PUBLIC_HOSTNAME, JENTIC_ROOT_PATH
+from src.config import (
+    JENTIC_PUBLIC_BASE_URL,
+    JENTIC_PUBLIC_HOSTNAME,
+    JENTIC_ROOT_PATH,
+    is_loopback_hostname,
+)
 
 
 def route_path(scope) -> str:
@@ -65,20 +70,20 @@ def build_canonical_url(request, path: str) -> str:
 
     Priority:
     1. ``JENTIC_PUBLIC_BASE_URL`` — fully-qualified canonical base (scheme + host + prefix).
-    2. ``JENTIC_PUBLIC_HOSTNAME`` when non-default (not ``"localhost"``) — synthesises
+    2. ``JENTIC_PUBLIC_HOSTNAME`` when non-loopback — synthesises
        ``https://<hostname><JENTIC_ROOT_PATH><path>``.  Uses the static
        ``JENTIC_ROOT_PATH`` env var, not ``scope["root_path"]``, so the URL
        stays deterministic even when ``X-Forwarded-Prefix`` varies per request.
        Assumes ``https`` — correct for any internet-facing host.
     3. ``build_absolute_url`` — request-header-derived; safe for local dev where
-       ``JENTIC_PUBLIC_HOSTNAME`` is the default ``"localhost"``.
+       ``JENTIC_PUBLIC_HOSTNAME`` is a loopback address (localhost, 127.0.0.1, ::1).
 
     Use this wherever a URL escapes the process: OAuth callbacks sent to
     Pipedream, approve-links stored in the DB, agent-identity issuer/aud values.
     """
     if JENTIC_PUBLIC_BASE_URL:
         return f"{JENTIC_PUBLIC_BASE_URL}{path}"
-    if JENTIC_PUBLIC_HOSTNAME.split(":")[0] != "localhost":
+    if not is_loopback_hostname(JENTIC_PUBLIC_HOSTNAME):
         return f"https://{JENTIC_PUBLIC_HOSTNAME}{JENTIC_ROOT_PATH}{path}"
     return build_absolute_url(request, path)
 

--- a/tests/test_canonical_url_fallback.py
+++ b/tests/test_canonical_url_fallback.py
@@ -1,0 +1,114 @@
+"""Unit tests for the build_canonical_url hostname fallback.
+
+Regression for issue #378: when JENTIC_PUBLIC_BASE_URL is unset but
+JENTIC_PUBLIC_HOSTNAME is set to a non-localhost value, build_canonical_url
+must return a URL rooted at that hostname rather than deriving the host from
+the inbound request headers. This ensures agents calling over docker-internal
+DNS get a public success_redirect_uri that Pipedream can redirect browsers to.
+"""
+
+from __future__ import annotations
+
+import pytest
+from src.utils import build_canonical_url
+
+
+class _FakeURL:
+    scheme = "http"
+
+
+class _FakeRequest:
+    """Minimal request shape with an internal docker-DNS Host header."""
+
+    def __init__(self, host: str = "jentic-mini-handle:8900", root_path: str = ""):
+        self.headers = {"host": host}
+        self.scope = {"root_path": root_path}
+        self.url = _FakeURL()
+
+
+# ── Priority 1: JENTIC_PUBLIC_BASE_URL always wins ───────────────────────────
+
+
+def test_base_url_wins_over_internal_host(monkeypatch):
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_BASE_URL", "https://x.example.com/jentic-mini")
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_HOSTNAME", "x.example.com")
+    monkeypatch.setattr("src.utils.JENTIC_ROOT_PATH", "/jentic-mini")
+    req = _FakeRequest(host="jentic-mini-handle:8900")
+    assert (
+        build_canonical_url(req, "/oauth-brokers/pipedream/connect-callback?app=gmail")
+        == "https://x.example.com/jentic-mini/oauth-brokers/pipedream/connect-callback?app=gmail"
+    )
+
+
+def test_base_url_wins_over_spoofed_host_header(monkeypatch):
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_BASE_URL", "https://canonical.example.com")
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_HOSTNAME", "canonical.example.com")
+    monkeypatch.setattr("src.utils.JENTIC_ROOT_PATH", "")
+    req = _FakeRequest(host="attacker.example.com")
+    assert build_canonical_url(req, "/path") == "https://canonical.example.com/path"
+
+
+# ── Priority 2: JENTIC_PUBLIC_HOSTNAME fallback (non-localhost) ───────────────
+
+
+def test_hostname_fallback_ignores_internal_host(monkeypatch):
+    """Core regression: docker-DNS host must not bleed into the canonical URL."""
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_BASE_URL", "")
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_HOSTNAME", "x.example.com")
+    monkeypatch.setattr("src.utils.JENTIC_ROOT_PATH", "")
+    req = _FakeRequest(host="jentic-mini-handle:8900")
+    assert (
+        build_canonical_url(req, "/oauth-brokers/pipedream/connect-callback?app=gmail")
+        == "https://x.example.com/oauth-brokers/pipedream/connect-callback?app=gmail"
+    )
+
+
+def test_hostname_fallback_includes_root_path(monkeypatch):
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_BASE_URL", "")
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_HOSTNAME", "x.example.com")
+    monkeypatch.setattr("src.utils.JENTIC_ROOT_PATH", "/jentic-mini")
+    req = _FakeRequest(host="jentic-mini-handle:8900")
+    assert (
+        build_canonical_url(req, "/oauth-brokers/pipedream/connect-callback?app=gmail")
+        == "https://x.example.com/jentic-mini/oauth-brokers/pipedream/connect-callback?app=gmail"
+    )
+
+
+def test_hostname_fallback_uses_https(monkeypatch):
+    """Scheme must always be https when synthesised from JENTIC_PUBLIC_HOSTNAME."""
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_BASE_URL", "")
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_HOSTNAME", "prod.example.com")
+    monkeypatch.setattr("src.utils.JENTIC_ROOT_PATH", "")
+    req = _FakeRequest(host="internal:8900")
+    result = build_canonical_url(req, "/callback")
+    assert result.startswith("https://")
+
+
+# ── Priority 3: localhost dev fallback uses request headers ──────────────────
+
+
+def test_localhost_dev_uses_request_headers(monkeypatch):
+    """When JENTIC_PUBLIC_HOSTNAME is the default 'localhost', fall back to
+    the request-derived URL so local dev ergonomics are preserved."""
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_BASE_URL", "")
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_HOSTNAME", "localhost")
+    monkeypatch.setattr("src.utils.JENTIC_ROOT_PATH", "")
+    req = _FakeRequest(host="localhost:8900")
+    result = build_canonical_url(req, "/callback")
+    assert "localhost" in result
+    assert "internal" not in result
+
+
+@pytest.mark.parametrize(
+    "host_header,expected_prefix",
+    [
+        ("localhost:8900", "http://localhost:8900"),
+        ("127.0.0.1:8900", "http://127.0.0.1:8900"),
+    ],
+)
+def test_localhost_variants_fall_back_to_headers(monkeypatch, host_header, expected_prefix):
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_BASE_URL", "")
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_HOSTNAME", "localhost")
+    monkeypatch.setattr("src.utils.JENTIC_ROOT_PATH", "")
+    req = _FakeRequest(host=host_header)
+    assert build_canonical_url(req, "/path").startswith(expected_prefix)

--- a/tests/test_canonical_url_fallback.py
+++ b/tests/test_canonical_url_fallback.py
@@ -50,8 +50,12 @@ class _FakeRequest:
         # Path silently dropped — hostname is not a URL.
         ("example.com/some/path", "example.com"),
         ("https://example.com/some/path", "example.com"),
-        # Empty / unset — defaults to localhost.
+        # Empty / unset / whitespace-only — defaults to localhost.
         ("", "localhost"),
+        ("   ", "localhost"),
+        # Whitespace stripped before parsing.
+        ("  example.com  ", "example.com"),
+        ("  https://example.com  ", "example.com"),
         # localhost passthrough.
         ("localhost", "localhost"),
         ("localhost:8900", "localhost:8900"),
@@ -149,6 +153,17 @@ def test_localhost_variants_fall_back_to_headers(monkeypatch, host_header, expec
     assert build_canonical_url(req, "/path").startswith(expected_prefix)
 
 
+def test_localhost_with_port_falls_back_to_headers(monkeypatch):
+    """JENTIC_PUBLIC_HOSTNAME=localhost:8900 must not produce an https canonical URL."""
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_BASE_URL", "")
+    monkeypatch.setattr("src.utils.JENTIC_PUBLIC_HOSTNAME", "localhost:8900")
+    monkeypatch.setattr("src.utils.JENTIC_ROOT_PATH", "")
+    req = _FakeRequest(host="localhost:8900")
+    result = build_canonical_url(req, "/callback")
+    assert not result.startswith("https://")
+    assert "localhost" in result
+
+
 # ── Startup warning for _HOSTNAME-only deployments ───────────────────────────
 
 
@@ -158,12 +173,15 @@ def test_startup_warning_emitted_when_hostname_set_without_base_url(monkeypatch)
     monkeypatch.setenv("JENTIC_PUBLIC_HOSTNAME", "prod.example.com")
     monkeypatch.delenv("JENTIC_PUBLIC_BASE_URL", raising=False)
     monkeypatch.delenv("JENTIC_ROOT_PATH", raising=False)
-    # always filter so Python doesn't deduplicate across test runs in the same process
-    with warnings.catch_warnings():
-        warnings.simplefilter("always")
-        with pytest.warns(UserWarning, match="JENTIC_PUBLIC_BASE_URL"):
-            importlib.reload(src.config)
-    importlib.reload(src.config)  # restore defaults
+    try:
+        # always filter so Python doesn't deduplicate across test runs in the same process
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            with pytest.warns(UserWarning, match="JENTIC_PUBLIC_BASE_URL"):
+                importlib.reload(src.config)
+    finally:
+        monkeypatch.delenv("JENTIC_PUBLIC_HOSTNAME", raising=False)
+        importlib.reload(src.config)
 
 
 def test_no_warning_when_base_url_set(monkeypatch):
@@ -171,17 +189,23 @@ def test_no_warning_when_base_url_set(monkeypatch):
     monkeypatch.setenv("JENTIC_PUBLIC_BASE_URL", "https://prod.example.com")
     monkeypatch.setenv("JENTIC_PUBLIC_HOSTNAME", "prod.example.com")
     monkeypatch.delenv("JENTIC_ROOT_PATH", raising=False)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", UserWarning)
-        importlib.reload(src.config)  # should not raise
-    importlib.reload(src.config)  # restore defaults
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            importlib.reload(src.config)  # should not raise
+    finally:
+        monkeypatch.delenv("JENTIC_PUBLIC_BASE_URL", raising=False)
+        monkeypatch.delenv("JENTIC_PUBLIC_HOSTNAME", raising=False)
+        importlib.reload(src.config)
 
 
 def test_no_warning_for_localhost(monkeypatch):
     """No UserWarning emitted when JENTIC_PUBLIC_HOSTNAME is the default 'localhost'."""
     monkeypatch.delenv("JENTIC_PUBLIC_HOSTNAME", raising=False)
     monkeypatch.delenv("JENTIC_PUBLIC_BASE_URL", raising=False)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", UserWarning)
-        importlib.reload(src.config)  # should not raise
-    importlib.reload(src.config)  # restore defaults
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            importlib.reload(src.config)  # should not raise
+    finally:
+        importlib.reload(src.config)

--- a/tests/test_canonical_url_fallback.py
+++ b/tests/test_canonical_url_fallback.py
@@ -14,6 +14,7 @@ import warnings
 
 import pytest
 import src.config
+from src.config import normalise_public_hostname
 from src.utils import build_canonical_url
 
 
@@ -28,6 +29,36 @@ class _FakeRequest:
         self.headers = {"host": host}
         self.scope = {"root_path": root_path}
         self.url = _FakeURL()
+
+
+# ── normalise_public_hostname ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Bare hostname — most common operator input.
+        ("example.com", "example.com"),
+        ("example.com:8900", "example.com:8900"),
+        # Scheme accidentally included — strip it.
+        ("https://example.com", "example.com"),
+        ("http://example.com", "example.com"),
+        ("https://example.com:8900", "example.com:8900"),
+        # Trailing slash — strip it.
+        ("example.com/", "example.com"),
+        ("https://example.com/", "example.com"),
+        # Path silently dropped — hostname is not a URL.
+        ("example.com/some/path", "example.com"),
+        ("https://example.com/some/path", "example.com"),
+        # Empty / unset — defaults to localhost.
+        ("", "localhost"),
+        # localhost passthrough.
+        ("localhost", "localhost"),
+        ("localhost:8900", "localhost:8900"),
+    ],
+)
+def test_normalise_public_hostname(raw, expected):
+    assert normalise_public_hostname(raw) == expected
 
 
 # ── Priority 1: JENTIC_PUBLIC_BASE_URL always wins ───────────────────────────

--- a/tests/test_canonical_url_fallback.py
+++ b/tests/test_canonical_url_fallback.py
@@ -9,7 +9,11 @@ DNS get a public success_redirect_uri that Pipedream can redirect browsers to.
 
 from __future__ import annotations
 
+import importlib
+import warnings
+
 import pytest
+import src.config
 from src.utils import build_canonical_url
 
 
@@ -112,3 +116,41 @@ def test_localhost_variants_fall_back_to_headers(monkeypatch, host_header, expec
     monkeypatch.setattr("src.utils.JENTIC_ROOT_PATH", "")
     req = _FakeRequest(host=host_header)
     assert build_canonical_url(req, "/path").startswith(expected_prefix)
+
+
+# ── Startup warning for _HOSTNAME-only deployments ───────────────────────────
+
+
+def test_startup_warning_emitted_when_hostname_set_without_base_url(monkeypatch):
+    """config.py must emit a UserWarning when JENTIC_PUBLIC_HOSTNAME is non-default
+    but JENTIC_PUBLIC_BASE_URL is unset, so operators know canonical URLs assume https."""
+    monkeypatch.setenv("JENTIC_PUBLIC_HOSTNAME", "prod.example.com")
+    monkeypatch.delenv("JENTIC_PUBLIC_BASE_URL", raising=False)
+    monkeypatch.delenv("JENTIC_ROOT_PATH", raising=False)
+    # always filter so Python doesn't deduplicate across test runs in the same process
+    with warnings.catch_warnings():
+        warnings.simplefilter("always")
+        with pytest.warns(UserWarning, match="JENTIC_PUBLIC_BASE_URL"):
+            importlib.reload(src.config)
+    importlib.reload(src.config)  # restore defaults
+
+
+def test_no_warning_when_base_url_set(monkeypatch):
+    """No UserWarning emitted when JENTIC_PUBLIC_BASE_URL is explicitly set."""
+    monkeypatch.setenv("JENTIC_PUBLIC_BASE_URL", "https://prod.example.com")
+    monkeypatch.setenv("JENTIC_PUBLIC_HOSTNAME", "prod.example.com")
+    monkeypatch.delenv("JENTIC_ROOT_PATH", raising=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        importlib.reload(src.config)  # should not raise
+    importlib.reload(src.config)  # restore defaults
+
+
+def test_no_warning_for_localhost(monkeypatch):
+    """No UserWarning emitted when JENTIC_PUBLIC_HOSTNAME is the default 'localhost'."""
+    monkeypatch.delenv("JENTIC_PUBLIC_HOSTNAME", raising=False)
+    monkeypatch.delenv("JENTIC_PUBLIC_BASE_URL", raising=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        importlib.reload(src.config)  # should not raise
+    importlib.reload(src.config)  # restore defaults

--- a/tests/test_canonical_url_fallback.py
+++ b/tests/test_canonical_url_fallback.py
@@ -55,8 +55,8 @@ def test_base_url_wins_over_spoofed_host_header(monkeypatch):
 # ── Priority 2: JENTIC_PUBLIC_HOSTNAME fallback (non-localhost) ───────────────
 
 
-def test_hostname_fallback_ignores_internal_host(monkeypatch):
-    """Core regression: docker-DNS host must not bleed into the canonical URL."""
+def test_hostname_fallback_wins_over_spoofed_host_header(monkeypatch):
+    """Core regression: docker-DNS / spoofed host must not bleed into the canonical URL."""
     monkeypatch.setattr("src.utils.JENTIC_PUBLIC_BASE_URL", "")
     monkeypatch.setattr("src.utils.JENTIC_PUBLIC_HOSTNAME", "x.example.com")
     monkeypatch.setattr("src.utils.JENTIC_ROOT_PATH", "")


### PR DESCRIPTION
## Summary

- `build_canonical_url` previously only pinned to `JENTIC_PUBLIC_BASE_URL`. Deployments that set `JENTIC_PUBLIC_HOSTNAME` without `JENTIC_PUBLIC_BASE_URL` still derived `success_redirect_uri` from the inbound `Host` header — so agents calling over docker-internal DNS produced an internal container hostname that browsers cannot resolve.
- Added a second fallback tier: when `JENTIC_PUBLIC_HOSTNAME` is set and is not the default `"localhost"`, synthesise `https://<hostname><JENTIC_ROOT_PATH><path>`. `https` is assumed — any internet-facing deployment is https, and `_HOSTNAME` without a scheme is unambiguous in that context.
- Added a startup `UserWarning` when `_HOSTNAME` is non-default and `_BASE_URL` is unset, nudging operators toward the explicit knob.

## Precedence after this fix

| Priority | Condition | Result |
|---|---|---|
| 1 | `JENTIC_PUBLIC_BASE_URL` set | use `_BASE_URL` directly |
| 2 | `JENTIC_PUBLIC_HOSTNAME` ≠ `"localhost"` | `https://<hostname><ROOT_PATH><path>` |
| 3 | dev / localhost | request-header-derived (existing behaviour) |

## Test plan

- [x] `pdm run test tests/test_canonical_url_fallback.py` — 8 new unit tests covering all three tiers, including the core regression (docker-DNS host ignored when `_HOSTNAME` set)
- [x] `pdm run test` — 390 passed, no regressions

Closes #378
Refs #380 #369