### PR TITLE
docs: add public beta warning and quick start to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Jentic One is a backend platform for secure third-party API execution. A statele
 
 ## Quick Start
 
-Install the CLI to deploy Jentic One locally or interact with an existing environment:
+Install `jenticctl` to deploy Jentic One locally or manage an existing environment:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@
  
 Jentic One is a backend platform for secure third-party API execution. A stateless **Broker** proxy injects stored credentials into outbound requests so secrets never leave the data plane, while a **Control Plane** (Registry, Admin, Control) manages the catalogue of available APIs, access grants, and credential storage.
 
+## Quick Start
+
+Install the CLI to deploy Jentic One locally or interact with an existing environment:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh
+```
+
+*For Docker, Helm, or manual deployments, see the full [Installation Guide](docs/installation.md).*
+
 ## What is Jentic One?
 
 AI agents increasingly need to call real third-party APIs — but handing an agent your raw API keys is a security problem. Jentic One is a **self-hosted gateway** that keeps that from happening: you register the APIs an agent may use, store the credentials once, and the agent calls out through the Broker. The Broker injects the right credential at execution time and forwards the request, so **secrets never leave your infrastructure** and never reach the agent. Every call is governed by fine-grained permissions and recorded in an append-only audit log.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@
   <img src="https://img.shields.io/badge/lint-ruff-FDBD79.svg?logo=ruff&logoColor=black" alt="Linted with Ruff">
   <img src="https://img.shields.io/badge/types-mypy_strict-F1E38B.svg" alt="mypy strict">
   <a href="https://www.conventionalcommits.org/"><img src="https://img.shields.io/badge/commits-conventional-EDADAF.svg?logo=conventionalcommits&logoColor=white" alt="Conventional Commits"></a>
-</p>
-
----
-
+ </p>
+ 
+> [!WARNING]
+> **Jentic One is currently in Public Beta.**  
+> APIs, database schemas, and CLI commands are subject to breaking changes without a major version bump. We do not recommend running this in production yet.
+ 
 Jentic One is a backend platform for secure third-party API execution. A stateless **Broker** proxy injects stored credentials into outbound requests so secrets never leave the data plane, while a **Control Plane** (Registry, Admin, Control) manages the catalogue of available APIs, access grants, and credential storage.
 
 ## What is Jentic One?


### PR DESCRIPTION
Adds the standard GitHub Markdown warning alert for the Public Beta status and hoists the `jenticctl` install command to a Quick Start section near the top for better visibility.