### PR TITLE
feat(ui): add extraRoutes seam to App for downstream SPA composition

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -38,17 +38,20 @@ import { publicDocsRoutes } from '@/modules/docs/routes';
  *
  * `extraRoutes` is the SPA extension seam (parallel to the CLI's
  * `AppContainer.ExtraCommands`): a downstream build passes additional
- * `RouteObject`s that are appended into the authenticated shell, so it can ship
- * its own SPA (OSS shell + built-in routes + its extras) without editing this
- * repo. Omitted (the default) for the OSS binary.
+ * `RouteObject`s that are appended into the authenticated shell (and claim their
+ * nav-slot path, suppressing that slot's placeholder), so it can ship its own
+ * SPA (OSS shell + built-in routes + its extras) without editing this repo.
+ * Omitted (the default) for the OSS binary.
  */
 export function App({ extraRoutes = [] }: { extraRoutes?: RouteObject[] } = {}) {
 	return useRoutes(buildRoutes(extraRoutes));
 }
 
 function buildRoutes(extraRoutes: RouteObject[] = []): RouteObject[] {
-	// A nav slot gets a placeholder until a real module route claims its path.
-	const claimed = new Set(moduleRoutes.map((r) => r.path).filter(Boolean));
+	// A nav slot gets a placeholder until a real route claims its path. Both
+	// moduleRoutes AND extraRoutes count as "claimed" so a downstream route at a
+	// nav-slot path suppresses that slot's placeholder (no duplicate entry).
+	const claimed = new Set([...moduleRoutes, ...extraRoutes].map((r) => r.path).filter(Boolean));
 	const placeholderRoutes: RouteObject[] = sortedNavItems()
 		.filter((item) => item.to !== ROUTES.app && !claimed.has(relativeToApp(item.to)))
 		.map((item) => ({

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -35,12 +35,18 @@ import { publicDocsRoutes } from '@/modules/docs/routes';
  * Because the bundle is served under `/app`, bare API prefixes (`/credentials`,
  * `/agents`, …) can never collide with an SPA route on hard refresh — they live
  * in a different namespace from the SPA entirely.
+ *
+ * `extraRoutes` is the SPA extension seam (parallel to the CLI's
+ * `AppContainer.ExtraCommands`): a downstream build passes additional
+ * `RouteObject`s that are appended into the authenticated shell, so it can ship
+ * its own SPA (OSS shell + built-in routes + its extras) without editing this
+ * repo. Omitted (the default) for the OSS binary.
  */
-export function App() {
-	return useRoutes(buildRoutes());
+export function App({ extraRoutes = [] }: { extraRoutes?: RouteObject[] } = {}) {
+	return useRoutes(buildRoutes(extraRoutes));
 }
 
-function buildRoutes(): RouteObject[] {
+function buildRoutes(extraRoutes: RouteObject[] = []): RouteObject[] {
 	// A nav slot gets a placeholder until a real module route claims its path.
 	const claimed = new Set(moduleRoutes.map((r) => r.path).filter(Boolean));
 	const placeholderRoutes: RouteObject[] = sortedNavItems()
@@ -82,7 +88,12 @@ function buildRoutes(): RouteObject[] {
 					// `[...moduleRoutes, ...extraRoutes]` at this single point
 					// without editing the registry. Order is load-bearing —
 					// placeholders stay last so a real module route wins.
-					children: [dashboardIndexRoute, ...moduleRoutes, ...placeholderRoutes],
+					children: [
+						dashboardIndexRoute,
+						...moduleRoutes,
+						...extraRoutes,
+						...placeholderRoutes,
+					],
 				},
 			],
 		},


### PR DESCRIPTION
## Summary

`App` now accepts an optional `extraRoutes: RouteObject[]`, appended into the authenticated shell (after `moduleRoutes`, before the nav placeholders). This lets a **downstream build** compose its own SPA — this app's shell + built-in routes + its own additional routes — by rendering `<App extraRoutes={...} />` from its own entry, **without editing this repo**.

It's the SPA analog of the CLI's `AppContainer.ExtraCommands` extension seam (same model: this repo owns the assembly; a downstream injects extras).

## Details
- One optional prop, defaulting to `[]`. `buildRoutes` threads it into the shell's `children` at the single documented composition point (already spread, not inlined).
- The OSS binary is **unchanged** — `extraRoutes` defaults to empty.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint src/App.tsx` clean (prettier included)
- [x] `npm run build` green (2813 modules) — behavior identical for the default (no-extraRoutes) build
- [x] Verified a downstream entry rendering `<App extraRoutes={...} />` builds and includes both the built-in routes and the injected ones

Made with [Cursor](https://cursor.com)