### PR TITLE
ci(release-please.yml): guard fromJson against empty pr output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -78,7 +78,11 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}
+          # A step's env: is interpolated even when its if: will skip it, so
+          # fromJson runs regardless. When release-please decides no release is
+          # needed, outputs.pr is empty/undefined and fromJson('') throws before
+          # the if can skip the step. Fall back to '{}' so it parses to null.
+          PR_NUMBER: ${{ fromJson(steps.release.outputs.pr || '{}').number }}
           # The App slug from the token step; used to derive the committer
           # identity so this commit is attributed to the same bot that authors
           # the rest of the Release PR (we push with the App token, not


### PR DESCRIPTION
## Summary

- Follow-up to #694. A step's `env:` block is interpolated during expression evaluation for the **whole step**, *before* the runner applies the `if:` skip. So when `release-please` decides no release is needed, `steps.release.outputs.pr` is empty/undefined and `fromJson('')` throws a `JsonReader` error before the "Regenerate OpenAPI specs" step can be skipped — failing the whole workflow on ordinary pushes to `main`.
- Fix: fall back to `'{}'` so `fromJson` always receives valid JSON: `fromJson(steps.release.outputs.pr || '{}').number`. When there's no Release PR, `.number` resolves to `null` and the step is still skipped by its `if:` guard, so `PR_NUMBER` is never actually used.

## Test plan

- [ ] Push a non-release-triggering commit to `main` (or a commit release-please ignores) and confirm the `release-please` workflow completes without the `JsonReader` error and the regen step is skipped.
- [ ] Push a release-triggering commit and confirm the regen step still runs with the correct `PR_NUMBER`.

> Depends on #694 (which introduced this workflow step). Please **squash + merge** (repo convention).

Made with [Cursor](https://cursor.com)