### PR TITLE
fix(install): sync build source by fetch+reset so a rewritten main can't dead-end install

### DIFF
--- a/cli/internal/install/build.go
+++ b/cli/internal/install/build.go
@@ -195,7 +195,22 @@ func (p BuildPlan) fetchSource(w io.Writer) error {
 	common := append([]string{"-c", "credential.helper="}, gitAuthArgs()...)
 
 	if isGitRepo(p.SourceDir) {
-		return runGit(w, p.SourceDir, append(append([]string{}, common...), "pull", "--ff-only")...)
+		// Sync to the remote's default branch by fetch + hard reset rather than
+		// `pull --ff-only`. A fast-forward pull dead-ends ("Not possible to
+		// fast-forward") whenever upstream history was rewritten/force-pushed —
+		// e.g. after an OSS re-baseline of the published repo. $SourceDir is a
+		// throwaway build checkout under ~/.jentic (never a tree the user edits),
+		// so matching the remote exactly is the correct, always-succeeding sync.
+		fetch := append(append([]string{}, common...), "fetch", "--prune", "origin")
+		if err := runGit(w, p.SourceDir, fetch...); err != nil {
+			return fmt.Errorf("fetch source: %w", err)
+		}
+		branch := remoteDefaultBranch(p.SourceDir)
+		reset := append(append([]string{}, common...), "reset", "--hard", "origin/"+branch)
+		if err := runGit(w, p.SourceDir, reset...); err != nil {
+			return fmt.Errorf("sync source to origin/%s: %w", branch, err)
+		}
+		return nil
 	}
 	if err := os.MkdirAll(filepath.Dir(p.SourceDir), 0o700); err != nil {
 		return fmt.Errorf("create source parent: %w", err)
@@ -212,6 +227,20 @@ func (p BuildPlan) fetchSource(w io.Writer) error {
 		return fmt.Errorf("clone failed (check the ref and your token's access): %w", err)
 	}
 	return nil
+}
+
+// remoteDefaultBranch returns origin's default branch name (e.g. "main"),
+// falling back to "main" when it can't be resolved. Lets the build checkout
+// re-sync to whatever branch the remote publishes as HEAD.
+func remoteDefaultBranch(dir string) string {
+	out, err := exec.Command("git", "-C", dir, "symbolic-ref", "--short",
+		"refs/remotes/origin/HEAD").Output() //nolint:gosec // dir is a CLI-internal build checkout path.
+	if err == nil {
+		if b := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(string(out)), "origin/")); b != "" {
+			return b
+		}
+	}
+	return "main"
 }
 
 // gitAuthArgs returns a `git -c http.extraheader=...` prefix carrying a Basic


### PR DESCRIPTION
## Problem

`jenticctl install` builds from a source checkout under `~/.jentic/src` and refreshed it with `git pull --ff-only`. After the OSS re-baseline rewrote (force-pushed) `main`, an existing `~/.jentic/src` clone can no longer fast-forward across the diverged history:

```
+ 4a47223...77c923f main -> origin/main (forced update)
...
fatal: Not possible to fast-forward, aborting.
error: image build failed: exit status 128
```

So every user who re-runs `install` against a pre-rebaseline clone hits a hard failure.

## Fix

Replace the ff-only pull with `git fetch --prune origin` + `git reset --hard origin/<default-branch>`. The `~/.jentic/src` checkout is a throwaway build mirror (never a tree the user edits), so matching the remote exactly is correct and always succeeds regardless of upstream history rewrites. Default branch is resolved from `origin/HEAD` (falls back to `main`).

## Test plan
- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `go test ./internal/install/` passes
- [ ] Manual: re-run `jenticctl install` against a stale `~/.jentic/src` — no longer errors

Made with [Cursor](https://cursor.com)