### PR TITLE
ci(release-please): fix cli changelog-path to unblock release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -63,7 +63,7 @@
       "component": "cli",
       "include-component-in-tag": true,
       "include-v-in-tag": true,
-      "changelog-path": "../CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "plugins": [


### PR DESCRIPTION
## Summary

Hotfix for the `release-please` workflow, which is currently failing on `main` with:

```
Error: release-please failed: illegal pathing characters in path: cli/../CHANGELOG.md
```

release-please prefixes each package's `changelog-path` with the package directory, so the `cli` package's `"../CHANGELOG.md"` resolved to `cli/../CHANGELOG.md`. The `../` trips release-please's directory-traversal guard.

Fix: set the `cli` package's `changelog-path` to `"CHANGELOG.md"` (the same value as the root `.` package). Both packages now point at the root `CHANGELOG.md` with no traversal segment, which is how release-please expects shared changelogs to be configured.

Follow-up to #700 (which introduced the `cli` package + lockstep tagging).

## Test plan

- [ ] Merge and confirm the `release-please` workflow completes without the `illegal pathing characters` error.
- [ ] Confirm the resulting Release PR still bumps both `.` and `cli` in lockstep and writes to the root `CHANGELOG.md`.

> Please **squash + merge** (repo convention).

Made with [Cursor](https://cursor.com)