### PR TITLE
fix(auth): prevent SQLite deadlock in JWT assertion token exchange

### DIFF
--- a/src/jentic_one/auth/services/assertion_service.py
+++ b/src/jentic_one/auth/services/assertion_service.py
@@ -82,6 +82,10 @@ class AssertionService:
         if not issuer or not isinstance(issuer, str):
             raise InvalidGrantError(_INVALID)
 
+        # Phase 1: verify assertion + record audit in a single transaction.
+        # This transaction is committed BEFORE issuing tokens so that
+        # issue_pair's own run_in_transaction doesn't deadlock waiting for
+        # this connection's write lock to release (SQLite single-writer).
         async with self._ctx.admin_db.transaction() as session:
             agent = await AgentRepository.get_by_id_for_update(session, issuer)
 
@@ -125,10 +129,10 @@ class AssertionService:
                 origin=None,
             )
 
-            token_svc = TokenService(self._ctx)
-            access_token, refresh_token = await token_svc.issue_pair(
-                agent.id, ActorType.AGENT, scopes
-            )
+        # Phase 2: issue tokens (outside the transaction above).
+        # issue_pair uses its own run_in_transaction internally.
+        token_svc = TokenService(self._ctx)
+        access_token, refresh_token = await token_svc.issue_pair(agent.id, ActorType.AGENT, scopes)
 
         return access_token, refresh_token
 

--- a/src/jentic_one/shared/db/session.py
+++ b/src/jentic_one/shared/db/session.py
@@ -163,8 +163,8 @@ class DatabaseSession:
         self,
         fn: Callable[[AsyncSession], Awaitable[T]],
         *,
-        retries: int = 2,
-        backoff_s: float = 0.05,
+        retries: int = 4,
+        backoff_s: float = 0.25,
     ) -> T:
         """Run ``fn(session)`` inside a transaction, retrying transient failures.
 

--- a/src/jentic_one/shared/db/session.py
+++ b/src/jentic_one/shared/db/session.py
@@ -163,8 +163,8 @@ class DatabaseSession:
         self,
         fn: Callable[[AsyncSession], Awaitable[T]],
         *,
-        retries: int = 4,
-        backoff_s: float = 0.25,
+        retries: int = 2,
+        backoff_s: float = 0.05,
     ) -> T:
         """Run ``fn(session)`` inside a transaction, retrying transient failures.
 


### PR DESCRIPTION
## Summary

Prevents a SQLite deadlock in the JWT assertion token exchange flow. The `issue_pair` call was nested inside an outer transaction, causing it to wait indefinitely for the write lock held by that same connection. Moved token issuance outside the transaction boundary.

Only affects SQLite (local dev / CLI) — Postgres handles concurrent transactions fine.

## Related issue


## Changes

- Move `TokenService.issue_pair()` call outside the assertion verification transaction in `AssertionService` so the two write transactions run sequentially, not nested
- Revert speculative retry budget increase in `DatabaseSession` (root cause is fixed, band-aid no longer needed)

## Testing

- `make check` passes (lint, typecheck, arch tests)
- Manually verified: JWT assertion exchange no longer hangs on SQLite backend

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] `make check` passes (lint, type check, secrets audit, arch tests)
- [ ] Tests added/updated for the change
- [ ] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included
