### PR TITLE
ci(build.go): put gosec nolint on the flagged exec.Command line

### DIFF
--- a/cli/internal/install/build.go
+++ b/cli/internal/install/build.go
@@ -233,8 +233,8 @@ func (p BuildPlan) fetchSource(w io.Writer) error {
 // falling back to "main" when it can't be resolved. Lets the build checkout
 // re-sync to whatever branch the remote publishes as HEAD.
 func remoteDefaultBranch(dir string) string {
-	out, err := exec.Command("git", "-C", dir, "symbolic-ref", "--short",
-		"refs/remotes/origin/HEAD").Output() //nolint:gosec // dir is a CLI-internal build checkout path.
+	//nolint:gosec // dir is a CLI-internal build checkout path.
+	out, err := exec.Command("git", "-C", dir, "symbolic-ref", "--short", "refs/remotes/origin/HEAD").Output()
 	if err == nil {
 		if b := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(string(out)), "origin/")); b != "" {
 			return b


### PR DESCRIPTION
## Summary

Fixes a golangci-lint failure on `main` in `cli/internal/install/build.go`.

The `exec.Command(...)` call in `remoteDefaultBranch` spanned two lines with the `//nolint:gosec` directive on the second line. `gosec` attributes the `G204` finding to the call's *first* line, so the directive didn't cover it — golangci-lint reported **both** the unsuppressed `G204` and a `nolintlint` "directive unused" error:

```
build.go:236:14: G204: Subprocess launched with variable (gosec)
build.go:237:40: directive `//nolint:gosec ...` is unused for linter "gosec" (nolintlint)
```

- Join the call onto a single line and move the `//nolint:gosec` directive directly above it, so it covers the finding (matching the single-line pattern used elsewhere in this package).

## Test plan

- [x] `gofmt -l` clean; `go build ./internal/install/` succeeds
- [ ] CI: golangci-lint passes on `cli/`

_Please squash + merge._

Made with [Cursor](https://cursor.com)