### PR TITLE
ci(release-please.yml): check out repo before regenerating specs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -51,6 +51,19 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # release-please-action does not check out the repo, so nothing is on disk
+      # for the toolchain caches or `gh pr checkout` below. Check out here, gated
+      # on a Release PR existing so we skip the clone on no-release pushes.
+      # fetch-depth: 0 gives gh pr checkout the full history + remote refs it
+      # needs to switch to the PR branch. Use the App token so the later push
+      # back to the Release PR is authorised.
+      - name: Checkout repository
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
       # When release-please opens/updates its "chore(main): release X.Y.Z" PR,
       # the version bump can invalidate generated artifacts (the control-plane
       # OpenAPI spec + the UI client derived from it). Regenerate them on the PR


### PR DESCRIPTION
## Summary

- Follow-up to #694 / #695. `release-please-action` does **not** check out the repository, so the toolchain caches (`setup-uv`, `setup-node`) and the later `gh pr checkout "$PR_NUMBER"` had nothing on disk to operate on.
- Adds an `actions/checkout@v7` step immediately after the release-please action and before the toolchain setup, gated on `steps.release.outputs.pr` so no clone happens on no-release pushes.
- `fetch-depth: 0` so `gh pr checkout` has the full history + remote refs to switch to the Release PR branch.
- `token: ${{ steps.app-token.outputs.token }}` — checkout persists this into git config, so the push back to the Release PR is authorised with the **App token** (not `GITHUB_TOKEN`), which is what keeps downstream release workflows triggering.

## Test plan

- [ ] Push a release-triggering commit to `main`; confirm the workflow checks out, `gh pr checkout` succeeds, `make openapi` + `npm run codegen` run, and the regenerated specs are pushed to the Release PR under the App bot identity.
- [ ] Push a non-release commit; confirm the checkout + regen steps are skipped (no heavy clone).

> Depends on #694 (introduces the step) and #695 (the fromJson guard). Please **squash + merge** (repo convention).

Made with [Cursor](https://cursor.com)