### PR TITLE
fix(auth): retry DCR admin-DB write on transient SQLite lock

### DIFF
--- a/src/jentic_one/auth/services/registration_service.py
+++ b/src/jentic_one/auth/services/registration_service.py
@@ -10,6 +10,9 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from jentic_one.admin.core.schema.agents import Agent
 from jentic_one.admin.repos import ActorScopeGrantRepository
 from jentic_one.admin.repos.agent_repo import AgentRepository
 from jentic_one.auth.services.errors import InvalidGrantError, RegistrationAccessDeniedError
@@ -99,7 +102,7 @@ class RegistrationService:
         rat_ttl = self._ctx.config.auth.rat_ttl_seconds
         rat_expires_at = datetime.now(UTC) + timedelta(seconds=rat_ttl)
 
-        async with self._ctx.admin_db.transaction() as session:
+        async def _write(session: AsyncSession) -> Agent:
             agent = await AgentRepository.create_dcr(
                 session,
                 name=client_name,
@@ -137,6 +140,14 @@ class RegistrationService:
                 actor_id=agent.id,
                 actor_type=ActorType.AGENT.value,
             )
+            return agent
+
+        # Route through run_in_transaction so a transient SQLite write-lock —
+        # DCR contends on the admin DB with the background job worker's poll and
+        # concurrent token-mint traffic — is retried (with WAL + busy_timeout)
+        # rather than surfaced as a 500 "database is locked" on first contention.
+        # The RAT is generated above so its plaintext stays stable across a retry.
+        agent = await self._ctx.admin_db.run_in_transaction(_write)
 
         base_url = self._ctx.config.auth.canonical_base_url
         return RegisterResult(

--- a/tests/unit/auth/test_registration_scopes.py
+++ b/tests/unit/auth/test_registration_scopes.py
@@ -14,6 +14,14 @@ def _make_ctx() -> MagicMock:
     mock_session.commit = AsyncMock()
     ctx.admin_db.transaction.return_value.__aenter__ = AsyncMock(return_value=mock_session)
     ctx.admin_db.transaction.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    # register() routes its write through run_in_transaction; mirror the real
+    # helper by invoking the passed callback against the mock session so the
+    # _write body (create_dcr + scope grants) actually runs.
+    async def _run_in_transaction(fn: Any, **_kwargs: Any) -> Any:
+        return await fn(mock_session)
+
+    ctx.admin_db.run_in_transaction = AsyncMock(side_effect=_run_in_transaction)
     ctx.config.auth.rat_ttl_seconds = 900
     ctx.config.auth.canonical_base_url = "https://auth.example.com"
     return ctx

--- a/tests/unit/auth/test_registration_service.py
+++ b/tests/unit/auth/test_registration_service.py
@@ -20,6 +20,14 @@ def _make_ctx() -> MagicMock:
     ctx.admin_db.transaction.return_value.__aexit__ = AsyncMock(return_value=False)
     ctx.admin_db.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
     ctx.admin_db.session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    # register() routes its write through run_in_transaction; mirror the real
+    # helper by invoking the passed callback against the mock session so tests
+    # exercise the actual _write body (and its return value).
+    async def _run_in_transaction(fn: Any, **_kwargs: Any) -> Any:
+        return await fn(mock_session)
+
+    ctx.admin_db.run_in_transaction = AsyncMock(side_effect=_run_in_transaction)
     ctx.config.auth.rat_ttl_seconds = 900
     ctx.config.auth.canonical_base_url = "https://auth.example.com"
     return ctx


### PR DESCRIPTION
## Summary

Fixes a `database is locked` error hit during agent Dynamic Client Registration (DCR) when running on the SQLite backend (e.g. the Docker/SQLite setup).

This is the same class of bug as #648 (the token-mint fix), in a code path that was missed. The SQLite write strategy relies on two layers:

- `transaction()` — issues `BEGIN IMMEDIATE`, maps a lock to `DatabaseUnavailableError`, retries only at commit.
- `run_in_transaction()` — the outer wrapper that retries the whole write on a **fresh session with backoff**, absorbing transient `database is locked` under concurrency.

Every other contended admin-DB write (`token_service.issue_pair` / `issue_access_only`, `worker._claim_next`) already routes through `run_in_transaction`. But `RegistrationService.register()` used the bare `transaction()`, so when its `BEGIN IMMEDIATE` collided with the worker's 2s poll or a concurrent token mint and `busy_timeout` was exhausted, the lock surfaced straight to the client with no retry. Under Docker/SQLite all four surfaces share the one admin DB file and the worker is always polling, so this is easy to hit.

## Changes

- Route the DCR write through `run_in_transaction` (mirrors `token_service` and `worker`): extract `create_dcr` + scope grants + audit + event emit into a `_write(session)` callback.
- The RAT is generated **before** the transaction so its plaintext stays stable across a retry, keeping the callback idempotent (required by `run_in_transaction`).
- Update the registration service unit test to mock `run_in_transaction` by invoking the callback, mirroring `test_token_service`.

## Test plan

- [x] `tests/unit/auth/test_registration_service.py` passes
- [x] `tests/unit/auth/web/test_registration_router.py` passes
- [x] `tests/unit/auth/test_token_service.py` + `tests/unit/shared/db/` pass (no regression)
- [x] `mypy` clean on the changed service
- [ ] Manual: register an agent repeatedly under load against the Docker/SQLite config; no `database is locked` 500s

Note: use **squash + merge**.

Made with [Cursor](https://cursor.com)