### PR TITLE
fix(deps): bump idna from 3.13 to 3.15

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -927,13 +927,13 @@ files = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 requires_python = ">=3.8"
 summary = "Internationalized Domain Names in Applications (IDNA)"
 groups = ["default", "dev"]
 files = [
-    {file = "idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3"},
-    {file = "idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242"},
+    {file = "idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"},
+    {file = "idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"},
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `idna` from 3.13 to 3.15 in `pdm.lock`
- Fixes CVE-2026-45409: a bypass of the CVE-2024-3651 fix where payloads like `"٠" * N` invoke `valid_contexto` before the length check is applied, allowing CPU exhaustion via `idna.encode()`
- This closes the Trivy code-scanning alert [#672](https://github.com/jentic/jentic-mini/security/code-scanning/672)

## Test plan

- [x] CI Docker build runs Trivy; alert #672 should no longer appear after this merges
- [x] `pdm install` in CI installs idna 3.15 into the venv baked into the Docker image

Closes https://github.com/jentic/jentic-mini/security/code-scanning/672