### PR TITLE
docs(skill): reflect catalog:import default-grant for cataloged imports

### DIFF
--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -135,13 +135,16 @@ jentic catalog search "spreadsheets"
 jentic catalog import googleapis.com/sheets
 ```
 
-   Importing **writes** to the shared registry, so it needs the `apis:write`
-   scope, which you don't hold by default. If `import` fails with `403 … requires
-   one of: apis:write`, request the scope, wait for a human to approve, then
-   refresh your token and retry — you don't need a human to import for you:
+   Importing an **already-cataloged** API is gated on `catalog:import`, which an
+   approved agent holds **by default** — no access request needed. Just run the
+   import. (This is narrower than importing arbitrary URL/inline specs via
+   `POST /apis`, which still needs `apis:write`.) If `import` unexpectedly fails
+   with `403 … requires one of: catalog:import` — e.g. you were approved before
+   `catalog:import` became a default scope and weren't re-granted — request it,
+   wait for a human to approve, refresh your token, then retry:
 
 ```
-jentic access request --scope apis:write --wait
+jentic access request --scope catalog:import --wait
 jentic access refresh
 jentic catalog import googleapis.com/sheets
 ```
@@ -163,10 +166,10 @@ direct.)
 
 If `search` returns no results, it prints a hint to run `jentic catalog search`
 / `jentic catalog import` first — that almost always means nothing relevant is
-imported yet. **Reading** the registry needs no extra access (an approved agent
-already has it); only **importing** does — request `apis:write` as shown above
-if `import` is denied. Don't file an access request for a made-up "catalog read"
-scope.
+imported yet. Both **reading** the registry and **importing a cataloged API**
+need no request — an approved agent already holds `apis:read` and
+`catalog:import` by default, so just import and search again. Don't file an
+access request for a made-up "catalog read" scope.
 
 ### 4. Inspect the operation's contract
 
@@ -220,7 +223,8 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   scopes but your current token can't use it until you refresh.
 - `jentic catalog search "<query>"` — find importable APIs in the public catalog.
 - `jentic catalog import <vendor/name>` — import an API into the local registry
-  (required before `search` can find its operations).
+  (required before `search` can find its operations). Gated on `catalog:import`,
+  a default agent scope — no access request needed.
 - `jentic search "<query>"` — discover imported operations (JSON when piped);
   pass a hit's `operation_id` to `inspect`/`execute`.
 - `jentic apis operations <vendor/name/version>` — list an imported API's
@@ -242,11 +246,11 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   operator to run `jentic bootstrap` / `jentic register` and approve you.
 - `search` returning `{"data": []}` usually means **nothing is imported yet**,
   not that you lack access. Run `jentic catalog search` → `jentic catalog
-  import`, then search again. Reading the registry needs no grant (an approved
-  agent already has it); **importing** needs `apis:write` — request it with
-  `jentic access request --scope apis:write --wait` (then `jentic access
-  refresh`) if `import` is denied. Don't invent other "catalog read" scopes;
-  they're rejected.
+  import`, then search again. Both reading the registry and importing a
+  cataloged API need no grant — an approved agent already holds `apis:read` and
+  `catalog:import` by default. (Importing arbitrary URL/inline specs via `POST
+  /apis` is the only import path that needs `apis:write`.) Don't invent other
+  "catalog read" scopes; they're rejected.
 - An `execute` failure is not always an access problem. A DNS/transport error
   (`lookup broker.jentic.ai: no such host`, connection refused — exit **1**)
   means the **broker target** is wrong; on a local install point at the local


### PR DESCRIPTION
## Summary

Follow-up to #544, which added the narrow `catalog:import` scope, granted it to agents by default (`DEFAULT_AGENT_SCOPES`), and re-gated `POST /catalog/{api_id}:import` off `apis:write`. The bundled agent skill (`cli/internal/skillgen/content/jentic.md`) was never updated, so it still told agents that `jentic catalog import` requires `apis:write` and instructed them to file an access request and wait for a human — an obsolete human-in-the-loop detour for something that now works out of the box.

- **Step 3**: importing an already-cataloged API is a default `catalog:import` capability — run it directly, no request. Keeps a correct fallback for the caveat #544 itself raised (no backfill): pre-change agents that hit `403 … requires one of: catalog:import` request **`catalog:import`** (not `apis:write`) and refresh.
- Clarifies that `apis:write` now only covers arbitrary URL/inline import via `POST /apis`.
- Updates the no-results paragraph, Quick Reference, and Pitfalls to match.

Docs-only change to the canonical skill content; the managed-block hash re-stamps automatically on the next `jentic skill init/update`.

## Verification

- Two independent reviews (backend-behavior + editorial/parser) confirmed: the endpoint is gated on `catalog:import` (`catalog.py`), it's in `DEFAULT_AGENT_SCOPES` (`scopes.py`), the implication chain is `apis:write ⇒ catalog:import ⇒ apis:read` with no reverse (`permissions.py`), `POST /apis` still needs `apis:write` (`apis.py`), there is **no** migration/backfill so pre-change agents are correctly denied until re-granted (`agent_service.py` `if not existing_grants` guard), and the 403 detail literally reads `This action requires one of: catalog:import` (`deps.py`).
- `go test ./internal/skillgen/... ./internal/cmd/...` passes; a render check confirmed the generated skill contains `catalog:import` and no longer tells agents to `--scope apis:write` for import.
- No stale `apis:write` catalog-import hints remain elsewhere in the CLI.

Please **squash + merge**.

Made with [Cursor](https://cursor.com)