### PR TITLE
fix(search): render FTS config as regconfig so Postgres lexical search works

### DIFF
--- a/src/jentic_one/registry/repos/search/postgres_lexical.py
+++ b/src/jentic_one/registry/repos/search/postgres_lexical.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import Float, cast, func, literal, select, tuple_
+from sqlalchemy import Float, cast, func, literal, literal_column, select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
 
 from jentic_one.registry.core.schema.api_revisions import ApiRevision
 from jentic_one.registry.core.schema.operations import Operation
@@ -24,7 +25,13 @@ from jentic_one.registry.repos.search.protocol import SearchCursor, SearchHit
 from jentic_one.registry.repos.search.registry import register_strategy
 from jentic_one.shared.models import ApiRevisionState
 
-_TS_CONFIG = "english"
+# The text-search configuration must reach Postgres as a ``regconfig``, not a
+# bound VARCHAR: ``to_tsvector`` / ``websearch_to_tsquery`` only overload on
+# ``(regconfig, text)``. A bound ``literal("english")`` renders as ``$n::VARCHAR``
+# and fails with ``function to_tsvector(character varying, text) does not exist``.
+# Render it inline as a regconfig literal instead. The value is a fixed constant
+# (never user input), so inlining is safe from injection.
+_TS_CONFIG: ColumnElement[str] = literal_column("'english'::regconfig")
 
 
 @register_strategy
@@ -44,8 +51,8 @@ class PostgresLexicalStrategy:
         limit: int = 20,
         cursor: SearchCursor | None = None,
     ) -> list[SearchHit]:
-        document = func.to_tsvector(literal(_TS_CONFIG), func.coalesce(Operation.search_text, ""))
-        tsquery = func.websearch_to_tsquery(literal(_TS_CONFIG), query)
+        document = func.to_tsvector(_TS_CONFIG, func.coalesce(Operation.search_text, ""))
+        tsquery = func.websearch_to_tsquery(_TS_CONFIG, query)
         rank = func.ts_rank_cd(document, tsquery)
         # Squash unbounded rank into (0, 1] distance (see module docstring).
         distance = cast(1.0 / (rank + 1.0), Float).label("distance")

--- a/tests/unit/registry/search/test_postgres_lexical.py
+++ b/tests/unit/registry/search/test_postgres_lexical.py
@@ -1,0 +1,47 @@
+"""Regression tests for the Postgres lexical search strategy's SQL.
+
+Guards the FTS-config type bug: ``to_tsvector`` / ``websearch_to_tsquery`` only
+overload on ``(regconfig, text)`` in Postgres. Rendering the config as a bound
+``VARCHAR`` (``literal("english")``) produces ``to_tsvector($n::VARCHAR, ...)``,
+which fails at runtime with:
+
+    function to_tsvector(character varying, text) does not exist
+
+so `jentic search` 500s. The strategy must render the config inline as
+``'english'::regconfig``. These tests compile the exact constructs the strategy
+uses (no live DB needed) and assert the rendered SQL is the regconfig form.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects import postgresql
+
+from jentic_one.registry.core.schema.operations import Operation
+from jentic_one.registry.repos.search import postgres_lexical
+
+
+def _rendered_fts_sql() -> str:
+    cfg = postgres_lexical._TS_CONFIG
+    document = func.to_tsvector(cfg, func.coalesce(Operation.search_text, ""))
+    tsquery = func.websearch_to_tsquery(cfg, "spreadsheet values")
+    stmt = select(Operation.id).where(document.op("@@")(tsquery))
+    return str(stmt.compile(dialect=postgresql.dialect()))
+
+
+def test_fts_config_rendered_as_regconfig() -> None:
+    sql = _rendered_fts_sql()
+    assert "'english'::regconfig" in sql, sql
+
+
+def test_fts_config_not_bound_as_varchar() -> None:
+    # The exact failure signature: a VARCHAR-typed config argument. If the config
+    # is ever bound as a plain param again, this catches it before runtime.
+    sql = _rendered_fts_sql().lower()
+    assert "::varchar" not in sql.split("to_tsvector", 1)[1].split(")", 1)[0], sql
+
+
+def test_uses_both_fts_functions_with_regconfig() -> None:
+    sql = _rendered_fts_sql()
+    assert "to_tsvector('english'::regconfig" in sql, sql
+    assert "websearch_to_tsquery('english'::regconfig" in sql, sql


### PR DESCRIPTION
## Problem

Every `jentic search` on a **Postgres** backend returns **500**:

```
asyncpg.exceptions.UndefinedFunctionError:
  function to_tsvector(character varying, text) does not exist
```

The Postgres lexical strategy bound the text-search config as a `VARCHAR`
(`literal("english")`), so the query compiled to `to_tsvector($n::VARCHAR, …)`.
Postgres only overloads `to_tsvector` / `websearch_to_tsquery` on
`(regconfig, text)`, so no function matched → 500. (SQLite uses a separate FTS
path, so this only affected Postgres.)

## Fix

Render the config inline as `'english'::regconfig` (`literal_column`), so both
FTS functions resolve. The value is a fixed constant (never user input), so
inlining is injection-safe.

Verified against a live Postgres: the old `::varchar` form errors, the new
`::regconfig` form returns results.

## Test

Adds `tests/unit/registry/search/test_postgres_lexical.py` — compiles the query
and asserts it renders `'english'::regconfig` (no live DB needed). Confirmed it
**fails if the fix is reverted**.

## Test plan
- [x] `ruff` + `mypy` clean
- [x] new unit test passes; regression-guards the bug
- [x] fixed SQL verified to execute on a real Postgres DB
- [ ] CI green

Made with [Cursor](https://cursor.com)