### PR TITLE
docs(intake): point de-dup at the candidate_issues list, not a live search

### DIFF
--- a/.harness/ISSUE_INTAKE_STANDARDS.md
+++ b/.harness/ISSUE_INTAKE_STANDARDS.md
@@ -112,10 +112,11 @@ Apply one `severity:*` label. **Severity is the priority signal** for this repo.
 
 ### 4. De-duplicate (suggest — never auto-close)
 
-Search existing issues (open **and** closed) for the same symptom. Duplicate
-detection is **advisory**: you suggest, a human decides. This avoids the
-well-documented failure mode where a bot builds false-duplicate chains that bury
-real reports and seal off the appeals process.
+Compare against the **`candidate_issues`** list in `.harness/intake-input.json` (recent
+issues as `{number, title}`, supplied to you because you cannot search issues yourself)
+for the same symptom. Duplicate detection is **advisory**: you suggest, a human decides.
+This avoids the well-documented failure mode where a bot builds false-duplicate chains
+that bury real reports and seal off the appeals process.
 
 If you find a likely duplicate:
 


### PR DESCRIPTION
## Summary

The intake agent is tokenless (`[Read, Grep]`) and can't search issues itself, so steering note §4 ("Search existing issues…") described a capability the runtime doesn't have — de-dup was a silent no-op.

Paired with **jentic/harness#198**, which supplies recent issues as a `candidate_issues` list (`[{number, title}]`) in `.harness/intake-input.json` (fetched orchestrator-side via the App token, sanitized). This PR updates §4 so the instruction matches the runtime: compare against that provided list rather than implying a live search.

## Context

Surfaced by jentic/jentic-one#587 (a near-duplicate of #584 that never got `duplicate-candidate` because the agent couldn't see #584). Tracked as jentic/harness#194.

> **Merge order:** this is docs-only and harmless on its own, but de-dup only actually works once jentic/harness#198 is deployed (it's what writes `candidate_issues`).

Squash-merge per convention.

Made with [Cursor](https://cursor.com)