### PR TITLE
test(prefix-mount): add e2e for approve link, login, logout, docs

### DIFF
--- a/ui/e2e/docker/prefix-mount.spec.ts
+++ b/ui/e2e/docker/prefix-mount.spec.ts
@@ -7,39 +7,18 @@ const PREFIX_BASE = 'http://localhost:8901/foo';
 const ADMIN_USER = 'admin';
 const ADMIN_PASS = 'admin123';
 
-async function authenticate(page: Page) {
-	await page.goto(`${PREFIX_BASE}/`);
-
-	const setupVisible = await page
-		.getByText(/create admin account/i)
-		.isVisible({ timeout: 15_000 })
-		.catch(() => false);
-
-	if (setupVisible) {
-		await page.getByLabel('Username').fill(ADMIN_USER);
-		await page.getByRole('textbox', { name: 'Password' }).fill(ADMIN_PASS);
-		await page.getByRole('button', { name: /create account/i }).click();
-		await expect(page.getByText(/setup complete/i)).toBeVisible({ timeout: 30_000 });
-		await page.goto(`${PREFIX_BASE}/`);
-		// Wait for dashboard to confirm the session is established before returning.
-		await expect(page.getByRole('heading', { name: /dashboard/i })).toBeVisible({
-			timeout: 15_000,
-		});
-		return;
-	}
-
-	const loginVisible = await page
-		.getByRole('button', { name: /^log in$/i })
-		.isVisible({ timeout: 15_000 })
-		.catch(() => false);
-	if (loginVisible) {
-		await page.getByLabel('Username').fill(ADMIN_USER);
-		await page.getByRole('textbox', { name: 'Password' }).fill(ADMIN_PASS);
-		await page.getByRole('button', { name: /^log in$/i }).click();
-		await expect(page.getByRole('heading', { name: /dashboard/i })).toBeVisible({
-			timeout: 15_000,
-		});
-	}
+// Log in via the API endpoints rather than the UI so the new tests don't
+// depend on the login form rendering within a tight timeout. The session
+// cookie is stored in the browser context by Playwright and is available
+// to subsequent page.goto() navigations.
+async function loginViaApi(page: Page) {
+	const healthRes = await page.request.get(`${PREFIX_BASE}/health`);
+	const { status } = await healthRes.json();
+	const endpoint = status === 'setup_required' ? '/user/create' : '/user/login';
+	const res = await page.request.post(`${PREFIX_BASE}${endpoint}`, {
+		data: { username: ADMIN_USER, password: ADMIN_PASS },
+	});
+	expect(res.ok(), `${endpoint} failed: ${res.status()}`).toBeTruthy();
 }
 
 test.describe('Reverse-proxy prefix mount', () => {
@@ -128,32 +107,41 @@ test.describe('Reverse-proxy prefix mount', () => {
 	});
 
 	test('dashboard "Review" link has a single /foo prefix', async ({ page }) => {
-		await authenticate(page);
+		await loginViaApi(page);
+		// Navigate to the dashboard so the browser context has the session cookie
+		// in a same-site page load before we make additional API calls.
+		await page.goto(`${PREFIX_BASE}/`);
+		await page.getByRole('heading', { name: /dashboard/i }).waitFor({ timeout: 15_000 });
 
-		// Seed a pending access request via the admin session (cookies shared with page).
-		const tk = await page.request.post(`${PREFIX_BASE}/toolkits`, {
-			data: { name: `prefix-test-${Date.now()}` },
-		});
-		expect(tk.ok()).toBeTruthy();
-		const { id: toolkitId } = await tk.json();
+		// Create a toolkit and a pending access request via fetch() running inside
+		// the browser page — guarantees the SameSite=Strict session cookie is sent.
+		const { toolkitId, reqId } = await page.evaluate(async (base: string) => {
+			const tk = await fetch(`${base}/toolkits`, {
+				method: 'POST',
+				credentials: 'include',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ name: `prefix-test-${Date.now()}` }),
+			});
+			if (!tk.ok) throw new Error(`POST /toolkits → ${tk.status}`);
+			const { id: toolkitId } = await tk.json();
 
-		const reqRes = await page.request.post(
-			`${PREFIX_BASE}/toolkits/${toolkitId}/access-requests`,
-			{
-				data: {
-					type: 'grant',
-					credential_id: 'api.example.com',
-					reason: 'e2e regression guard for issue #382',
-				},
-			},
-		);
-		expect(reqRes.ok()).toBeTruthy();
-		const { id: reqId } = await reqRes.json();
+			const req = await fetch(`${base}/toolkits/${toolkitId}/access-requests`, {
+				method: 'POST',
+				credentials: 'include',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ type: 'grant', credential_id: 'api.example.com' }),
+			});
+			if (!req.ok) throw new Error(`POST /access-requests → ${req.status}`);
+			const { id: reqId } = await req.json();
 
+			return { toolkitId: toolkitId as string, reqId: reqId as string };
+		}, PREFIX_BASE);
+
+		// Reload the dashboard so usePendingRequests re-fetches the new request.
 		await page.goto(`${PREFIX_BASE}/`);
 
 		const reviewLink = page.getByRole('link', { name: /review/i });
-		await expect(reviewLink).toBeVisible({ timeout: 10_000 });
+		await expect(reviewLink).toBeVisible({ timeout: 15_000 });
 
 		const href = await reviewLink.getAttribute('href');
 		expect(href).toBeTruthy();
@@ -163,12 +151,9 @@ test.describe('Reverse-proxy prefix mount', () => {
 	});
 
 	test('login redirect from a protected route preserves the prefix', async ({ page }) => {
-		// Ensure the admin account exists without loading any page (which would set
-		// browser cookies and leave the context authenticated). On a fresh container
-		// the health check returns setup_required; create the account via the API and
-		// immediately clear the resulting session cookie so the subsequent page load
-		// starts genuinely logged out. On a reused container the account already
-		// exists and no cookies are set.
+		// Ensure admin exists without acquiring a session in the browser context.
+		// On a fresh container /user/create sets a cookie — clear it immediately.
+		// On a reused container the admin already exists and no cookies are touched.
 		const healthRes = await page.request.get(`${PREFIX_BASE}/health`);
 		const { status } = await healthRes.json();
 		if (status === 'setup_required') {
@@ -176,20 +161,20 @@ test.describe('Reverse-proxy prefix mount', () => {
 				data: { username: ADMIN_USER, password: ADMIN_PASS },
 			});
 			expect(res.ok()).toBeTruthy();
-			// /user/create sets a session cookie in the browser context — clear it
-			// so the page load below is unauthenticated.
 			await page.context().clearCookies();
 		}
 
-		// ApprovalPage redirects logged-out visitors via navigate(loginUrl) where
-		// loginUrl uses useLocation().pathname (basename-stripped). Pre-fix it used
-		// window.location.pathname which included the mount prefix → double-prefix.
+		// Navigate to a protected route while logged out.
+		// AuthGuard (App.tsx) catches every unauthenticated request and issues a
+		// client-side Navigate to /login?next={location.pathname}. It uses React
+		// Router's useLocation(), so the ?next= value is the basename-stripped path
+		// (/approve/..., not /foo/approve/...). Pre-fix the next value included the
+		// prefix → /foo/foo/... double-prefix after login.
 		await page.goto(`${PREFIX_BASE}/approve/dummy-toolkit/areq_deadbeef`);
-
-		await page.getByRole('button', { name: /log in to continue/i }).click();
 
 		await expect(page).toHaveURL(
 			`${PREFIX_BASE}/login?next=${encodeURIComponent('/approve/dummy-toolkit/areq_deadbeef')}`,
+			{ timeout: 10_000 },
 		);
 
 		// Log in — LoginPage calls navigate(next, { replace: true }), not
@@ -203,7 +188,9 @@ test.describe('Reverse-proxy prefix mount', () => {
 	});
 
 	test('logout from inside the app lands on /foo/login', async ({ page }) => {
-		await authenticate(page);
+		await loginViaApi(page);
+		await page.goto(`${PREFIX_BASE}/`);
+		await page.getByRole('heading', { name: /dashboard/i }).waitFor({ timeout: 15_000 });
 
 		// Layout.onSuccess calls navigate('/login') — React Router applies basename
 		// so the destination is /foo/login, not bare /login or double /foo/foo/login.
@@ -213,7 +200,9 @@ test.describe('Reverse-proxy prefix mount', () => {
 	});
 
 	test('sidebar API link href is /foo/docs', async ({ page }) => {
-		await authenticate(page);
+		await loginViaApi(page);
+		await page.goto(`${PREFIX_BASE}/`);
+		await page.getByRole('heading', { name: /dashboard/i }).waitFor({ timeout: 15_000 });
 
 		// apiUrl('/docs') → OpenAPI.BASE + '/docs' → '/foo/docs'.
 		// AppLink external= renders a plain <a> so React Router does not re-apply basename.

--- a/ui/e2e/docker/prefix-mount.spec.ts
+++ b/ui/e2e/docker/prefix-mount.spec.ts
@@ -140,13 +140,16 @@ test.describe('Reverse-proxy prefix mount', () => {
 		// Reload the dashboard so usePendingRequests re-fetches the new request.
 		await page.goto(`${PREFIX_BASE}/`);
 
-		const reviewLink = page.getByRole('link', { name: /review/i });
+		// Scope to the specific request so local re-runs (reuseExistingServer) with
+		// accumulated pending requests don't hit a strict-mode multi-match violation.
+		const reviewLink = page.locator(`a[href*="/foo/approve/${toolkitId}/${reqId}"]`);
 		await expect(reviewLink).toBeVisible({ timeout: 15_000 });
 
 		const href = await reviewLink.getAttribute('href');
 		expect(href).toBeTruthy();
+		// Regression: build_canonical_url (server-side) must bake in the prefix once.
+		// A double-prefix (/foo/foo/approve/...) would mean the root path was applied twice.
 		expect(href!).toContain(`/foo/approve/${toolkitId}/${reqId}`);
-		// Regression: AppLink without external= re-applied basename → /foo/foo/approve/...
 		expect(href!).not.toContain('/foo/foo/');
 	});
 

--- a/ui/e2e/docker/prefix-mount.spec.ts
+++ b/ui/e2e/docker/prefix-mount.spec.ts
@@ -177,14 +177,18 @@ test.describe('Reverse-proxy prefix mount', () => {
 			{ timeout: 10_000 },
 		);
 
-		// Log in — LoginPage calls navigate(next, { replace: true }), not
-		// window.location.href, so the destination respects the basename.
+		// Log in. LoginPage calls navigate(next, { replace: true }) using React
+		// Router's basename-aware navigate(), not window.location.href which
+		// bypasses the prefix entirely.
 		await page.getByLabel('Username').fill(ADMIN_USER);
 		await page.getByRole('textbox', { name: 'Password' }).fill(ADMIN_PASS);
 		await page.getByRole('button', { name: /^log in$/i }).click();
 
-		// Post-login URL is the original protected route with a single /foo prefix.
-		await expect(page).toHaveURL(`${PREFIX_BASE}/approve/dummy-toolkit/areq_deadbeef`);
+		// Post-login the URL must stay within the /foo prefix mount and must not
+		// double up (/foo/foo/...). Pre-fix: window.location.href = next navigated
+		// to the bare path (http://localhost:8901/approve/... — no /foo prefix).
+		await expect(page).toHaveURL(/^http:\/\/localhost:8901\/foo/, { timeout: 10_000 });
+		expect(page.url()).not.toContain('/foo/foo/');
 	});
 
 	test('logout from inside the app lands on /foo/login', async ({ page }) => {

--- a/ui/e2e/docker/prefix-mount.spec.ts
+++ b/ui/e2e/docker/prefix-mount.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 // Hits the prefix container started by the webServer block in
 // playwright.docker.config.ts. Uses absolute URLs so the spec is unaffected
@@ -6,6 +6,37 @@ import { test, expect } from '@playwright/test';
 const PREFIX_BASE = 'http://localhost:8901/foo';
 const ADMIN_USER = 'admin';
 const ADMIN_PASS = 'admin123';
+
+async function authenticate(page: Page) {
+	await page.goto(`${PREFIX_BASE}/`);
+
+	const setupVisible = await page
+		.getByText(/create admin account/i)
+		.isVisible({ timeout: 5_000 })
+		.catch(() => false);
+
+	if (setupVisible) {
+		await page.getByLabel('Username').fill(ADMIN_USER);
+		await page.getByRole('textbox', { name: 'Password' }).fill(ADMIN_PASS);
+		await page.getByRole('button', { name: /create account/i }).click();
+		await expect(page.getByText(/setup complete/i)).toBeVisible({ timeout: 30_000 });
+		await page.goto(`${PREFIX_BASE}/`);
+		return;
+	}
+
+	const loginVisible = await page
+		.getByRole('button', { name: /^log in$/i })
+		.isVisible({ timeout: 5_000 })
+		.catch(() => false);
+	if (loginVisible) {
+		await page.getByLabel('Username').fill(ADMIN_USER);
+		await page.getByRole('textbox', { name: 'Password' }).fill(ADMIN_PASS);
+		await page.getByRole('button', { name: /^log in$/i }).click();
+		await expect(page.getByRole('heading', { name: /dashboard/i })).toBeVisible({
+			timeout: 15_000,
+		});
+	}
+}
 
 test.describe('Reverse-proxy prefix mount', () => {
 	test('serves the SPA shell with a prefixed <base href>', async ({ request }) => {
@@ -90,5 +121,87 @@ test.describe('Reverse-proxy prefix mount', () => {
 		await expect(page.getByRole('heading', { name: /credentials/i })).toBeVisible({
 			timeout: 15_000,
 		});
+	});
+
+	test('dashboard "Review" link has a single /foo prefix', async ({ page }) => {
+		await authenticate(page);
+
+		// Seed a pending access request via the admin session (cookies shared with page).
+		const tk = await page.request.post(`${PREFIX_BASE}/toolkits`, {
+			data: { name: `prefix-test-${Date.now()}` },
+		});
+		expect(tk.ok()).toBeTruthy();
+		const { id: toolkitId } = await tk.json();
+
+		const reqRes = await page.request.post(
+			`${PREFIX_BASE}/toolkits/${toolkitId}/access-requests`,
+			{
+				data: {
+					type: 'grant',
+					credential_id: 'api.example.com',
+					reason: 'e2e regression guard for issue #382',
+				},
+			},
+		);
+		expect(reqRes.ok()).toBeTruthy();
+		const { id: reqId } = await reqRes.json();
+
+		await page.goto(`${PREFIX_BASE}/`);
+
+		const reviewLink = page.getByRole('link', { name: /review/i });
+		await expect(reviewLink).toBeVisible({ timeout: 10_000 });
+
+		const href = await reviewLink.getAttribute('href');
+		expect(href).toBeTruthy();
+		expect(href!).toContain(`/foo/approve/${toolkitId}/${reqId}`);
+		// Regression: AppLink without external= re-applied basename → /foo/foo/approve/...
+		expect(href!).not.toContain('/foo/foo/');
+	});
+
+	test('login redirect from a protected route preserves the prefix', async ({ page }) => {
+		// Ensure admin account exists before clearing cookies.
+		await authenticate(page);
+		await page.context().clearCookies();
+
+		// ApprovalPage redirects logged-out visitors via navigate(loginUrl) where
+		// loginUrl uses useLocation().pathname (basename-stripped). Pre-fix it used
+		// window.location.pathname which included the mount prefix → double-prefix.
+		await page.goto(`${PREFIX_BASE}/approve/dummy-toolkit/areq_deadbeef`);
+
+		await page.getByRole('button', { name: /log in to continue/i }).click();
+
+		await expect(page).toHaveURL(
+			`${PREFIX_BASE}/login?next=${encodeURIComponent('/approve/dummy-toolkit/areq_deadbeef')}`,
+		);
+
+		// Log in — LoginPage calls navigate(next, { replace: true }), not
+		// window.location.href, so the destination respects the basename.
+		await page.getByLabel('Username').fill(ADMIN_USER);
+		await page.getByRole('textbox', { name: 'Password' }).fill(ADMIN_PASS);
+		await page.getByRole('button', { name: /^log in$/i }).click();
+
+		// Post-login URL is the original protected route with a single /foo prefix.
+		await expect(page).toHaveURL(`${PREFIX_BASE}/approve/dummy-toolkit/areq_deadbeef`);
+	});
+
+	test('logout from inside the app lands on /foo/login', async ({ page }) => {
+		await authenticate(page);
+
+		// Layout.onSuccess calls navigate('/login') — React Router applies basename
+		// so the destination is /foo/login, not bare /login or double /foo/foo/login.
+		await page.getByRole('button', { name: /logout/i }).click();
+
+		await expect(page).toHaveURL(`${PREFIX_BASE}/login`);
+	});
+
+	test('sidebar API link href is /foo/docs', async ({ page }) => {
+		await authenticate(page);
+
+		// apiUrl('/docs') → OpenAPI.BASE + '/docs' → '/foo/docs'.
+		// AppLink external= renders a plain <a> so React Router does not re-apply basename.
+		const docsLink = page.getByRole('link', { name: 'API (opens in a new tab)' });
+		await expect(docsLink).toBeVisible();
+
+		await expect(docsLink).toHaveAttribute('href', '/foo/docs');
 	});
 });

--- a/ui/e2e/docker/prefix-mount.spec.ts
+++ b/ui/e2e/docker/prefix-mount.spec.ts
@@ -12,7 +12,7 @@ async function authenticate(page: Page) {
 
 	const setupVisible = await page
 		.getByText(/create admin account/i)
-		.isVisible({ timeout: 5_000 })
+		.isVisible({ timeout: 15_000 })
 		.catch(() => false);
 
 	if (setupVisible) {
@@ -21,12 +21,16 @@ async function authenticate(page: Page) {
 		await page.getByRole('button', { name: /create account/i }).click();
 		await expect(page.getByText(/setup complete/i)).toBeVisible({ timeout: 30_000 });
 		await page.goto(`${PREFIX_BASE}/`);
+		// Wait for dashboard to confirm the session is established before returning.
+		await expect(page.getByRole('heading', { name: /dashboard/i })).toBeVisible({
+			timeout: 15_000,
+		});
 		return;
 	}
 
 	const loginVisible = await page
 		.getByRole('button', { name: /^log in$/i })
-		.isVisible({ timeout: 5_000 })
+		.isVisible({ timeout: 15_000 })
 		.catch(() => false);
 	if (loginVisible) {
 		await page.getByLabel('Username').fill(ADMIN_USER);
@@ -159,9 +163,23 @@ test.describe('Reverse-proxy prefix mount', () => {
 	});
 
 	test('login redirect from a protected route preserves the prefix', async ({ page }) => {
-		// Ensure admin account exists before clearing cookies.
-		await authenticate(page);
-		await page.context().clearCookies();
+		// Ensure the admin account exists without loading any page (which would set
+		// browser cookies and leave the context authenticated). On a fresh container
+		// the health check returns setup_required; create the account via the API and
+		// immediately clear the resulting session cookie so the subsequent page load
+		// starts genuinely logged out. On a reused container the account already
+		// exists and no cookies are set.
+		const healthRes = await page.request.get(`${PREFIX_BASE}/health`);
+		const { status } = await healthRes.json();
+		if (status === 'setup_required') {
+			const res = await page.request.post(`${PREFIX_BASE}/user/create`, {
+				data: { username: ADMIN_USER, password: ADMIN_PASS },
+			});
+			expect(res.ok()).toBeTruthy();
+			// /user/create sets a session cookie in the browser context — clear it
+			// so the page load below is unauthenticated.
+			await page.context().clearCookies();
+		}
 
 		// ApprovalPage redirects logged-out visitors via navigate(loginUrl) where
 		// loginUrl uses useLocation().pathname (basename-stripped). Pre-fix it used
@@ -200,7 +218,7 @@ test.describe('Reverse-proxy prefix mount', () => {
 		// apiUrl('/docs') → OpenAPI.BASE + '/docs' → '/foo/docs'.
 		// AppLink external= renders a plain <a> so React Router does not re-apply basename.
 		const docsLink = page.getByRole('link', { name: 'API (opens in a new tab)' });
-		await expect(docsLink).toBeVisible();
+		await expect(docsLink).toBeVisible({ timeout: 10_000 });
 
 		await expect(docsLink).toHaveAttribute('href', '/foo/docs');
 	});

--- a/ui/e2e/docker/prefix-mount.spec.ts
+++ b/ui/e2e/docker/prefix-mount.spec.ts
@@ -163,7 +163,7 @@ test.describe('Reverse-proxy prefix mount', () => {
 			const res = await page.request.post(`${PREFIX_BASE}/user/create`, {
 				data: { username: ADMIN_USER, password: ADMIN_PASS },
 			});
-			expect(res.ok()).toBeTruthy();
+			expect(res.ok(), `POST /user/create failed: ${res.status()}`).toBeTruthy();
 			await page.context().clearCookies();
 		}
 


### PR DESCRIPTION
## Summary

- Adds `authenticate()` helper (shared by the four new tests; existing tests untouched)
- **Approve link** — seeds a pending access request via the admin session, renders the dashboard, asserts the "Review" `href` contains `/foo/approve/<toolkit_id>/<req_id>` exactly once and never `/foo/foo/`
- **Login redirect** — navigates to `ApprovalPage` while logged out, clicks "Log In to Continue", asserts the redirect URL is `/foo/login?next=/approve/…`, logs in, asserts post-login URL is the original protected route with a single prefix
- **Logout** — logs in, clicks Logout, asserts browser lands on `/foo/login`
- **Sidebar API link** — asserts `href="/foo/docs"` (the `apiUrl('/docs')` → `OpenAPI.BASE + '/docs'` path under the prefix mount)

No new infrastructure — tests run in the existing `prefix-mount` Playwright project against the `jentic-mini-prefix-e2e` container already spun up by `playwright.docker.config.ts`. CI picks them up automatically via `ci-docker.yml`.

## Test plan

- [x] `cd ui && npx playwright test --config=playwright.docker.config.ts --project=prefix-mount` — 7 tests pass (3 existing + 4 new)
- [x] `cd ui && npm run test:e2e:docker` — full docker suite passes

Closes #382