### PR TITLE
feat(cli): export tree builders + core.Run for downstream CLI composition

### DIFF
--- a/cli/internal/cmd/common.go
+++ b/cli/internal/cmd/common.go
@@ -16,6 +16,10 @@ type exitCodeError struct{ code int }
 
 func (e *exitCodeError) Error() string { return fmt.Sprintf("child exited with code %d", e.code) }
 
+// ExitCode satisfies core.ExitCoder so core.Run mirrors a wrapped child's exit
+// code verbatim.
+func (e *exitCodeError) ExitCode() int { return e.code }
+
 // resolveIdentity loads the CLI config once and resolves the profile name and
 // control-plane base URL, honouring explicit flag values over config/defaults.
 func (a *App) resolveIdentity(profileFlag, baseURLFlag string) (profileName, baseURL string, err error) {

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -2,12 +2,8 @@
 package cmd
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -163,48 +159,36 @@ func appFromContainer(deps *core.AppContainer) (*App, error) {
 	return &App{Paths: paths, Out: deps.Out, Err: deps.Err}, nil
 }
 
-// runRoot builds the root command via the built-in tree builder, wires a
-// signal-cancelled context, and executes it. It composes the tree through
-// core.NewRootCmd so any injected ExtraCommands are appended after the built-in
-// set. The real work lives here (rather than in Execute*) so that deferred
-// cleanup (the signal-context cancel) always runs before the process exits.
-func runRoot(build func(*App) *cobra.Command) int {
-	deps := defaultContainer()
-
-	// Adapt the internal (*App)-based tree builder to core.TreeBuilder. App
-	// construction (path resolution) can fail; surface it as a build-time panic
-	// captured below rather than threading an error through the cobra tree.
-	var buildErr error
-	tree := func(d *core.AppContainer) *cobra.Command {
+// treeBuilder adapts an internal (*App)-based command-tree builder to a
+// core.TreeBuilder (which operates on the exported *core.AppContainer). Path
+// resolution can fail; surface it as a command that errors at run time rather
+// than threading an error through the cobra tree. This is the single definition
+// shared by the built-in binaries (runRoot) and the exported downstream builders
+// (pkg/clitree).
+func treeBuilder(build func(*App) *cobra.Command) core.TreeBuilder {
+	return func(d *core.AppContainer) *cobra.Command {
 		app, err := appFromContainer(d)
 		if err != nil {
-			buildErr = err
-			return &cobra.Command{RunE: func(*cobra.Command, []string) error { return err }}
+			return &cobra.Command{
+				RunE: func(*cobra.Command, []string) error { return err },
+			}
 		}
 		return build(app)
 	}
+}
 
-	root := core.NewRootCmd(deps, tree)
-	if buildErr != nil {
-		fmt.Fprintln(os.Stderr, "error:", buildErr)
-		return 1
-	}
+// APITreeBuilder / CtlTreeBuilder expose the built-in command trees as
+// core.TreeBuilders so a downstream module can compose them via
+// core.NewRootCmd(deps, APITreeBuilder()). They live in internal/cmd (which may
+// see *App); a thin exported wrapper is re-exported from cli/pkg/clitree so
+// other modules can import them (internal/ is not importable cross-module).
+func APITreeBuilder() core.TreeBuilder { return treeBuilder(newAPIRootCmd) }
+func CtlTreeBuilder() core.TreeBuilder { return treeBuilder(newCtlRootCmd) }
 
-	// Cancel the command context on the first SIGINT/SIGTERM so long-running
-	// commands (e.g. register) can unwind gracefully.
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
-
-	err := root.ExecuteContext(ctx)
-	if err == nil {
-		return 0
-	}
-	// A wrapped child's non-zero exit is mirrored verbatim, not reported as a
-	// CLI error.
-	var ec *exitCodeError
-	if errors.As(err, &ec) {
-		return ec.code
-	}
-	fmt.Fprintln(os.Stderr, "error:", err)
-	return 1
+// runRoot builds the root command via the built-in tree builder and runs it
+// through core.Run (shared signal-context + exit-code semantics).
+func runRoot(build func(*App) *cobra.Command) int {
+	deps := defaultContainer()
+	root := core.NewRootCmd(deps, treeBuilder(build))
+	return core.Run(root)
 }

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -144,7 +144,7 @@ func ExecuteAPI() {
 // A downstream package builds its own core.AppContainer{ExtraCommands: ...} and
 // calls core.NewRootCmd directly from its own main.go.
 func defaultContainer() *core.AppContainer {
-	return &core.AppContainer{Out: os.Stdout, Err: os.Stderr}
+	return &core.AppContainer{In: os.Stdin, Out: os.Stdout, Err: os.Stderr}
 }
 
 // appFromContainer derives the internal App (resolved paths + streams) from the
@@ -161,16 +161,24 @@ func appFromContainer(deps *core.AppContainer) (*App, error) {
 
 // treeBuilder adapts an internal (*App)-based command-tree builder to a
 // core.TreeBuilder (which operates on the exported *core.AppContainer). Path
-// resolution can fail; surface it as a command that errors at run time rather
-// than threading an error through the cobra tree. This is the single definition
-// shared by the built-in binaries (runRoot) and the exported downstream builders
-// (pkg/clitree).
+// resolution can fail; surface it as a command that FAILS CLOSED rather than
+// threading an error out-of-band. This is the single definition shared by the
+// built-in binaries (runRoot) and the exported downstream builders (pkg/clitree).
+//
+// The failure root uses PersistentPreRunE so the error also fires for any
+// commands appended via AppContainer.ExtraCommands (which are attached to this
+// root by core.NewRootCmd) — otherwise a downstream's extra command would run
+// against an unresolved container and could silently succeed. SilenceUsage/
+// SilenceErrors mirror the real roots so the error prints once, without usage.
 func treeBuilder(build func(*App) *cobra.Command) core.TreeBuilder {
 	return func(d *core.AppContainer) *cobra.Command {
 		app, err := appFromContainer(d)
 		if err != nil {
 			return &cobra.Command{
-				RunE: func(*cobra.Command, []string) error { return err },
+				SilenceUsage:      true,
+				SilenceErrors:     true,
+				RunE:              func(*cobra.Command, []string) error { return err },
+				PersistentPreRunE: func(*cobra.Command, []string) error { return err },
 			}
 		}
 		return build(app)

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -185,12 +185,15 @@ func treeBuilder(build func(*App) *cobra.Command) core.TreeBuilder {
 	}
 }
 
-// APITreeBuilder / CtlTreeBuilder expose the built-in command trees as
-// core.TreeBuilders so a downstream module can compose them via
-// core.NewRootCmd(deps, APITreeBuilder()). They live in internal/cmd (which may
-// see *App); a thin exported wrapper is re-exported from cli/pkg/clitree so
-// other modules can import them (internal/ is not importable cross-module).
+// APITreeBuilder exposes the built-in `jentic` (API) command tree as a
+// core.TreeBuilder so a downstream module can compose it via
+// core.NewRootCmd(deps, APITreeBuilder()). It lives in internal/cmd (which may
+// see *App); cli/pkg/clitree re-exports it so other modules can import it
+// (internal/ is not importable cross-module).
 func APITreeBuilder() core.TreeBuilder { return treeBuilder(newAPIRootCmd) }
+
+// CtlTreeBuilder exposes the built-in `jenticctl` (installer/lifecycle) command
+// tree as a core.TreeBuilder. See APITreeBuilder.
 func CtlTreeBuilder() core.TreeBuilder { return treeBuilder(newCtlRootCmd) }
 
 // runRoot builds the root command via the built-in tree builder and runs it

--- a/cli/pkg/clitree/clitree.go
+++ b/cli/pkg/clitree/clitree.go
@@ -1,0 +1,27 @@
+// Package clitree exposes the built-in CLI command-tree builders as
+// core.TreeBuilders so a downstream module (a separate overlay binary) can
+// compose them via core.NewRootCmd without editing the built-in tree.
+//
+// The actual builders live in internal/cmd (they need the internal *App /
+// path resolution). internal/ is not importable across modules, so this
+// exported package is the bridge: it imports internal/cmd (allowed — same
+// module) and re-exports the two builders. The dependency edge stays one-way
+// (clitree → internal/cmd → pkg/core); nothing internal imports clitree.
+package clitree
+
+import (
+	"github.com/jentic/jentic-one/cli/internal/cmd"
+	"github.com/jentic/jentic-one/cli/pkg/core"
+)
+
+// API returns the built-in `jentic` (API-spec) command-tree builder.
+// Compose it with your own container:
+//
+//	deps := &core.AppContainer{ExtraCommands: myFactories}
+//	root := core.NewRootCmd(deps, clitree.API())
+//	os.Exit(core.Run(root))
+func API() core.TreeBuilder { return cmd.APITreeBuilder() }
+
+// Ctl returns the built-in `jenticctl` (installer / lifecycle) command-tree
+// builder.
+func Ctl() core.TreeBuilder { return cmd.CtlTreeBuilder() }

--- a/cli/pkg/clitree/clitree_test.go
+++ b/cli/pkg/clitree/clitree_test.go
@@ -1,0 +1,43 @@
+package clitree_test
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/pkg/clitree"
+	"github.com/jentic/jentic-one/cli/pkg/core"
+)
+
+// Test that a downstream binary can compose the built-in tree via the exported
+// builder + core.NewRootCmd, and that ExtraCommands are appended (not shadowed).
+func TestDownstreamCompositionAppendsExtraCommands(t *testing.T) {
+	for name, build := range map[string]core.TreeBuilder{
+		"api": clitree.API(),
+		"ctl": clitree.Ctl(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			extra := func(*core.AppContainer) *cobra.Command {
+				return &cobra.Command{Use: "ent-only-xyz"}
+			}
+			deps := &core.AppContainer{ExtraCommands: []core.CommandFactory{extra}}
+			root := core.NewRootCmd(deps, build)
+
+			// The built-in tree must be present (has subcommands) ...
+			if !root.HasSubCommands() {
+				t.Fatalf("%s: built-in tree has no subcommands", name)
+			}
+			// ... and our injected command must be appended.
+			var found bool
+			for _, c := range root.Commands() {
+				if c.Use == "ent-only-xyz" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("%s: injected ExtraCommand was not appended to the root", name)
+			}
+		})
+	}
+}

--- a/cli/pkg/core/container.go
+++ b/cli/pkg/core/container.go
@@ -9,7 +9,13 @@
 package core
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"io"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 )
@@ -49,4 +55,36 @@ func NewRootCmd(deps *AppContainer, build TreeBuilder) *cobra.Command {
 		root.AddCommand(f(deps))
 	}
 	return root
+}
+
+// ExitCoder is an error that carries a process exit code. A wrapped child
+// command's non-zero exit is surfaced as one of these so Run can mirror it
+// verbatim (rather than reporting it as a generic CLI error). internal/cmd's
+// exit-code error implements this; downstream errors may too.
+type ExitCoder interface {
+	error
+	ExitCode() int
+}
+
+// Run executes a root command with a signal-cancelled context and returns the
+// process exit code. It is the shared entry point for the built-in binaries and
+// any downstream binary composed via NewRootCmd, so exit-code / signal semantics
+// stay identical. Callers typically do: os.Exit(core.Run(root)).
+func Run(root *cobra.Command) int {
+	// Cancel the command context on the first SIGINT/SIGTERM so long-running
+	// commands can unwind gracefully.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	err := root.ExecuteContext(ctx)
+	if err == nil {
+		return 0
+	}
+	// A wrapped child's non-zero exit is mirrored verbatim.
+	var ec ExitCoder
+	if errors.As(err, &ec) {
+		return ec.ExitCode()
+	}
+	fmt.Fprintln(os.Stderr, "error:", err)
+	return 1
 }

--- a/cli/pkg/core/container.go
+++ b/cli/pkg/core/container.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"os/signal"
 	"syscall"
 
@@ -37,7 +36,10 @@ type TreeBuilder func(deps *AppContainer) *cobra.Command
 //
 // It deliberately carries NO migration-target list (see the package doc).
 type AppContainer struct {
-	// Out and Err are the standard output streams (overridable in tests).
+	// In, Out, and Err are the standard streams (overridable in tests / by a
+	// downstream). NewRootCmd wires them onto the root command, so command
+	// bodies should read cmd.InOrStdin() / cmd.OutOrStdout() / cmd.ErrOrStderr().
+	In  io.Reader
 	Out io.Writer
 	Err io.Writer
 
@@ -48,9 +50,20 @@ type AppContainer struct {
 
 // NewRootCmd builds a root command tree using the injected container. `build`
 // assembles the built-in command set (supplied by internal/cmd); any
-// ExtraCommands are appended last so they never shadow built-in commands.
+// ExtraCommands are appended last so they never shadow built-in commands. The
+// container's streams are wired onto the root so both cobra's own output and
+// core.Run's error output honor the injected Out/Err/In.
 func NewRootCmd(deps *AppContainer, build TreeBuilder) *cobra.Command {
 	root := build(deps)
+	if deps.In != nil {
+		root.SetIn(deps.In)
+	}
+	if deps.Out != nil {
+		root.SetOut(deps.Out)
+	}
+	if deps.Err != nil {
+		root.SetErr(deps.Err)
+	}
 	for _, f := range deps.ExtraCommands {
 		root.AddCommand(f(deps))
 	}
@@ -85,6 +98,8 @@ func Run(root *cobra.Command) int {
 	if errors.As(err, &ec) {
 		return ec.ExitCode()
 	}
-	fmt.Fprintln(os.Stderr, "error:", err)
+	// Write to the root's error stream so an injected AppContainer.Err is honored
+	// (NewRootCmd wired it via root.SetErr); falls back to os.Stderr otherwise.
+	fmt.Fprintln(root.ErrOrStderr(), "error:", err)
 	return 1
 }

--- a/cli/pkg/core/run_test.go
+++ b/cli/pkg/core/run_test.go
@@ -2,6 +2,7 @@ package core_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -10,11 +11,11 @@ import (
 	"github.com/jentic/jentic-one/cli/pkg/core"
 )
 
-// codedErr implements core.ExitCoder.
-type codedErr struct{ code int }
+// codedError implements core.ExitCoder.
+type codedError struct{ code int }
 
-func (e *codedErr) Error() string { return fmt.Sprintf("boom %d", e.code) }
-func (e *codedErr) ExitCode() int { return e.code }
+func (e *codedError) Error() string { return fmt.Sprintf("boom %d", e.code) }
+func (e *codedError) ExitCode() int { return e.code }
 
 func TestRunMirrorsExitCoder(t *testing.T) {
 	for _, code := range []int{2, 3, 42} {
@@ -22,7 +23,7 @@ func TestRunMirrorsExitCoder(t *testing.T) {
 			Use:           "x",
 			SilenceUsage:  true,
 			SilenceErrors: true,
-			RunE:          func(*cobra.Command, []string) error { return &codedErr{code: code} },
+			RunE:          func(*cobra.Command, []string) error { return &codedError{code: code} },
 		}
 		if got := core.Run(root); got != code {
 			t.Fatalf("Run mirrored exit code = %d, want %d", got, code)
@@ -35,7 +36,7 @@ func TestRunMirrorsWrappedExitCoder(t *testing.T) {
 		Use:           "x",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		RunE:          func(*cobra.Command, []string) error { return fmt.Errorf("wrap: %w", &codedErr{code: 7}) },
+		RunE:          func(*cobra.Command, []string) error { return fmt.Errorf("wrap: %w", &codedError{code: 7}) },
 	}
 	if got := core.Run(root); got != 7 {
 		t.Fatalf("Run through wrapped ExitCoder = %d, want 7", got)
@@ -47,8 +48,12 @@ func TestRunReturns0OnSuccessAnd1OnPlainError(t *testing.T) {
 	if got := core.Run(ok); got != 0 {
 		t.Fatalf("Run(success) = %d, want 0", got)
 	}
-	bad := &cobra.Command{Use: "x", SilenceUsage: true, SilenceErrors: true,
-		RunE: func(*cobra.Command, []string) error { return fmt.Errorf("plain") }}
+	bad := &cobra.Command{
+		Use:           "x",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE:          func(*cobra.Command, []string) error { return errors.New("plain") },
+	}
 	if got := core.Run(bad); got != 1 {
 		t.Fatalf("Run(plain error) = %d, want 1", got)
 	}
@@ -64,7 +69,7 @@ func TestNewRootCmdWiresErrStreamForRun(t *testing.T) {
 			Use:           "x",
 			SilenceUsage:  true,
 			SilenceErrors: true,
-			RunE:          func(*cobra.Command, []string) error { return fmt.Errorf("kaboom") },
+			RunE:          func(*cobra.Command, []string) error { return errors.New("kaboom") },
 		}
 	}
 	root := core.NewRootCmd(deps, build)

--- a/cli/pkg/core/run_test.go
+++ b/cli/pkg/core/run_test.go
@@ -1,0 +1,77 @@
+package core_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/pkg/core"
+)
+
+// codedErr implements core.ExitCoder.
+type codedErr struct{ code int }
+
+func (e *codedErr) Error() string { return fmt.Sprintf("boom %d", e.code) }
+func (e *codedErr) ExitCode() int { return e.code }
+
+func TestRunMirrorsExitCoder(t *testing.T) {
+	for _, code := range []int{2, 3, 42} {
+		root := &cobra.Command{
+			Use:           "x",
+			SilenceUsage:  true,
+			SilenceErrors: true,
+			RunE:          func(*cobra.Command, []string) error { return &codedErr{code: code} },
+		}
+		if got := core.Run(root); got != code {
+			t.Fatalf("Run mirrored exit code = %d, want %d", got, code)
+		}
+	}
+}
+
+func TestRunMirrorsWrappedExitCoder(t *testing.T) {
+	root := &cobra.Command{
+		Use:           "x",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE:          func(*cobra.Command, []string) error { return fmt.Errorf("wrap: %w", &codedErr{code: 7}) },
+	}
+	if got := core.Run(root); got != 7 {
+		t.Fatalf("Run through wrapped ExitCoder = %d, want 7", got)
+	}
+}
+
+func TestRunReturns0OnSuccessAnd1OnPlainError(t *testing.T) {
+	ok := &cobra.Command{Use: "x", RunE: func(*cobra.Command, []string) error { return nil }}
+	if got := core.Run(ok); got != 0 {
+		t.Fatalf("Run(success) = %d, want 0", got)
+	}
+	bad := &cobra.Command{Use: "x", SilenceUsage: true, SilenceErrors: true,
+		RunE: func(*cobra.Command, []string) error { return fmt.Errorf("plain") }}
+	if got := core.Run(bad); got != 1 {
+		t.Fatalf("Run(plain error) = %d, want 1", got)
+	}
+}
+
+// NewRootCmd must wire the container's Err stream so Run's error output is
+// captured there (not leaked to os.Stderr).
+func TestNewRootCmdWiresErrStreamForRun(t *testing.T) {
+	var errBuf bytes.Buffer
+	deps := &core.AppContainer{Err: &errBuf}
+	build := func(*core.AppContainer) *cobra.Command {
+		return &cobra.Command{
+			Use:           "x",
+			SilenceUsage:  true,
+			SilenceErrors: true,
+			RunE:          func(*cobra.Command, []string) error { return fmt.Errorf("kaboom") },
+		}
+	}
+	root := core.NewRootCmd(deps, build)
+	if got := core.Run(root); got != 1 {
+		t.Fatalf("Run = %d, want 1", got)
+	}
+	if !bytes.Contains(errBuf.Bytes(), []byte("kaboom")) {
+		t.Fatalf("error not written to injected Err stream; got %q", errBuf.String())
+	}
+}


### PR DESCRIPTION
## Summary

Completes the `cli/pkg/core` extension seam so a **downstream module** can build its own `jentic`/`jenticctl` binaries that include the built-in command tree plus its own commands — without editing this repo or importing `internal/`.

### The gap this closes
`pkg/core` already had `AppContainer`, `TreeBuilder`, and `NewRootCmd(deps, build)`, and the docs said "a downstream builds its own container and calls `NewRootCmd`." But there was **no way to obtain the built-in tree**: the builders (`newAPIRootCmd`/`newCtlRootCmd`) and the `*App→*AppContainer` adapter lived unexported in `internal/cmd`, which other modules cannot import (Go `internal/` rule).

### Changes
- **`pkg/core`**: add `Run(root) int` (signal-context + exit-code mirroring, extracted from `runRoot` so built-in and downstream binaries share identical semantics) and an `ExitCoder` interface (so a wrapped child's exit code is mirrored without `pkg/core` importing `internal/`).
- **`internal/cmd`**: add exported `APITreeBuilder()`/`CtlTreeBuilder()` and a single shared `treeBuilder` adapter; refactor `runRoot` to use `treeBuilder` + `core.Run` (removes the duplicated signal/exit logic). `exitCodeError` now implements `ExitCoder`.
- **`pkg/clitree`** (new): an exported bridge that re-exports the two builders, so a downstream imports `clitree` + `core` instead of `internal/`. Dependency edge stays one-directional: `clitree → internal/cmd → pkg/core` (nothing internal imports clitree; `pkg/core` imports nothing internal).

### Downstream usage
```go
deps := &core.AppContainer{ExtraCommands: myFactories}
root := core.NewRootCmd(deps, clitree.API())
os.Exit(core.Run(root))
```

## Test plan
- [x] `go build ./...` green
- [x] `go vet ./pkg/... ./internal/cmd/`
- [x] `go test ./pkg/... ./internal/cmd/` — all pass (incl. the full internal/cmd suite, proving built-in behavior is unchanged after the runRoot refactor)
- [x] New `pkg/clitree` test: downstream composition appends `ExtraCommands` to the built-in tree for both `api` and `ctl`
- [x] `jentic --help` / `jenticctl --help` run unchanged (banner + tree intact)

Made with [Cursor](https://cursor.com)