### PR TITLE
fix(access-requests): replace leaked <missing> placeholder with actionable field error

### DIFF
--- a/src/jentic_one/control/services/access_requests/effects.py
+++ b/src/jentic_one/control/services/access_requests/effects.py
@@ -15,6 +15,7 @@ from jentic_one.control.repos.toolkit_permission_repo import ToolkitPermissionRe
 from jentic_one.control.scoping.filters import build_access_filters, toolkit_owner_scope
 from jentic_one.control.services.access_requests.errors import (
     CredentialNotFoundForBindError,
+    RequiredFieldMissingError,
     RulesNotSupportedForBindError,
     ToolkitNotVisibleError,
     ToolkitReferenceAmbiguousError,
@@ -182,9 +183,13 @@ class EffectApplicator:
         # credential. Attribute a missing id to the right side so the 422 names
         # the actual problem instead of always blaming the credential.
         if not item.to_id:
-            raise ToolkitNotVisibleError("<missing>")
+            raise RequiredFieldMissingError(
+                "to_id", context="credential:bind requires a target toolkit"
+            )
         if not item.resource_id:
-            raise CredentialNotFoundForBindError("<missing>")
+            raise RequiredFieldMissingError(
+                "resource_id", context="credential:bind requires a credential"
+            )
         filters = build_access_filters(identity, Credential)
         credential = await CredentialRepository.get_by_id(
             session, item.resource_id, filters=filters

--- a/src/jentic_one/control/services/access_requests/errors.py
+++ b/src/jentic_one/control/services/access_requests/errors.py
@@ -201,15 +201,26 @@ class RulesNotSupportedForBindError(AccessRequestServiceError):
         self.action = action
 
 
+class RequiredFieldMissingError(AccessRequestServiceError):
+    """Raised when a required field is absent on an access request item."""
+
+    def __init__(self, field: str, *, context: str) -> None:
+        super().__init__(
+            f"Required field '{field}' is missing on the access request item; {context}"
+        )
+        self.field = field
+        self.context = context
+
+
 def assert_grantable_scope(scope: str | None) -> None:
     """Raise UnsupportedScopeGrantError unless ``scope`` is self-service grantable.
 
     Single source of truth for the scope:grant allow-list check, shared by the
     file-time guard (AccessRequestService) and the decide-time guard
-    (EffectApplicator) so the two can never drift. A falsy scope (missing, None,
-    or empty string) is reported as ``"<missing>"``. See issue #672.
+    (EffectApplicator) so the two can never drift. A falsy scope is reported as
+    a missing-field error. See issue #672.
     """
     if not scope:
-        raise UnsupportedScopeGrantError("<missing>")
+        raise RequiredFieldMissingError("resource_id", context="scope:grant requires a scope value")
     if scope not in GRANTABLE_SCOPES:
         raise UnsupportedScopeGrantError(scope)

--- a/src/jentic_one/control/services/access_requests/service.py
+++ b/src/jentic_one/control/services/access_requests/service.py
@@ -32,6 +32,7 @@ from jentic_one.control.services.access_requests.errors import (
     NotAReviewerError,
     PrerequisiteNotMetError,
     RequestNotPendingError,
+    RequiredFieldMissingError,
     RulesNotSupportedForBindError,
     ToolkitNotVisibleError,
     ToolkitReferenceUnresolvedError,
@@ -74,6 +75,7 @@ _UNFULFILLABLE_BIND_TARGET: tuple[type[Exception], ...] = (
     ToolkitReferenceUnresolvedError,
     ToolkitNotVisibleError,
     CredentialNotFoundForBindError,
+    RequiredFieldMissingError,
 )
 
 

--- a/src/jentic_one/control/web/errors.py
+++ b/src/jentic_one/control/web/errors.py
@@ -16,6 +16,7 @@ from jentic_one.control.services.access_requests.errors import (
     NotAReviewerError,
     PrerequisiteNotMetError,
     RequestNotPendingError,
+    RequiredFieldMissingError,
     RulesNotSupportedForBindError,
     ToolkitNotVisibleError,
     ToolkitReferenceAmbiguousError,
@@ -70,6 +71,7 @@ _ACCESS_REQUEST_ERROR_MAP: dict[type[Exception], tuple[int, str]] = {
     CredentialNotFoundForBindError: (422, "access_request_credential_not_found"),
     UnsupportedScopeGrantError: (422, "access_request_unsupported_scope"),
     RulesNotSupportedForBindError: (422, "access_request_rules_not_supported_for_bind"),
+    RequiredFieldMissingError: (422, "access_request_required_field_missing"),
 }
 
 

--- a/tests/unit/control/access_requests/test_effects.py
+++ b/tests/unit/control/access_requests/test_effects.py
@@ -17,6 +17,7 @@ from jentic_one.control.services.access_requests.effects import (
 )
 from jentic_one.control.services.access_requests.errors import (
     CredentialNotFoundForBindError,
+    RequiredFieldMissingError,
     RulesNotSupportedForBindError,
     ToolkitNotVisibleError,
     ToolkitReferenceAmbiguousError,
@@ -614,28 +615,31 @@ async def test_validate_credential_bind_missing_resource_id_raises(
     item = _make_item(resource_type="credential", action="bind", resource_id=None)
     applicator = EffectApplicator(ctx)
 
-    with pytest.raises(CredentialNotFoundForBindError):
+    with pytest.raises(RequiredFieldMissingError) as exc_info:
         await applicator.validate(item, identity=_make_identity(), control_session=session)
+    assert exc_info.value.field == "resource_id"
+    assert "<missing>" not in str(exc_info.value)
     mock_credential_repo.get_by_id.assert_not_called()
 
 
 @patch(f"{_MODULE}.CredentialRepository")
 @patch(f"{_MODULE}.EffectsRepository")
-async def test_validate_credential_bind_missing_to_id_raises_toolkit_error(
+async def test_validate_credential_bind_missing_to_id_raises(
     mock_effects_repo: MagicMock,
     mock_credential_repo: MagicMock,
 ) -> None:
     """A credential:bind missing its to_id (the toolkit target) fails validate()
-    as a toolkit error, not a misleading 'credential not found' — to_id names the
-    toolkit, resource_id names the credential."""
+    with a clear missing-field error, not a misleading 'toolkit not visible'."""
     ctx = _make_ctx()
     session = _make_session()
     mock_credential_repo.get_by_id = AsyncMock(return_value=None)
     item = _make_item(resource_type="credential", action="bind", to_id=None, resource_id="cred_001")
     applicator = EffectApplicator(ctx)
 
-    with pytest.raises(ToolkitNotVisibleError):
+    with pytest.raises(RequiredFieldMissingError) as exc_info:
         await applicator.validate(item, identity=_make_identity(), control_session=session)
+    assert exc_info.value.field == "to_id"
+    assert "<missing>" not in str(exc_info.value)
     mock_credential_repo.get_by_id.assert_not_called()
 
 
@@ -684,14 +688,16 @@ async def test_validate_scope_grant_missing_resource_id_raises(
     mock_effects_repo: MagicMock,
 ) -> None:
     """A scope-grant item with no resource_id must fail validate() as a 422
-    UnsupportedScopeGrantError, not slip through to a 500 mid-apply."""
+    RequiredFieldMissingError, not slip through to a 500 mid-apply."""
     ctx = _make_ctx()
     session = _make_session()
     item = _make_item(resource_type="scope", action="grant", resource_id=None)
     applicator = EffectApplicator(ctx)
 
-    with pytest.raises(UnsupportedScopeGrantError):
+    with pytest.raises(RequiredFieldMissingError) as exc_info:
         await applicator.validate(item, identity=_make_identity(), control_session=session)
+    assert exc_info.value.field == "resource_id"
+    assert "<missing>" not in str(exc_info.value)
 
 
 # --- unsupported combination ---


### PR DESCRIPTION
## Summary

- Introduces `RequiredFieldMissingError` for access request items missing required fields (`to_id`, `resource_id`)
- Replaces three sites that raised domain exceptions with `"<missing>"` as a placeholder ID, leaking it into Problem Details responses
- Agents now get clear messages like `"Required field 'to_id' is missing on the access request item; credential:bind requires a target toolkit"`

## Test plan

- [x] Updated 3 existing unit tests to assert new exception type
- [x] Verified no `"<missing>"` remains in error paths (`grep` clean)
- [x] `make test-fast` passes (1929 tests, 78.64% coverage)
- [x] `ruff check` + `mypy` clean