### PR TITLE
ci(docker-security): pull fresh base image on every security scan

### DIFF
--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           context: .
           load: true
+          pull: true
           tags: jentic-mini:security-scan
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Adds `pull: true` to the `docker/build-push-action` step in `docker-security.yml`
- Forces Docker to re-pull the latest `python:3.11-slim` digest on every Trivy scan run, rather than serving a stale cached layer
- Ensures newly patched OS packages (glibc, libcap, sed, systemd) are included in the scanned image without a manual cache bust

## Why only the security workflow?

`ci-docker.yml` and `docker-publish.yml` are left unchanged — they benefit from GHA layer caching for speed and reproducibility. Only the security scan needs freshness to produce accurate CVE results.

## Test plan

- [x] Verify the `Docker Image Security Scan` workflow completes successfully on this PR
- [x] Confirm Trivy alert count drops for the open CVEs (glibc, libcap, sed) once the patched `python:3.11-slim` digest is pulled

🤖 Generated with [Claude Code](https://claude.com/claude-code)