### PR TITLE
fix(uninstall): remove docker data volume by name on purge

### DIFF
--- a/cli/internal/cmd/uninstall.go
+++ b/cli/internal/cmd/uninstall.go
@@ -207,7 +207,24 @@ func (a *App) uninstallDocker(opts *uninstallOptions, composePath string) error 
 			fmt.Fprintln(a.Out, theme.Dimf("the database volume may survive; once the daemon is up remove it with: docker volume rm %s", vols))
 			return nil
 		}
-		fmt.Fprintln(a.Out, theme.Successf("Stopped Docker stack and removed its data volume."))
+		// `docker compose down -v` only removes volumes declared in the compose
+		// file under the pinned project. A volume created under a different
+		// project name (a pre-pinning install, a regenerated compose file, etc.)
+		// survives that otherwise-successful teardown, so remove the known
+		// project-prefixed volume(s) by name too. Best-effort: a failure here is
+		// non-fatal and points the operator at the manual removal.
+		hints := a.uninstallVolumeHint()
+		removed, rmErr := install.RemoveDataVolumes(a.Out, hints)
+		if rmErr != nil {
+			fmt.Fprintln(a.Out, theme.Warnf("could not remove the data volume by name (continuing): %v", rmErr))
+			fmt.Fprintln(a.Out, theme.Dimf("remove it by hand with: docker volume rm %s", strings.Join(hints, " ")))
+			return nil
+		}
+		if len(removed) > 0 {
+			fmt.Fprintln(a.Out, theme.Successf("Stopped Docker stack and removed its data volume (%s).", strings.Join(removed, ", ")))
+		} else {
+			fmt.Fprintln(a.Out, theme.Successf("Stopped Docker stack; no data volume found to remove (already gone)."))
+		}
 		return nil
 	}
 

--- a/cli/internal/cmd/uninstall_test.go
+++ b/cli/internal/cmd/uninstall_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -235,6 +236,68 @@ func TestUninstall_DockerPurgeAttemptsVolumeRemoval(t *testing.T) {
 	wantVol := install.DataVolumeNames(false)[0]
 	if strings.Contains(s, "may survive") && !strings.Contains(s, wantVol) {
 		t.Errorf("failure hint should name the data volume %q:\n%s", wantVol, s)
+	}
+}
+
+// fakePurgeDocker installs a `docker` stub on PATH that makes the purge path
+// deterministic without a real daemon: `docker compose … down -v` succeeds but
+// removes nothing (the wrong-project-name case that leaves the volume behind),
+// and `docker volume rm <name>` succeeds while appending <name> to a log file.
+// Returns the log path so the test can assert the explicit fallback ran. This
+// reproduces the reported bug: down -v exits 0 yet the volume survives, so the
+// by-name removal is what actually deletes it. POSIX-only (shell stub).
+func fakePurgeDocker(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-stub PATH technique is POSIX-only")
+	}
+	dir := t.TempDir()
+	log := filepath.Join(dir, "rm_log")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"rm\" ]; then\n" +
+		"  echo \"$3\" >> '" + log + "'\n" +
+		"  echo \"$3\"\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		// Every other invocation (compose … down -v, etc.) succeeds as a no-op,
+		// standing in for a `down -v` that matched no volumes.
+		"exit 0\n"
+	docker := filepath.Join(dir, "docker")
+	if err := os.WriteFile(docker, []byte(script), 0o755); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return log
+}
+
+// The regression fix: when `docker compose down -v` succeeds but removes no
+// volume (the volume was created under a different project name), --purge must
+// still delete the known project-prefixed volume by name. With a sqlite
+// manifest that volume is jentic_jentic-data, and the success message must name
+// it so the operator sees the data was actually removed.
+func TestUninstall_DockerPurgeRemovesVolumeByNameWhenDownVIsNoop(t *testing.T) {
+	log := fakePurgeDocker(t)
+
+	app, out := newTestApp(t)
+	if err := os.WriteFile(app.Paths.ComposePath(), []byte("services: {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := &config.Manifest{DB: "sqlite"}
+	if err := m.Save(app.Paths); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.uninstallE(&uninstallOptions{yes: true, purge: true}); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	wantVol := install.DataVolumeNames(false)[0] // jentic_jentic-data
+	logged, _ := os.ReadFile(log)
+	if !strings.Contains(string(logged), wantVol) {
+		t.Errorf("expected explicit `docker volume rm %s` fallback; rm log:\n%s", wantVol, logged)
+	}
+	if s := out.String(); !strings.Contains(s, wantVol) {
+		t.Errorf("success message should name the removed volume %q:\n%s", wantVol, s)
 	}
 }
 

--- a/cli/internal/install/compose.go
+++ b/cli/internal/install/compose.go
@@ -458,6 +458,41 @@ func ComposeDownVolumes(w io.Writer, composePath string) error {
 	return run(w, "docker", composeArgs(composePath, "down", "-v")...)
 }
 
+// RemoveDataVolumes removes the named docker volumes explicitly, by name. It is
+// the belt-and-suspenders companion to ComposeDownVolumes: `docker compose down
+// -v` only removes volumes declared in the compose file for the pinned project,
+// so a volume created under a different project name (a pre-pinning install, a
+// regenerated compose file, or a stack first brought up from a different
+// directory basename) survives an otherwise-successful `down -v`. Removing the
+// project-prefixed volume names directly closes that gap.
+//
+// A volume that does not exist is treated as a no-op (not an error): the goal is
+// "ensure gone", and `down -v` having already removed it is success, not
+// failure. It returns the names that were actually removed so the caller can
+// report accurately. If docker is not on PATH it returns an error immediately so
+// the caller can surface the manual-removal hint rather than failing deep in
+// exec.
+func RemoveDataVolumes(w io.Writer, names []string) (removed []string, err error) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		return nil, errors.New("`docker` not found on PATH; cannot remove the data volume(s)")
+	}
+	for _, name := range names {
+		out, rmErr := runCapture(w, "", "volume", "rm", name)
+		if rmErr == nil {
+			removed = append(removed, name)
+			continue
+		}
+		// `docker volume rm` on a missing volume exits non-zero with "no such
+		// volume" — that is the success case for us (it is already gone). Any
+		// other failure (e.g. the volume is still in use) is a real error.
+		if strings.Contains(strings.ToLower(out), "no such volume") {
+			continue
+		}
+		return removed, fmt.Errorf("docker volume rm %s: %w", name, rmErr)
+	}
+	return removed, nil
+}
+
 // ComposePs returns the `docker compose ps` output for the stack.
 func ComposePs(composePath string) (string, error) {
 	out, err := exec.Command("docker", composeArgs(composePath, "ps")...).CombinedOutput() //nolint:gosec // composePath is CLI-managed under JENTIC_HOME.

--- a/cli/internal/install/compose_test.go
+++ b/cli/internal/install/compose_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -170,5 +171,82 @@ func TestWriteComposeArtifactsPostgresWritesInitSQL(t *testing.T) {
 		if !strings.Contains(string(sql), "CREATE SCHEMA IF NOT EXISTS "+schema) {
 			t.Errorf("init SQL missing schema %q:\n%s", schema, sql)
 		}
+	}
+}
+
+// fakeVolumeDocker installs a `docker` stub on PATH that handles `docker volume
+// rm <name>`: it succeeds unless <name> is in missing (which makes it print the
+// daemon's real "no such volume" message and exit 1, exactly as a missing
+// volume does). Every `volume rm` invocation appends its target name to a log
+// file so the test can assert which volumes removal was attempted for. Returns
+// the log-file path. POSIX-only (shell stub), mirroring fakeDocker.
+func fakeVolumeDocker(t *testing.T, missing ...string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-stub PATH technique is POSIX-only")
+	}
+	dir := t.TempDir()
+	log := filepath.Join(dir, "rm_log")
+	var missingClauses strings.Builder
+	for _, m := range missing {
+		missingClauses.WriteString("    if [ \"$3\" = \"" + m + "\" ]; then\n")
+		missingClauses.WriteString("      echo \"Error: No such volume: " + m + "\" 1>&2\n")
+		missingClauses.WriteString("      exit 1\n")
+		missingClauses.WriteString("    fi\n")
+	}
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"rm\" ]; then\n" +
+		"  echo \"$3\" >> '" + log + "'\n" +
+		missingClauses.String() +
+		"  echo \"$3\"\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 0\n"
+	docker := filepath.Join(dir, "docker")
+	if err := os.WriteFile(docker, []byte(script), 0o755); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return log
+}
+
+func TestRemoveDataVolumesRemovesEachName(t *testing.T) {
+	log := fakeVolumeDocker(t)
+
+	var buf strings.Builder
+	names := []string{"jentic_jentic-data", "jentic_db-data"}
+	removed, err := RemoveDataVolumes(&buf, names)
+	if err != nil {
+		t.Fatalf("RemoveDataVolumes: %v", err)
+	}
+	if len(removed) != len(names) {
+		t.Fatalf("removed = %v, want %v", removed, names)
+	}
+	for i, n := range names {
+		if removed[i] != n {
+			t.Errorf("removed[%d] = %q, want %q", i, removed[i], n)
+		}
+	}
+	logged, _ := os.ReadFile(log)
+	for _, n := range names {
+		if !strings.Contains(string(logged), n) {
+			t.Errorf("expected docker volume rm to be attempted for %q; log:\n%s", n, logged)
+		}
+	}
+}
+
+func TestRemoveDataVolumesSwallowsMissingVolume(t *testing.T) {
+	// The SQLite volume is already gone (down -v removed it); the Postgres one
+	// does not exist. Neither is an error, and only the present one is reported
+	// as removed.
+	fakeVolumeDocker(t, "jentic_jentic-data")
+
+	var buf strings.Builder
+	removed, err := RemoveDataVolumes(&buf, []string{"jentic_jentic-data", "jentic_db-data"})
+	if err != nil {
+		t.Fatalf("missing volume must be a no-op, got: %v", err)
+	}
+	if len(removed) != 1 || removed[0] != "jentic_db-data" {
+		t.Errorf("removed = %v, want [jentic_db-data] (missing one skipped)", removed)
 	}
 }


### PR DESCRIPTION
## Summary

- `jenticctl uninstall --purge` (and the interactive "delete the data" confirmation) relied solely on `docker compose down -v`, which only removes volumes declared for the pinned `jentic` project. A volume created under a different project name (a pre-pinning install, a regenerated compose file, or a stack first brought up from a different directory basename) survived an otherwise-successful teardown — so uninstall reported success while the SQLite volume lived on and a reinstall silently reattached the old data.
- Add `install.RemoveDataVolumes`, which removes each project-prefixed volume by explicit name, swallows "no such volume" (already gone = success), and returns the names actually removed.
- The purge branch now calls it after `ComposeDownVolumes` and reports accurately: it names the removed volume(s), or prints "no data volume found to remove (already gone)" when none were removed, and keeps the non-fatal manual-removal hint on error. The keep-data path is unchanged.

## Test plan

- [x] `RemoveDataVolumes` removes each named volume and reports it; a missing volume is swallowed and only present volumes are returned (`compose_test.go`, fake-docker PATH stub).
- [x] Uninstall purge with a `sqlite` manifest removes `jentic_jentic-data` by name and names it in the success message even when `down -v` is a no-op (`uninstall_test.go`).
- [x] `go build ./...`, `go vet ./...`, `gofmt -l`, and full `go test ./...` for the CLI all pass.

Please use **squash + merge**.

Made with [Cursor](https://cursor.com)