### PR TITLE
fix(cli): stop telemetry consent prompt swallowing the first Enter

### DIFF
--- a/cli/internal/cmd/apis.go
+++ b/cli/internal/cmd/apis.go
@@ -615,14 +615,13 @@ func (a *App) apisRemove(ctx context.Context, ident *identityOptions, o *apisRmO
 
 func confirmDelete(target string) (bool, error) {
 	confirm := false
-	form := install.NewForm(huh.NewGroup(
+	if err := install.RunConfirm(
 		huh.NewConfirm().
 			Title(fmt.Sprintf("Delete %s? This cannot be undone.", target)).
 			Affirmative("Yes, delete").
 			Negative("Cancel").
 			Value(&confirm),
-	))
-	if err := form.Run(); err != nil {
+	); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
 			return false, nil
 		}

--- a/cli/internal/cmd/install.go
+++ b/cli/internal/cmd/install.go
@@ -234,13 +234,12 @@ func (a *App) offerWizard(cmd *cobra.Command, opts *installOptions, started bool
 	}
 
 	cont := true
-	if err := huh.NewConfirm().
+	if err := install.RunConfirm(huh.NewConfirm().
 		Title("Continue to guided setup?").
 		Description("Creates your first admin account, connects your AI operator, and gets you to a first call.").
 		Affirmative("Yes, guide me").
 		Negative("I'll do it myself").
-		Value(&cont).
-		Run(); err != nil || !cont {
+		Value(&cont)); err != nil || !cont {
 		fmt.Fprintln(a.Out, theme.Dim.Render("Skipping the wizard. Run `jenticctl wizard` whenever you're ready."))
 		return
 	}

--- a/cli/internal/cmd/stop.go
+++ b/cli/internal/cmd/stop.go
@@ -147,14 +147,13 @@ func (a *App) stopDocker(opts *stopOptions, composePath string) error {
 // discards the database.
 func confirmRemoveVolumes() (bool, error) {
 	confirm := false
-	form := install.NewForm(huh.NewGroup(
+	if err := install.RunConfirm(
 		huh.NewConfirm().
 			Title("Remove the stack's data volumes? This permanently deletes the database.").
 			Affirmative("Yes, delete the data").
 			Negative("Cancel").
 			Value(&confirm),
-	))
-	if err := form.Run(); err != nil {
+	); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
 			return false, nil
 		}

--- a/cli/internal/cmd/telemetry_consent.go
+++ b/cli/internal/cmd/telemetry_consent.go
@@ -46,14 +46,14 @@ func (a *App) ensureTelemetryConsent(interactive bool) (proceed bool, enabled bo
 		fmt.Fprintln(a.Out, theme.Dim.Render("For details: https://github.com/jentic/jentic-one#readme"))
 		fmt.Fprintln(a.Out)
 
-		if err := install.NewForm(huh.NewGroup(
+		if err := install.RunConfirm(
 			huh.NewConfirm().
 				Title("Allow Jentic to collect anonymous telemetry?").
 				Description("Anonymized usage events only — absolutely no personal data, no API payloads.").
 				Affirmative("Enable Telemetry").
 				Negative("Disable Telemetry").
 				Value(&enabled),
-		)).Run(); err != nil {
+		); err != nil {
 			if errors.Is(err, huh.ErrUserAborted) {
 				fmt.Fprintln(a.Out)
 				fmt.Fprintln(a.Out, theme.Warnf("Install cancelled — telemetry consent is required to proceed."))

--- a/cli/internal/cmd/uninstall.go
+++ b/cli/internal/cmd/uninstall.go
@@ -253,7 +253,7 @@ func (a *App) uninstallVolumeHint() []string {
 
 func confirmUninstall(dir string) (bool, error) {
 	confirm := false
-	form := install.NewForm(huh.NewGroup(
+	if err := install.RunConfirm(
 		huh.NewConfirm().
 			Title(fmt.Sprintf("Delete everything under %s?", dir)).
 			Description("Config files are backed up to *-old. This also stops the stack; " +
@@ -261,8 +261,7 @@ func confirmUninstall(dir string) (bool, error) {
 			Affirmative("Yes, uninstall").
 			Negative("Cancel").
 			Value(&confirm),
-	))
-	if err := form.Run(); err != nil {
+	); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
 			return false, nil
 		}
@@ -280,15 +279,14 @@ func confirmUninstall(dir string) (bool, error) {
 // is the non-destructive one — preserve the volume and let the teardown finish.
 func confirmUninstallVolumes(dbLabel string) (bool, error) {
 	confirm := false
-	form := install.NewForm(huh.NewGroup(
+	if err := install.RunConfirm(
 		huh.NewConfirm().
 			Title(fmt.Sprintf("Also delete the Docker data volume? This permanently deletes %s.", dbLabel)).
 			Description("Keep it to let a later `install` reattach your data.").
 			Affirmative("Yes, delete the data").
 			Negative("No, keep the data").
 			Value(&confirm),
-	))
-	if err := form.Run(); err != nil {
+	); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
 			return false, nil
 		}

--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -367,14 +367,13 @@ func confirmApply(doCLI, doStack bool, repo, ref string) (bool, error) {
 		what = "the stack"
 	}
 	confirm := false
-	form := install.NewForm(huh.NewGroup(
+	if err := install.RunConfirm(
 		huh.NewConfirm().
 			Title(fmt.Sprintf("Rebuild %s from %s@%s?", what, repo, ref)).
 			Affirmative("Yes, update").
 			Negative("Cancel").
 			Value(&confirm),
-	))
-	if err := form.Run(); err != nil {
+	); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
 			return false, nil
 		}

--- a/cli/internal/cmd/wizard.go
+++ b/cli/internal/cmd/wizard.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/x/term"
 	"github.com/jentic/jentic-one/cli/internal/config"
+	"github.com/jentic/jentic-one/cli/internal/install"
 	"github.com/jentic/jentic-one/cli/internal/serverinfo"
 	"github.com/jentic/jentic-one/cli/internal/theme"
 	"github.com/spf13/cobra"
@@ -133,13 +134,12 @@ func (a *App) wizardE(ctx context.Context, opts *wizardOptions) error {
 	// Step 2: offer to connect an operator.
 	if interactive {
 		connect := true
-		if err := huh.NewConfirm().
+		if err := install.RunConfirm(huh.NewConfirm().
 			Title("Connect an AI operator now?").
 			Description("Registers an agent for your operator (Claude, Cursor, …) and writes its skill.").
 			Affirmative("Yes, connect it").
 			Negative("Not now").
-			Value(&connect).
-			Run(); err != nil {
+			Value(&connect)); err != nil {
 			if errors.Is(err, huh.ErrUserAborted) {
 				a.wizardExitHint()
 				return nil

--- a/cli/internal/install/form_guard_test.go
+++ b/cli/internal/install/form_guard_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -40,6 +41,45 @@ func TestAllFormsUseSharedConstructors(t *testing.T) {
 				rel, _ := filepath.Rel(root, path)
 				t.Errorf("%s calls %s directly; use install.NewForm / install.Input instead", rel, tok)
 			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk module: %v", err)
+	}
+}
+
+// TestNoConfirmRunEscapeHatch forbids running a huh confirm on its own
+// (huh.NewConfirm()....Run()), which bypasses the shared brand theme and quit
+// keymap and reintroduces the swallowed-first-Enter bug. Standalone confirms
+// must go through install.RunConfirm; multi-field wizard sections compose
+// huh.NewConfirm into install.NewForm groups (sections.go) and never call .Run()
+// on the confirm itself.
+func TestNoConfirmRunEscapeHatch(t *testing.T) {
+	root := moduleRoot(t)
+	// theme.go documents and implements the sanctioned helper; exempt it.
+	allowed := filepath.Join(root, "internal", "install", "theme.go")
+	// Matches huh.NewConfirm()...Run() across lines, with any builder chain in
+	// between, but stops at the first Run( so it can't span unrelated calls.
+	pattern := regexp.MustCompile(`huh\.NewConfirm\((?s:[^;]*?)\.Run\(`)
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		if path == allowed {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if pattern.Match(data) {
+			rel, _ := filepath.Rel(root, path)
+			t.Errorf("%s runs a huh confirm directly (huh.NewConfirm()....Run()); use install.RunConfirm instead", rel)
 		}
 		return nil
 	})

--- a/cli/internal/install/theme.go
+++ b/cli/internal/install/theme.go
@@ -1,7 +1,10 @@
 package install
 
 import (
+	"os"
+
 	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/jentic/jentic-one/cli/internal/theme"
@@ -50,6 +53,14 @@ func FormTheme() *huh.Theme {
 	// radio selector colour.
 	t.Focused.TextInput.Prompt = t.Focused.TextInput.Prompt.Foreground(theme.Brand)
 
+	// Confirm buttons (Yes/No). huh's default theme paints the focused button
+	// with a fuchsia background that is off-brand; repaint both so the selected
+	// answer reads as Jentic green and the other is a muted, unobtrusive button.
+	t.Focused.FocusedButton = lipgloss.NewStyle().
+		Foreground(theme.White).Background(theme.Green).Bold(true).Padding(0, 2)
+	t.Focused.BlurredButton = lipgloss.NewStyle().
+		Foreground(theme.Muted).Padding(0, 2)
+
 	// Mute everything in blurred (not-yet-focused) fields so nothing there looks
 	// selectable or active. Keep the radio glyphs (muted) so no stray "> " shows.
 	muted := lipgloss.NewStyle().Foreground(theme.Muted)
@@ -87,4 +98,21 @@ func NewForm(groups ...*huh.Group) *huh.Form {
 // test). Callers chain the usual huh.Input options (Title, Value, Validate, ...).
 func Input() *huh.Input {
 	return huh.NewInput().Prompt(PromptGlyph)
+}
+
+// RunConfirm runs a standalone yes/no confirm prompt with the shared brand theme
+// and quit keymap. Use it instead of huh.NewConfirm().Run() so every one-off
+// confirm looks the same as the wizard's forms.
+//
+// It deliberately runs without huh's default tea.WithReportFocus(): when a
+// confirm program starts back-to-back with another (e.g. right after the wizard
+// exits), focus reporting makes the terminal emit an initial focus event whose
+// handshake swallows the user's first Enter, so the prompt appears to need two
+// presses. Dropping it (while keeping huh's stderr output) fixes that. We must
+// re-add tea.WithOutput(os.Stderr) because WithProgramOptions replaces huh's
+// defaults wholesale.
+func RunConfirm(c *huh.Confirm) error {
+	return NewForm(huh.NewGroup(c)).
+		WithProgramOptions(tea.WithOutput(os.Stderr)).
+		Run()
 }

--- a/cli/internal/install/theme_test.go
+++ b/cli/internal/install/theme_test.go
@@ -34,3 +34,16 @@ func TestPromptGlyphIsRadioRing(t *testing.T) {
 		t.Errorf("PromptGlyph = %q, want it to contain %q", PromptGlyph, theme.SelectOn)
 	}
 }
+
+// Confirm buttons must be repainted with Jentic brand colours rather than huh's
+// default fuchsia focused button: the focused (selected) button uses the brand
+// green background and the blurred button the muted grey-teal foreground.
+func TestFormThemeBrandsConfirmButtons(t *testing.T) {
+	ft := FormTheme()
+	if got := ft.Focused.FocusedButton.GetBackground(); got != theme.Green {
+		t.Errorf("focused confirm button background = %v, want brand green %v", got, theme.Green)
+	}
+	if got := ft.Focused.BlurredButton.GetForeground(); got != theme.Muted {
+		t.Errorf("blurred confirm button foreground = %v, want muted %v", got, theme.Muted)
+	}
+}


### PR DESCRIPTION
## Summary

The install flow's telemetry consent prompt appeared to require pressing Enter twice, and its Yes/No buttons rendered in an off-brand fuchsia rather than Jentic colours. Both are fixed, and the fix is applied consistently to every standalone confirm prompt in the CLI.

- **Swallowed first Enter:** the telemetry prompt ran its own `huh` program immediately after the wizard's program exited. `huh.NewForm` seeds the program with `tea.WithReportFocus()`, so starting a second program back-to-back made the terminal emit an initial focus event whose handshake consumed the user's first Enter. New `install.RunConfirm` runs standalone confirms through the shared brand form but drops focus reporting (`WithProgramOptions(tea.WithOutput(os.Stderr))`), fixing the double-Enter.
- **Brand colours:** `FormTheme()` never styled the Confirm buttons, so they fell through to `huh.ThemeCharm()`'s fuchsia focused button. Now the selected button uses Jentic green and the other is muted grey-teal — this fixes every confirm in the CLI (telemetry, wizard sections, guided-setup, update, delete, stop, uninstall).
- **Consistency + guards:** every standalone confirm now goes through `install.RunConfirm`. `TestNoConfirmRunEscapeHatch` forbids `huh.NewConfirm().Run()`, and `TestFormThemeBrandsConfirmButtons` pins the button colours.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...` (v2.12.2, same as CI) — 0 issues
- [ ] Manual: run `jenticctl install` in a real terminal, reach the telemetry step, confirm a single Enter advances it and the Yes/No buttons are Jentic-green (not purple)

Please use **squash + merge**.

Made with [Cursor](https://cursor.com)