### PR TITLE
fix(broker): resolve server_variables on non-.local hosts

### DIFF
--- a/alembic/versions/0008_connect_labels_server_variables.py
+++ b/alembic/versions/0008_connect_labels_server_variables.py
@@ -1,0 +1,61 @@
+"""Add server_variables column to oauth_broker_connect_labels.
+
+Multi-tenant public specs (e.g. Jira's https://{your-domain}.atlassian.net)
+carry an OpenAPI server template variable that must be bound to a concrete
+tenant value (e.g. your-domain=acme) to reach the right host. For the
+Pipedream OAuth path the tenant is collected at connect-link time and carried
+through the connect-callback into oauth_broker_connect_labels, so that
+discover_accounts can (a) resolve the real host for the credential route and
+(b) persist server_variables on the resulting pipedream_oauth credential.
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-06-09
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0008"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(table: str, column: str) -> bool:
+    conn = op.get_bind()
+    rows = conn.exec_driver_sql(f"PRAGMA table_info({table})").fetchall()
+    return any(r[1] == column for r in rows)
+
+
+def upgrade() -> None:
+    # JSON-encoded dict of OpenAPI server variables (e.g. {"your-domain": "acme"}).
+    if not _has_column("oauth_broker_connect_labels", "server_variables"):
+        op.execute("ALTER TABLE oauth_broker_connect_labels ADD COLUMN server_variables TEXT")
+
+
+def downgrade() -> None:
+    # SQLite cannot drop a column directly; recreate the table without it.
+    op.execute("PRAGMA foreign_keys = OFF")
+    op.execute("DROP TABLE IF EXISTS oauth_broker_connect_labels_old")
+    op.execute("""
+    CREATE TABLE oauth_broker_connect_labels_old (
+        id               TEXT PRIMARY KEY,
+        broker_id        TEXT NOT NULL REFERENCES oauth_brokers(id) ON DELETE CASCADE,
+        external_user_id TEXT NOT NULL,
+        app_slug         TEXT NOT NULL,
+        label            TEXT NOT NULL,
+        api_id           TEXT,
+        created_at       REAL DEFAULT (unixepoch())
+    )
+    """)
+    op.execute("""
+    INSERT OR IGNORE INTO oauth_broker_connect_labels_old
+        SELECT id, broker_id, external_user_id, app_slug, label, api_id, created_at
+        FROM oauth_broker_connect_labels
+    """)
+    op.execute("DROP TABLE oauth_broker_connect_labels")
+    op.execute("ALTER TABLE oauth_broker_connect_labels_old RENAME TO oauth_broker_connect_labels")
+    op.execute("PRAGMA foreign_keys = ON")

--- a/src/brokers/pipedream.py
+++ b/src/brokers/pipedream.py
@@ -22,6 +22,7 @@ Token cache: Pipedream access tokens expire in ~1 hour. We cache in memory
 from __future__ import annotations
 
 import base64
+import json
 import logging
 import mimetypes
 import time
@@ -485,13 +486,13 @@ class PipedreamOAuthBroker:
             # Multiple pending rows per app_slug are possible (e.g. two Gmail connects).
             # Use a list per slug so each new account consumes one label in order.
             async with db.execute(
-                "SELECT app_slug, label, api_id FROM oauth_broker_connect_labels "
+                "SELECT app_slug, label, api_id, server_variables FROM oauth_broker_connect_labels "
                 "WHERE broker_id=? AND external_user_id=? ORDER BY created_at ASC",
                 (self.broker_id, external_user_id),
             ) as cur:
-                pending: dict[str, list[tuple[str, str | None]]] = {}
+                pending: dict[str, list[tuple[str, str | None, str | None]]] = {}
                 for r in await cur.fetchall():
-                    pending.setdefault(r[0], []).append((r[1], r[2]))
+                    pending.setdefault(r[0], []).append((r[1], r[2], r[3]))
 
             consumed_slugs: set[str] = set()
             seen_account_ids: set[str] = set()
@@ -505,6 +506,7 @@ class PipedreamOAuthBroker:
 
                 # Default label/api_id — overridden below for new accounts with pending labels.
                 label, user_api_id = app_slug, None
+                user_server_variables: str | None = None
                 has_pending_label = False
 
                 # If no pending label, check if we already have a stored api_id for this account
@@ -527,7 +529,7 @@ class PipedreamOAuthBroker:
                 if not user_api_id and account_id not in existing_account_ids:
                     _peek_queue = pending.get(app_slug, [])
                     if _peek_queue:
-                        _peek_label, _peek_api_id = _peek_queue[0]  # peek, don't pop
+                        _peek_label, _peek_api_id, _peek_sv = _peek_queue[0]  # peek, don't pop
                         if _peek_api_id:
                             user_api_id = _peek_api_id
                             log.info(
@@ -535,6 +537,8 @@ class PipedreamOAuthBroker:
                                 user_api_id,
                                 account_id,
                             )
+                        if _peek_sv:
+                            user_server_variables = _peek_sv
 
                 # Use user-specified api_id if provided; otherwise fall back to slug map
                 if user_api_id:
@@ -547,14 +551,28 @@ class PipedreamOAuthBroker:
                     # Resolve the real hostname from the imported spec's base_url.
                     # The credential api_id must be the real HTTP host (e.g. gmail.googleapis.com)
                     # so that the broker's prefix-match lookup works at execution time.
+                    #
+                    # For multi-tenant specs the base_url carries a template variable
+                    # (e.g. Jira's 'https://{your-domain}.atlassian.net'). A bare
+                    # urlparse(...).hostname would yield the literal '{your-domain}.atlassian.net',
+                    # which is not a routable host. If the connect-link supplied
+                    # server_variables (e.g. {"your-domain": "acme"}), substitute them
+                    # first so the route is the concrete tenant host (acme.atlassian.net).
                     try:
-                        async with get_db() as _rdb:
-                            async with _rdb.execute(
-                                "SELECT base_url FROM apis WHERE id=?", (user_api_id,)
-                            ) as _rcur:
-                                _rrow = await _rcur.fetchone()
-                        if _rrow and _rrow[0]:
-                            _real_host = urlparse(_rrow[0]).hostname
+                        _sv_dict: dict[str, str] | None = None
+                        if user_server_variables:
+                            try:
+                                _sv_dict = json.loads(user_server_variables)
+                            except (ValueError, TypeError):
+                                log.warning(
+                                    "Invalid server_variables JSON for '%s': %r",
+                                    user_api_id,
+                                    user_server_variables,
+                                )
+                                _sv_dict = None
+                        _resolved_url = await vault._resolve_server_url(user_api_id, _sv_dict)
+                        if _resolved_url:
+                            _real_host = urlparse(_resolved_url).hostname
                             if _real_host:
                                 hosts = [_real_host]
                                 log.info("Resolved real host for '%s': %s", user_api_id, _real_host)
@@ -597,7 +615,9 @@ class PipedreamOAuthBroker:
                                 app_slug,
                             )
                             continue  # skip this account
-                        label, user_api_id = pending_queue.pop(0)
+                        label, user_api_id, _popped_sv = pending_queue.pop(0)
+                        if _popped_sv:
+                            user_server_variables = _popped_sv
                         has_pending_label = True
                         effective_label = label
                         await db.execute(
@@ -632,12 +652,29 @@ class PipedreamOAuthBroker:
                         # Existing credential: update the encrypted value and sync the label
                         # from oauth_broker_accounts (the authoritative source). Never read
                         # the label from credentials — that creates divergence.
-                        await db.execute(
-                            "UPDATE credentials SET label=?, encrypted_value=?, "
-                            "api_id=?, auth_type='pipedream_oauth', "
-                            "updated_at=unixepoch() WHERE id=?",
-                            (effective_label, enc_account_id, api_host, cred_id),
-                        )
+                        # Persist server_variables (tenant binding for multi-tenant specs)
+                        # so the broker can resolve the concrete host at request time; only
+                        # overwrite when we have a fresh value, never clobber with NULL.
+                        if user_server_variables:
+                            await db.execute(
+                                "UPDATE credentials SET label=?, encrypted_value=?, "
+                                "api_id=?, auth_type='pipedream_oauth', server_variables=?, "
+                                "updated_at=unixepoch() WHERE id=?",
+                                (
+                                    effective_label,
+                                    enc_account_id,
+                                    api_host,
+                                    user_server_variables,
+                                    cred_id,
+                                ),
+                            )
+                        else:
+                            await db.execute(
+                                "UPDATE credentials SET label=?, encrypted_value=?, "
+                                "api_id=?, auth_type='pipedream_oauth', "
+                                "updated_at=unixepoch() WHERE id=?",
+                                (effective_label, enc_account_id, api_host, cred_id),
+                            )
                     else:
                         # New credential: use the effective_label from oauth_broker_accounts.
                         # env_var must be unique per (account_id, api_host) — include
@@ -648,9 +685,16 @@ class PipedreamOAuthBroker:
                         env_var = f"PIPEDREAM_{account_id.upper().replace('-', '_')}_{safe_host}"
                         await db.execute(
                             "INSERT INTO credentials "
-                            "(id, label, env_var, encrypted_value, api_id, auth_type) "
-                            "VALUES (?, ?, ?, ?, ?, 'pipedream_oauth')",
-                            (cred_id, effective_label, env_var, enc_account_id, api_host),
+                            "(id, label, env_var, encrypted_value, api_id, auth_type, server_variables) "
+                            "VALUES (?, ?, ?, ?, ?, 'pipedream_oauth', ?)",
+                            (
+                                cred_id,
+                                effective_label,
+                                env_var,
+                                enc_account_id,
+                                api_host,
+                                user_server_variables,
+                            ),
                         )
 
                     # Upsert credential_routes so the broker can match incoming requests

--- a/src/routers/broker.py
+++ b/src/routers/broker.py
@@ -345,6 +345,60 @@ async def _find_credential_for_host(
     return headers, api_id, first_credential_id, is_ambiguous
 
 
+async def _resolve_routing_host(
+    upstream_host: str, credential_id: str
+) -> tuple[str | None, str | None]:
+    """Resolve the real upstream host from a credential's server_variables.
+
+    The host the caller addressed (upstream_host) can differ from the real
+    upstream in two cases:
+      1. .local self-hosted APIs — upstream_host is a semantic routing key
+         (e.g. 'bedroom.go2rtc.local'), not a real DNS name.
+      2. Multi-tenant public specs whose server URL carries a template var
+         (e.g. Jira's 'https://{your-domain}.atlassian.net'), where the {var}
+         must be substituted from the credential's server_variables to reach
+         the tenant (e.g. acme.atlassian.net).
+
+    Returns (resolved_host, resolved_scheme). Both are None when there is
+    nothing to resolve (no credential, no server_variables, or the resolved
+    host matches upstream_host), so callers keep the original host.
+    """
+    cred = await vault.get_credential(credential_id)
+    if not cred:
+        return None, None
+    server_variables = cred.get("server_variables") or {}
+    if not server_variables:
+        if upstream_host.endswith(".local"):
+            log.warning(
+                "broker: .local route %r — credential %r has no server_variables; "
+                "cannot resolve upstream",
+                upstream_host,
+                credential_id,
+            )
+        return None, None
+
+    resolved = await vault._resolve_server_url(cred.get("api_id"), server_variables)
+    if not resolved:
+        log.warning(
+            "broker: route %r — could not resolve upstream from server_variables %r",
+            upstream_host,
+            server_variables,
+        )
+        return None, None
+
+    parsed = urlparse(resolved)
+    resolved_host = parsed.netloc
+    if not resolved_host or resolved_host == upstream_host:
+        return None, None
+    log.debug(
+        "broker: route %r resolved to upstream %r (scheme=%s) via server_variables",
+        upstream_host,
+        resolved_host,
+        parsed.scheme,
+    )
+    return resolved_host, parsed.scheme or None
+
+
 async def _find_pipedream_credential_for_host(
     host: str,
     path: str,
@@ -919,48 +973,19 @@ async def broker(request: Request, target: str):
 
     # ── Routing host ──────────────────────────────────────────────────────────
     # upstream_host is the host the caller addressed in the broker URL.
-    # For .local self-hosted APIs, the upstream_host is a semantic routing key
-    # (e.g. 'bedroom.go2rtc.local') — not a real DNS name. Resolve the actual
-    # upstream from the matched credential's server_variables.
+    # The real upstream host can differ from upstream_host in two cases:
+    #   1. .local self-hosted APIs — upstream_host is a semantic routing key
+    #      (e.g. 'bedroom.go2rtc.local'), not a real DNS name.
+    #   2. Multi-tenant public specs whose server URL carries a template var
+    #      (e.g. Jira's 'https://{your-domain}.atlassian.net'). Here the spec
+    #      base_url has a {var} that must be substituted from the credential's
+    #      server_variables to reach the tenant (e.g. acme.atlassian.net).
+    # In both cases we resolve via the matched credential's server_variables.
     routing_host = upstream_host
-    _resolved_scheme = None  # populated by .local server_variables resolution
-    if upstream_host.endswith(".local"):
-        # Find the credential's server_variables and resolve via the API's
-        # confirmed overlay server URL template.
-        _local_cred = None
-        if inject_headers is not None:
-            # Try to get the credential record that produced inject_headers
-            if credential_id:
-                _local_cred = await vault.get_credential(credential_id)
-        if _local_cred is None and credential_id:
-            _local_cred = await vault.get_credential(credential_id)
-        if _local_cred:
-            _sv = _local_cred.get("server_variables") or {}
-            _cred_api_id = _local_cred.get("api_id")
-            if _sv:
-                _resolved = await vault._resolve_server_url(_cred_api_id, _sv)
-                if _resolved:
-                    _p = urlparse(_resolved)
-                    routing_host = _p.netloc or routing_host
-                    _resolved_scheme = _p.scheme
-                    log.debug(
-                        "broker: .local route %r resolved to upstream %r (scheme=%s) via server_variables",
-                        upstream_host,
-                        routing_host,
-                        _resolved_scheme,
-                    )
-                else:
-                    log.warning(
-                        "broker: .local route %r — could not resolve upstream from server_variables %r",
-                        upstream_host,
-                        _sv,
-                    )
-            elif _sv is not None:
-                log.warning(
-                    "broker: .local route %r — credential %r has no server_variables; cannot resolve upstream",
-                    upstream_host,
-                    credential_id,
-                )
+    _resolved_scheme = None  # populated by server_variables resolution
+    if credential_id:
+        _routed_host, _resolved_scheme = await _resolve_routing_host(upstream_host, credential_id)
+        routing_host = _routed_host or routing_host
 
     # ── Pipedream credential path ─────────────────────────────────────────────
     # If the vault lookup yielded no headers, check for an explicitly-provisioned
@@ -989,6 +1014,15 @@ async def broker(request: Request, target: str):
             )
             pd_source_toolkit = toolkit_id
         if pd_account_id and pd_cred_id:
+            # Resolve the real upstream host from the Pipedream credential's
+            # server_variables (e.g. Jira's {your-domain}.atlassian.net →
+            # acme.atlassian.net). Multi-tenant specs require this; without it
+            # the bare slug-derived host (atlassian.net) would be used verbatim.
+            _pd_routed_host, _pd_scheme = await _resolve_routing_host(upstream_host, pd_cred_id)
+            if _pd_routed_host:
+                routing_host = _pd_routed_host
+                if _pd_scheme:
+                    _resolved_scheme = _pd_scheme
             # Policy check for this Pipedream credential (same gate as vault path)
             if toolkit_id or grant_ids:
                 try:

--- a/src/routers/oauth_brokers.py
+++ b/src/routers/oauth_brokers.py
@@ -13,6 +13,7 @@ Future:
   jentic    — Jentic's own OAuth service (once app approvals are in place)
 """
 
+import json
 import logging
 import time
 import urllib.error
@@ -517,6 +518,20 @@ class ConnectLinkRequest(NormModel):
         ),
         examples=["googleapis.com/gmail", "slack.com/api", "api.github.com"],
     )
+    server_variables: dict[str, str] | None = Field(
+        None,
+        description=(
+            "Values for the OpenAPI server template variables of multi-tenant APIs "
+            "(e.g. Jira's base URL `https://{your-domain}.atlassian.net`). "
+            "Provide the tenant value keyed by variable name, e.g. "
+            '`{"your-domain": "acme"}` to route to `acme.atlassian.net`. '
+            "Required for APIs whose catalog base URL contains a `{variable}` — without "
+            "it the broker cannot resolve the concrete tenant host. "
+            "Discover required variables via `GET /catalog?q=<name>` (look for "
+            "`server_variables`). Omit for single-tenant apps (Gmail, Slack, etc.)."
+        ),
+        examples=[{"your-domain": "acme"}],
+    )
 
 
 @router.post(
@@ -587,6 +602,10 @@ async def create_connect_link(broker_id: BrokerIdPath, body: ConnectLinkRequest,
     }
     if body.api_id:
         callback_params["api_id"] = body.api_id
+    if body.server_variables:
+        # JSON-encode the tenant binding so it survives the browser redirect and
+        # lands in oauth_broker_connect_labels for discover_accounts to consume.
+        callback_params["server_variables"] = json.dumps(body.server_variables)
     callback_path = (
         f"/oauth-brokers/{broker_id}/connect-callback?{urllib.parse.urlencode(callback_params)}"
     )
@@ -627,6 +646,9 @@ async def connect_callback(
     app: str = Query(..., description="Pipedream app slug"),
     external_user_id: str = Query("default"),
     api_id: str | None = Query(None),
+    server_variables: str | None = Query(
+        None, description="JSON-encoded OpenAPI server variables set at connect-link time"
+    ),
     replace_account_id: str | None = Query(
         None, description="Account ID to delete after successful reconnect"
     ),
@@ -649,8 +671,8 @@ async def connect_callback(
     async with get_db() as db:
         await db.execute(
             """INSERT OR REPLACE INTO oauth_broker_connect_labels
-               (id, broker_id, external_user_id, app_slug, label, api_id, created_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+               (id, broker_id, external_user_id, app_slug, label, api_id, server_variables, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 str(uuid.uuid4()),
                 broker_id,
@@ -658,6 +680,7 @@ async def connect_callback(
                 app,
                 label,
                 api_id,
+                server_variables,
                 time.time(),
             ),
         )

--- a/tests/test_pipedream_multitenant.py
+++ b/tests/test_pipedream_multitenant.py
@@ -1,0 +1,226 @@
+"""Pipedream multi-tenant routing tests — issue #485.
+
+Jira Cloud's catalog spec uses a templated base URL
+(https://{your-domain}.atlassian.net). When connecting Jira via a Pipedream
+OAuth broker the tenant ('your-domain') is collected at connect-link time,
+carried through the connect-callback into oauth_broker_connect_labels, and must
+end up:
+
+  1. resolved into the credential's route host (acme.atlassian.net, not the
+     literal {your-domain}.atlassian.net or the tenant-less atlassian.net), and
+  2. persisted as server_variables on the pipedream_oauth credential so the
+     broker can re-resolve the host at request time.
+
+These tests drive the real discover_accounts() with the Pipedream HTTP layer
+and catalog import mocked, then assert the resulting DB rows.
+"""
+
+import asyncio
+import json
+import os
+
+import aiosqlite
+import pytest
+from src import vault
+from src.brokers.pipedream import PipedreamOAuthBroker
+
+
+BROKER_ID = "test-pd-jira-broker"
+EXTERNAL_USER = "default"
+JIRA_API_ID = "atlassian.net"
+JIRA_BASE_URL = "https://{your-domain}.atlassian.net"
+ACCOUNT_ID = "apn_jira_acme"
+
+
+@pytest.fixture
+def jira_pipedream_env(client, monkeypatch):
+    """Seed a Jira-like API + a connect-label carrying the tenant, mock Pipedream IO."""
+
+    db_path = os.environ["DB_PATH"]
+
+    async def setup():
+        specs_dir = os.path.join(os.path.dirname(db_path), "specs")
+        os.makedirs(specs_dir, exist_ok=True)
+        jira_spec = {
+            "openapi": "3.0.1",
+            "info": {"title": "The Jira Cloud platform REST API", "version": "1001.0.0"},
+            "servers": [
+                {
+                    "url": JIRA_BASE_URL,
+                    "variables": {"your-domain": {"description": "Your Atlassian domain name."}},
+                }
+            ],
+            "components": {"securitySchemes": {"BearerAuth": {"type": "http", "scheme": "bearer"}}},
+            "paths": {
+                "/rest/api/3/myself": {
+                    "get": {"operationId": "getMyself", "responses": {"200": {"description": "ok"}}}
+                }
+            },
+        }
+        jira_path = os.path.join(specs_dir, "atlassian_net.json")
+        with open(jira_path, "w") as f:
+            json.dump(jira_spec, f)
+
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute("PRAGMA foreign_keys = ON")
+            await db.execute(
+                "INSERT OR IGNORE INTO oauth_brokers "
+                "(id, type, client_id, client_secret_enc, project_id, environment, default_external_user_id) "
+                "VALUES (?, 'pipedream', 'cid', ?, 'proj_test', 'development', ?)",
+                (BROKER_ID, vault.encrypt("csec"), EXTERNAL_USER),
+            )
+            await db.execute(
+                "INSERT OR IGNORE INTO apis (id, name, base_url, spec_path) VALUES (?, ?, ?, ?)",
+                (JIRA_API_ID, "Jira Cloud", JIRA_BASE_URL, jira_path),
+            )
+            # Connect-label written by the connect-callback at connect time, carrying
+            # the tenant binding the user supplied on the connect-link request.
+            await db.execute(
+                "INSERT OR REPLACE INTO oauth_broker_connect_labels "
+                "(id, broker_id, external_user_id, app_slug, label, api_id, server_variables, created_at) "
+                "VALUES (?, ?, ?, 'jira', 'acme jira', ?, ?, ?)",
+                (
+                    "lbl-jira",
+                    BROKER_ID,
+                    EXTERNAL_USER,
+                    JIRA_API_ID,
+                    json.dumps({"your-domain": "acme"}),
+                    1.0,
+                ),
+            )
+            await db.commit()
+
+    asyncio.run(setup())
+
+    # Mock the external Pipedream surface so discover_accounts runs offline.
+    async def fake_token(self):
+        return "fake-pd-token"
+
+    async def fake_import(api_id):
+        # API row is already seeded; nothing to fetch from the catalog.
+        return None
+
+    fake_accounts = {
+        "accounts": [
+            {"id": ACCOUNT_ID, "app": {"name_slug": "jira", "slug": "jira"}},
+        ]
+    }
+
+    class _FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return fake_accounts
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, *a, **kw):
+            return _FakeResp()
+
+    monkeypatch.setattr(PipedreamOAuthBroker, "_get_access_token", fake_token)
+    monkeypatch.setattr("src.brokers.pipedream.ensure_catalog_api_imported", fake_import)
+    monkeypatch.setattr("src.brokers.pipedream.httpx.AsyncClient", _FakeClient)
+
+    yield
+
+    async def teardown():
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute(
+                "DELETE FROM credential_routes WHERE credential_id IN "
+                "(SELECT id FROM credentials WHERE id LIKE ?)",
+                (f"{BROKER_ID}-{ACCOUNT_ID}-%",),
+            )
+            await db.execute(
+                "DELETE FROM credentials WHERE id LIKE ?", (f"{BROKER_ID}-{ACCOUNT_ID}-%",)
+            )
+            await db.execute("DELETE FROM oauth_broker_accounts WHERE broker_id=?", (BROKER_ID,))
+            await db.execute(
+                "DELETE FROM oauth_broker_connect_labels WHERE broker_id=?", (BROKER_ID,)
+            )
+            await db.execute("DELETE FROM oauth_brokers WHERE id=?", (BROKER_ID,))
+            await db.execute("DELETE FROM apis WHERE id=?", (JIRA_API_ID,))
+            await db.commit()
+
+    asyncio.run(teardown())
+
+
+def test_pipedream_jira_credential_carries_tenant(jira_pipedream_env):
+    """discover_accounts must resolve the tenant host and persist server_variables.
+
+    Regression for #485 on the Pipedream path: before the fix the credential was
+    created with no server_variables and a route to the tenant-less / templated
+    host, so the broker could never reach acme.atlassian.net.
+    """
+
+    async def run():
+        broker = PipedreamOAuthBroker(
+            broker_id=BROKER_ID,
+            client_id="cid",
+            client_secret="csec",
+            project_id="proj_test",
+            environment="development",
+            default_external_user_id=EXTERNAL_USER,
+        )
+        count = await broker.discover_accounts(EXTERNAL_USER)
+        assert count >= 1, "expected at least one discovered account-host pair"
+
+        db_path = os.environ["DB_PATH"]
+        async with aiosqlite.connect(db_path) as db:
+            async with db.execute(
+                "SELECT id, api_id, server_variables FROM credentials WHERE id LIKE ?",
+                (f"{BROKER_ID}-{ACCOUNT_ID}-%",),
+            ) as cur:
+                cred = await cur.fetchone()
+            assert cred is not None, "pipedream credential was not created"
+            cred_id, api_id, sv_raw = cred
+
+            # server_variables must be persisted so the broker can re-resolve.
+            assert sv_raw, "credential is missing server_variables (tenant binding lost)"
+            assert json.loads(sv_raw) == {"your-domain": "acme"}
+
+            # The credential's route host must be the concrete tenant host.
+            async with db.execute(
+                "SELECT host FROM credential_routes WHERE credential_id=?", (cred_id,)
+            ) as cur:
+                routes = {r[0] for r in await cur.fetchall()}
+            assert "acme.atlassian.net" in routes, f"expected tenant host route, got: {routes}"
+            assert "{your-domain}.atlassian.net" not in routes, (
+                f"templated host leaked into routes: {routes}"
+            )
+
+    asyncio.run(run())
+
+
+def test_pipedream_credential_resolves_via_server_url(jira_pipedream_env):
+    """The stored server_variables resolve to the tenant host through the vault helper.
+
+    This mirrors the broker-time _resolve_routing_host path: given the credential's
+    api_id + server_variables, vault._resolve_server_url must yield the tenant host.
+    """
+
+    async def run():
+        broker = PipedreamOAuthBroker(
+            broker_id=BROKER_ID,
+            client_id="cid",
+            client_secret="csec",
+            project_id="proj_test",
+            environment="development",
+            default_external_user_id=EXTERNAL_USER,
+        )
+        await broker.discover_accounts(EXTERNAL_USER)
+
+        resolved = await vault._resolve_server_url(JIRA_API_ID, {"your-domain": "acme"})
+        assert resolved == "https://acme.atlassian.net", (
+            f"expected tenant-resolved URL, got: {resolved}"
+        )
+
+    asyncio.run(run())

--- a/tests/test_server_url_resolution.py
+++ b/tests/test_server_url_resolution.py
@@ -173,3 +173,106 @@ def test_broker_uses_http_for_http_template(client, agent_key_header, local_apis
     url = data["would_send"]["url"]
     assert url.startswith("http://"), f"Expected http:// upstream URL, got: {url}"
     assert "192.168.1.50:8123" in url, f"Expected resolved host in URL, got: {url}"
+
+
+# ── Multi-tenant public spec (non-.local) — issue #485 ────────────────────────
+# Jira Cloud's spec uses https://{your-domain}.atlassian.net — a public host with
+# a mandatory server variable. The api_id derives to atlassian.net (no tenant).
+# Resolution must run for this non-.local host too, substituting the tenant.
+JIRA_API_ID = "atlassian.net"
+
+
+@pytest.fixture(scope="module")
+def jira_multitenant_credential(client):
+    """Register a Jira-like multi-tenant API + bearer credential carrying the tenant."""
+
+    async def setup():
+        db_path = os.environ["DB_PATH"]
+        specs_dir = os.path.join(os.path.dirname(db_path), "specs")
+        os.makedirs(specs_dir, exist_ok=True)
+
+        # Mirrors the real catalog Jira spec's servers[] block.
+        jira_spec = {
+            "openapi": "3.0.1",
+            "info": {"title": "The Jira Cloud platform REST API", "version": "1001.0.0"},
+            "servers": [
+                {
+                    "url": "https://{your-domain}.atlassian.net",
+                    "variables": {"your-domain": {"description": "Your Atlassian domain name."}},
+                }
+            ],
+            "components": {"securitySchemes": {"BearerAuth": {"type": "http", "scheme": "bearer"}}},
+            "paths": {
+                "/rest/api/3/myself": {
+                    "get": {"operationId": "getMyself", "responses": {"200": {"description": "ok"}}}
+                }
+            },
+        }
+        jira_path = os.path.join(specs_dir, "atlassian_net.json")
+        with open(jira_path, "w") as f:
+            json.dump(jira_spec, f)
+
+        enc = vault.encrypt("fake-token")
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute(
+                "INSERT OR IGNORE INTO apis (id, name, base_url, spec_path) VALUES (?, ?, ?, ?)",
+                (JIRA_API_ID, "Jira Cloud", "https://{your-domain}.atlassian.net", jira_path),
+            )
+            await db.execute(
+                "INSERT OR IGNORE INTO credentials "
+                "(id, label, env_var, encrypted_value, api_id, auth_type, server_variables, scheme) "
+                "VALUES (?, ?, ?, ?, ?, 'bearer', ?, ?)",
+                (
+                    "jira-cred",
+                    "Jira Token",
+                    "JIRA_TOKEN",
+                    enc,
+                    JIRA_API_ID,
+                    json.dumps({"your-domain": "acme"}),
+                    json.dumps({"in": "header", "name": "Authorization", "prefix": "Bearer "}),
+                ),
+            )
+            await db.execute(
+                "INSERT OR IGNORE INTO credential_routes (credential_id, host) VALUES (?, ?)",
+                ("jira-cred", JIRA_API_ID),
+            )
+            await db.execute(
+                "INSERT OR IGNORE INTO toolkit_credentials (toolkit_id, credential_id) "
+                "VALUES ('default', 'jira-cred')",
+            )
+            await db.commit()
+
+    asyncio.run(setup())
+    yield
+
+    async def teardown():
+        db_path = os.environ["DB_PATH"]
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute("DELETE FROM credential_routes WHERE credential_id='jira-cred'")
+            await db.execute("DELETE FROM toolkit_credentials WHERE credential_id='jira-cred'")
+            await db.execute("DELETE FROM credentials WHERE id='jira-cred'")
+            await db.execute("DELETE FROM apis WHERE id=?", (JIRA_API_ID,))
+            await db.commit()
+
+    asyncio.run(teardown())
+
+
+def test_broker_resolves_server_variable_for_non_local_host(
+    client, agent_key_header, jira_multitenant_credential
+):
+    """Regression for #485: server_variables must resolve on non-.local hosts.
+
+    A Jira-like spec (https://{your-domain}.atlassian.net) addressed at the bare
+    api_id host 'atlassian.net' must be rewritten to the tenant host
+    'acme.atlassian.net' using the credential's server_variables — not sent
+    verbatim to the tenant-less host.
+    """
+    resp = client.get(
+        f"/{JIRA_API_ID}/rest/api/3/myself",
+        headers={**agent_key_header, "X-Jentic-Simulate": "true"},
+    )
+    assert resp.status_code == 200, f"Simulate failed: {resp.text}"
+    url = resp.json()["would_send"]["url"]
+    assert url == "https://acme.atlassian.net/rest/api/3/myself", (
+        f"Expected tenant-resolved Jira URL, got: {url}"
+    )


### PR DESCRIPTION
## Summary

The broker only substituted OpenAPI `server_variables` into the routing host when the upstream host ended in `.local`. Public **multi-tenant** specs — notably **Jira Cloud** (`https://{your-domain}.atlassian.net`) — carry a mandatory server variable on a non-`.local` host, so the tenant subdomain was never resolved and requests were sent to the bare, tenant-less host (`atlassian.net`) → failure.

- Extract `_resolve_routing_host()` helper that substitutes a matched credential's `server_variables` via `vault._resolve_server_url`, returning the resolved host/scheme **regardless of the `.local` suffix**.
- Apply it on the vault path (any credential with `server_variables`) and on the Pipedream proxy path (using the matched `pd_cred_id`), so `atlassian.net` → `acme.atlassian.net`.
- `.local` self-hosted resolution behaviour is preserved (same helper, same warnings).

## How it was found

Traced the real catalog Jira spec (`atlassian.com/jira`). Its `servers[]` is `https://{your-domain}.atlassian.net` with a mandatory `your-domain` variable (no default). Resolution logic worked in isolation but was gated behind `if upstream_host.endswith(".local")`, so the Pipedream proxy path used the tenant-less host verbatim.

## Test plan

- [x] New regression test `test_broker_resolves_server_variable_for_non_local_host` — asserts `/atlassian.net/rest/api/3/myself` resolves to `https://acme.atlassian.net/rest/api/3/myself` via simulate mode.
- [x] Existing `.local` HTTPS/HTTP scheme tests still pass.
- [x] `pytest -k "broker or server_url or pipedream or capability_server"` → 32 passed.
- [x] `ruff check` + `ruff format --check` clean.

Verified in the `jentic-mini-parallel` playground (backend `:5180`, UI `:5181`).

Closes #485

> Please **squash + merge** to keep `main` history clean (one commit per PR).
