### PR TITLE
fix(search): include active IMPORTED revisions in lexical search

### DIFF
--- a/src/jentic_one/registry/repos/search/postgres_lexical.py
+++ b/src/jentic_one/registry/repos/search/postgres_lexical.py
@@ -2,8 +2,9 @@
 
 Uses PostgreSQL's native full-text search: ``to_tsvector`` over the operation's
 ``search_text`` matched against ``websearch_to_tsquery`` and ranked with
-``ts_rank_cd``. Applies the same revision-pin and published-state filters as the
-other strategies and paginates with a keyset cursor on ``(distance, id)``.
+``ts_rank_cd``. Applies the same revision-pin and active-state (published or
+imported) filters as the other strategies and paginates with a keyset cursor on
+``(distance, id)``.
 
 ``ts_rank_cd`` is unbounded and always non-negative. We squash it into ``[0, 1)``
 via ``rank / (rank + 1)`` and expose ``distance = 1 - squashed = 1 / (rank + 1)``
@@ -32,6 +33,12 @@ from jentic_one.shared.models import ApiRevisionState
 # Render it inline as a regconfig literal instead. The value is a fixed constant
 # (never user input), so inlining is safe from injection.
 _TS_CONFIG: ColumnElement[str] = literal_column("'english'::regconfig")
+
+# The set of "active" revision states a search can surface. Mirrors the
+# ``ix_api_revisions_one_active`` partial unique index and ``is_current`` — a
+# catalog import lands as IMPORTED and must be searchable without a manual
+# promote to PUBLISHED.
+_ACTIVE_STATES = (ApiRevisionState.PUBLISHED, ApiRevisionState.IMPORTED)
 
 
 @register_strategy
@@ -73,12 +80,12 @@ class PostgresLexicalStrategy:
             stmt = stmt.where(
                 (
                     ApiRevision.api_id.notin_(list(pins.keys()))
-                    & (ApiRevision.state == ApiRevisionState.PUBLISHED)
+                    & ApiRevision.state.in_(_ACTIVE_STATES)
                 )
                 | ApiRevision.id.in_(list(pins.values()))
             )
         else:
-            stmt = stmt.where(ApiRevision.state == ApiRevisionState.PUBLISHED)
+            stmt = stmt.where(ApiRevision.state.in_(_ACTIVE_STATES))
 
         if api_filters:
             stmt = stmt.where(ApiRevision.api_id.in_(api_filters))

--- a/src/jentic_one/registry/repos/search/sqlite_lexical.py
+++ b/src/jentic_one/registry/repos/search/sqlite_lexical.py
@@ -2,8 +2,8 @@
 
 Ranks operations by SQLite's built-in ``bm25()`` over the ``operations_fts``
 virtual table, joins back to ``operations``/``api_revisions`` to apply the same
-revision-pin and published-state filters as every other strategy, and returns
-distance-ordered hits with keyset pagination.
+revision-pin and active-state (published or imported) filters as every other
+strategy, and returns distance-ordered hits with keyset pagination.
 
 SQLite's ``bm25()`` returns a value where a *more negative* number is a better
 match. We negate it into a non-negative relevance score, squash the unbounded
@@ -50,6 +50,16 @@ class SqliteLexicalStrategy:
 
         where_clauses = ["operations_fts MATCH :query"]
 
+        # Active revision states a search can surface (mirrors the
+        # ``ix_api_revisions_one_active`` index): a catalog import lands as
+        # IMPORTED and must be searchable without a manual promote.
+        active_binds = []
+        for i, state in enumerate((ApiRevisionState.PUBLISHED, ApiRevisionState.IMPORTED)):
+            key = f"active_state_{i}"
+            active_binds.append(f":{key}")
+            params[key] = state.value
+        active_clause = "ar.state IN (" + ", ".join(active_binds) + ")"
+
         pins = revision_pins or {}
         if pins:
             pin_api_binds = []
@@ -64,13 +74,11 @@ class SqliteLexicalStrategy:
                 params[key] = str(rev_id)
             where_clauses.append(
                 "((ar.api_id NOT IN (" + ", ".join(pin_api_binds) + ")"
-                " AND ar.state = :published_state)"
+                " AND " + active_clause + ")"
                 " OR ar.id IN (" + ", ".join(pin_rev_binds) + "))"
             )
-            params["published_state"] = ApiRevisionState.PUBLISHED.value
         else:
-            where_clauses.append("ar.state = :published_state")
-            params["published_state"] = ApiRevisionState.PUBLISHED.value
+            where_clauses.append(active_clause)
 
         if api_filters:
             filter_binds = []

--- a/tests/integration/registry/ingest/test_search_state_filter.py
+++ b/tests/integration/registry/ingest/test_search_state_filter.py
@@ -1,0 +1,118 @@
+"""Integration tests for the search revision-state filter.
+
+Search must surface *active* revisions — both PUBLISHED and IMPORTED — so that
+catalog imports (which land as IMPORTED, never auto-promoted) are findable
+without a manual promote. DRAFT and ARCHIVED revisions must stay excluded.
+
+Runs end-to-end through the real ``Ingestor`` (populates ``search_text`` and,
+on SQLite, the ``operations_fts`` triggers) and the real ``SearchService``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from jentic_one.registry.ingest.ingestor import Ingestor
+from jentic_one.registry.ingest.models import ApiIdentifier, IngestSpecification, SpecType
+from jentic_one.registry.repos.revision_repo import ApiRevisionRepository
+from jentic_one.registry.services.search_service import SearchService
+from jentic_one.shared.config import SearchConfig
+from jentic_one.shared.context import Context
+from jentic_one.shared.models import ApiRevisionState
+
+pytestmark = pytest.mark.integration
+
+
+def _spec(*, vendor: str, marker: str, origin: str | None) -> IngestSpecification:
+    """A one-operation spec whose summary embeds a unique searchable ``marker``."""
+    return IngestSpecification(
+        api_identifier=ApiIdentifier(
+            vendor=vendor,
+            name="api",
+            version="1.0.0",
+            filename="spec.yaml",
+        ),
+        spec_type=SpecType.OPENAPI,
+        content={
+            "openapi": "3.1.0",
+            "info": {"title": "API", "version": "1.0.0"},
+            "paths": {
+                "/things": {
+                    "get": {
+                        "operationId": f"list_{marker}",
+                        "summary": f"List {marker} things",
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        },
+        sha=f"sha-{marker}",
+        origin=origin,
+    )
+
+
+async def _search_hit_count(ctx: Context, query: str) -> int:
+    """Return how many operations search returns for ``query``."""
+    page = await SearchService(ctx).search(query=query, limit=50)
+    return len(page.data)
+
+
+async def test_search_returns_imported_revisions(
+    ingest_context: Context, clean_registry: None
+) -> None:
+    """A catalog-style IMPORTED revision (origin set, never promoted) is searchable."""
+    ingest_context.config.search = SearchConfig(enabled=True, search_enabled=True)
+    ingestor = Ingestor(ingest_context)
+
+    result = await ingestor.ingest(
+        _spec(vendor="imported.example.com", marker="importedmarker", origin="catalog"),
+        created_by="usr_test",
+    )
+    # Precondition: ingest really produced an IMPORTED revision, not PUBLISHED.
+    assert result.state == ApiRevisionState.IMPORTED
+
+    assert await _search_hit_count(ingest_context, "importedmarker") == 1
+
+
+async def test_search_excludes_draft_revisions(
+    ingest_context: Context, clean_registry: None
+) -> None:
+    """A DRAFT revision (uploaded, no origin) must NOT be searchable until promoted."""
+    ingest_context.config.search = SearchConfig(enabled=True, search_enabled=True)
+    ingestor = Ingestor(ingest_context)
+
+    result = await ingestor.ingest(
+        _spec(vendor="draft.example.com", marker="draftmarker", origin=None),
+        created_by="usr_test",
+    )
+    assert result.state == ApiRevisionState.DRAFT
+
+    assert await _search_hit_count(ingest_context, "draftmarker") == 0
+
+
+async def test_search_excludes_archived_revisions(
+    ingest_context: Context, clean_registry: None
+) -> None:
+    """Once an IMPORTED revision is archived, it drops out of search results."""
+    ingest_context.config.search = SearchConfig(enabled=True, search_enabled=True)
+    ingestor = Ingestor(ingest_context)
+
+    result = await ingestor.ingest(
+        _spec(vendor="archived.example.com", marker="archivedmarker", origin="catalog"),
+        created_by="usr_test",
+    )
+    assert result.state == ApiRevisionState.IMPORTED
+
+    # Sanity: findable while active.
+    assert await _search_hit_count(ingest_context, "archivedmarker") == 1
+
+    async with ingest_context.registry_db.transaction() as session:
+        await ApiRevisionRepository.set_state(
+            session,
+            uuid.UUID(str(result.revision_id)),
+            ApiRevisionState.ARCHIVED,
+        )
+
+    assert await _search_hit_count(ingest_context, "archivedmarker") == 0


### PR DESCRIPTION
## Summary

Catalog imports were invisible to search. Both the Postgres and SQLite lexical
search strategies hard-filtered to `state == PUBLISHED`, but `jentic catalog
import` creates revisions in the `IMPORTED` state (`origin` set) and nothing
auto-promotes them. Everywhere else in the system (the
`ix_api_revisions_one_active` unique index, `is_current`) treats `IMPORTED` as
active — search was the lone exception, so a `jentic catalog import` followed by
a search returned empty results.

The `tsvector`/FTS wiring itself was correct; this is purely a semantic
state-filter fix.

- Widen both strategies' state filter from `PUBLISHED` to `{PUBLISHED, IMPORTED}`
  in the pinned and unpinned branches (`postgres_lexical.py` uses a shared
  `_ACTIVE_STATES` tuple with `.in_()`; `sqlite_lexical.py` uses `ar.state IN (…)`
  and drops the single `published_state` bind).
- Update both strategy docstrings from "published-state" to "active-state
  (published or imported)".
- Add a real-DB (SQLite) integration test that drives the actual `Ingestor` +
  `SearchService` and asserts an `IMPORTED` catalog revision is searchable while
  `DRAFT` and `ARCHIVED` are excluded.

## Test plan

- [x] `make lint` (ruff + format + mypy) clean
- [x] `make test-unit` — 1789 passed
- [x] `make test-arch` — 128 passed
- [x] `tests/integration/registry` on SQLite — 93 passed
- [x] search unit tests — 33 passed
- [ ] Postgres integration path (covered by CI; not run locally)

Please **squash + merge**.

Made with [Cursor](https://cursor.com)