### PR TITLE
fix(db): take the SQLite write lock up front with BEGIN IMMEDIATE

### DIFF
--- a/src/jentic_one/shared/db/backends/__init__.py
+++ b/src/jentic_one/shared/db/backends/__init__.py
@@ -11,6 +11,7 @@ from jentic_one.shared.db.backends.postgres import PostgresBackend
 from jentic_one.shared.db.backends.registry import get_backend
 from jentic_one.shared.db.backends.sqlite import (
     SqliteBackend,
+    configure_sqlite_deferred_control,
     configure_sqlite_pragmas,
     enable_sqlite_foreign_keys,
 )
@@ -19,6 +20,7 @@ __all__ = [
     "DatabaseBackend",
     "PostgresBackend",
     "SqliteBackend",
+    "configure_sqlite_deferred_control",
     "configure_sqlite_pragmas",
     "enable_sqlite_foreign_keys",
     "get_backend",

--- a/src/jentic_one/shared/db/backends/sqlite.py
+++ b/src/jentic_one/shared/db/backends/sqlite.py
@@ -12,7 +12,7 @@ from sqlalchemy import event
 from sqlalchemy.engine import URL
 from sqlalchemy.engine.interfaces import DBAPIConnection
 from sqlalchemy.ext.asyncio import AsyncEngine
-from sqlalchemy.pool import ConnectionPoolEntry
+from sqlalchemy.pool import ConnectionPoolEntry, StaticPool
 
 from jentic_one.shared.config import DatabaseConfig
 from jentic_one.shared.db.backends.base import DatabaseBackend
@@ -31,9 +31,54 @@ class SqliteBackend(DatabaseBackend):
         return URL.create(drivername="sqlite+aiosqlite", database=database)
 
     def engine_kwargs(self, config: DatabaseConfig) -> dict[str, Any]:
+        # ``:memory:`` must share a single connection: a second connection would
+        # open a *separate, empty* database. StaticPool keeps exactly one.
+        if (config.path or ":memory:") == ":memory:":
+            return {
+                "poolclass": StaticPool,
+                "connect_args": {"check_same_thread": False},
+            }
+        # A file DB keeps the default async pool so *nested* sessions (a session
+        # opened while another is still held on the same DB — a real pattern in
+        # the service layer, e.g. audit-within-a-request) don't self-deadlock on
+        # a single connection. Concurrent writers are instead made lock-safe with
+        # ``BEGIN IMMEDIATE`` + ``busy_timeout`` (see configure_sqlite_*): a
+        # second writer *waits* for the lock instead of failing instantly with
+        # ``database is locked``, and the run_in_transaction retry covers the
+        # rare wait that still exceeds ``busy_timeout``.
         return {
             "connect_args": {"check_same_thread": False},
         }
+
+
+def configure_sqlite_deferred_control(engine: AsyncEngine) -> None:
+    """Hand transaction control to us so writes can take the lock up front.
+
+    aiosqlite (like pysqlite) opens transactions lazily in ``DEFERRED`` mode: the
+    first statement decides the lock. A *write* transaction that reads before it
+    writes — as the token, registration, and refresh paths all do (``SELECT``
+    then ``UPDATE``/``INSERT``) — would take a *read* lock first, then try to
+    upgrade to a *write* lock. Under WAL that upgrade cannot wait (waiting would
+    deadlock two readers each wanting to write), so SQLite returns ``SQLITE_BUSY``
+    immediately, ignoring ``busy_timeout`` → ``database is locked``.
+
+    Setting ``isolation_level = None`` disables the driver's implicit ``BEGIN``,
+    so no transaction is opened until we say so. The *write* path
+    (:meth:`DatabaseSession.transaction`) then emits ``BEGIN IMMEDIATE`` to grab
+    the write lock up front (a bounded wait governed by ``busy_timeout``), while
+    read-only :meth:`DatabaseSession.session` blocks stay lock-free and never
+    contend — which also means a read session can safely nest a write
+    transaction on the same file without self-deadlocking.
+    """
+
+    sync_engine = engine.sync_engine
+
+    @event.listens_for(sync_engine, "connect")
+    def _disable_implicit_begin(
+        dbapi_connection: DBAPIConnection, _record: ConnectionPoolEntry
+    ) -> None:
+        # Hand transaction control to us; aiosqlite mirrors the pysqlite API.
+        dbapi_connection.isolation_level = None
 
 
 def configure_sqlite_pragmas(

--- a/src/jentic_one/shared/db/session.py
+++ b/src/jentic_one/shared/db/session.py
@@ -8,6 +8,7 @@ from contextlib import asynccontextmanager
 from typing import TypeVar
 
 import structlog
+from sqlalchemy import text
 from sqlalchemy.engine import URL
 from sqlalchemy.exc import DisconnectionError, IntegrityError, OperationalError
 from sqlalchemy.ext.asyncio import (
@@ -18,7 +19,11 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from jentic_one.shared.config import DatabaseConfig
-from jentic_one.shared.db.backends import configure_sqlite_pragmas, get_backend
+from jentic_one.shared.db.backends import (
+    configure_sqlite_deferred_control,
+    configure_sqlite_pragmas,
+    get_backend,
+)
 from jentic_one.shared.db.backends.base import DatabaseBackend
 from jentic_one.shared.db.errors import DatabaseIntegrityError, DatabaseUnavailableError
 
@@ -40,6 +45,9 @@ class DatabaseSession:
         self._backend = get_backend(config)
         self._engine: AsyncEngine | None = None
         self._session_factory: async_sessionmaker[AsyncSession] | None = None
+        # SQLite hands transaction control to us (isolation_level=None), so the
+        # write path must open its transaction explicitly with BEGIN IMMEDIATE.
+        self._is_sqlite = self._backend.dialect_name == "sqlite"
 
     @property
     def engine(self) -> AsyncEngine:
@@ -70,6 +78,7 @@ class DatabaseSession:
                 journal_mode=self._config.journal_mode,
                 busy_timeout_ms=self._config.busy_timeout_ms,
             )
+            configure_sqlite_deferred_control(self._engine)
         self._session_factory = async_sessionmaker(bind=self._engine, expire_on_commit=False)
 
     async def close(self) -> None:
@@ -89,6 +98,22 @@ class DatabaseSession:
             finally:
                 await sess.close()
 
+    async def _begin_write(self, sess: AsyncSession) -> None:
+        """Open the write transaction with the write lock already held (SQLite).
+
+        SQLite hands transaction control to us (``isolation_level=None``), so the
+        write path opens its transaction explicitly with ``BEGIN IMMEDIATE`` —
+        taking the single-writer file lock up front rather than starting as a
+        reader and failing to upgrade under WAL (which surfaces as an instant
+        ``database is locked``, ignoring ``busy_timeout``). Read-only
+        :meth:`session` blocks skip this and stay lock-free, so a read session
+        can safely nest a write transaction on the same file.
+
+        A no-op on Postgres, whose MVCC needs no explicit write-lock priming.
+        """
+        if self._is_sqlite:
+            await sess.execute(text("BEGIN IMMEDIATE"))
+
     @asynccontextmanager
     async def transaction(self, *, retries: int = 1) -> AsyncGenerator[AsyncSession, None]:
         """Yield a session inside a transaction that commits on clean exit.
@@ -104,6 +129,7 @@ class DatabaseSession:
         factory = self.session_factory
         async with factory() as sess:
             try:
+                await self._begin_write(sess)
                 yield sess
             except IntegrityError as exc:
                 await sess.rollback()

--- a/tests/unit/shared/db/test_backends.py
+++ b/tests/unit/shared/db/test_backends.py
@@ -15,6 +15,7 @@ from jentic_one.shared.db.backends import (
     configure_sqlite_pragmas,
     get_backend,
 )
+from jentic_one.shared.db.session import DatabaseSession
 
 
 def test_get_backend_returns_postgres_by_default() -> None:
@@ -98,3 +99,114 @@ async def test_sqlite_connect_hook_sets_wal_and_busy_timeout(tmp_path: Path) -> 
         assert foreign_keys == 1
     finally:
         await engine.dispose()
+
+
+def test_sqlite_engine_kwargs_file_uses_default_pool() -> None:
+    """A file-backed SQLite engine keeps the default pool (no StaticPool).
+
+    A single connection would self-deadlock the service layer's nested-session
+    pattern (a session opened while another is held on the same DB, e.g.
+    audit-within-a-request). Concurrent writers are instead made lock-safe with
+    ``BEGIN IMMEDIATE`` + ``busy_timeout`` so they wait rather than failing
+    instantly with ``database is locked``.
+    """
+    config = DatabaseConfig(backend="sqlite", path="/tmp/x.db")
+    kwargs = SqliteBackend().engine_kwargs(config)
+    assert "poolclass" not in kwargs
+
+
+def test_sqlite_engine_kwargs_memory_uses_static_pool() -> None:
+    """An in-memory SQLite engine must share one connection (StaticPool).
+
+    A second connection to ``:memory:`` opens a separate, empty database, so the
+    engine has to reuse a single connection.
+    """
+    from sqlalchemy.pool import StaticPool
+
+    config = DatabaseConfig(backend="sqlite", path=":memory:")
+    kwargs = SqliteBackend().engine_kwargs(config)
+    assert kwargs["poolclass"] is StaticPool
+
+
+@pytest.mark.asyncio
+async def test_sqlite_write_transaction_takes_write_lock_up_front(tmp_path: Path) -> None:
+    """A write ``transaction()`` that reads before it writes holds the write lock.
+
+    The write path opens with ``BEGIN IMMEDIATE``, so a concurrent writer on a
+    second connection must *wait* on ``busy_timeout`` (and fail busy when it
+    expires) rather than the first transaction failing to upgrade a read lock —
+    i.e. the transaction is genuinely a writer from its first statement.
+    """
+    import asyncio
+
+    from sqlalchemy.exc import DatabaseError
+
+    from jentic_one.shared.db.errors import DatabaseUnavailableError
+
+    db = DatabaseSession(
+        DatabaseConfig(backend="sqlite", path=str(tmp_path / "immediate.db"), busy_timeout_ms=200)
+    )
+    await db.connect()
+    try:
+        async with db.transaction() as sess:
+            await sess.execute(text("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)"))
+            await sess.execute(text("INSERT INTO t (id, v) VALUES (1, 0)"))
+
+        # Hold a write transaction open (read first, so under DEFERRED this would
+        # only be a read lock — BEGIN IMMEDIATE makes it a write lock up front).
+        holder_ready = asyncio.Event()
+        release_holder = asyncio.Event()
+
+        async def holder() -> None:
+            async with db.transaction() as sess:
+                await sess.execute(text("SELECT v FROM t WHERE id = 1"))
+                holder_ready.set()
+                await release_holder.wait()
+
+        async def contender() -> None:
+            await holder_ready.wait()
+            async with db.transaction() as sess:
+                await sess.execute(text("UPDATE t SET v = v + 1 WHERE id = 1"))
+
+        holder_task = asyncio.create_task(holder())
+        # The contender must fail busy because the holder owns the write lock.
+        with pytest.raises((DatabaseUnavailableError, DatabaseError)):
+            await asyncio.wait_for(contender(), timeout=5)
+        release_holder.set()
+        await holder_task
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_session_serializes_concurrent_read_then_write(tmp_path: Path) -> None:
+    """Concurrent read-then-write transactions on one DatabaseSession don't lock.
+
+    This is the ``jentic register`` shape: the token/mint path reads a row then
+    writes it, while a background loop writes the same DB. Before the fix these
+    raced to ``database is locked``; BEGIN IMMEDIATE + busy_timeout serialize
+    them into ordered, lossless updates.
+    """
+    import asyncio
+
+    db = DatabaseSession(DatabaseConfig(backend="sqlite", path=str(tmp_path / "reg.db")))
+    await db.connect()
+    try:
+        async with db.transaction() as sess:
+            await sess.execute(text("CREATE TABLE counter (id INTEGER PRIMARY KEY, n INTEGER)"))
+            await sess.execute(text("INSERT INTO counter (id, n) VALUES (1, 0)"))
+
+        async def bump() -> None:
+            await db.run_in_transaction(_bump_once)
+
+        async def _bump_once(sess: AsyncSession) -> None:
+            row = (await sess.execute(text("SELECT n FROM counter WHERE id = 1"))).scalar_one()
+            await sess.execute(text("UPDATE counter SET n = :n WHERE id = 1"), {"n": row + 1})
+
+        await asyncio.gather(*(bump() for _ in range(10)))
+
+        async with db.session() as sess:
+            total = (await sess.execute(text("SELECT n FROM counter WHERE id = 1"))).scalar_one()
+        assert total == 10
+    finally:
+        await db.close()


### PR DESCRIPTION
## Summary

Fixes the SQLite `database is locked` failures reported in #534 (seen during `jentic register` and other concurrent-writer paths on a local SQLite install).

**Root cause:** the `local-sqlite` deployment runs request handlers plus two background loops (job worker + `CredentialExpiryScanner`) that all write to the same SQLite files. The access-token / DCR-register paths do read-then-write inside one transaction (`SELECT` → `INSERT`/`UPDATE`). aiosqlite opens transactions in **DEFERRED** mode, so those take a *read* lock and then try to *upgrade* to a *write* lock. Under WAL that upgrade cannot wait, so SQLite returns `SQLITE_BUSY` **immediately — ignoring `busy_timeout`** — surfacing as `database is locked`. The existing WAL + `busy_timeout` + `run_in_transaction` retries couldn't cover this instant-failure case.

**Fix:**
- `configure_sqlite_deferred_control()` sets `isolation_level=None`, handing transaction control to us.
- `DatabaseSession.transaction()` now opens the write path with `BEGIN IMMEDIATE` on SQLite, grabbing the single-writer lock up front so a second writer *waits* (bounded by `busy_timeout`) instead of failing instantly. Read-only `session()` blocks stay lock-free, so a read session can still nest a write transaction on the same file without self-deadlocking.
- File DBs keep the default multi-connection pool; `:memory:` keeps `StaticPool`.
- Added unit coverage: pool selection per DB kind, write-lock-up-front, and concurrent read-then-write serialization.

## Test plan

- [x] `uv run pytest tests/unit/shared/db/` — 19 passed
- [x] lint (`ruff check` + `ruff format --check`) and `mypy` clean on changed files
- [x] `JENTIC_TEST_BACKEND=sqlite` integration suite: the two genuine lock failures (`test_login_locked_account`, `test_login_already_locked_raises`) are now fixed; that test file drops from a 66s timeout to ~6s. The only remaining SQLite integration failures (`test_verify` permission-grant setup) are **pre-existing on `main`** and unrelated to locking.
- [ ] Reviewer: confirm Postgres path is unaffected (`_begin_write` is a no-op on Postgres).

Closes #534

_Please squash + merge._

Made with [Cursor](https://cursor.com)