### PR TITLE
feat(ci): add ux and ax experience labels to intake taxonomy

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -143,6 +143,14 @@
   color: 5319e7
   description: Trigger AI review that cascades to implement
 
+# --- Experience ---
+- name: ux
+  color: f9d0c4
+  description: User experience — friction, clarity, or polish in the human-facing UI or CLI
+- name: ax
+  color: c5def5
+  description: Agent experience — friction, clarity, or reliability for AI agents using Jentic APIs, SDKs, or the agent-facing CLI
+
 # --- Community / housekeeping ---
 - name: good first issue
   color: 7057ff

--- a/.harness/ISSUE_INTAKE_STANDARDS.md
+++ b/.harness/ISSUE_INTAKE_STANDARDS.md
@@ -59,6 +59,15 @@ prefix `[bug]` / `[request]` is a hint from the author, not authoritative — a
   `area:ui`, …). If genuinely ambiguous, do **not** guess — leave area unset and
   rely on the author-loop / `needs-human` (see below).
 
+### 1b. Experience tags (optional, additive)
+
+Apply at most one of `ux` / `ax` when the issue is *specifically about experience quality* — not merely incidentally involving a UI or an API:
+
+- **`ux`** — the complaint or request is centrally about the experience of a human using the UI or CLI (navigation, wording, layout, discoverability, visual polish). Do **not** apply to a straightforward bug that happens to be in the UI.
+- **`ax`** — the complaint or request is centrally about the experience of an AI agent consuming Jentic APIs, SDKs, or agent-facing CLI surfaces (ergonomics, predictability, error clarity, schema design). Do **not** apply to a generic API or CLI bug.
+
+These are additive: a `pain-point` about confusing UI copy is both `pain-point` and `ux`; a `bug` where a button is broken is just `bug`. When in doubt, omit.
+
 ### 2. Score (labels + comment): product-fit and feasibility
 
 Judge two **independent** axes and apply the matching labels:


### PR DESCRIPTION
<!--
Thanks for contributing to Jentic One!
Keep PRs focused and reviewable. Do not include secrets or credentials.
-->

## Summary

<!-- What does this change and why? -->

Adds two optional cross-cutting labels — `ux` (human-facing UI/CLI experience) and `ax` (agent-facing API/CLI experience) — to labels.yml and the intake standards. The agent applies them only when the issue is centrally about experience quality, not incidentally touching a UI or API.

## Related issue

<!-- e.g. Closes #123 -->

## Changes

- Adds `ux` and `ax` labels into the issue-triage agent context, along with explanations on how to use them.

## Testing

<!-- How did you verify this? `make check` output, new/updated tests, manual steps. -->

## Checklist

- [ ] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [ ] `make check` passes (lint, type check, secrets audit, arch tests)
- [ ] Tests added/updated for the change
- [ ] Docs updated where relevant
- [ ] No secrets, credentials, or internal-only references included
