### PR TITLE
ci(release-please.yml): regenerate OpenAPI specs on the Release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,7 +45,69 @@ jobs:
           app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # When release-please opens/updates its "chore(main): release X.Y.Z" PR,
+      # the version bump can invalidate generated artifacts (the control-plane
+      # OpenAPI spec + the UI client derived from it). Regenerate them on the PR
+      # branch and push back so the Release PR is self-consistent and does not
+      # trip the openapi-client-drift / conformance gates when merged.
+      - name: Set up toolchain
+        if: ${{ steps.release.outputs.pr }}
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        if: ${{ steps.release.outputs.pr }}
+        run: uv python install 3.12
+
+      - name: Set up Node.js
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Regenerate OpenAPI specs
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}
+          # The App slug from the token step; used to derive the committer
+          # identity so this commit is attributed to the same bot that authors
+          # the rest of the Release PR (we push with the App token, not
+          # GITHUB_TOKEN — see the header comment).
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          # Check out the release-please PR branch so regenerated files are
+          # committed onto the Release PR, not a detached HEAD.
+          gh pr checkout "$PR_NUMBER"
+
+          # Install backend deps, then regenerate the control spec + ui/openapi.json.
+          make sync
+          make openapi
+
+          # Refresh the generated UI client from the (possibly updated) spec.
+          cd ui && npm ci && npm run codegen
+          cd ..
+
+          # Attribute the commit to the release-please App's bot user (the token
+          # actually pushing this), matching GitHub's <slug>[bot] convention:
+          #   name  = <slug>[bot]
+          #   email = <bot-user-id>+<slug>[bot]@users.noreply.github.com
+          BOT_NAME="${APP_SLUG}[bot]"
+          BOT_USER_ID="$(gh api "/users/${BOT_NAME}" --jq .id)"
+          git config user.name "$BOT_NAME"
+          git config user.email "${BOT_USER_ID}+${BOT_NAME}@users.noreply.github.com"
+          git add openapi/ ui/
+
+          if ! git diff --staged --quiet; then
+            git commit -m "chore: regenerate openapi specs for version bump"
+            git push
+          fi


### PR DESCRIPTION
## Summary

- The release-please version bump can invalidate generated artifacts (the control-plane OpenAPI spec `openapi/control/control.openapi.yaml` + `ui/openapi.json`, and the UI client under `ui/src/shared/api/generated`). This adds a step that regenerates them **on the Release PR branch** and pushes back, so the standing "chore(main): release X.Y.Z" PR is self-consistent and won't trip the `openapi-client-drift` / conformance gates when merged.
- Gives the `release-please-action` an `id` so `steps.release.outputs.pr` is usable, and gates all new steps on a Release PR actually existing.
- Sets up the toolchain to match `ci.yml` exactly: `astral-sh/setup-uv@v7` + Python 3.12 + Node 22 (npm cache). Runs `make sync && make openapi`, then `cd ui && npm ci && npm run codegen`.
- Attributes the pushed commit to the release-please **App bot** (`<app-slug>[bot]`, id resolved via `gh api`) rather than `github-actions[bot]`, since the push uses the App token (not `GITHUB_TOKEN`) — keeping the committer identity consistent with the rest of the Release PR.

## Test plan

- [ ] Trigger the `release-please` workflow on `main` (merge a conventional commit) and confirm the Release PR is created/updated.
- [ ] Confirm the "Regenerate OpenAPI specs" step runs only when a Release PR exists, checks it out, regenerates, and pushes a `chore: regenerate openapi specs for version bump` commit **only when there's a diff**.
- [ ] Confirm the pushed commit is attributed to the App bot identity.
- [ ] Confirm the resulting Release PR passes `openapi-client-drift` and the OpenAPI conformance arch test.

> Please **squash + merge** this PR (repo convention).

Made with [Cursor](https://cursor.com)