### PR TITLE
fix(auth): set owner_id on DCR agent approval for toolkit visibility

### DIFF
--- a/src/jentic_one/admin/repos/agent_repo.py
+++ b/src/jentic_one/admin/repos/agent_repo.py
@@ -118,6 +118,8 @@ class AgentRepository:
         agent.status = ActorStatus.ACTIVE
         agent.approved_by = approved_by
         agent.approved_at = datetime.now(UTC)
+        if agent.owner_id is None:
+            agent.owner_id = approved_by
         # Invalidate RAT in the same flush — approval and RAT clearing are one
         # logical operation per RFC 7592 (single-use credential).
         agent.registration_access_token_hash = None

--- a/src/jentic_one/auth/services/agent_service.py
+++ b/src/jentic_one/auth/services/agent_service.py
@@ -184,6 +184,7 @@ class AgentService:
                 target_id=agent_id,
                 actor_type=identity.actor_type,
                 actor_id=identity.sub,
+                after={"owner_id": agent.owner_id},
                 origin=identity.origin.value,
             )
             await emit_event_best_effort(

--- a/tests/unit/admin/repos/test_agent_repo.py
+++ b/tests/unit/admin/repos/test_agent_repo.py
@@ -1,0 +1,52 @@
+"""Unit tests for AgentRepository.set_approval owner_id assignment."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from jentic_one.admin.core.schema.agents import Agent
+from jentic_one.admin.repos.agent_repo import AgentRepository
+
+
+def _make_agent(*, owner_id: str | None = None) -> Agent:
+    agent = MagicMock(spec=Agent)
+    agent.id = "agnt_test1"
+    agent.name = "dcr-agent"
+    agent.owner_id = owner_id
+    agent.status = "pending"
+    agent.approved_by = None
+    agent.approved_at = None
+    agent.registration_access_token_hash = "hash123"
+    agent.rat_expires_at = None
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_set_approval_assigns_owner_id_when_none() -> None:
+    """DCR agents (owner_id=None) get owner_id set to the approver."""
+    agent = _make_agent(owner_id=None)
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=agent)
+    session.flush = AsyncMock()
+
+    result = await AgentRepository.set_approval(session, "agnt_test1", approved_by="usr_admin1")
+
+    assert result.owner_id == "usr_admin1"
+    assert result.approved_by == "usr_admin1"
+    assert result.status == "active"
+
+
+@pytest.mark.asyncio
+async def test_set_approval_preserves_existing_owner_id() -> None:
+    """Manually-created agents retain their original owner_id on approval."""
+    agent = _make_agent(owner_id="usr_original_owner")
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=agent)
+    session.flush = AsyncMock()
+
+    result = await AgentRepository.set_approval(session, "agnt_test1", approved_by="usr_admin1")
+
+    assert result.owner_id == "usr_original_owner"
+    assert result.approved_by == "usr_admin1"


### PR DESCRIPTION
## Summary

DCR-registered agents couldn't discover pre-seeded toolkits or credentials — `GET /toolkits` and `GET /credentials` returned empty arrays after successful authentication.

**Root cause:** `AgentRepository.create_dcr()` creates agents with `owner_id=None`, and the approval flow never set it. The token service derives `parent_actor_id` from `owner_id`, so it stayed `None`. The access filter in `build_access_filters()` then fell through to `col == identity.sub` — showing only resources the agent itself created (none).

**Fix:** Set `owner_id = approved_by` during approval when it's currently unset. The approver is the natural parent — their resources become visible via the existing delegation logic. Manually-created agents (which already have `owner_id`) are unaffected.

## Changes

- `AgentRepository.set_approval()` — conditionally assign `owner_id` for DCR agents
- `AgentService.approve()` — include `owner_id` in the APPROVE audit entry
- New unit tests verifying both cases (None → set, existing → preserved)

## Test plan

- [x] New unit tests pass
- [x] Existing approval tests unaffected
- [x] `make lint` + `make typecheck` clean
- [x] `make test-arch` passes (one pre-existing unrelated failure in `admin/services/auth_service.py`)