### PR TITLE
Fix #97: Docs: Import source types undocumented -- no enum or error hints

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -143,6 +143,16 @@ A `POST /localhost/transform` pseudo-operation accepting `{data, filter}` is a p
 
 `POST /import` accepts a batch of sources. The endpoint auto-detects OpenAPI vs Arazzo by inspecting the document — there is no top-level `type: "workflow"` field on the request.
 
+### Source Types
+
+`POST /import` accepts `sources[].type` with three valid values: `inline`, `url`, `path`. Each type requires different companion fields:
+
+| Type     | Required Field(s)        | Optional Field(s)    | Description                                      |
+|----------|--------------------------|----------------------|--------------------------------------------------|
+| `inline` | `content` (JSON string)  | `filename`           | Spec content posted directly in the request      |
+| `url`    | `url` (fetch spec URL)   | `filename`           | Fetch spec from a remote HTTP/HTTPS URL          |
+| `path`   | `path` (local file path) | —                    | Local filesystem path already accessible to container |
+
 ### From a URL
 
 ```http

--- a/src/routers/import_.py
+++ b/src/routers/import_.py
@@ -53,7 +53,8 @@ class ImportSource(NormModel):
     """Single import source for an OpenAPI spec or Arazzo workflow. Can be local file, URL, or inline content."""
 
     type: NormStr = Field(
-        description="Source type: 'path' (local file), 'url' (fetch from URL), or 'inline' (spec content in request)"
+        description="Source type: 'path' (local file), 'url' (fetch from URL), or 'inline' (spec content in request)",
+        enum=["inline", "url", "path"],
     )
     path: str | None = Field(
         default=None, description="Local file system path (required if type='path')"
@@ -141,7 +142,7 @@ def _load_doc(source: ImportSource) -> tuple[dict, str | None]:
         return doc, str(dest)
 
     else:
-        raise ValueError(f"Unknown source type: {source.type!r}")
+        raise ValueError(f"Unknown source type: {source.type!r}. Valid: inline, url, path")
 
 
 def _is_arazzo(doc: dict) -> bool:


### PR DESCRIPTION
Fixes #97

https://github.com/jentic/jentic-mini/issues/97