### PR TITLE
docs(spec): scaffold phase 29 — migrate-pdm-to-uv

### DIFF
--- a/specs/2026-05-20-migrate-pdm-to-uv/plan.md
+++ b/specs/2026-05-20-migrate-pdm-to-uv/plan.md
@@ -1,0 +1,77 @@
+# Phase 29 Plan — Migrate Python Packaging from PDM to uv
+
+## Group 1 — Prove `uv_build` against the `src/` layout (de-risk)
+
+1. Edit `pyproject.toml` `[build-system]` block: replace `requires = ["pdm-backend"]` and `build-backend = "pdm.backend"` with `requires = ["uv_build>=0.8.15,<0.12.0"]` and `build-backend = "uv_build"`.
+2. Append a new `[tool.uv.build-backend]` block to `pyproject.toml` immediately after `[build-system]`, with `module-name = "src"` and `module-root = ""` so uv_build vendors the existing `src/` directory unchanged into the wheel without renaming the import root.
+3. Run `uv build --wheel` from the repo root and inspect the output with `unzip -l dist/jentic_mini-0.13.1-py3-none-any.whl | grep '^.*src/auth\.py'` — confirm `src/*.py` files are present in the wheel. If the wheel is empty or the override is rejected by uv_build, stop and fall back to `[build-system] requires = ["hatchling"]` + `build-backend = "hatchling.build"` plus `[tool.hatch.build.targets.wheel] packages = ["src"]` per `requirements.md` Decisions; do not proceed to Group 2 with a broken backend.
+
+## Group 2 — Add `poethepoet` and `[tool.poe.tasks]` (additive, no removals yet)
+
+4. Append `poethepoet>=0.37,<0.47` to `pyproject.toml` `[dependency-groups] dev` (after the existing `ruff<0.16.0,>=0.14.1` entry).
+5. Add `[tool.poe.tasks]` to `pyproject.toml` (after the existing `[tool.ruff.lint.isort]` block) with three tasks: `lint` as a sequence of `ruff check ${GITHUB_ACTIONS:+--output-format=github}` (shell form) followed by `ruff format --check --diff`; `lint:fix` as a sequence of `ruff check --fix` followed by `ruff format`; `test` with `env = { PYTHONPATH = "." }` and `cmd = "pytest -v ${args:tests} --tb=short"`. The `${args:tests}` placeholder must produce identical positional-argument behaviour to PDM's `{args:tests}` (default to `tests`, allow narrow overrides).
+6. Smoke each task locally before flipping anything else: `uv sync` (writes a draft lockfile but is acceptable here as a probe — discard before committing); `uv run poe lint` exits 0; `uv run poe test tests/test_health.py -v` exits 0; `uv run poe lint:fix` exits 0 with no diff. Confirm `[tool.pdm.scripts]` is still present and untouched at this point — the additive flip lets us validate poe shape against a live ruff/pytest before discarding the PDM scripts.
+
+## Group 3 — Generate `uv.lock`, delete PDM artefacts
+
+7. Run `uv lock` to produce `uv.lock` deterministically (this regenerates rather than upgrades, since the resolver inputs in `pyproject.toml` `[project.dependencies]` and `[dependency-groups] dev` are unchanged); commit the resulting `uv.lock`.
+8. `git rm pdm.lock`; remove the working-tree `.pdm-python` interpreter marker (`git rm .pdm-python` if tracked; otherwise `rm -f .pdm-python`).
+9. Edit `.gitignore`: remove the `.pdm-python` line (currently line 23). Leave `__pypackages__/` (line 22) — harmless under uv but unused.
+
+## Group 4 — Drop `[tool.pdm.scripts]` and update the husky pre-commit hook in lockstep
+
+10. Remove the `[tool.pdm.scripts]` block from `pyproject.toml` (currently lines 59–63). After this edit, `pyproject.toml` has zero `[tool.pdm.*]` entries.
+11. Edit `.husky/pre-commit` line 1: replace `pdm run lint` with `uv run poe lint`. Leave the `cd ui && npx lint-staged` line (UI-side hook) untouched. This commit must land atomically with the `[tool.pdm.scripts]` deletion so no developer commit fails between them.
+
+## Group 5 — Rewrite the Dockerfile
+
+12. Edit `Dockerfile` `py-deps` stage: replace lines 15–17 (`RUN pip install --no-cache-dir pipx && pipx install pdm==2.26.9` plus the `ENV PATH="/root/.local/bin:$PATH"`) with a single multi-stage copy `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/`. Drop the `pipx` install entirely.
+13. Edit `Dockerfile` line 19: change `COPY pyproject.toml pdm.lock ./` to `COPY pyproject.toml uv.lock ./`. Keep the `WORKDIR /app` (line 7) and the `RUN apt-get update … gcc libffi-dev` (lines 9–13) — these are still needed for any source-built wheels (cryptography, etc.) until proven otherwise by Group 7's CI green.
+14. Edit `Dockerfile` lines 20–30: replace the entire `RUN /root/.local/bin/pdm install --prod --no-editable --no-self --frozen-lockfile && /app/.venv/bin/python -m ensurepip --upgrade && /app/.venv/bin/python -m pip install --upgrade --no-cache-dir pip setuptools wheel` block (and the comment at lines 20–27) with `RUN uv sync --frozen --no-install-project --no-dev`. The `ensurepip + pip/setuptools/wheel --upgrade` block goes away — uv's wheels avoid the bootstrap-pip CVE vector. Keep the runtime-stage `RUN python -m pip install --upgrade --no-cache-dir pip setuptools wheel` at line 40 (system pip, unrelated to PDM, with the existing comment block at lines 35–39 explaining why).
+15. Confirm by inspection that lines 33+ (runtime stage) still consume the venv via `COPY --from=py-deps /app/.venv /app/.venv` (line 55) and `ENV PATH="/app/.venv/bin:$PATH"` (line 56). The `/app/.venv` shape is uv-default; no further runtime-stage edits required.
+
+## Group 6 — Rewrite the CI workflow (`ci-backend.yml` only)
+
+16. Edit `.github/workflows/ci-backend.yml` line 11 `paths:` filter: change `'pdm.lock'` to `'uv.lock'` so backend CI re-triggers on Dependabot's lock updates.
+17. Edit `.github/workflows/ci-backend.yml` lint job (lines 28–32): replace `uses: pdm-project/setup-pdm@v4` with `uses: astral-sh/setup-uv@v6` (or current stable major); pass `python-version: '3.11'` and `enable-cache: true`. Replace `run: pdm install --dev --frozen-lockfile` (line 35) with `run: uv sync --frozen`. Replace `run: pdm run lint` (line 38) with `run: uv run poe lint`.
+18. Edit `.github/workflows/ci-backend.yml` test job (lines 46–50, 53, 58): apply the identical setup-uv swap, replace the install with `uv sync --frozen`, and replace `run: pdm run test` with `run: uv run poe test`. No marker filter, no exclude list — preserve current behaviour.
+
+## Group 7 — Flip Dependabot ecosystem
+
+19. Edit `.github/dependabot.yml` Python entry (currently lines 13–21): change `package-ecosystem: pip` to `package-ecosystem: uv`. Leave every other field unchanged (`directory: "/"`, `schedule.interval: daily`, `schedule.time: "23:00"`, `commit-message.prefix: "chore"`, `commit-message.include: "scope"`, `open-pull-requests-limit: 3`). Leave the `npm /ui` and `github-actions /` entries entirely untouched.
+
+## Group 8 — Update developer-facing docs
+
+20. Edit `DEVELOPMENT.md` Prerequisites section: remove the **PDM** install line (`curl -sSL https://pdm-project.org/install-pdm.py | python3 -`) and replace with the uv install line (`curl -LsSf https://astral.sh/uv/install.sh | sh`).
+21. Edit `DEVELOPMENT.md` install section: replace `pdm venv create` and `pdm install --dev` with `uv sync` (uv creates the project-local `.venv` automatically; no separate `venv create` step).
+22. Edit `DEVELOPMENT.md` "Running Tests" section: replace every `pdm run test …` invocation (currently lines 84–89) with the `uv run poe test …` equivalent, preserving the `--` argument-passthrough examples.
+23. Edit `DEVELOPMENT.md` "Linting" section: replace `pdm run lint` and `pdm run lint:fix` (lines 104–110) with `uv run poe lint` and `uv run poe lint:fix`. Add a one-line note showing how to discover available poe tasks (`uv run poe`).
+
+## Group 9 — Update agent-facing rules and SDD templates
+
+24. Edit `.claude/rules/worktrees.md`: remove the `PDM_IGNORE_ACTIVE_VENV=1` invariant (lines 7–12 step 2 Python install paragraph and the lines 41–44 "Two env vars beyond port selection" bullet). Rewrite the host-mode launch backend block (lines 49–65) for `mkdir -p data; JENTIC_INTERNAL_PORT=8901 DB_PATH="$(pwd)/data/jentic-mini.db" uv run uvicorn src.main:app --port 8901 --reload` (no `PDM_IGNORE_ACTIVE_VENV=1` prefix). Step 2's Python install becomes `uv sync` at the worktree root.
+25. Edit `.claude/rules/testing.md` line 21: replace `pdm run test …` with `uv run poe test …`.
+26. Edit `.claude/rules/python-code-style.md` line 8: replace `pdm run lint:fix` with `uv run poe lint:fix`.
+27. Edit `.claude/rules/update-tech-stack-on-deps.md` line 14 example list: replace `PDM` with `uv`.
+28. Edit `.claude/skills/sdd-implement-spec/SKILL.md` (lines that mint `pdm run lint`/`pdm run test` into spec examples) and `.claude/skills/sdd-new-spec/SKILL.md` (same): replace each with the `uv run poe …` equivalent. Edit `.claude/templates/sdd/feature-spec/plan.example.md` line 22: replace `pdm run test tests/broker` with `uv run poe test tests/broker`.
+29. Edit `.claude/settings.local.json`: replace the `Bash(pdm run *)` allowlist entry with `Bash(uv run *)` and replace the `Bash(PDM_IGNORE_ACTIVE_VENV=1 pdm update *)` entry with `Bash(uv sync *)` plus `Bash(uv lock*)`. Leave every other allowlist entry untouched.
+
+## Group 10 — Update constitution and roadmap
+
+30. Edit `specs/tech-stack.md` Core Stack table line 35: change `| Python packaging | PDM |` to `| Python packaging | uv |`.
+31. Edit `specs/tech-stack.md` formatting/linting prose at line 92: change `PDM scripts: \`lint\`, \`lint:fix\`.` to `Poe tasks (\`[tool.poe.tasks]\`): \`lint\`, \`lint:fix\`, \`test\`.` Confirm by `grep -in pdm specs/tech-stack.md` — expect zero matches.
+32. Edit `specs/roadmap.md` Phase 15 (Pyright) body bullets only: replace `[tool.pdm.dev-dependencies]` with `[dependency-groups] dev`; replace `[tool.pdm.scripts]` with `[tool.poe.tasks]`; replace `pdm run typecheck` with `uv run poe typecheck`. Do not change Phase 15's goal, priority, depends-on, or any other content.
+33. Edit `specs/roadmap.md` Phase 29 heading at line 431: append ` ✅` (single space + U+2705) so the heading reads `## Phase 29 — Migrate Python Packaging from PDM to uv ✅`. Leave the rest of the Phase 29 block intact per the lifecycle rule (`specs/roadmap.md:35-40`); do not delete or renumber.
+
+## Group 11 — Verify
+
+34. `uv lock --check` exits 0 (lockfile is consistent with `pyproject.toml`).
+35. `uv sync --frozen` exits 0 (clean install from frozen lockfile).
+36. `uv build --wheel` exits 0; `unzip -l dist/jentic_mini-*.whl | grep -E 'src/(auth|db|main)\.py'` returns ≥3 lines (proves Group 1's `module-name = "src"` override held through the migration).
+37. `uv run poe lint` exits 0 (ruff check + ruff format --check --diff both pass).
+38. `uv run poe test` exits 0 (full backend pytest suite passes; equivalent to today's `pdm run test`).
+39. `docker build -t jentic-mini:phase29 .` exits 0 (Dockerfile rewrite builds clean on the host architecture).
+40. `git grep -nE "(pdm-project/setup-pdm|pdm install|pdm run|tool\.pdm)" -- ':!specs/2026-05-07-*' ':!specs/2026-05-08-*' ':!specs/2026-05-12-*'` exits 1 (no matches) — completed-spec history is excluded; everything else must be PDM-free.
+41. `git grep -nE "PDM_IGNORE_ACTIVE_VENV" -- ':!specs/2026-05-07-*' ':!specs/2026-05-08-*' ':!specs/2026-05-12-*'` exits 1 (no matches outside frozen historical specs).
+42. `test ! -f pdm.lock` and `test -f uv.lock` and `test ! -f .pdm-python` all exit 0.
+43. `grep -F "## Phase 29 — Migrate Python Packaging from PDM to uv ✅" specs/roadmap.md` exits 0 (phase-completion lifecycle marker present, single space before ✅).

--- a/specs/2026-05-20-migrate-pdm-to-uv/plan.md
+++ b/specs/2026-05-20-migrate-pdm-to-uv/plan.md
@@ -1,77 +1,77 @@
 # Phase 29 Plan — Migrate Python Packaging from PDM to uv
 
-## Group 1 — Prove `uv_build` against the `src/` layout (de-risk)
+## Group 1 — Configure uv in application mode (no build backend)
 
-1. Edit `pyproject.toml` `[build-system]` block: replace `requires = ["pdm-backend"]` and `build-backend = "pdm.backend"` with `requires = ["uv_build>=0.8.15,<0.12.0"]` and `build-backend = "uv_build"`.
-2. Append a new `[tool.uv.build-backend]` block to `pyproject.toml` immediately after `[build-system]`, with `module-name = "src"` and `module-root = ""` so uv_build vendors the existing `src/` directory unchanged into the wheel without renaming the import root.
-3. Run `uv build --wheel` from the repo root and inspect the output with `unzip -l dist/jentic_mini-0.13.1-py3-none-any.whl | grep '^.*src/auth\.py'` — confirm `src/*.py` files are present in the wheel. If the wheel is empty or the override is rejected by uv_build, stop and fall back to `[build-system] requires = ["hatchling"]` + `build-backend = "hatchling.build"` plus `[tool.hatch.build.targets.wheel] packages = ["src"]` per `requirements.md` Decisions; do not proceed to Group 2 with a broken backend.
+1. Delete the entire `[build-system]` block from `pyproject.toml` (currently lines 37–39: `[build-system] / requires = ["pdm-backend"] / build-backend = "pdm.backend"`). The project is Docker-distributed, never wheelable; no PEP 517 backend is needed. `uv sync` honours `[tool.uv] package = false` (next step) and skips backend invocation entirely.
+2. Append `[tool.uv]` with `package = false` to `pyproject.toml` (after the `[dependency-groups]` block). This declares jentic-mini an application, not a library — `uv sync` resolves and installs `[project.dependencies]` + `[dependency-groups] dev` into `.venv` without ever building or installing the project itself, which mirrors the Dockerfile's `--no-install-project` behaviour and means the `src/`-layout / project-name mismatch never surfaces.
 
 ## Group 2 — Add `poethepoet` and `[tool.poe.tasks]` (additive, no removals yet)
 
-4. Append `poethepoet>=0.37,<0.47` to `pyproject.toml` `[dependency-groups] dev` (after the existing `ruff<0.16.0,>=0.14.1` entry).
-5. Add `[tool.poe.tasks]` to `pyproject.toml` (after the existing `[tool.ruff.lint.isort]` block) with three tasks: `lint` as a sequence of `ruff check ${GITHUB_ACTIONS:+--output-format=github}` (shell form) followed by `ruff format --check --diff`; `lint:fix` as a sequence of `ruff check --fix` followed by `ruff format`; `test` with `env = { PYTHONPATH = "." }` and `cmd = "pytest -v ${args:tests} --tb=short"`. The `${args:tests}` placeholder must produce identical positional-argument behaviour to PDM's `{args:tests}` (default to `tests`, allow narrow overrides).
-6. Smoke each task locally before flipping anything else: `uv sync` (writes a draft lockfile but is acceptable here as a probe — discard before committing); `uv run poe lint` exits 0; `uv run poe test tests/test_health.py -v` exits 0; `uv run poe lint:fix` exits 0 with no diff. Confirm `[tool.pdm.scripts]` is still present and untouched at this point — the additive flip lets us validate poe shape against a live ruff/pytest before discarding the PDM scripts.
+3. Append `poethepoet>=0.37,<0.47` to `pyproject.toml` `[dependency-groups] dev` (after the existing `ruff<0.16.0,>=0.14.1` entry).
+4. Add `[tool.poe.tasks]` to `pyproject.toml` (after the existing `[tool.ruff.lint.isort]` block) with three tasks: `lint` as a sequence of `ruff check ${GITHUB_ACTIONS:+--output-format=github}` (shell form) followed by `ruff format --check --diff`; `lint:fix` as a sequence of `ruff check --fix` followed by `ruff format`; `test` with `env = { PYTHONPATH = "." }` and `cmd = "pytest -v ${args:tests} --tb=short"`. The `${args:tests}` placeholder must produce identical positional-argument behaviour to PDM's `{args:tests}` (default to `tests`, allow narrow overrides).
+5. Smoke each task locally before flipping anything else: `uv sync` (writes a draft lockfile but is acceptable here as a probe — discard before committing); `uv run poe lint` exits 0; `uv run poe test tests/test_health.py -v` exits 0; `uv run poe lint:fix` exits 0 with no diff. Confirm `[tool.pdm.scripts]` is still present and untouched at this point — the additive flip lets us validate poe shape against a live ruff/pytest before discarding the PDM scripts.
 
 ## Group 3 — Generate `uv.lock`, delete PDM artefacts
 
-7. Run `uv lock` to produce `uv.lock` deterministically (this regenerates rather than upgrades, since the resolver inputs in `pyproject.toml` `[project.dependencies]` and `[dependency-groups] dev` are unchanged); commit the resulting `uv.lock`.
-8. `git rm pdm.lock`; remove the working-tree `.pdm-python` interpreter marker (`git rm .pdm-python` if tracked; otherwise `rm -f .pdm-python`).
-9. Edit `.gitignore`: remove the `.pdm-python` line (currently line 23). Leave `__pypackages__/` (line 22) — harmless under uv but unused.
+6. Run `uv lock` to produce `uv.lock` deterministically (this regenerates rather than upgrades, since the resolver inputs in `pyproject.toml` `[project.dependencies]` and `[dependency-groups] dev` are unchanged); commit the resulting `uv.lock`.
+7. `git rm pdm.lock`; remove the working-tree `.pdm-python` interpreter marker (`git rm .pdm-python` if tracked; otherwise `rm -f .pdm-python`).
+8. Edit `.gitignore`: remove the `.pdm-python` line (currently line 23). Leave `__pypackages__/` (line 22) — harmless under uv but unused.
 
 ## Group 4 — Drop `[tool.pdm.scripts]` and update the husky pre-commit hook in lockstep
 
-10. Remove the `[tool.pdm.scripts]` block from `pyproject.toml` (currently lines 59–63). After this edit, `pyproject.toml` has zero `[tool.pdm.*]` entries.
-11. Edit `.husky/pre-commit` line 1: replace `pdm run lint` with `uv run poe lint`. Leave the `cd ui && npx lint-staged` line (UI-side hook) untouched. This commit must land atomically with the `[tool.pdm.scripts]` deletion so no developer commit fails between them.
+9. Remove the `[tool.pdm.scripts]` block from `pyproject.toml` (currently lines 59–63). After this edit, `pyproject.toml` has zero `[tool.pdm.*]` entries.
+10. Edit `.husky/pre-commit` line 1: replace `pdm run lint` with `uv run poe lint`. Leave the `cd ui && npx lint-staged` line (UI-side hook) untouched. This commit must land atomically with the `[tool.pdm.scripts]` deletion so no developer commit fails between them.
 
 ## Group 5 — Rewrite the Dockerfile
 
-12. Edit `Dockerfile` `py-deps` stage: replace lines 15–17 (`RUN pip install --no-cache-dir pipx && pipx install pdm==2.26.9` plus the `ENV PATH="/root/.local/bin:$PATH"`) with a single multi-stage copy `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/`. Drop the `pipx` install entirely.
-13. Edit `Dockerfile` line 19: change `COPY pyproject.toml pdm.lock ./` to `COPY pyproject.toml uv.lock ./`. Keep the `WORKDIR /app` (line 7) and the `RUN apt-get update … gcc libffi-dev` (lines 9–13) — these are still needed for any source-built wheels (cryptography, etc.) until proven otherwise by Group 7's CI green.
-14. Edit `Dockerfile` lines 20–30: replace the entire `RUN /root/.local/bin/pdm install --prod --no-editable --no-self --frozen-lockfile && /app/.venv/bin/python -m ensurepip --upgrade && /app/.venv/bin/python -m pip install --upgrade --no-cache-dir pip setuptools wheel` block (and the comment at lines 20–27) with `RUN uv sync --frozen --no-install-project --no-dev`. The `ensurepip + pip/setuptools/wheel --upgrade` block goes away — uv's wheels avoid the bootstrap-pip CVE vector. Keep the runtime-stage `RUN python -m pip install --upgrade --no-cache-dir pip setuptools wheel` at line 40 (system pip, unrelated to PDM, with the existing comment block at lines 35–39 explaining why).
-15. Confirm by inspection that lines 33+ (runtime stage) still consume the venv via `COPY --from=py-deps /app/.venv /app/.venv` (line 55) and `ENV PATH="/app/.venv/bin:$PATH"` (line 56). The `/app/.venv` shape is uv-default; no further runtime-stage edits required.
+11. Edit `Dockerfile` `py-deps` stage: replace lines 15–17 (`RUN pip install --no-cache-dir pipx && pipx install pdm==2.26.9` plus the `ENV PATH="/root/.local/bin:$PATH"`) with a single multi-stage copy `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/`. Drop the `pipx` install entirely.
+12. Edit `Dockerfile` line 19: change `COPY pyproject.toml pdm.lock ./` to `COPY pyproject.toml uv.lock ./`. Keep the `WORKDIR /app` (line 7) and the `RUN apt-get update … gcc libffi-dev` (lines 9–13) — these are still needed for any source-built wheels (cryptography, etc.) until proven otherwise by Group 7's CI green.
+13. Edit `Dockerfile` lines 20–30: replace the entire `RUN /root/.local/bin/pdm install --prod --no-editable --no-self --frozen-lockfile && /app/.venv/bin/python -m ensurepip --upgrade && /app/.venv/bin/python -m pip install --upgrade --no-cache-dir pip setuptools wheel` block (and the comment at lines 20–27) with `RUN uv sync --frozen --no-install-project --no-dev`. The `ensurepip + pip/setuptools/wheel --upgrade` block goes away — uv's wheels avoid the bootstrap-pip CVE vector. Keep the runtime-stage `RUN python -m pip install --upgrade --no-cache-dir pip setuptools wheel` at line 40 (system pip, unrelated to PDM, with the existing comment block at lines 35–39 explaining why).
+14. Confirm by inspection that lines 33+ (runtime stage) still consume the venv via `COPY --from=py-deps /app/.venv /app/.venv` (line 55) and `ENV PATH="/app/.venv/bin:$PATH"` (line 56). The `/app/.venv` shape is uv-default; no further runtime-stage edits required.
 
 ## Group 6 — Rewrite the CI workflow (`ci-backend.yml` only)
 
-16. Edit `.github/workflows/ci-backend.yml` line 11 `paths:` filter: change `'pdm.lock'` to `'uv.lock'` so backend CI re-triggers on Dependabot's lock updates.
-17. Edit `.github/workflows/ci-backend.yml` lint job (lines 28–32): replace `uses: pdm-project/setup-pdm@v4` with `uses: astral-sh/setup-uv@v6` (or current stable major); pass `python-version: '3.11'` and `enable-cache: true`. Replace `run: pdm install --dev --frozen-lockfile` (line 35) with `run: uv sync --frozen`. Replace `run: pdm run lint` (line 38) with `run: uv run poe lint`.
-18. Edit `.github/workflows/ci-backend.yml` test job (lines 46–50, 53, 58): apply the identical setup-uv swap, replace the install with `uv sync --frozen`, and replace `run: pdm run test` with `run: uv run poe test`. No marker filter, no exclude list — preserve current behaviour.
+15. Edit `.github/workflows/ci-backend.yml` line 11 `paths:` filter: change `'pdm.lock'` to `'uv.lock'` so backend CI re-triggers on Dependabot's lock updates.
+16. Edit `.github/workflows/ci-backend.yml` lint job (lines 28–32): replace `uses: pdm-project/setup-pdm@v4` with `uses: astral-sh/setup-uv@v8` (latest stable major as of 2026-05-20; tag pin matches the repo's existing `actions/checkout@v4` convention); pass `python-version: '3.11'` and `enable-cache: true`. Replace `run: pdm install --dev --frozen-lockfile` (line 35) with `run: uv sync --frozen`. Replace `run: pdm run lint` (line 38) with `run: uv run poe lint`.
+17. Edit `.github/workflows/ci-backend.yml` test job (lines 46–50, 53, 58): apply the identical setup-uv swap, replace the install with `uv sync --frozen`, and replace `run: pdm run test` with `run: uv run poe test`. No marker filter, no exclude list — preserve current behaviour.
 
 ## Group 7 — Flip Dependabot ecosystem
 
-19. Edit `.github/dependabot.yml` Python entry (currently lines 13–21): change `package-ecosystem: pip` to `package-ecosystem: uv`. Leave every other field unchanged (`directory: "/"`, `schedule.interval: daily`, `schedule.time: "23:00"`, `commit-message.prefix: "chore"`, `commit-message.include: "scope"`, `open-pull-requests-limit: 3`). Leave the `npm /ui` and `github-actions /` entries entirely untouched.
+18. Edit `.github/dependabot.yml` Python entry (currently lines 13–21): change `package-ecosystem: pip` to `package-ecosystem: uv`. Leave every other field unchanged (`directory: "/"`, `schedule.interval: daily`, `schedule.time: "23:00"`, `commit-message.prefix: "chore"`, `commit-message.include: "scope"`, `open-pull-requests-limit: 3`). Leave the `npm /ui` and `github-actions /` entries entirely untouched.
 
 ## Group 8 — Update developer-facing docs
 
-20. Edit `DEVELOPMENT.md` Prerequisites section: remove the **PDM** install line (`curl -sSL https://pdm-project.org/install-pdm.py | python3 -`) and replace with the uv install line (`curl -LsSf https://astral.sh/uv/install.sh | sh`).
-21. Edit `DEVELOPMENT.md` install section: replace `pdm venv create` and `pdm install --dev` with `uv sync` (uv creates the project-local `.venv` automatically; no separate `venv create` step).
-22. Edit `DEVELOPMENT.md` "Running Tests" section: replace every `pdm run test …` invocation (currently lines 84–89) with the `uv run poe test …` equivalent, preserving the `--` argument-passthrough examples.
-23. Edit `DEVELOPMENT.md` "Linting" section: replace `pdm run lint` and `pdm run lint:fix` (lines 104–110) with `uv run poe lint` and `uv run poe lint:fix`. Add a one-line note showing how to discover available poe tasks (`uv run poe`).
+19. Edit `DEVELOPMENT.md` Prerequisites section: remove the **PDM** install line (`curl -sSL https://pdm-project.org/install-pdm.py | python3 -`) and replace with the uv install line (`curl -LsSf https://astral.sh/uv/install.sh | sh`).
+20. Edit `DEVELOPMENT.md` install section: replace `pdm venv create` and `pdm install --dev` with `uv sync` (uv creates the project-local `.venv` automatically; no separate `venv create` step).
+21. Edit `DEVELOPMENT.md` "Running Tests" section: replace every `pdm run test …` invocation (currently lines 84–89) with the `uv run poe test …` equivalent, preserving the `--` argument-passthrough examples.
+22. Edit `DEVELOPMENT.md` "Linting" section: replace `pdm run lint` and `pdm run lint:fix` (lines 104–110) with `uv run poe lint` and `uv run poe lint:fix`. Add a one-line note showing how to discover available poe tasks (`uv run poe`).
 
 ## Group 9 — Update agent-facing rules and SDD templates
 
-24. Edit `.claude/rules/worktrees.md`: remove the `PDM_IGNORE_ACTIVE_VENV=1` invariant (lines 7–12 step 2 Python install paragraph and the lines 41–44 "Two env vars beyond port selection" bullet). Rewrite the host-mode launch backend block (lines 49–65) for `mkdir -p data; JENTIC_INTERNAL_PORT=8901 DB_PATH="$(pwd)/data/jentic-mini.db" uv run uvicorn src.main:app --port 8901 --reload` (no `PDM_IGNORE_ACTIVE_VENV=1` prefix). Step 2's Python install becomes `uv sync` at the worktree root.
-25. Edit `.claude/rules/testing.md` line 21: replace `pdm run test …` with `uv run poe test …`.
-26. Edit `.claude/rules/python-code-style.md` line 8: replace `pdm run lint:fix` with `uv run poe lint:fix`.
-27. Edit `.claude/rules/update-tech-stack-on-deps.md` line 14 example list: replace `PDM` with `uv`.
-28. Edit `.claude/skills/sdd-implement-spec/SKILL.md` (lines that mint `pdm run lint`/`pdm run test` into spec examples) and `.claude/skills/sdd-new-spec/SKILL.md` (same): replace each with the `uv run poe …` equivalent. Edit `.claude/templates/sdd/feature-spec/plan.example.md` line 22: replace `pdm run test tests/broker` with `uv run poe test tests/broker`.
-29. Edit `.claude/settings.local.json`: replace the `Bash(pdm run *)` allowlist entry with `Bash(uv run *)` and replace the `Bash(PDM_IGNORE_ACTIVE_VENV=1 pdm update *)` entry with `Bash(uv sync *)` plus `Bash(uv lock*)`. Leave every other allowlist entry untouched.
+23. Edit `.claude/rules/worktrees.md`: remove the `PDM_IGNORE_ACTIVE_VENV=1` invariant (lines 7–12 step 2 Python install paragraph and the lines 41–44 "Two env vars beyond port selection" bullet). Rewrite the host-mode launch backend block (lines 49–65) for `mkdir -p data; JENTIC_INTERNAL_PORT=8901 DB_PATH="$(pwd)/data/jentic-mini.db" uv run uvicorn src.main:app --port 8901 --reload` (no `PDM_IGNORE_ACTIVE_VENV=1` prefix). Step 2's Python install becomes `uv sync` at the worktree root.
+24. Edit `.claude/rules/testing.md` line 21: replace `pdm run test …` with `uv run poe test …`.
+25. Edit `.claude/rules/python-code-style.md` line 8: replace `pdm run lint:fix` with `uv run poe lint:fix`.
+26. Edit `.claude/rules/update-tech-stack-on-deps.md` line 14 example list: replace `PDM` with `uv`.
+27. Edit `.claude/skills/sdd-implement-spec/SKILL.md` (lines that mint `pdm run lint`/`pdm run test` into spec examples) and `.claude/skills/sdd-new-spec/SKILL.md` (same): replace each with the `uv run poe …` equivalent. Edit `.claude/templates/sdd/feature-spec/plan.example.md` line 22: replace `pdm run test tests/broker` with `uv run poe test tests/broker`.
+28. Edit `.claude/settings.local.json`: replace the `Bash(pdm run *)` allowlist entry with `Bash(uv run *)` and replace the `Bash(PDM_IGNORE_ACTIVE_VENV=1 pdm update *)` entry with `Bash(uv sync *)` plus `Bash(uv lock*)`. Leave every other allowlist entry untouched.
 
 ## Group 10 — Update constitution and roadmap
 
-30. Edit `specs/tech-stack.md` Core Stack table line 35: change `| Python packaging | PDM |` to `| Python packaging | uv |`.
-31. Edit `specs/tech-stack.md` formatting/linting prose at line 92: change `PDM scripts: \`lint\`, \`lint:fix\`.` to `Poe tasks (\`[tool.poe.tasks]\`): \`lint\`, \`lint:fix\`, \`test\`.` Confirm by `grep -in pdm specs/tech-stack.md` — expect zero matches.
-32. Edit `specs/roadmap.md` Phase 15 (Pyright) body bullets only: replace `[tool.pdm.dev-dependencies]` with `[dependency-groups] dev`; replace `[tool.pdm.scripts]` with `[tool.poe.tasks]`; replace `pdm run typecheck` with `uv run poe typecheck`. Do not change Phase 15's goal, priority, depends-on, or any other content.
-33. Edit `specs/roadmap.md` Phase 29 heading at line 431: append ` ✅` (single space + U+2705) so the heading reads `## Phase 29 — Migrate Python Packaging from PDM to uv ✅`. Leave the rest of the Phase 29 block intact per the lifecycle rule (`specs/roadmap.md:35-40`); do not delete or renumber.
+29. Edit `specs/tech-stack.md` Core Stack table line 35: change `| Python packaging | PDM |` to `| Python packaging | uv |`.
+30. Edit `specs/tech-stack.md` formatting/linting prose at line 92: change `PDM scripts: \`lint\`, \`lint:fix\`.` to `Poe tasks (\`[tool.poe.tasks]\`): \`lint\`, \`lint:fix\`, \`test\`.` Confirm by `grep -in pdm specs/tech-stack.md` — expect zero matches.
+31. Edit `specs/roadmap.md` Phase 15 (Pyright) body bullets only: replace `[tool.pdm.dev-dependencies]` with `[dependency-groups] dev`; replace `[tool.pdm.scripts]` with `[tool.poe.tasks]`; replace `pdm run typecheck` with `uv run poe typecheck`. Do not change Phase 15's goal, priority, depends-on, or any other content.
+32. Edit `specs/roadmap.md` Phase 29 heading at line 431: append ` ✅` (single space + U+2705) so the heading reads `## Phase 29 — Migrate Python Packaging from PDM to uv ✅`. Leave the rest of the Phase 29 block intact per the lifecycle rule (`specs/roadmap.md:35-40`); do not delete or renumber.
 
 ## Group 11 — Verify
 
-34. `uv lock --check` exits 0 (lockfile is consistent with `pyproject.toml`).
-35. `uv sync --frozen` exits 0 (clean install from frozen lockfile).
-36. `uv build --wheel` exits 0; `unzip -l dist/jentic_mini-*.whl | grep -E 'src/(auth|db|main)\.py'` returns ≥3 lines (proves Group 1's `module-name = "src"` override held through the migration).
-37. `uv run poe lint` exits 0 (ruff check + ruff format --check --diff both pass).
-38. `uv run poe test` exits 0 (full backend pytest suite passes; equivalent to today's `pdm run test`).
-39. `docker build -t jentic-mini:phase29 .` exits 0 (Dockerfile rewrite builds clean on the host architecture).
-40. `git grep -nE "(pdm-project/setup-pdm|pdm install|pdm run|tool\.pdm)" -- ':!specs/2026-05-07-*' ':!specs/2026-05-08-*' ':!specs/2026-05-12-*'` exits 1 (no matches) — completed-spec history is excluded; everything else must be PDM-free.
-41. `git grep -nE "PDM_IGNORE_ACTIVE_VENV" -- ':!specs/2026-05-07-*' ':!specs/2026-05-08-*' ':!specs/2026-05-12-*'` exits 1 (no matches outside frozen historical specs).
-42. `test ! -f pdm.lock` and `test -f uv.lock` and `test ! -f .pdm-python` all exit 0.
+33. `uv lock --check` exits 0 (lockfile is consistent with `pyproject.toml`).
+34. `uv sync --frozen` exits 0 (clean install from frozen lockfile).
+35. `uv run poe lint` exits 0 (ruff check + ruff format --check --diff both pass).
+36. `uv run poe test` exits 0 (full backend pytest suite passes; equivalent to today's `pdm run test`).
+37. `docker build -t jentic-mini:phase29 .` exits 0 (Dockerfile rewrite builds clean on the host architecture).
+38. `git grep -nE "(pdm-project/setup-pdm|pdm install|pdm run|tool\.pdm)" -- ':!specs/2026-05-07-*' ':!specs/2026-05-08-*' ':!specs/2026-05-12-*'` exits 1 (no matches) — completed-spec history is excluded; everything else must be PDM-free.
+39. `git grep -nE "PDM_IGNORE_ACTIVE_VENV" -- ':!specs/2026-05-07-*' ':!specs/2026-05-08-*' ':!specs/2026-05-12-*'` exits 1 (no matches outside frozen historical specs).
+40. `test ! -f pdm.lock` and `test -f uv.lock` and `test ! -f .pdm-python` all exit 0.
+41. `grep -nE '^\[build-system\]' pyproject.toml` exits 1 (no `[build-system]` block remains; uv runs in application mode per `[tool.uv] package = false`).
+42. `grep -nE '^package = false' pyproject.toml` exits 0 (the `[tool.uv] package = false` declaration is present).
 43. `grep -F "## Phase 29 — Migrate Python Packaging from PDM to uv ✅" specs/roadmap.md` exits 0 (phase-completion lifecycle marker present, single space before ✅).

--- a/specs/2026-05-20-migrate-pdm-to-uv/requirements.md
+++ b/specs/2026-05-20-migrate-pdm-to-uv/requirements.md
@@ -1,0 +1,71 @@
+# Phase 29 Requirements — Migrate Python Packaging from PDM to uv
+
+## Scope
+
+Replace PDM with [astral-sh/uv](https://docs.astral.sh/uv/) as the project's Python package manager and replace `[tool.pdm.scripts]` with `[tool.poe.tasks]` (run via `poethepoet`) so task invocation becomes `uv run poe <task>`. Flip `[build-system]` from `pdm-backend` to `uv_build`, with a `[tool.uv.build-backend]` override that accommodates the project's `src/`-rooted import layout. Replace `pdm.lock` with `uv.lock` and rewrite every consumer of PDM commands across the repo: `Dockerfile`, CI workflows, `.github/dependabot.yml`, `DEVELOPMENT.md`, the `.husky/pre-commit` hook, every `.claude/rules/*.md` rule that names PDM, the SDD skill templates that mint future-spec examples, the agent-harness allowlist, and `specs/tech-stack.md`. Mark Phase 29 ✅ in `specs/roadmap.md` on completion.
+
+The migration is a hard cutover — no PDM-also-works fallback, no shim layer. The single behavioural change a user can observe is that `package-ecosystem: uv` in `.github/dependabot.yml` re-enables Dependabot's daily Python bumps, which have been silently inert for ~4 weeks because Dependabot's pip parser short-circuits on `pdm.lock` and the upstream PDM-side fix in dependabot-core ([PR #12435](https://github.com/dependabot/dependabot-core/pull/12435)) was abandoned on 2026-05-19.
+
+## Out of Scope
+
+- Adding new tests, behavioural changes to `src/**` or `ui/**`, or any backend/UI feature work
+- Switching the runtime base image (`python:3.11-slim`), the non-root `jentic` user model, or the multi-stage Dockerfile shape
+- Introducing Pyright / `pdm run typecheck` (Phase 15 territory — Phase 29 only neutralizes Phase 15's stale PDM references, it does not implement type-checking)
+- Adding a workspace layout (`[tool.uv.workspace]`) — `jentic-mini` remains a single-package project
+- PyPI publication wiring — the `[build-system]` block exists for `uv sync` / `uv build` consistency only; the project is Docker-distributed
+- Reintroducing any lock-sync workflow (the previous `dependabot-pdm-lock.yml` was deleted by #417 and must stay deleted; uv updates `uv.lock` atomically inside the same Dependabot PR)
+- Retroactive edits to `specs/2026-05-07-…`, `specs/2026-05-08-…`, `specs/2026-05-12-…` — completed-spec history is read-only
+- Updating `docs/decisions.md` — there is no PDM ADR there; only an unrelated `auth_type` entry
+
+## Decisions
+
+### Build-backend choice and `src/`-layout override
+
+Adopt `uv_build` as the PEP 517 backend, mirroring the convention in [jentic-openapi-tools](https://github.com/jentic/jentic-openapi-tools/blob/main/pyproject.toml). The project's modules import as `from src.foo import bar` even though the project name is `jentic-mini`, so default uv_build discovery (`src/jentic_mini/`) does not match — add `[tool.uv.build-backend]` with `module-name = "src"` and `module-root = ""` to vendor the `src/` directory unchanged into the wheel. If `uv build --wheel` does not produce a wheel containing `src/*.py` after this override, the migration stops and switches the backend to `hatchling` with `[tool.hatch.build.targets.wheel] packages = ["src"]` rather than renaming `src/` (which would touch every import in the codebase and is far outside this phase). This is verified in Group 1 of `plan.md` so the load-bearing risk is settled before any other migration step.
+
+### Maximalist sweep over the roadmap-body's bullet list
+
+The phase body in `specs/roadmap.md` enumerates the obvious targets but omits PDM consumers that would silently break post-migration: `.husky/pre-commit:1` invokes `pdm run lint` on every commit; `.claude/rules/python-code-style.md` and `.claude/rules/update-tech-stack-on-deps.md` reference PDM; `.claude/skills/sdd-implement-spec/SKILL.md`, `.claude/skills/sdd-new-spec/SKILL.md`, and `.claude/templates/sdd/feature-spec/plan.example.md` mint stale `pdm run …` examples into every future spec; `.claude/settings.local.json` allowlists `Bash(pdm run *)`; `.pdm-python` lives at the repo root and `.gitignore` carries a stale `.pdm-python` entry. All in-scope. The validation Verify group greps the tracked tree to confirm none survive.
+
+### Phase 15's roadmap entry must be neutralized
+
+`specs/roadmap.md` Phase 15 (Pyright) currently instructs the future implementer to add pyright to `[tool.pdm.dev-dependencies]` and create a `pdm run typecheck` script. Leaving these references stale would ship contradictory instructions in the same `roadmap.md` that this PR rewrites elsewhere. Phase 15's body is rewritten in-place here — only the bullets that name PDM mechanics (`[tool.pdm.dev-dependencies]` → `[dependency-groups] dev`; `[tool.pdm.scripts]` → `[tool.poe.tasks]`; `pdm run typecheck` → `uv run poe typecheck`). Phase 15's goal, priority, and substantive content stay identical; this is a mechanical translation, not a re-scoping.
+
+### `.python-version` is not added in this phase
+
+uv resolves the interpreter floor from `[project] requires-python = ">=3.11"`; `astral-sh/setup-uv` accepts an explicit `python-version` input and the Dockerfile's `python:3.11-slim` base image pins 3.11 directly. Adding a `.python-version` file would be optional symmetry with the sister-repo and is reserved for a follow-up if uv-managed Python provisioning becomes useful.
+
+### Karpathy "no shims" applies to docs
+
+`DEVELOPMENT.md`, `.claude/rules/worktrees.md`, `.claude/rules/testing.md`, and the other doc edits rewrite cleanly — no "previously PDM, now uv" footnotes. Git history is the searchability backstop. This matches the team's `karpathy-guidelines.md` rule "no backwards-compatibility hacks".
+
+## Constraints
+
+Load-bearing invariants from `specs/mission.md` and `specs/tech-stack.md` that this phase must preserve.
+
+- **Python 3.11+ floor** (`specs/tech-stack.md:18,32`; `pyproject.toml requires-python = ">=3.11"`) — the new `astral-sh/setup-uv` step and Dockerfile must keep targeting 3.11. uv must not silently bump the interpreter.
+- **Container is the deployment shape** (`specs/tech-stack.md:20,38`; `specs/mission.md` Current State) — the Dockerfile's three-stage layout (UI build → py-deps → runtime) and runtime user (`jentic`) must survive intact; uv replaces PDM **inside** the existing stage, not by collapsing stages.
+- **Multi-arch publish (`amd64`, `arm64`)** (`specs/tech-stack.md:99`) — uv's official static binaries cover both arches, but the Dockerfile change must be exercised on `linux/arm64` (recent commit `567e28c` shows arm64 is historically fragile to packaging-tool changes).
+- **`semantic-release` mutates `[project] version`** (`.releaserc.json` `prepareCmd`) — the regex `s/^version = .*/version = "${nextRelease.version}"/` must still match; uv_build does not change the `version =` line shape, but the migration must not move it into a `[tool.uv]` block or similar.
+- **Ruff config and `tests/conftest.py` per-file-ignores** (`pyproject.toml:41-58`) — the lint/test invocations under poe must produce identical ruff behaviour and preserve `[tool.ruff.lint.per-file-ignores]` verbatim.
+- **`[tool.poe.tasks].test` env must set `PYTHONPATH = "."`** — preserves the `from src.foo import bar` test-import contract that `tests/conftest.py` relies on (carries over from PDM's `test.env = { PYTHONPATH = "." }`).
+- **No reintroduction of a lock-sync workflow** — `.github/workflows/dependabot-pdm-lock.yml` was deleted by #417; uv updates `uv.lock` inside the same Dependabot PR, so the migration must not add a new sync workflow.
+- **Trivy/CodeQL security scans must stay green** (`.github/workflows/docker-security.yml`, `codeql.yml`) — the Dockerfile rewrite drops the PDM-stage `ensurepip + pip/setuptools/wheel --upgrade` block (which existed to clear CVE noise inside the PDM-managed venv). Trivy must show no regression on the new image; the runtime-stage `pip install --upgrade pip setuptools wheel` (system pip, unrelated to PDM, comment block at `Dockerfile:35-39`) survives.
+- **`tests/conftest.py` must set `DB_PATH` before any `src.*` import** (`specs/tech-stack.md:83`) — unaffected by this phase but listed to confirm we're not touching test bootstrap.
+- **Roadmap lifecycle: completed phases retain their block, append ` ✅` (single space + U+2705)** (`specs/roadmap.md:35-40`) — the leading space is load-bearing because the Verify grep is `grep -F "## Phase 29 — Migrate Python Packaging from PDM to uv ✅"`; `Title✅` (no space) silently fails.
+
+## Context
+
+Phase 29 exists because Dependabot has been silently un-bumping every Python dependency for ~4 weeks. Dependabot's pip parser sees `pdm.lock` alongside PEP 621 fields and short-circuits — no PRs are opened. The two Python CVE bumps in the silent window (`fix(deps): bump idna from 3.13 to 3.15` (#415, May 20) and `chore(deps): bump urllib3 from 2.6.3 to 2.7.0` (#387, May 12)) were both human-authored, and the upstream PDM-ecosystem fix in `dependabot/dependabot-core#12435` was abandoned by its author on 2026-05-19. uv has a first-class Dependabot ecosystem that reads `[project.dependencies]` and `[dependency-groups]`, updates `uv.lock` atomically in the same PR, and does not require a custom lock-sync workflow.
+
+The migration was preceded by #417 (`ci(dependabot): align auto-merge with app token and drop dead lock-sync`), which deleted the never-triggered `dependabot-pdm-lock.yml`, and #418 (`docs(roadmap): add phase 29 — migrate from pdm to uv`), which froze the scope. After Phase 29 lands, Dependabot's daily 23:00 UTC schedule resumes opening Python PRs against `pyproject.toml`, and they auto-merge through the existing ecosystem-agnostic `dependabot-merge.yml` (which uses `dependabot/fetch-metadata@v3` and works the same for `package-ecosystem: uv`).
+
+The phase touches no documentation outside the developer-and-agent-facing surfaces it explicitly names. `docs/architecture.md`, `docs/auth.md`, `docs/oauth-broker.md`, `docs/decisions.md`, `docs/versioning.md`, `AGENTS.md`, and `README.md` have zero PDM mentions and are not edited.
+
+## Stakeholder Notes
+
+- **Dependabot** — the migration's positive stakeholder. After merge, the next daily cycle should open the first Python bump PR; absence of one within ~24h of merge is a regression to investigate. Not a merge gate (Dependabot only fires after the config lands on `main`).
+- **Self-hosters pulling `jentic/jentic-mini:latest` / `ghcr.io/jentic/jentic-mini:latest`** — change is opaque: same port, env-vars, volumes, entrypoint. Image is smaller (no pipx + pdm bootstrap layer).
+- **Contributors with PDM-managed `.venv`** — `uv sync` reuses `.venv/` cleanly; `DEVELOPMENT.md` rewrite is the canonical signal. Worktree contributors lose the `PDM_IGNORE_ACTIVE_VENV=1` invariant entirely (uv does not inherit `VIRTUAL_ENV` the same way).
+- **Agents running `pdm run …` inline** — the `.claude/settings.local.json` allowlist is updated in-scope; agents will not hit permission prompts post-merge.
+- **CI maintainers** — `setup-pdm`'s GHA cache key changes to `setup-uv`'s; one-time cache miss; subsequent runs benefit from uv's per-module wheel cache.

--- a/specs/2026-05-20-migrate-pdm-to-uv/requirements.md
+++ b/specs/2026-05-20-migrate-pdm-to-uv/requirements.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Replace PDM with [astral-sh/uv](https://docs.astral.sh/uv/) as the project's Python package manager and replace `[tool.pdm.scripts]` with `[tool.poe.tasks]` (run via `poethepoet`) so task invocation becomes `uv run poe <task>`. Flip `[build-system]` from `pdm-backend` to `uv_build`, with a `[tool.uv.build-backend]` override that accommodates the project's `src/`-rooted import layout. Replace `pdm.lock` with `uv.lock` and rewrite every consumer of PDM commands across the repo: `Dockerfile`, CI workflows, `.github/dependabot.yml`, `DEVELOPMENT.md`, the `.husky/pre-commit` hook, every `.claude/rules/*.md` rule that names PDM, the SDD skill templates that mint future-spec examples, the agent-harness allowlist, and `specs/tech-stack.md`. Mark Phase 29 ✅ in `specs/roadmap.md` on completion.
+Replace PDM with [astral-sh/uv](https://docs.astral.sh/uv/) as the project's Python package manager and replace `[tool.pdm.scripts]` with `[tool.poe.tasks]` (run via `poethepoet`) so task invocation becomes `uv run poe <task>`. jentic-mini is Docker-distributed and never wheelable, so delete the `[build-system]` block entirely and add `[tool.uv] package = false` to declare the project an application — uv resolves and installs dependencies into `.venv` without invoking any PEP 517 backend. Replace `pdm.lock` with `uv.lock` and rewrite every consumer of PDM commands across the repo: `Dockerfile`, CI workflows, `.github/dependabot.yml`, `DEVELOPMENT.md`, the `.husky/pre-commit` hook, every `.claude/rules/*.md` rule that names PDM, the SDD skill templates that mint future-spec examples, the agent-harness allowlist, and `specs/tech-stack.md`. Mark Phase 29 ✅ in `specs/roadmap.md` on completion.
 
 The migration is a hard cutover — no PDM-also-works fallback, no shim layer. The single behavioural change a user can observe is that `package-ecosystem: uv` in `.github/dependabot.yml` re-enables Dependabot's daily Python bumps, which have been silently inert for ~4 weeks because Dependabot's pip parser short-circuits on `pdm.lock` and the upstream PDM-side fix in dependabot-core ([PR #12435](https://github.com/dependabot/dependabot-core/pull/12435)) was abandoned on 2026-05-19.
 
@@ -12,16 +12,16 @@ The migration is a hard cutover — no PDM-also-works fallback, no shim layer. T
 - Switching the runtime base image (`python:3.11-slim`), the non-root `jentic` user model, or the multi-stage Dockerfile shape
 - Introducing Pyright / `pdm run typecheck` (Phase 15 territory — Phase 29 only neutralizes Phase 15's stale PDM references, it does not implement type-checking)
 - Adding a workspace layout (`[tool.uv.workspace]`) — `jentic-mini` remains a single-package project
-- PyPI publication wiring — the `[build-system]` block exists for `uv sync` / `uv build` consistency only; the project is Docker-distributed
+- PyPI publication wiring — the project is Docker-distributed; application mode (`[tool.uv] package = false`) means no wheel is ever built. Future PyPI publishing would re-introduce a `[build-system]` block, but that is not in scope here.
 - Reintroducing any lock-sync workflow (the previous `dependabot-pdm-lock.yml` was deleted by #417 and must stay deleted; uv updates `uv.lock` atomically inside the same Dependabot PR)
 - Retroactive edits to `specs/2026-05-07-…`, `specs/2026-05-08-…`, `specs/2026-05-12-…` — completed-spec history is read-only
 - Updating `docs/decisions.md` — there is no PDM ADR there; only an unrelated `auth_type` entry
 
 ## Decisions
 
-### Build-backend choice and `src/`-layout override
+### Application mode, no PEP 517 backend
 
-Adopt `uv_build` as the PEP 517 backend, mirroring the convention in [jentic-openapi-tools](https://github.com/jentic/jentic-openapi-tools/blob/main/pyproject.toml). The project's modules import as `from src.foo import bar` even though the project name is `jentic-mini`, so default uv_build discovery (`src/jentic_mini/`) does not match — add `[tool.uv.build-backend]` with `module-name = "src"` and `module-root = ""` to vendor the `src/` directory unchanged into the wheel. If `uv build --wheel` does not produce a wheel containing `src/*.py` after this override, the migration stops and switches the backend to `hatchling` with `[tool.hatch.build.targets.wheel] packages = ["src"]` rather than renaming `src/` (which would touch every import in the codebase and is far outside this phase). This is verified in Group 1 of `plan.md` so the load-bearing risk is settled before any other migration step.
+jentic-mini is Docker-distributed and never wheelable — no PyPI publish, no sdist, no consumer of `uv build` exists today. The Dockerfile already runs `uv sync --frozen --no-install-project --no-dev` (Group 5), which installs `[project.dependencies]` + `[dependency-groups] dev` without invoking any PEP 517 backend. Adopt `[tool.uv] package = false` to declare jentic-mini an application and delete the entire `[build-system]` block; uv treats the project as application-only and never asks a backend for help. This sidesteps the `src/`-layout / project-name mismatch entirely (default `uv_build` discovery looks for `src/jentic_mini/` based on the project name, which does not exist; modules actually import as `from src.foo import bar`). The simpler shape removes a load-bearing risk from the migration: no wheel ever has to be built or proven, no `[tool.uv.build-backend]` override is needed, no hatchling fallback is needed. If a future phase adds PyPI publishing, flip `package = false` back and choose a backend at that time — that's a one-line change.
 
 ### Maximalist sweep over the roadmap-body's bullet list
 
@@ -35,7 +35,15 @@ The phase body in `specs/roadmap.md` enumerates the obvious targets but omits PD
 
 uv resolves the interpreter floor from `[project] requires-python = ">=3.11"`; `astral-sh/setup-uv` accepts an explicit `python-version` input and the Dockerfile's `python:3.11-slim` base image pins 3.11 directly. Adding a `.python-version` file would be optional symmetry with the sister-repo and is reserved for a follow-up if uv-managed Python provisioning becomes useful.
 
-### Karpathy "no shims" applies to docs
+### Recommended uv installation method per context
+
+uv ships in three forms; this phase picks one per context to match where the install actually runs:
+
+- **Developer machines (`DEVELOPMENT.md` Prerequisites)** — the official standalone installer, `curl -LsSf https://astral.sh/uv/install.sh | sh` (Linux/macOS) or `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"` (Windows). Recommended by Astral as the default path; no Python prerequisite, no `pipx`/`pip` bootstrap, self-updates via `uv self update`. Plan task 19 wires this into `DEVELOPMENT.md`.
+- **Docker `py-deps` stage** — `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/`. Pulls the static binary out of the official OCI image — no curl, no shell installer, no extra layer for `pipx`. This is the pattern Astral documents for Dockerfiles and matches what jentic-openapi-tools uses. Plan task 11 wires this in.
+- **GitHub Actions** — `astral-sh/setup-uv@v8` with `enable-cache: true`. The official Action handles tool-cache placement and lets uv reuse the GHA cache across runs. Plan tasks 16–17 wire this in.
+
+Homebrew (`brew install uv`) and `pipx install uv` are valid alternatives for developer machines but are not recommended here — the standalone installer is the documented default and is what the rest of the migration assumes.
 
 `DEVELOPMENT.md`, `.claude/rules/worktrees.md`, `.claude/rules/testing.md`, and the other doc edits rewrite cleanly — no "previously PDM, now uv" footnotes. Git history is the searchability backstop. This matches the team's `karpathy-guidelines.md` rule "no backwards-compatibility hacks".
 
@@ -46,7 +54,7 @@ Load-bearing invariants from `specs/mission.md` and `specs/tech-stack.md` that t
 - **Python 3.11+ floor** (`specs/tech-stack.md:18,32`; `pyproject.toml requires-python = ">=3.11"`) — the new `astral-sh/setup-uv` step and Dockerfile must keep targeting 3.11. uv must not silently bump the interpreter.
 - **Container is the deployment shape** (`specs/tech-stack.md:20,38`; `specs/mission.md` Current State) — the Dockerfile's three-stage layout (UI build → py-deps → runtime) and runtime user (`jentic`) must survive intact; uv replaces PDM **inside** the existing stage, not by collapsing stages.
 - **Multi-arch publish (`amd64`, `arm64`)** (`specs/tech-stack.md:99`) — uv's official static binaries cover both arches, but the Dockerfile change must be exercised on `linux/arm64` (recent commit `567e28c` shows arm64 is historically fragile to packaging-tool changes).
-- **`semantic-release` mutates `[project] version`** (`.releaserc.json` `prepareCmd`) — the regex `s/^version = .*/version = "${nextRelease.version}"/` must still match; uv_build does not change the `version =` line shape, but the migration must not move it into a `[tool.uv]` block or similar.
+- **`semantic-release` mutates `[project] version`** (`.releaserc.json` `prepareCmd`) — the regex `s/^version = .*/version = "${nextRelease.version}"/` must still match. Application mode (`[tool.uv] package = false`) leaves `[project] version` untouched, but the migration must not move it into a `[tool.uv]` block or similar.
 - **Ruff config and `tests/conftest.py` per-file-ignores** (`pyproject.toml:41-58`) — the lint/test invocations under poe must produce identical ruff behaviour and preserve `[tool.ruff.lint.per-file-ignores]` verbatim.
 - **`[tool.poe.tasks].test` env must set `PYTHONPATH = "."`** — preserves the `from src.foo import bar` test-import contract that `tests/conftest.py` relies on (carries over from PDM's `test.env = { PYTHONPATH = "." }`).
 - **No reintroduction of a lock-sync workflow** — `.github/workflows/dependabot-pdm-lock.yml` was deleted by #417; uv updates `uv.lock` inside the same Dependabot PR, so the migration must not add a new sync workflow.

--- a/specs/2026-05-20-migrate-pdm-to-uv/validation.md
+++ b/specs/2026-05-20-migrate-pdm-to-uv/validation.md
@@ -1,0 +1,153 @@
+# Phase 29 Validation — Migrate Python Packaging from PDM to uv
+
+## Definition of Done
+
+All of the following must be true before this branch is merged.
+
+### 1. `uv.lock` is consistent with `pyproject.toml`
+
+```
+uv lock --check
+```
+
+Exits 0. Confirms no stale lock was committed (`--check` is the alias for `--locked`; non-zero exit indicates `uv.lock` would change if regenerated).
+
+### 2. Frozen sync installs cleanly
+
+```
+uv sync --frozen
+```
+
+Exits 0. The `--frozen` flag refuses to update `uv.lock`, so this doubles as a strict-reproducibility gate equivalent to PDM's `--frozen-lockfile`.
+
+### 3. uv_build override produces a wheel that contains `src/`
+
+```
+uv build --wheel && unzip -l dist/jentic_mini-*.whl | grep -E 'src/(auth|db|main)\.py'
+```
+
+`uv build --wheel` exits 0; the `grep` returns ≥3 lines listing `src/auth.py`, `src/db.py`, `src/main.py` inside the wheel. Proves `[tool.uv.build-backend] module-name = "src", module-root = ""` actually vendored the existing `src/` directory; if this fails, the migration is on the hatchling fallback path per `requirements.md` Decisions and the assertion text changes accordingly.
+
+### 4. Lint passes under poe
+
+```
+uv run poe lint
+```
+
+Exits 0. Runs `ruff check` then `ruff format --check --diff` in sequence (matches the previous `pdm run lint` composite).
+
+### 5. Backend test suite passes under poe
+
+```
+uv run poe test
+```
+
+Exits 0. Runs `pytest -v tests --tb=short` with `PYTHONPATH=.` (matches the previous `pdm run test`). Full suite, no marker filter, no exclude.
+
+### 6. Dockerfile builds clean
+
+```
+docker build -t jentic-mini:phase29 .
+```
+
+Exits 0 on the host architecture. The build must complete without the previous `pipx install pdm` or `ensurepip --upgrade` layers.
+
+### 7. `ci-backend.yml` workflow green on the PR
+
+The GitHub Actions check `Backend / lint` and `Backend / backend-tests` must report success on the PR's head commit. Both jobs use `astral-sh/setup-uv@vN`, `uv sync --frozen`, and the new `uv run poe lint` / `uv run poe test` invocations; the `paths:` filter must trigger on the changed `pyproject.toml`/`uv.lock`/`Dockerfile`/`src/` paths.
+
+### 8. `ci-docker.yml` workflow green on the PR
+
+The GitHub Actions check `Docker Build & E2E` must report success. This builds the rewritten Dockerfile, runs `docker run -d -p 8900:8900 -v jentic-ci-data:/app/data -e JENTIC_TELEMETRY=off jentic-mini:latest`, polls `curl -sf http://localhost:8900/health` until ready, asserts `/health` returns one of `ok|setup_required|account_required`, asserts `/docs` contains `swagger-ui`, then runs `cd ui && npm run test:e2e:docker` (Playwright real-server suite).
+
+### 9. `docker-security.yml` (Trivy) green on the PR
+
+The GitHub Actions check for the Trivy scan must report success. The new image (no PDM-stage `ensurepip + pip/setuptools/wheel --upgrade`) must show no new HIGH/CRITICAL findings vs. `main`.
+
+### 10. `codeql.yml` green on the PR
+
+The GitHub Actions check for CodeQL (Python + JS/TS matrix) must report success. No new findings from the packaging swap.
+
+### 11. No `pdm` or `PDM_IGNORE_ACTIVE_VENV` references survive in tracked code
+
+```
+git grep -nE "(pdm-project/setup-pdm|pdm install|pdm run|tool\.pdm)" -- ':!specs/2026-05-07-*' ':!specs/2026-05-08-*' ':!specs/2026-05-12-*'
+```
+
+Exits 1 (no matches). The exclude paths cover frozen completed-spec directories which are read-only history.
+
+```
+git grep -nE "PDM_IGNORE_ACTIVE_VENV" -- ':!specs/2026-05-07-*' ':!specs/2026-05-08-*' ':!specs/2026-05-12-*'
+```
+
+Exits 1 (no matches outside historical specs).
+
+### 12. `pdm.lock` and `.pdm-python` are gone; `uv.lock` is present
+
+```
+test ! -f pdm.lock && test -f uv.lock && test ! -f .pdm-python
+```
+
+Exits 0.
+
+### 13. `[build-system]` is the uv-flavoured one
+
+```
+grep -F 'requires = ["uv_build' pyproject.toml && grep -F 'build-backend = "uv_build"' pyproject.toml
+```
+
+Both greps exit 0. `grep -nE 'pdm-backend|pdm\.backend' pyproject.toml` exits 1 (no leftover PDM backend reference).
+
+### 14. `.github/dependabot.yml` Python entry uses uv
+
+```
+grep -nF 'package-ecosystem: "uv"' .github/dependabot.yml || grep -nF 'package-ecosystem: uv' .github/dependabot.yml
+```
+
+Exits 0 (matches either YAML quoting style). `grep -nF 'package-ecosystem: "pip"' .github/dependabot.yml` and `grep -nF 'package-ecosystem: pip' .github/dependabot.yml` both exit 1 (no `pip` ecosystem entry remains).
+
+### 15. `specs/tech-stack.md` Core Stack reflects the swap
+
+```
+grep -nE '^\| Python packaging \| uv \|' specs/tech-stack.md
+```
+
+Exits 0. `grep -in pdm specs/tech-stack.md` exits 1.
+
+### 16. Phase 29 lifecycle marker present
+
+```
+grep -F "## Phase 29 — Migrate Python Packaging from PDM to uv ✅" specs/roadmap.md
+```
+
+Exits 0. The single space before U+2705 is load-bearing per the lifecycle rule (`specs/roadmap.md:35-40`); a heading rendered as `Title✅` (no space) silently fails this assertion.
+
+### 17. Phase 15's body no longer mints PDM commands into a future spec
+
+```
+sed -n '/^## Phase 15 /,/^## Phase 16 /p' specs/roadmap.md | grep -inE "tool\.pdm|pdm run"
+```
+
+Exits 1 (no matches inside the Phase 15 block). Phase 15's goal, depends-on, priority, and substantive content are otherwise unchanged — verified by reviewer inspection of the diff.
+
+### 18. Husky hook runs lint via uv
+
+```
+grep -nF 'uv run poe lint' .husky/pre-commit
+```
+
+Exits 0 on line 1. `grep -nF 'pdm run' .husky/pre-commit` exits 1.
+
+## Not Required
+
+- **Adding new tests.** This phase is a tooling swap; the existing pytest suite re-run under `uv run poe test` is the equivalence proof.
+- **Schemathesis CLI gate.** Schemathesis remains in dev-deps but is not wired into CI today (per Phase 24 / Phase 25 validation precedent — known FastAPI-TestClient incompatibility in `tests/test_openapi_contract.py`); not a Phase 29 concern.
+- **Vitest / mocked Playwright runs.** Phase 29 doesn't touch `ui/src/**`; `ci-ui.yml`'s path filter naturally skips on this PR. The Docker E2E (`ci-docker.yml`'s `npm run test:e2e:docker`) is the only browser-driven gate that's load-bearing.
+- **Manual security review.** Trivy and CodeQL CI gates cover the security surface.
+- **`docs/`, `AGENTS.md`, `README.md`, `CLAUDE.md` edits.** These files have zero PDM mentions today; nothing to rewrite.
+- **`docs/decisions.md` ADR.** No PDM ADR exists; only an unrelated `auth_type` entry.
+- **Backwards-compat "PDM also works" mode.** Hard cutover per `karpathy-guidelines.md`.
+- **Adding `.python-version`.** Optional symmetry with the sister-repo; deferred unless uv-managed Python provisioning becomes useful.
+- **Verifying the first Dependabot Python PR pre-merge.** Dependabot only opens PRs after the new config lands on `main` (daily 23:00 UTC schedule), so this cannot be a merge gate. Recorded as a post-merge confirmation in the PR body: within ~24h of merge, a `chore(deps): bump …` PR should open and flow through `dependabot-merge.yml` cleanly. Absence is a regression to investigate, not a reason to revert.
+- **Rebuilding worktrees in CI.** The `.claude/rules/worktrees.md` rewrite is verified by reading the file post-edit.
+- **Reintroducing a lock-sync workflow.** `dependabot-pdm-lock.yml` was deleted in #417 and must stay deleted; uv updates `uv.lock` atomically inside the same Dependabot PR.

--- a/specs/2026-05-20-migrate-pdm-to-uv/validation.md
+++ b/specs/2026-05-20-migrate-pdm-to-uv/validation.md
@@ -20,13 +20,19 @@ uv sync --frozen
 
 Exits 0. The `--frozen` flag refuses to update `uv.lock`, so this doubles as a strict-reproducibility gate equivalent to PDM's `--frozen-lockfile`.
 
-### 3. uv_build override produces a wheel that contains `src/`
+### 3. uv runs in application mode (no build backend)
 
 ```
-uv build --wheel && unzip -l dist/jentic_mini-*.whl | grep -E 'src/(auth|db|main)\.py'
+grep -nE '^\[build-system\]' pyproject.toml
 ```
 
-`uv build --wheel` exits 0; the `grep` returns ≥3 lines listing `src/auth.py`, `src/db.py`, `src/main.py` inside the wheel. Proves `[tool.uv.build-backend] module-name = "src", module-root = ""` actually vendored the existing `src/` directory; if this fails, the migration is on the hatchling fallback path per `requirements.md` Decisions and the assertion text changes accordingly.
+Exits 1 (no `[build-system]` block remains). jentic-mini is Docker-distributed and never wheelable, so no PEP 517 backend is needed.
+
+```
+grep -nE '^package = false' pyproject.toml
+```
+
+Exits 0. The `[tool.uv] package = false` declaration is present, telling uv this is an application — `uv sync` resolves and installs `[project.dependencies]` + `[dependency-groups] dev` into `.venv` without invoking any backend. This sidesteps the `src/`-layout / project-name mismatch entirely (uv would otherwise look for `src/jentic_mini/` based on the project name).
 
 ### 4. Lint passes under poe
 
@@ -54,7 +60,7 @@ Exits 0 on the host architecture. The build must complete without the previous `
 
 ### 7. `ci-backend.yml` workflow green on the PR
 
-The GitHub Actions check `Backend / lint` and `Backend / backend-tests` must report success on the PR's head commit. Both jobs use `astral-sh/setup-uv@vN`, `uv sync --frozen`, and the new `uv run poe lint` / `uv run poe test` invocations; the `paths:` filter must trigger on the changed `pyproject.toml`/`uv.lock`/`Dockerfile`/`src/` paths.
+The GitHub Actions check `Backend / lint` and `Backend / backend-tests` must report success on the PR's head commit. Both jobs use `astral-sh/setup-uv@v8`, `uv sync --frozen`, and the new `uv run poe lint` / `uv run poe test` invocations; the `paths:` filter must trigger on the changed `pyproject.toml`/`uv.lock`/`Dockerfile`/`src/` paths.
 
 ### 8. `ci-docker.yml` workflow green on the PR
 
@@ -90,21 +96,21 @@ test ! -f pdm.lock && test -f uv.lock && test ! -f .pdm-python
 
 Exits 0.
 
-### 13. `[build-system]` is the uv-flavoured one
+### 13. No PDM backend reference remains
 
 ```
-grep -F 'requires = ["uv_build' pyproject.toml && grep -F 'build-backend = "uv_build"' pyproject.toml
+grep -nE 'pdm-backend|pdm\.backend' pyproject.toml
 ```
 
-Both greps exit 0. `grep -nE 'pdm-backend|pdm\.backend' pyproject.toml` exits 1 (no leftover PDM backend reference).
+Exits 1. The full `[build-system]` block (which previously named `pdm-backend`) is gone — see #3.
 
 ### 14. `.github/dependabot.yml` Python entry uses uv
 
 ```
-grep -nF 'package-ecosystem: "uv"' .github/dependabot.yml || grep -nF 'package-ecosystem: uv' .github/dependabot.yml
+grep -nE 'package-ecosystem:\s*"?uv"?' .github/dependabot.yml
 ```
 
-Exits 0 (matches either YAML quoting style). `grep -nF 'package-ecosystem: "pip"' .github/dependabot.yml` and `grep -nF 'package-ecosystem: pip' .github/dependabot.yml` both exit 1 (no `pip` ecosystem entry remains).
+Exits 0 (matches either YAML quoting style in a single regex). `grep -nE 'package-ecosystem:\s*"?pip"?' .github/dependabot.yml` exits 1 (no `pip` ecosystem entry remains).
 
 ### 15. `specs/tech-stack.md` Core Stack reflects the swap
 


### PR DESCRIPTION
## Summary

Spec scaffold for **Phase 29: Migrate Python Packaging from PDM to uv** from `specs/roadmap.md`.

This PR adds **spec files only** — no code changes. Implementation follows in a separate PR once this spec is approved.

### Scope

Replace PDM with [astral-sh/uv](https://docs.astral.sh/uv/) and replace `[tool.pdm.scripts]` with `[tool.poe.tasks]` (run via `poethepoet`) so task invocation becomes `uv run poe <task>`. Flip `[build-system]` from `pdm-backend` to `uv_build` with a `[tool.uv.build-backend]` override that vendors the existing `src/` directory unchanged. Replace `pdm.lock` with `uv.lock`. Rewrite every PDM consumer across the repo: `Dockerfile`, `ci-backend.yml`, `.github/dependabot.yml` (Python ecosystem flips from `pip` to `uv`), `DEVELOPMENT.md`, `.husky/pre-commit`, every `.claude/rules/*.md` rule that names PDM, the SDD skill templates that mint future-spec examples, the agent-harness allowlist, and `specs/tech-stack.md`. Mark Phase 29 ✅ on completion. The migration unblocks Dependabot's daily Python bumps, which have been silently inert for ~4 weeks since the upstream PDM-side fix in dependabot-core (PR #12435) was abandoned on 2026-05-19.

### Out of Scope

- New tests or behavioural changes to `src/**` / `ui/**`
- Switching the runtime base image (`python:3.11-slim`), the non-root `jentic` user, or the multi-stage Dockerfile shape
- Pyright / `pdm run typecheck` (Phase 15 — Phase 29 only neutralizes Phase 15's stale PDM references)
- Adding a `[tool.uv.workspace]` workspace layout — `jentic-mini` remains single-package
- PyPI publication wiring — `[build-system]` is for `uv sync` / `uv build` consistency only
- Reintroducing any lock-sync workflow — uv updates `uv.lock` atomically inside the same Dependabot PR
- Retroactive edits to `specs/2026-05-07-…` / `specs/2026-05-08-…` / `specs/2026-05-12-…` (frozen historical specs)
- `docs/decisions.md` — there is no PDM ADR there

### Key decisions

- **Build-backend choice and `src/`-layout override** — adopt `uv_build` with `[tool.uv.build-backend] module-name = "src", module-root = ""` so the wheel vendors the existing `src/` directory without renaming imports; Group 1 of `plan.md` runs `uv build --wheel` first to settle this risk before any other migration step. Documented `hatchling` fallback if uv_build can't accommodate the layout.
- **Maximalist sweep over the roadmap-body's bullet list** — phase body misses `.husky/pre-commit`, `.claude/rules/python-code-style.md`, `.claude/rules/update-tech-stack-on-deps.md`, SDD skill/template files that mint future-spec examples, `.claude/settings.local.json` allowlist, `.pdm-python` file, `.gitignore` entry. All in-scope; Verify greps the tracked tree to confirm none survive.
- **Phase 15's roadmap entry is neutralized in-place** — Phase 15 (Pyright) currently instructs the future implementer to use `[tool.pdm.dev-dependencies]` and `pdm run typecheck`. Mechanically translated to `[dependency-groups] dev` and `uv run poe typecheck`; goal/priority/depends-on/substantive content unchanged.
- **`.python-version` is not added in this phase** — uv resolves the floor from `requires-python = ">=3.11"`; deferred unless uv-managed Python provisioning becomes useful.
- **Karpathy "no shims" applies to docs** — clean rewrite, no "previously PDM, now uv" footnotes; git history is the searchability backstop.

## Files

- `specs/2026-05-20-migrate-pdm-to-uv/requirements.md`
- `specs/2026-05-20-migrate-pdm-to-uv/plan.md`
- `specs/2026-05-20-migrate-pdm-to-uv/validation.md`

## Review guidance

Reviewers should verify:

- The phase goal is captured faithfully (see `specs/roadmap.md` Phase 29).
- Scope, constraints, and decisions match intent — particularly the **maximalist sweep** decision (PDM consumers the phase body didn't list, e.g. `.husky/pre-commit`, SDD templates, `.claude/settings.local.json`) and the **Phase 15 in-place rewrite** (mechanical translation of PDM mechanics, no scope change).
- `plan.md`'s Group 1 (`uv_build` wheel smoke before anything else) is the right de-risk point given the `src/`-layout / `name = "jentic-mini"` mismatch.
- Validation gates are realistic for the phase: `uv lock --check`, `uv sync --frozen`, `uv build --wheel` + wheel-content grep, `uv run poe lint/test`, four CI gates (`ci-backend`, `ci-docker`, `docker-security`, `codeql`), grep assertions for residual `pdm`/`PDM_IGNORE_ACTIVE_VENV`, and the `## Phase 29 — … ✅` lifecycle grep.
- The `Not Required` section explicitly defers the post-merge first-Dependabot-PR check (Dependabot only fires after the new config lands on `main`, so it cannot be a merge gate).

Refs: `specs/roadmap.md` Phase 29.