### PR TITLE
fix(sqlite): eliminate "database is locked" via write-scoped BEGIN IMMEDIATE

### DIFF
--- a/src/jentic_one/admin/services/auth_service.py
+++ b/src/jentic_one/admin/services/auth_service.py
@@ -54,6 +54,8 @@ class AuthService:
     async def login(self, payload: LoginPayload) -> TokenBundle:
         config = self._ctx.config.admin.auth
 
+        account_locked_user_id: str | None = None
+
         async with self._ctx.admin_db.session() as session:
             user = await UserRepository.get_by_email(session, payload.email)
             if user is None:
@@ -67,22 +69,29 @@ class AuthService:
                 raise InvalidCredentialsError()
 
             if secret.locked_until is not None and secret.locked_until > datetime.now(UTC):
-                login_counter.add(1, {"outcome": "lockout"})
-                async with self._ctx.admin_db.transaction() as audit_session:
-                    await record_audit(
-                        audit_session,
-                        action=AuditAction.LOGIN_FAILED,
-                        target_type=AuditTargetType.SESSION,
-                        target_id=user.id,
-                        actor_type=ActorType.USER,
-                        actor_id=user.id,
-                        reason="account_locked",
-                        origin=None,
-                    )
-                raise AccountLockedError(user.id)
+                # Defer the audit write until *after* this read session closes:
+                # holding this read connection open while opening a write
+                # transaction on the same database self-deadlocks under SQLite
+                # (the writer waits on a lock the outer read still holds).
+                account_locked_user_id = user.id
+            else:
+                password_valid = verify_password(payload.password, secret.password_hash)
+                failed_count = secret.failed_login_count
 
-            password_valid = verify_password(payload.password, secret.password_hash)
-            failed_count = secret.failed_login_count
+        if account_locked_user_id is not None:
+            login_counter.add(1, {"outcome": "lockout"})
+            async with self._ctx.admin_db.transaction() as audit_session:
+                await record_audit(
+                    audit_session,
+                    action=AuditAction.LOGIN_FAILED,
+                    target_type=AuditTargetType.SESSION,
+                    target_id=account_locked_user_id,
+                    actor_type=ActorType.USER,
+                    actor_id=account_locked_user_id,
+                    reason="account_locked",
+                    origin=None,
+                )
+            raise AccountLockedError(account_locked_user_id)
 
         if not password_valid:
             async with self._ctx.admin_db.transaction() as session:

--- a/src/jentic_one/shared/db/backends/__init__.py
+++ b/src/jentic_one/shared/db/backends/__init__.py
@@ -13,6 +13,7 @@ from jentic_one.shared.db.backends.sqlite import (
     SqliteBackend,
     configure_sqlite_pragmas,
     enable_sqlite_foreign_keys,
+    enable_sqlite_immediate_begin,
 )
 
 __all__ = [
@@ -21,5 +22,6 @@ __all__ = [
     "SqliteBackend",
     "configure_sqlite_pragmas",
     "enable_sqlite_foreign_keys",
+    "enable_sqlite_immediate_begin",
     "get_backend",
 ]

--- a/src/jentic_one/shared/db/backends/__init__.py
+++ b/src/jentic_one/shared/db/backends/__init__.py
@@ -13,7 +13,7 @@ from jentic_one.shared.db.backends.sqlite import (
     SqliteBackend,
     configure_sqlite_pragmas,
     enable_sqlite_foreign_keys,
-    enable_sqlite_immediate_begin,
+    enable_sqlite_manual_begin,
 )
 
 __all__ = [
@@ -22,6 +22,6 @@ __all__ = [
     "SqliteBackend",
     "configure_sqlite_pragmas",
     "enable_sqlite_foreign_keys",
-    "enable_sqlite_immediate_begin",
+    "enable_sqlite_manual_begin",
     "get_backend",
 ]

--- a/src/jentic_one/shared/db/backends/sqlite.py
+++ b/src/jentic_one/shared/db/backends/sqlite.py
@@ -68,6 +68,40 @@ def configure_sqlite_pragmas(
         cursor.close()
 
 
+def enable_sqlite_immediate_begin(engine: AsyncEngine) -> None:
+    """Make SQLite transactions begin with ``BEGIN IMMEDIATE``.
+
+    By default pysqlite/aiosqlite open transactions in *deferred* mode: the
+    write lock is only acquired when the first write statement runs. A
+    transaction that reads first (e.g. ``UPDATE ... WHERE id = (SELECT ...)``)
+    therefore holds a read snapshot and then tries to *upgrade* to a writer. If
+    another connection has committed a write in the meantime, SQLite raises
+    ``SQLITE_BUSY_SNAPSHOT`` ("database is locked") *immediately* — ``PRAGMA
+    busy_timeout`` does not apply to snapshot-upgrade conflicts, only to
+    acquiring an initial lock.
+
+    Emitting ``BEGIN IMMEDIATE`` takes the write lock up front, so there is no
+    read→write upgrade to fail on and ``busy_timeout`` governs the wait. This
+    serialises writers (the price of SQLite) but eliminates the spurious
+    "database is locked" errors between concurrent writers such as the job
+    worker and request handlers.
+    """
+
+    sync_engine = engine.sync_engine
+
+    @event.listens_for(sync_engine, "connect")
+    def _disable_pysqlite_implicit_begin(
+        dbapi_connection: DBAPIConnection, _record: ConnectionPoolEntry
+    ) -> None:
+        # Stop the DBAPI from emitting its own implicit (deferred) BEGIN so we
+        # can control transaction start with the event below.
+        dbapi_connection.isolation_level = None
+
+    @event.listens_for(sync_engine, "begin")
+    def _emit_begin_immediate(conn: Any) -> None:
+        conn.exec_driver_sql("BEGIN IMMEDIATE")
+
+
 def enable_sqlite_foreign_keys(engine: AsyncEngine) -> None:
     """Backwards-compatible alias that configures pragmas with defaults."""
     configure_sqlite_pragmas(engine)

--- a/src/jentic_one/shared/db/backends/sqlite.py
+++ b/src/jentic_one/shared/db/backends/sqlite.py
@@ -68,23 +68,29 @@ def configure_sqlite_pragmas(
         cursor.close()
 
 
-def enable_sqlite_immediate_begin(engine: AsyncEngine) -> None:
-    """Make SQLite transactions begin with ``BEGIN IMMEDIATE``.
+def enable_sqlite_manual_begin(engine: AsyncEngine) -> None:
+    """Hand transaction control to the application so writes can BEGIN IMMEDIATE.
 
-    By default pysqlite/aiosqlite open transactions in *deferred* mode: the
-    write lock is only acquired when the first write statement runs. A
-    transaction that reads first (e.g. ``UPDATE ... WHERE id = (SELECT ...)``)
-    therefore holds a read snapshot and then tries to *upgrade* to a writer. If
-    another connection has committed a write in the meantime, SQLite raises
+    Setting ``isolation_level = None`` on each raw DBAPI connection disables
+    pysqlite's legacy implicit ``BEGIN``. This leaves reads in autocommit — a
+    plain ``SELECT`` via a read-only session takes only a shared read lock, so
+    WAL's reader/writer concurrency is preserved — and lets the *write* path
+    issue an explicit ``BEGIN IMMEDIATE`` (see ``DatabaseSession.transaction``).
+
+    Why the write path needs ``BEGIN IMMEDIATE``: under a *deferred* begin a
+    write transaction that reads first (e.g. ``UPDATE ... WHERE id = (SELECT
+    ...)``) holds a read snapshot and then tries to *upgrade* to a writer. If
+    another connection committed a write in the meantime, SQLite raises
     ``SQLITE_BUSY_SNAPSHOT`` ("database is locked") *immediately* — ``PRAGMA
     busy_timeout`` does not apply to snapshot-upgrade conflicts, only to
-    acquiring an initial lock.
+    acquiring an initial lock. ``BEGIN IMMEDIATE`` takes the write lock up
+    front, so there is no read→write upgrade to fail on and ``busy_timeout``
+    governs the wait.
 
-    Emitting ``BEGIN IMMEDIATE`` takes the write lock up front, so there is no
-    read→write upgrade to fail on and ``busy_timeout`` governs the wait. This
-    serialises writers (the price of SQLite) but eliminates the spurious
-    "database is locked" errors between concurrent writers such as the job
-    worker and request handlers.
+    Crucially this is applied to writes only, not reads: a global
+    ``BEGIN IMMEDIATE`` (via a ``begin`` event) would fire on every session's
+    autobegin — including read-only ones — making every read take a write lock
+    and defeating WAL.
     """
 
     sync_engine = engine.sync_engine
@@ -93,13 +99,7 @@ def enable_sqlite_immediate_begin(engine: AsyncEngine) -> None:
     def _disable_pysqlite_implicit_begin(
         dbapi_connection: DBAPIConnection, _record: ConnectionPoolEntry
     ) -> None:
-        # Stop the DBAPI from emitting its own implicit (deferred) BEGIN so we
-        # can control transaction start with the event below.
         dbapi_connection.isolation_level = None
-
-    @event.listens_for(sync_engine, "begin")
-    def _emit_begin_immediate(conn: Any) -> None:
-        conn.exec_driver_sql("BEGIN IMMEDIATE")
 
 
 def enable_sqlite_foreign_keys(engine: AsyncEngine) -> None:

--- a/src/jentic_one/shared/db/session.py
+++ b/src/jentic_one/shared/db/session.py
@@ -18,7 +18,11 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from jentic_one.shared.config import DatabaseConfig
-from jentic_one.shared.db.backends import configure_sqlite_pragmas, get_backend
+from jentic_one.shared.db.backends import (
+    configure_sqlite_pragmas,
+    enable_sqlite_immediate_begin,
+    get_backend,
+)
 from jentic_one.shared.db.backends.base import DatabaseBackend
 from jentic_one.shared.db.errors import DatabaseIntegrityError, DatabaseUnavailableError
 
@@ -70,6 +74,7 @@ class DatabaseSession:
                 journal_mode=self._config.journal_mode,
                 busy_timeout_ms=self._config.busy_timeout_ms,
             )
+            enable_sqlite_immediate_begin(self._engine)
         self._session_factory = async_sessionmaker(bind=self._engine, expire_on_commit=False)
 
     async def close(self) -> None:

--- a/src/jentic_one/shared/db/session.py
+++ b/src/jentic_one/shared/db/session.py
@@ -20,7 +20,7 @@ from sqlalchemy.ext.asyncio import (
 from jentic_one.shared.config import DatabaseConfig
 from jentic_one.shared.db.backends import (
     configure_sqlite_pragmas,
-    enable_sqlite_immediate_begin,
+    enable_sqlite_manual_begin,
     get_backend,
 )
 from jentic_one.shared.db.backends.base import DatabaseBackend
@@ -44,6 +44,7 @@ class DatabaseSession:
         self._backend = get_backend(config)
         self._engine: AsyncEngine | None = None
         self._session_factory: async_sessionmaker[AsyncSession] | None = None
+        self._is_sqlite = self._backend.dialect_name == "sqlite"
 
     @property
     def engine(self) -> AsyncEngine:
@@ -74,7 +75,7 @@ class DatabaseSession:
                 journal_mode=self._config.journal_mode,
                 busy_timeout_ms=self._config.busy_timeout_ms,
             )
-            enable_sqlite_immediate_begin(self._engine)
+            enable_sqlite_manual_begin(self._engine)
         self._session_factory = async_sessionmaker(bind=self._engine, expire_on_commit=False)
 
     async def close(self) -> None:
@@ -105,10 +106,24 @@ class DatabaseSession:
 
         The *retries* parameter controls how many times a transient error during
         commit is retried before giving up (default 1 retry).
+
+        On SQLite this opens the transaction with ``BEGIN IMMEDIATE`` so the
+        write lock is taken up front (see ``enable_sqlite_manual_begin``): it
+        avoids the read→write upgrade that raises ``SQLITE_BUSY_SNAPSHOT``, and
+        it is scoped to this write path only — reads via :meth:`session` stay in
+        autocommit so WAL's reader/writer concurrency is preserved.
         """
         factory = self.session_factory
         async with factory() as sess:
             try:
+                if self._is_sqlite:
+                    # isolation_level=None disabled the DBAPI's implicit BEGIN,
+                    # so start the write transaction explicitly and eagerly
+                    # acquire the write lock. busy_timeout governs the wait; a
+                    # timeout surfaces here as OperationalError and is mapped to
+                    # DatabaseUnavailableError (and retried via run_in_transaction).
+                    conn = await sess.connection()
+                    await conn.exec_driver_sql("BEGIN IMMEDIATE")
                 yield sess
             except IntegrityError as exc:
                 await sess.rollback()

--- a/src/jentic_one/shared/jobs/worker.py
+++ b/src/jentic_one/shared/jobs/worker.py
@@ -140,7 +140,7 @@ class WorkerLoop:
         now = datetime.now(UTC)
         visible_at = now + timedelta(seconds=self._config.visibility_timeout_s)
 
-        async with self._db.transaction() as session:
+        async def _claim(session: Any) -> Any:
             claimable = or_(
                 (Job.status == JobStatus.QUEUED)
                 & (or_(Job.visible_at.is_(None), Job.visible_at <= now)),
@@ -165,8 +165,14 @@ class WorkerLoop:
                 .returning(Job)
             )
             result = await session.execute(stmt)
-            job = result.scalar_one_or_none()
-            return job
+            return result.scalar_one_or_none()
+
+        # Use run_in_transaction so a transient "database is locked" (SQLite
+        # write contention with request handlers or the import job) is retried
+        # with backoff instead of crashing the poll tick. The claim is
+        # idempotent across attempts: it either flips one claimable row or
+        # matches none.
+        return await self._db.run_in_transaction(_claim)
 
     async def _execute_handler(self, handler: Any, job: Any) -> JobResultPayload:
         """Run the handler within a transaction."""

--- a/tests/unit/registry/search/test_postgres_lexical.py
+++ b/tests/unit/registry/search/test_postgres_lexical.py
@@ -26,7 +26,8 @@ def _rendered_fts_sql() -> str:
     document = func.to_tsvector(cfg, func.coalesce(Operation.search_text, ""))
     tsquery = func.websearch_to_tsquery(cfg, "spreadsheet values")
     stmt = select(Operation.id).where(document.op("@@")(tsquery))
-    return str(stmt.compile(dialect=postgresql.dialect()))
+    compiled: str = str(stmt.compile(dialect=postgresql.dialect()))  # type: ignore[no-untyped-call]
+    return compiled
 
 
 def test_fts_config_rendered_as_regconfig() -> None:

--- a/tests/unit/shared/db/test_sqlite_concurrency.py
+++ b/tests/unit/shared/db/test_sqlite_concurrency.py
@@ -1,0 +1,106 @@
+"""Concurrency tests for the SQLite write path (BEGIN IMMEDIATE).
+
+These use a real file-backed SQLite ``DatabaseSession`` (WAL is a no-op for
+``:memory:``) to prove the two properties the fix must uphold:
+
+- Writes go through ``BEGIN IMMEDIATE`` so concurrent writers *serialize* on the
+  write lock instead of failing with "database is locked" (the read->write
+  upgrade / ``SQLITE_BUSY_SNAPSHOT`` class of error).
+- Reads via :meth:`DatabaseSession.session` stay in autocommit and do NOT take a
+  write lock, so a held-open read session never blocks a writer — WAL's
+  reader/writer concurrency is preserved. This is the regression guard against a
+  blanket ``BEGIN IMMEDIATE`` that fires on every autobegin, including reads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+
+from jentic_one.shared.config import DatabaseConfig
+from jentic_one.shared.db.session import DatabaseSession
+
+
+@pytest.fixture()
+async def file_db(tmp_path: Path) -> DatabaseSession:
+    db = DatabaseSession(DatabaseConfig(backend="sqlite", path=str(tmp_path / "concurrency.db")))
+    await db.connect()
+    async with db.transaction() as sess:
+        await sess.execute(text("CREATE TABLE t (x INTEGER)"))
+    return db
+
+
+@pytest.mark.asyncio
+async def test_write_transaction_emits_begin_immediate(file_db: DatabaseSession) -> None:
+    """The write path opens the transaction with BEGIN IMMEDIATE, not deferred."""
+    statements: list[str] = []
+
+    from sqlalchemy import event
+
+    sync_engine = file_db.engine.sync_engine
+
+    @event.listens_for(sync_engine, "before_cursor_execute")
+    def _capture(_conn, _cursor, statement, _params, _context, _executemany) -> None:
+        statements.append(statement)
+
+    async with file_db.transaction() as sess:
+        await sess.execute(text("INSERT INTO t VALUES (1)"))
+
+    assert any("BEGIN IMMEDIATE" in s for s in statements), statements
+
+
+@pytest.mark.asyncio
+async def test_read_session_does_not_block_writer(file_db: DatabaseSession) -> None:
+    """A held-open read session must NOT hold a write lock (WAL concurrency)."""
+    read_open = asyncio.Event()
+    release = asyncio.Event()
+
+    async def hold_read() -> None:
+        async with file_db.session() as sess:
+            await sess.execute(text("SELECT count(*) FROM t"))
+            read_open.set()
+            await release.wait()
+
+    async def do_write() -> str:
+        await read_open.wait()
+        async with file_db.transaction() as sess:
+            await sess.execute(text("INSERT INTO t VALUES (2)"))
+        return "written"
+
+    reader = asyncio.create_task(hold_read())
+    try:
+        # If reads took a write lock, this write would block until release and
+        # time out. It must complete promptly instead.
+        result = await asyncio.wait_for(do_write(), timeout=5.0)
+        assert result == "written"
+    finally:
+        release.set()
+        await reader
+
+
+@pytest.mark.asyncio
+async def test_concurrent_writers_serialize_without_lock_error(
+    file_db: DatabaseSession,
+) -> None:
+    """Many concurrent read-then-write transactions all succeed (no lock error).
+
+    Each transaction does a SELECT then an INSERT — the read->write upgrade shape
+    that raises SQLITE_BUSY_SNAPSHOT under a deferred BEGIN. With BEGIN IMMEDIATE
+    they serialize on the write lock and all commit.
+    """
+
+    async def read_then_write(n: int) -> int:
+        async with file_db.transaction() as sess:
+            await sess.execute(text("SELECT count(*) FROM t"))
+            await sess.execute(text("INSERT INTO t VALUES (:x)"), {"x": n})
+        return n
+
+    results = await asyncio.gather(*(read_then_write(i) for i in range(10)))
+
+    assert sorted(results) == list(range(10))
+    async with file_db.session() as sess:
+        count = (await sess.execute(text("SELECT count(*) FROM t"))).scalar_one()
+    assert count == 10


### PR DESCRIPTION
## Summary

WAL + `busy_timeout=5000` (already on `main`) did **not** stop `sqlite3.OperationalError: database is locked`. On a live SQLite install the job worker's claim and the token mint (`POST /oauth/token` -> 503) both failed on the **same statement**:

```
UPDATE jobs SET status=?, visible_at=?, attempts=(attempts+?)
WHERE jobs.id = (SELECT jobs.id FROM jobs WHERE kind IN (?) ... LIMIT 1)
RETURNING ...
```

**Contention (corrected):** `jobs` and `access_tokens` both live in **`admin.db`**. The worker's claim transaction reads first (the `SELECT` subquery) then upgrades to a writer (the `UPDATE`), racing the token `INSERT` on the same file. Under pysqlite/aiosqlite's default *deferred* `BEGIN`, a read->write upgrade that loses the race raises `SQLITE_BUSY_SNAPSHOT` **immediately** -- and `busy_timeout` does **not** apply to snapshot-upgrade conflicts. (The import job writes to a *separate* file, `registry.db`, so it is not the contender.)

## Changes

- **`enable_sqlite_manual_begin()`** (`shared/db/backends/sqlite.py`): sets `isolation_level = None` to disable pysqlite's implicit `BEGIN`. Reads via `.session()` stay in autocommit (shared read lock only), preserving WAL reader/writer concurrency.
- **`DatabaseSession.transaction()`**: for the sqlite backend, explicitly emits `BEGIN IMMEDIATE` at transaction start (inside the try/except, so a `busy_timeout` expiry surfaces as `OperationalError` -> `DatabaseUnavailableError` and is retried by `run_in_transaction`). The write lock is taken up front, so there is no read->write upgrade to fail on.
- **Worker `_claim_next`**: runs via `run_in_transaction` (retry + backoff) so a transient lock retries instead of crashing the poll tick.
- **`auth_service.login`**: write the account-locked audit entry **after** the read session closes (opening a write transaction inside an open read session on the same DB self-deadlocks once writes take an immediate lock; ordering only).
- **`test_postgres_lexical`**: annotate a pre-existing untyped `dialect().compile()` call so `mypy` (and CI lint, red on `main`) passes.

### Why write-scoped (important)
An earlier revision applied `BEGIN IMMEDIATE` via a global `begin` event. Because `AsyncSession` autobegins on the first `SELECT`, that fired on **every** transaction incl. read-only `.session()`, making all reads take a write lock and defeating WAL. This PR scopes `BEGIN IMMEDIATE` to the write path only.

## Tests

New `tests/unit/shared/db/test_sqlite_concurrency.py`:
- asserts `BEGIN IMMEDIATE` is emitted on the write path
- asserts a held-open read session does **not** block a concurrent writer (WAL guard)
- asserts concurrent read-then-write transactions serialize and all commit with no "database is locked"

- [x] `ruff` + `mypy` clean (full repo, 1000 files)
- [x] SQLite integration suite: **444 passed, 8 skipped**
- [x] New concurrency tests + affected unit tests pass

## Follow-up (not in this PR)
The worker's `_execute_handler` wraps the entire job handler in one admin.db `transaction()`. For the import handler that now holds the admin.db write lock across a ~30s network fetch, which can still 503 a token mint during an active import. Fixing this means scoping the handler's slow I/O outside the admin.db write transaction -- tracked separately.