### PR TITLE
chore(install): default to Postgres; tune SQLite for mint contention

### DIFF
--- a/cli/internal/authclient/client.go
+++ b/cli/internal/authclient/client.go
@@ -32,8 +32,15 @@ type Client struct {
 }
 
 // New returns a client for the given base URL (trailing slash trimmed).
+//
+// The timeout is generous (60s) because token minting writes to the admin DB,
+// which under the SQLite backend can briefly queue behind another writer (a
+// concurrent broker execution or job) holding the single file-wide write lock.
+// The mint waits out that lock via busy_timeout + retry, so a short client
+// timeout would surface a spurious "context deadline exceeded" for a request
+// that is about to succeed.
 func New(baseURL string) *Client {
-	return &Client{http: httpx.New(baseURL, 15*time.Second)}
+	return &Client{http: httpx.New(baseURL, 60*time.Second)}
 }
 
 // HTTPError is the shared problem-details transport error.

--- a/cli/internal/install/compose_test.go
+++ b/cli/internal/install/compose_test.go
@@ -45,6 +45,7 @@ func TestMigrateArgsDisablesTTY(t *testing.T) {
 
 func TestRenderComposeSQLite(t *testing.T) {
 	d := NewDraft()
+	d.DBBackend = BackendSQLite
 	d.RuntimePath = RuntimeDocker
 	d.Apps = []string{"registry", "admin"}
 	cfg := composeConfigFor("/home/u/.jentic")
@@ -132,6 +133,7 @@ func TestRenderComposePostgres(t *testing.T) {
 func TestWriteComposeArtifactsSQLite(t *testing.T) {
 	dir := t.TempDir()
 	d := NewDraft()
+	d.DBBackend = BackendSQLite
 	d.RuntimePath = RuntimeDocker
 	cfg := composeConfigFor(dir)
 

--- a/cli/internal/install/draft.go
+++ b/cli/internal/install/draft.go
@@ -143,7 +143,7 @@ type Draft struct {
 func NewDraft() *Draft {
 	return &Draft{
 		RuntimePath:     RuntimeDocker,
-		DBBackend:       BackendSQLite,
+		DBBackend:       BackendPostgres,
 		PGHost:          "localhost",
 		PGPort:          "5432",
 		PGName:          "jentic",

--- a/cli/internal/install/draft_test.go
+++ b/cli/internal/install/draft_test.go
@@ -7,11 +7,11 @@ func TestNewDraftDefaults(t *testing.T) {
 	if d.RuntimePath != RuntimeDocker {
 		t.Errorf("RuntimePath = %q", d.RuntimePath)
 	}
-	if d.DBBackend != BackendSQLite {
+	if d.DBBackend != BackendPostgres {
 		t.Errorf("DBBackend = %q", d.DBBackend)
 	}
-	if d.IsPostgres() {
-		t.Errorf("IsPostgres should be false by default")
+	if !d.IsPostgres() {
+		t.Errorf("IsPostgres should be true by default")
 	}
 	if !d.IsDocker() {
 		t.Errorf("IsDocker should be true by default")

--- a/cli/internal/install/render_test.go
+++ b/cli/internal/install/render_test.go
@@ -27,6 +27,7 @@ func renderToMap(t *testing.T, d *Draft) map[string]any {
 
 func TestRenderSQLite(t *testing.T) {
 	d := NewDraft()
+	d.DBBackend = BackendSQLite
 	d.SQLiteDir = "/data"
 	out := renderToMap(t, d)
 
@@ -76,6 +77,7 @@ func TestRenderPostgres(t *testing.T) {
 
 func TestRenderDockerSQLiteUsesContainerPaths(t *testing.T) {
 	d := NewDraft()
+	d.DBBackend = BackendSQLite
 	d.RuntimePath = RuntimeDocker
 	d.SQLiteDir = "/home/u/.jentic/data" // host dir, ignored under Docker
 	out := renderToMap(t, d)

--- a/cli/internal/install/sections.go
+++ b/cli/internal/install/sections.go
@@ -162,15 +162,15 @@ var componentsSection = Section{
 var databaseSection = Section{
 	ID:    "database",
 	Title: "Database",
-	Blurb: "SQLite needs no extra services; Postgres runs as a managed container.",
+	Blurb: "Postgres (recommended) runs as a managed container and handles concurrent writers; SQLite is single-file with no Docker, best for single-user/dev.",
 	Groups: func(d *Draft) []*huh.Group {
 		return []*huh.Group{
 			huh.NewGroup(
 				huh.NewSelect[string]().
 					Title("Database backend").
 					Options(
-						huh.NewOption("SQLite (single-file, no Docker)", BackendSQLite),
-						huh.NewOption("PostgreSQL", BackendPostgres),
+						huh.NewOption("PostgreSQL (recommended)", BackendPostgres),
+						huh.NewOption("SQLite (single-file, no Docker — single-user/dev)", BackendSQLite),
 					).
 					Value(&d.DBBackend),
 			),

--- a/cli/internal/install/sections_test.go
+++ b/cli/internal/install/sections_test.go
@@ -33,6 +33,7 @@ func TestSectionsRegistryWellFormed(t *testing.T) {
 
 func TestDatabaseSummarySwitchesBackend(t *testing.T) {
 	d := NewDraft()
+	d.DBBackend = BackendSQLite
 	d.SQLiteDir = "/data"
 	sqlite := strings.Join(databaseSection.Summary(d), "\n")
 	if !strings.Contains(sqlite, "sqlite") || !strings.Contains(sqlite, "/data") {

--- a/src/jentic_one/auth/services/token_service.py
+++ b/src/jentic_one/auth/services/token_service.py
@@ -82,8 +82,9 @@ class TokenService:
         # Route through run_in_transaction so a transient SQLite write-lock under
         # concurrent mint traffic is retried (with WAL + busy_timeout) rather than
         # surfaced as a 500 on the first attempt. Token generation stays outside
-        # so the returned secret is stable across a retry.
-        await self._ctx.admin_db.run_in_transaction(_write)
+        # so the returned secret is stable across a retry. Generous budget so the
+        # mint rides out a longer lock hold instead of returning a 503.
+        await self._ctx.admin_db.run_in_transaction(_write, retries=8, backoff_s=0.25)
 
         return access_plain
 
@@ -132,7 +133,10 @@ class TokenService:
 
         # See issue_access_only: retry a transient admin-DB write-lock so the
         # mint/token path under concurrent writers doesn't 500 on first contention.
-        await self._ctx.admin_db.run_in_transaction(_write)
+        # Generous budget (retries + backoff) so the mint rides out a longer lock
+        # hold (e.g. a concurrent broker execution) on the SQLite backend instead
+        # of surfacing a 503 to the wizard.
+        await self._ctx.admin_db.run_in_transaction(_write, retries=8, backoff_s=0.25)
 
         return access_plain, refresh_plain
 

--- a/src/jentic_one/shared/config.py
+++ b/src/jentic_one/shared/config.py
@@ -71,7 +71,7 @@ class DatabaseConfig(BaseModel):
     # ``busy_timeout_ms`` is per-connection: when a write hits a held lock SQLite
     # waits up to this long for the lock to clear instead of failing instantly
     # with ``database is locked``.
-    busy_timeout_ms: int = 5000
+    busy_timeout_ms: int = 15000
     journal_mode: str = "WAL"
 
     @model_validator(mode="after")


### PR DESCRIPTION
## Summary

Make **PostgreSQL the recommended/default** install backend, and tune the SQLite path for the residual token-mint lock contention. Based on `fix/sqlite-lock-wal-busy-timeout` (#529), so this PR shows only the incremental changes.

Under the SQLite backend the broker, background worker, and OAuth token mint all write to the same `admin.db`, and SQLite serialises writers behind a single file-wide lock. A concurrent broker execution (which holds a write transaction across its upstream HTTP call) starves the token mint during `jenticctl wizard`, surfacing as `503 database_unavailable` or a client-side `context deadline exceeded`. Postgres handles these concurrent writers natively, so it becomes the recommended default; SQLite remains for single-user / dev.

## Changes

- **Installer default → Postgres** (`cli/internal/install`): `NewDraft` defaults `DBBackend` to `postgres`; the backend picker lists **"PostgreSQL (recommended)"** first and relabels SQLite as *single-file, no Docker — single-user/dev*; blurb updated. Install tests set `BackendSQLite` explicitly where they assert SQLite paths.
- **SQLite polish** (helps when SQLite is chosen):
  - `busy_timeout_ms` 5000 → 15000 (`shared/config.py`)
  - token mint `run_in_transaction` budget `retries=2, backoff=0.05s` → `retries=8, backoff=0.25s` on both `issue_pair` and `issue_access_only` (`auth/services/token_service.py`)
  - CLI auth client timeout 15s → 60s (`cli/internal/authclient/client.go`) so the mint can ride out a lock hold instead of a spurious client deadline

## Test plan

- [x] `ruff` + `mypy` clean (pre-commit hook)
- [x] Full CLI Go test suite green (`go test ./...`)
- [ ] `jenticctl install` (defaults to Postgres) + `jenticctl wizard` mints a token without 503
- [ ] Re-run wizard with SQLite selected to confirm the tuning reduces (not necessarily eliminates) contention

> Note: the SQLite tuning is a mitigation, not a cure — the underlying "DB write lock held across the upstream HTTP call" issue remains (stashed WIP for a follow-up). Postgres-as-default is the real fix for concurrent writers.

Made with [Cursor](https://cursor.com)