### PR TITLE
fix(ci): shorten ax label description to under 100 chars

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -149,7 +149,7 @@
   description: User experience — friction, clarity, or polish in the human-facing UI or CLI
 - name: ax
   color: c5def5
-  description: Agent experience — friction, clarity, or reliability for AI agents using Jentic APIs, SDKs, or the agent-facing CLI
+  description: Agent experience — friction, clarity, or reliability for AI agents (APIs, SDKs, CLI)
 
 # --- Community / housekeeping ---
 - name: good first issue


### PR DESCRIPTION
<!--
Thanks for contributing to Jentic One!
Keep PRs focused and reviewable. Do not include secrets or credentials.
-->

## Summary

<!-- What does this change and why? -->
Reduces the length of the newly-added `ax` label description to <100 chars (GitHub upper limit).

## Related issue

<!-- e.g. Closes #123 -->

## Changes

- Shorten the `ax` label description

## Testing

<!-- How did you verify this? `make check` output, new/updated tests, manual steps. -->

## Checklist

- [ ] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [ ] `make check` passes (lint, type check, secrets audit, arch tests)
- [ ] Tests added/updated for the change
- [ ] Docs updated where relevant
- [ ] No secrets, credentials, or internal-only references included
