### PR TITLE
ci(release): use GitHub App token for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,17 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.ARAZZO_BUILDER_APP_ID }}
+          private-key: ${{ secrets.ARAZZO_BUILDER_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@v6
         with:
@@ -25,7 +33,7 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: npx --yes --package semantic-release --package @semantic-release/exec --package @semantic-release/git semantic-release
 
       - name: Extract released version


### PR DESCRIPTION
## Summary

- Replace `secrets.GITHUB_TOKEN` with a GitHub App token (`ARAZZO_BUILDER_APP_ID` / `ARAZZO_BUILDER_PRIVATE_KEY`) in the release workflow
- Pass the app token to `actions/checkout` so semantic-release pushes (tags, commits) use the app identity
- This ensures the release tag push can trigger downstream workflows (e.g. `docker-publish.yml`), which `GITHUB_TOKEN` cannot do

## Test plan

- [x] Trigger `Release` workflow manually and verify semantic-release authenticates with the app token
- [x] Confirm the created tag triggers the `docker-publish` workflow


🤖 Generated with [Claude Code](https://claude.com/claude-code)