### PR TITLE
fix(install): enforce docker requirement in install.sh

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -203,6 +203,7 @@ check_prereqs() {
   need tar
   need mktemp
   need uname
+  need docker
 }
 
 # --- platform detection -----------------------------------------------------


### PR DESCRIPTION
Fixes #530 by requiring docker in `check_prereqs` before downloading/compiling Go and CLI binaries.