### PR TITLE
fix(github): intake output-guard + Slack notification polish

### DIFF
--- a/.github/workflows/intake-output-guard.yml
+++ b/.github/workflows/intake-output-guard.yml
@@ -9,6 +9,10 @@ name: Intake output guard
 #   - a label the harness is forbidden to apply (security / human-authority verdicts)
 #   - closing or locking an issue (harness must NEVER close — "triage, don't close")
 #   - an unmarked comment, or a second intake comment (one <!-- jentic-intake --> only)
+# The orchestrator's own "[Orchestrator] …" lifecycle notices (e.g. "Session
+# started") carry no intake marker by design; the guard silently minimizes them
+# (collapsed, tidy) WITHOUT posting a "reverted" notice or failing — they are
+# harness-controlled, not a violation.
 #
 # This is reactive (the bad action exists for the seconds until this runs, then is
 # reverted) — the same limitation as label-guard.yml / Kubernetes Prow. It only
@@ -120,7 +124,17 @@ jobs:
 
           # ---- Comment discipline: marked, and only one --------------------
           if [ "$ACTION" = "created" ] && [ -n "${COMMENT_NODE_ID:-}" ]; then
-            if ! printf '%s' "$COMMENT_BODY" | grep -Fq '<!-- jentic-intake -->'; then
+            if printf '%s' "$COMMENT_BODY" | grep -Eq '^\[Orchestrator\]'; then
+              # The orchestrator's own lifecycle notice (e.g. "[Orchestrator]
+              # Session started …"). Harness-controlled, NOT model output (the
+              # intake agent is tokenless and posts nothing itself), and the prefix
+              # is applied mechanically by the harness runtime (github_messages.py),
+              # so it can't be forged via a prompt-injected issue body. Minimize it
+              # silently for a tidy thread — but it is NOT a violation, so post no
+              # "reverted" notice and do not fail the job.
+              echo "Minimizing orchestrator lifecycle notice (not a violation)."
+              gh api graphql -f query='mutation($id:ID!){minimizeComment(input:{classifier:OUTDATED,subjectId:$id}){clientMutationId}}' -f id="$COMMENT_NODE_ID" || true
+            elif ! printf '%s' "$COMMENT_BODY" | grep -Fq '<!-- jentic-intake -->'; then
               echo "::error::Harness posted an unmarked comment — hiding it."
               gh api graphql -f query='mutation($id:ID!){minimizeComment(input:{classifier:OFF_TOPIC,subjectId:$id}){clientMutationId}}' -f id="$COMMENT_NODE_ID" || true
               violation="posted an unmarked comment"

--- a/.github/workflows/notify-new-feedback.yml
+++ b/.github/workflows/notify-new-feedback.yml
@@ -82,11 +82,34 @@ jobs:
           # in quick succession, so that snapshot can arrive empty/stale (observed
           # on #581: Slack showed "no labels" while the issue really had
           # documentation/area:docs/fit:high/feasibility:high). Fetching live is the
-          # source of truth. Soft-fail to an empty list if the API is unreachable.
+          # source of truth. Assign-then-read so a fetch FAILURE (warn, card may be
+          # incomplete) is distinguishable from an issue that genuinely has no
+          # labels — a swallowed failure would silently reproduce the "no labels"
+          # bug we're fixing.
+          if ! raw_labels="$(gh api "repos/$REPO/issues/$NUMBER" --jq '.labels[].name' 2>/tmp/gherr)"; then
+            echo "::warning::Could not fetch live labels for #$NUMBER ($(head -c 200 /tmp/gherr 2>/dev/null)); the Slack card may be incomplete."
+            raw_labels=""
+          fi
           labels=()
           while IFS= read -r lbl; do
             [ -n "$lbl" ] && labels+=("$lbl")
-          done < <(gh api "repos/$REPO/issues/$NUMBER" --jq '.labels[].name' 2>/dev/null || true)
+          done <<< "$raw_labels"
+
+          # Re-check needs-info against the LIVE labels, not just the payload
+          # snapshot the `if:` gate used. The gate reads
+          # github.event.issue.labels (point-in-time); in the same race that
+          # motivates the live fetch, the snapshot could miss a needs-info that is
+          # actually present. Skip the "triaged" ping in that case so the
+          # author-loop never notifies prematurely. (The needs-human escalation
+          # path sets ESCALATED and is exempt.)
+          if [ "$ESCALATED" != "true" ]; then
+            for lbl in "${labels[@]}"; do
+              if [ "$lbl" = "needs-info" ]; then
+                echo "Issue #$NUMBER still has needs-info (live) — skipping triaged notification."
+                exit 0
+              fi
+            done
+          fi
 
           # Per-label emoji (exact match — no substring collisions).
           emoji_for() {
@@ -142,7 +165,7 @@ jobs:
           # Sort labels into the triage dimensions so the card reads as a scannable
           # summary (Type · Area · Fit · Severity) instead of a flat label soup.
           # Remaining labels (status flags etc.) fall through to an "Also" line.
-          type_v=""; area_v=""; fit_v=""; sev_v=""; feas_v=""; extra=""
+          type_v=""; area_v=""; fit_v=""; sev_v=""; feas_v=""; feas_full=""; extra=""
           add_type() { [ -z "$type_v" ] && type_v="$1" || type_v="$type_v, $1"; }
           for lbl in "${labels[@]}"; do
             e="$(emoji_for "$lbl")"
@@ -152,7 +175,7 @@ jobs:
               area:*)             area_v="$e \`${lbl#area:}\`" ;;
               fit:*)              fit_v="$e \`${lbl#fit:}\`" ;;
               severity:*)         sev_v="$e \`${lbl#severity:}\`" ;;
-              feasibility:*)      feas_v="$e \`${lbl#feasibility:}\`" ;;
+              feasibility:*)      feas_v="$e \`${lbl#feasibility:}\`"; feas_full="$e \`$lbl\`" ;;
               *)                  extra="${extra}$e \`$lbl\`  " ;;
             esac
           done
@@ -162,6 +185,8 @@ jobs:
           # Severity is optional (e.g. docs); show feasibility there if no severity.
           if [ -n "$sev_v" ]; then
             sig_label="Severity"; sig_val="$sev_v"
+            # Severity won the signal slot; keep feasibility visible on "Also".
+            [ -n "$feas_full" ] && extra="${extra}${feas_full}  "
           elif [ -n "$feas_v" ]; then
             sig_label="Feasibility"; sig_val="$feas_v"
           else

--- a/.github/workflows/notify-new-feedback.yml
+++ b/.github/workflows/notify-new-feedback.yml
@@ -20,8 +20,10 @@ name: Notify Slack on triaged feedback
 # If the secret is absent the job no-ops (so forks / dry runs don't fail).
 #
 # Originally authored by @sophie-jentic (PR #557); carried forward with the review
-# fixes applied (UTF-8-safe truncation, exact-match label emojis, soft-fail) and
-# retimed to fire post-triage rather than on open.
+# fixes applied (UTF-8-safe truncation, exact-match label emojis, soft-fail),
+# retimed to fire post-triage, and the card reworked into scannable triage fields
+# (Type · Area · Fit · Severity) — reusing Sophie's per-label emojis and her
+# repo/"file new feedback" navigation footer.
 
 on:
   issues:
@@ -29,6 +31,7 @@ on:
 
 permissions:
   contents: none
+  issues: read
 
 concurrency:
   group: notify-feedback-${{ github.event.issue.number }}
@@ -57,12 +60,13 @@ jobs:
           # A UTF-8 locale so bash ${var:0:N} slices by character, not byte.
           LANG: C.UTF-8
           LC_ALL: C.UTF-8
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           TITLE: ${{ github.event.issue.title }}
           URL: ${{ github.event.issue.html_url }}
           NUMBER: ${{ github.event.issue.number }}
           AUTHOR: ${{ github.event.issue.user.login }}
-          LABELS: ${{ join(github.event.issue.labels.*.name, ', ') }}
+          REPO: ${{ github.repository }}
           BODY: ${{ github.event.issue.body }}
           ESCALATED: ${{ github.event.action == 'labeled' && github.event.label.name == 'needs-human' }}
         run: |
@@ -71,16 +75,18 @@ jobs:
             exit 0
           fi
 
-          # Split labels into an array on the ", " join separator.
+          # Read the issue's labels LIVE from the API, not from the webhook payload.
+          # This job fires on the `ai-intake` removal, and the payload's
+          # issue.labels is a snapshot from when the event was queued — during an
+          # intake pass the harness applies the triage labels and removes ai-intake
+          # in quick succession, so that snapshot can arrive empty/stale (observed
+          # on #581: Slack showed "no labels" while the issue really had
+          # documentation/area:docs/fit:high/feasibility:high). Fetching live is the
+          # source of truth. Soft-fail to an empty list if the API is unreachable.
           labels=()
-          if [ -n "$LABELS" ]; then
-            IFS=',' read -ra raw_labels <<< "$LABELS"
-            for raw in "${raw_labels[@]}"; do
-              lbl="${raw#"${raw%%[![:space:]]*}"}"   # ltrim
-              lbl="${lbl%"${lbl##*[![:space:]]}"}"   # rtrim
-              [ -n "$lbl" ] && labels+=("$lbl")
-            done
-          fi
+          while IFS= read -r lbl; do
+            [ -n "$lbl" ] && labels+=("$lbl")
+          done < <(gh api "repos/$REPO/issues/$NUMBER" --jq '.labels[].name' 2>/dev/null || true)
 
           # Per-label emoji (exact match — no substring collisions).
           emoji_for() {
@@ -133,11 +139,35 @@ jobs:
             header_text="$header_emoji Triaged feedback: #$NUMBER"
           fi
 
-          labels_fmt=""
+          # Sort labels into the triage dimensions so the card reads as a scannable
+          # summary (Type · Area · Fit · Severity) instead of a flat label soup.
+          # Remaining labels (status flags etc.) fall through to an "Also" line.
+          type_v=""; area_v=""; fit_v=""; sev_v=""; feas_v=""; extra=""
+          add_type() { [ -z "$type_v" ] && type_v="$1" || type_v="$type_v, $1"; }
           for lbl in "${labels[@]}"; do
-            labels_fmt="${labels_fmt}$(emoji_for "$lbl") \`${lbl}\`   "
+            e="$(emoji_for "$lbl")"
+            case "$lbl" in
+              bug|enhancement|idea|pain-point|documentation|question)
+                                  add_type "$e \`$lbl\`" ;;
+              area:*)             area_v="$e \`${lbl#area:}\`" ;;
+              fit:*)              fit_v="$e \`${lbl#fit:}\`" ;;
+              severity:*)         sev_v="$e \`${lbl#severity:}\`" ;;
+              feasibility:*)      feas_v="$e \`${lbl#feasibility:}\`" ;;
+              *)                  extra="${extra}$e \`$lbl\`  " ;;
+            esac
           done
-          [ -z "$labels_fmt" ] && labels_fmt="_no labels_"
+          [ -z "$type_v" ] && type_v="_—_"
+          [ -z "$area_v" ]  && area_v="_—_"
+          [ -z "$fit_v" ]   && fit_v="_—_"
+          # Severity is optional (e.g. docs); show feasibility there if no severity.
+          if [ -n "$sev_v" ]; then
+            sig_label="Severity"; sig_val="$sev_v"
+          elif [ -n "$feas_v" ]; then
+            sig_label="Feasibility"; sig_val="$feas_v"
+          else
+            sig_label="Severity"; sig_val="_—_"
+          fi
+          extra="${extra% }"; extra="${extra% }"
 
           # Clean the body to a single line, then character-slice to 240.
           cleaned="$(printf '%s' "$BODY" \
@@ -154,25 +184,52 @@ jobs:
           # Build the Slack Block Kit payload with jq so all fields are escaped.
           # Untrusted issue title/body are rendered as PLAIN TEXT (not mrkdwn) so
           # an attacker can't smuggle a clickable <url|link> or markup into the
-          # channel. Only the trusted issue URL is a link.
+          # channel. Only the trusted issue URL and the (repo-controlled) label
+          # values are mrkdwn.
+          footer_note="🤖 Auto-triaged by the intake harness"
+          [ "$ESCALATED" = "true" ] && footer_note="🙋 Escalated for human review"
           payload=$(jq -n \
             --arg header "$header_text" \
             --arg title "$TITLE" \
             --arg url "$URL" \
             --arg author "$AUTHOR" \
-            --arg labels "$labels_fmt" \
             --arg summary "$summary" \
             --arg number "$NUMBER" \
+            --arg type "$type_v" \
+            --arg area "$area_v" \
+            --arg fit "$fit_v" \
+            --arg sig_label "$sig_label" \
+            --arg sig_val "$sig_val" \
+            --arg extra "$extra" \
+            --arg footer "$footer_note" \
+            --arg repo_url "https://github.com/${REPO}" \
+            --arg new_url "https://github.com/${REPO}/issues/new/choose" \
             '{
-              blocks: [
-                { type: "header", text: { type: "plain_text", text: $header, emoji: true } },
-                { type: "section", text: { type: "plain_text", text: $title, emoji: false } },
-                { type: "section", text: { type: "plain_text", text: $summary, emoji: false } },
-                { type: "section", text: { type: "mrkdwn", text: ("*Labels:*\n" + $labels) } },
-                { type: "context", elements: [
-                    { type: "mrkdwn", text: ("Filed by *" + $author + "* · <" + $url + "|View issue #" + $number + ">") }
-                ] }
-              ]
+              blocks: (
+                [
+                  { type: "header", text: { type: "plain_text", text: $header, emoji: true } },
+                  { type: "section", text: { type: "plain_text", text: $title, emoji: false } },
+                  { type: "section", fields: [
+                      { type: "mrkdwn", text: ("*Type*\n" + $type) },
+                      { type: "mrkdwn", text: ("*Area*\n" + $area) },
+                      { type: "mrkdwn", text: ("*Fit*\n" + $fit) },
+                      { type: "mrkdwn", text: ("*" + $sig_label + "*\n" + $sig_val) }
+                  ] }
+                ]
+                + (if ($extra | length) > 0
+                   then [ { type: "context", elements: [ { type: "mrkdwn", text: ("Also: " + $extra) } ] } ]
+                   else [] end)
+                + [
+                  { type: "divider" },
+                  { type: "section", text: { type: "plain_text", text: $summary, emoji: false } },
+                  { type: "context", elements: [
+                      { type: "mrkdwn", text: ($footer + "  ·  filed by *" + $author + "*  ·  <" + $url + "|open #" + $number + ">") }
+                  ] },
+                  { type: "context", elements: [
+                      { type: "mrkdwn", text: ("📋 <" + $repo_url + "|jentic-one> · <" + $new_url + "|file new feedback>") }
+                  ] }
+                ]
+              )
             }')
 
           code=$(curl -sS -o /tmp/resp -w "%{http_code}" \


### PR DESCRIPTION
Two related intake-lifecycle fixes found while smoke-testing the harness live on #581.

## 1. Output guard: don't revert the orchestrator's own session notice

The intake output guard reverted any harness comment lacking the `<!-- jentic-intake -->` marker — but the orchestrator posts its own lifecycle notice (`[Orchestrator] Session started …`) which has no marker **by design**. So every intake run left a spurious `github-actions` "🛡️ reverted an unmarked comment" comment.

- `[Orchestrator]`-prefixed comments now get their own branch: **silently minimized** (collapsed, tidy thread), **no** reverted-notice, **no** job failure.
- Genuinely unmarked non-orchestrator comments are still reverted with a visible notice + failure (injection defense unchanged).
- Safe because the `[Orchestrator]` prefix is applied mechanically by the harness runtime (`github_messages.py`), never by the model — the intake agent is tokenless and posts nothing itself, so it can't be forged via a prompt-injected issue body.

## 2. Slack notification: read live labels + rework the card

The "triaged" Slack message showed **"no labels"** (seen on #581) even though the issue was fully labelled. It read labels from the webhook payload, but the job fires on the `ai-intake` removal — during a pass the harness applies triage labels and strips `ai-intake` in quick succession, so the payload snapshot arrives empty/stale.

- **Fetch labels live from the API** (`issues: read` + `GH_TOKEN`) instead of trusting the payload snapshot.
- **Reworked the card** into a scannable triage summary: **Type · Area · Fit · Severity** (falls back to Feasibility when severity is absent, e.g. docs), an "Also" line for remaining status labels, a divider, the body summary, and a footer.
- **Reuses @sophie-jentic's (#557)** per-label emojis and her repo / "file new feedback" navigation footer (trusted hardcoded links).
- Untrusted title/body stay `plain_text` so they can't smuggle mrkdwn links.

## Test plan

- [x] Both workflows: YAML parses
- [x] Guard: `[Orchestrator]` → silent-minimize; marked agent comment → visible; unmarked/injected → revert+notice+fail
- [x] Notify: label-sorting + Block Kit payload build validated with #581's labels (valid JSON, 7 blocks, footer nav correct)
- [ ] Observe on next intake run: session notice collapses with no guard comment; Slack card shows the real labels in Type/Area/Fit fields

Squash-merge per repo convention.