### PR TITLE
docs(auth): correct token endpoint schema from 'form body' to 'JSON body'

### DIFF
--- a/src/jentic_one/auth/web/schemas/oauth.py
+++ b/src/jentic_one/auth/web/schemas/oauth.py
@@ -6,7 +6,11 @@ from pydantic import BaseModel, Field
 
 
 class TokenRequest(BaseModel):
-    """Token endpoint request (form body)."""
+    """Token endpoint request (JSON body).
+
+    Note: this endpoint accepts application/json, not the
+    application/x-www-form-urlencoded encoding that RFC 6749 specifies.
+    """
 
     grant_type: str
     refresh_token: str | None = None
@@ -45,14 +49,14 @@ class MintResponse(BaseModel):
 
 
 class RevokeRequest(BaseModel):
-    """Revocation endpoint request (form body)."""
+    """Revocation endpoint request (JSON body)."""
 
     token: str
     token_type_hint: str | None = None
 
 
 class IntrospectRequest(BaseModel):
-    """Introspection endpoint request (form body)."""
+    """Introspection endpoint request (JSON body)."""
 
     token: str
     token_type_hint: str | None = None


### PR DESCRIPTION
## Summary

Corrects the OAuth token endpoint request schema documentation — the endpoint accepts a JSON body, not `application/x-www-form-urlencoded`.

## Related issue

## Changes

- Update schema docstring/description in `src/jentic_one/auth/web/schemas/oauth.py` to reflect that the token endpoint accepts JSON

## Testing

- `make check` passes
- No logic change — docs/schema description only

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] `make check` passes (lint, type check, secrets audit, arch tests)
- [ ] Tests added/updated for the change
- [x] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included
