### PR TITLE
chore(install): default the install backend to Postgres

### DIFF
--- a/cli/internal/install/compose_test.go
+++ b/cli/internal/install/compose_test.go
@@ -45,6 +45,7 @@ func TestMigrateArgsDisablesTTY(t *testing.T) {
 
 func TestRenderComposeSQLite(t *testing.T) {
 	d := NewDraft()
+	d.DBBackend = BackendSQLite
 	d.RuntimePath = RuntimeDocker
 	d.Apps = []string{"registry", "admin"}
 	cfg := composeConfigFor("/home/u/.jentic")
@@ -132,6 +133,7 @@ func TestRenderComposePostgres(t *testing.T) {
 func TestWriteComposeArtifactsSQLite(t *testing.T) {
 	dir := t.TempDir()
 	d := NewDraft()
+	d.DBBackend = BackendSQLite
 	d.RuntimePath = RuntimeDocker
 	cfg := composeConfigFor(dir)
 

--- a/cli/internal/install/draft.go
+++ b/cli/internal/install/draft.go
@@ -143,7 +143,7 @@ type Draft struct {
 func NewDraft() *Draft {
 	return &Draft{
 		RuntimePath:     RuntimeDocker,
-		DBBackend:       BackendSQLite,
+		DBBackend:       BackendPostgres,
 		PGHost:          "localhost",
 		PGPort:          "5432",
 		PGName:          "jentic",

--- a/cli/internal/install/draft_test.go
+++ b/cli/internal/install/draft_test.go
@@ -7,11 +7,11 @@ func TestNewDraftDefaults(t *testing.T) {
 	if d.RuntimePath != RuntimeDocker {
 		t.Errorf("RuntimePath = %q", d.RuntimePath)
 	}
-	if d.DBBackend != BackendSQLite {
+	if d.DBBackend != BackendPostgres {
 		t.Errorf("DBBackend = %q", d.DBBackend)
 	}
-	if d.IsPostgres() {
-		t.Errorf("IsPostgres should be false by default")
+	if !d.IsPostgres() {
+		t.Errorf("IsPostgres should be true by default")
 	}
 	if !d.IsDocker() {
 		t.Errorf("IsDocker should be true by default")

--- a/cli/internal/install/render_test.go
+++ b/cli/internal/install/render_test.go
@@ -27,6 +27,7 @@ func renderToMap(t *testing.T, d *Draft) map[string]any {
 
 func TestRenderSQLite(t *testing.T) {
 	d := NewDraft()
+	d.DBBackend = BackendSQLite
 	d.SQLiteDir = "/data"
 	out := renderToMap(t, d)
 
@@ -76,6 +77,7 @@ func TestRenderPostgres(t *testing.T) {
 
 func TestRenderDockerSQLiteUsesContainerPaths(t *testing.T) {
 	d := NewDraft()
+	d.DBBackend = BackendSQLite
 	d.RuntimePath = RuntimeDocker
 	d.SQLiteDir = "/home/u/.jentic/data" // host dir, ignored under Docker
 	out := renderToMap(t, d)

--- a/cli/internal/install/sections.go
+++ b/cli/internal/install/sections.go
@@ -162,15 +162,15 @@ var componentsSection = Section{
 var databaseSection = Section{
 	ID:    "database",
 	Title: "Database",
-	Blurb: "SQLite needs no extra services; Postgres runs as a managed container.",
+	Blurb: "Postgres (recommended) runs as a managed container and handles concurrent writers; SQLite is single-file with no Docker, best for single-user/dev.",
 	Groups: func(d *Draft) []*huh.Group {
 		return []*huh.Group{
 			huh.NewGroup(
 				huh.NewSelect[string]().
 					Title("Database backend").
 					Options(
-						huh.NewOption("SQLite (single-file, no Docker)", BackendSQLite),
-						huh.NewOption("PostgreSQL", BackendPostgres),
+						huh.NewOption("PostgreSQL (recommended)", BackendPostgres),
+						huh.NewOption("SQLite (single-file, no Docker — single-user/dev)", BackendSQLite),
 					).
 					Value(&d.DBBackend),
 			),

--- a/cli/internal/install/sections_test.go
+++ b/cli/internal/install/sections_test.go
@@ -33,6 +33,7 @@ func TestSectionsRegistryWellFormed(t *testing.T) {
 
 func TestDatabaseSummarySwitchesBackend(t *testing.T) {
 	d := NewDraft()
+	d.DBBackend = BackendSQLite
 	d.SQLiteDir = "/data"
 	sqlite := strings.Join(databaseSection.Summary(d), "\n")
 	if !strings.Contains(sqlite, "sqlite") || !strings.Contains(sqlite, "/data") {

--- a/tests/unit/registry/search/test_postgres_lexical.py
+++ b/tests/unit/registry/search/test_postgres_lexical.py
@@ -26,7 +26,8 @@ def _rendered_fts_sql() -> str:
     document = func.to_tsvector(cfg, func.coalesce(Operation.search_text, ""))
     tsquery = func.websearch_to_tsquery(cfg, "spreadsheet values")
     stmt = select(Operation.id).where(document.op("@@")(tsquery))
-    return str(stmt.compile(dialect=postgresql.dialect()))
+    compiled: str = str(stmt.compile(dialect=postgresql.dialect()))  # type: ignore[no-untyped-call]
+    return compiled
 
 
 def test_fts_config_rendered_as_regconfig() -> None:


### PR DESCRIPTION
## Summary

Make **PostgreSQL the recommended/default** database backend in `jenticctl install`.

Postgres handles concurrent writers (the broker, the background job worker, and the OAuth token mint all write to the admin DB) natively. SQLite serialises every writer behind a single file-wide lock, which starves the token mint under load — surfacing during `jenticctl wizard` as `503 database_unavailable` / a client-side `context deadline exceeded`. SQLite remains available as the single-user / dev option.

## Changes

- `NewDraft` defaults `DBBackend` to `postgres` (`cli/internal/install/draft.go`).
- The backend picker lists **"PostgreSQL (recommended)"** first and relabels SQLite as *single-file, no Docker — single-user/dev*; section blurb updated (`cli/internal/install/sections.go`).
- Install tests set `BackendSQLite` explicitly where they assert SQLite paths; `TestNewDraftDefaults` now expects the Postgres default.
- `test_postgres_lexical`: annotate the untyped `dialect().compile()` call so the repo-wide pre-commit mypy hook passes (a pre-existing failure on `main`, unrelated to this change).

## Test plan

- [x] `go build ./...` + `go test ./internal/install/... ./internal/cmd/...` green
- [x] `ruff` + `mypy` clean (pre-commit hook)
- [ ] `jenticctl install` defaults to Postgres and the wizard mints a token without a 503

Made with [Cursor](https://cursor.com)