### PR TITLE
docs(control,broker): clarify permission rules and broker path format

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -324,7 +324,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "2c4ea53d93a5d7661383e1c667d72270f9bf2fb6",
         "is_verified": false,
-        "line_number": 15827
+        "line_number": 15836
       }
     ],
     "src/jentic_one/auth/services/crypto.py": [
@@ -1544,5 +1544,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-01T16:24:17Z"
+  "generated_at": "2026-07-13T14:22:38Z"
 }

--- a/openapi/broker/broker.openapi.yaml
+++ b/openapi/broker/broker.openapi.yaml
@@ -33,6 +33,24 @@ info:
     Toolkit, credential, and API-revision management live on the
     [control plane](https://control-plane.example.com), not here.
 
+    ## Path format
+
+    The request path **is** the upstream URL. The broker reconstructs the
+    full target from your path, adding `https://` when no scheme is present:
+
+    | You send | Broker proxies to |
+    |----------|-------------------|
+    | `GET /api.example.com/v1/users` | `https://api.example.com/v1/users` |
+    | `POST /petstore.swagger.io/v2/pet` | `https://petstore.swagger.io/v2/pet` |
+    | `GET /http://127.0.0.1:8080/get` | `http://127.0.0.1:8080/get` |
+    | `GET /https://api.example.com/v1/users` | `https://api.example.com/v1/users` |
+
+    For HTTPS upstream targets (the common case), omit the scheme — just use
+    `/{host}/{path}`. For plain HTTP targets (e.g. local development), include
+    the full `http://` scheme in the path so the broker doesn't upgrade to HTTPS.
+
+    Query strings pass through as-is: `/api.example.com/search?q=foo` works.
+
     ## Tracing and audit
 
     Every brokered response carries W3C trace context (`traceparent`,

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -58,7 +58,15 @@ components:
       title: AccessRequestFileRequest
       type: object
     AccessRequestItemRequest:
-      description: A single line-item in a file request.
+      description: |-
+        A single line-item in a file request.
+
+        **Permission rules:** Rules control which upstream API operations the broker
+        allows through a credential binding. They are enforced per (toolkit_id,
+        credential_id) pair, so they can only be attached to credential:bind items —
+        not toolkit:bind or scope:grant. You do not need toolkits:write scope to set
+        rules; include them directly on the credential:bind item when filing the
+        access request, and the approver's decision persists them on the binding.
       properties:
         action:
           enum:
@@ -90,6 +98,7 @@ components:
               $ref: '#/components/schemas/jentic_one__control__web__schemas__access_requests__PermissionRuleSchema'
             type: array
           - type: 'null'
+          description: 'Permission rules for the binding (credential:bind only). Rules are evaluated first-match-wins by the broker; if no rule matches, the request is denied. Example: [{"effect": "allow", "path": ".*"}].'
           title: Rules
         to_id:
           anyOf:

--- a/src/jentic_one/control/services/access_requests/errors.py
+++ b/src/jentic_one/control/services/access_requests/errors.py
@@ -194,8 +194,11 @@ class RulesNotSupportedForBindError(AccessRequestServiceError):
 
     def __init__(self, resource_type: str, action: str) -> None:
         super().__init__(
-            f"rules are not supported on {resource_type}:{action}; "
-            "attach rules to a credential:bind instead"
+            f"Permission rules are not supported on {resource_type}:{action} items. "
+            "Rules are enforced per (toolkit_id, credential_id) binding, so they "
+            "can only be attached to credential:bind items. To set rules, file an "
+            "access request with resource_type='credential', action='bind' and "
+            "include your rules there (toolkits:write scope is not needed)."
         )
         self.resource_type = resource_type
         self.action = action

--- a/src/jentic_one/control/web/schemas/access_requests.py
+++ b/src/jentic_one/control/web/schemas/access_requests.py
@@ -41,7 +41,15 @@ class CredentialSpecSchema(BaseModel):
 
 
 class AccessRequestItemRequest(BaseModel):
-    """A single line-item in a file request."""
+    """A single line-item in a file request.
+
+    **Permission rules:** Rules control which upstream API operations the broker
+    allows through a credential binding. They are enforced per (toolkit_id,
+    credential_id) pair, so they can only be attached to credential:bind items —
+    not toolkit:bind or scope:grant. You do not need toolkits:write scope to set
+    rules; include them directly on the credential:bind item when filing the
+    access request, and the approver's decision persists them on the binding.
+    """
 
     resource_type: Literal["credential", "toolkit", "scope"]
     action: Literal["bind", "grant"]
@@ -49,7 +57,14 @@ class AccessRequestItemRequest(BaseModel):
     resource_reference: dict[str, Any] | None = None
     to_type: str | None = None
     to_id: str | None = None
-    rules: list[PermissionRuleSchema] | None = None
+    rules: list[PermissionRuleSchema] | None = Field(
+        default=None,
+        description=(
+            "Permission rules for the binding (credential:bind only). "
+            "Rules are evaluated first-match-wins by the broker; if no rule matches, "
+            'the request is denied. Example: [{"effect": "allow", "path": ".*"}].'
+        ),
+    )
 
     @model_validator(mode="after")
     def _check_resource_target(self) -> AccessRequestItemRequest:

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -79,7 +79,7 @@
         "type": "object"
       },
       "AccessRequestItemRequest": {
-        "description": "A single line-item in a file request.",
+        "description": "A single line-item in a file request.\n\n**Permission rules:** Rules control which upstream API operations the broker\nallows through a credential binding. They are enforced per (toolkit_id,\ncredential_id) pair, so they can only be attached to credential:bind items —\nnot toolkit:bind or scope:grant. You do not need toolkits:write scope to set\nrules; include them directly on the credential:bind item when filing the\naccess request, and the approver's decision persists them on the binding.",
         "properties": {
           "action": {
             "enum": [
@@ -133,6 +133,7 @@
                 "type": "null"
               }
             ],
+            "description": "Permission rules for the binding (credential:bind only). Rules are evaluated first-match-wins by the broker; if no rule matches, the request is denied. Example: [{\"effect\": \"allow\", \"path\": \".*\"}].",
             "title": "Rules"
           },
           "to_id": {

--- a/ui/src/shared/api/generated/models/AccessRequestItemRequest.ts
+++ b/ui/src/shared/api/generated/models/AccessRequestItemRequest.ts
@@ -5,12 +5,22 @@
 import type { jentic_one__control__web__schemas__access_requests__PermissionRuleSchema } from './jentic_one__control__web__schemas__access_requests__PermissionRuleSchema';
 /**
  * A single line-item in a file request.
+ *
+ * **Permission rules:** Rules control which upstream API operations the broker
+ * allows through a credential binding. They are enforced per (toolkit_id,
+ * credential_id) pair, so they can only be attached to credential:bind items —
+ * not toolkit:bind or scope:grant. You do not need toolkits:write scope to set
+ * rules; include them directly on the credential:bind item when filing the
+ * access request, and the approver's decision persists them on the binding.
  */
 export type AccessRequestItemRequest = {
     action: AccessRequestItemRequest.action;
     resource_id?: (string | null);
     resource_reference?: (Record<string, any> | null);
     resource_type: AccessRequestItemRequest.resource_type;
+    /**
+     * Permission rules for the binding (credential:bind only). Rules are evaluated first-match-wins by the broker; if no rule matches, the request is denied. Example: [{"effect": "allow", "path": ".*"}].
+     */
     rules?: (Array<jentic_one__control__web__schemas__access_requests__PermissionRuleSchema> | null);
     to_id?: (string | null);
     to_type?: (string | null);


### PR DESCRIPTION
## Summary

Improve developer experience when agents hit permission-related errors in the access request and broker flows.

## Changes

- Improve `RulesNotSupportedForBindError` message to explain that permission rules are enforced per `(toolkit_id, credential_id)` and must be attached to `credential:bind` items — not `toolkit:bind` — and that `toolkits:write` scope is not needed
- Add permission rules documentation to the `AccessRequestItemRequest` schema docstring and `rules` field description (propagates to generated OpenAPI spec + UI client)
- Add a "Path format" section to the broker OpenAPI spec with a table showing how request paths map to upstream URLs (including scheme and localhost examples)

## Testing

- `make check` passes (pre-existing unrelated failure in `test_origin_propagation` only)
- OpenAPI conformance arch tests pass (spec regenerated via `make openapi`)
- All 53 rule-related unit tests pass
- YAML validity confirmed for both specs

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] `make check` passes (lint, type check, secrets audit, arch tests)
- [ ] Tests added/updated for the change
- [x] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included
