### PR TITLE
ci(release): fix cli tag identity + run it after GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,23 +122,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # GoReleaser needs full history/tags
-      # Mirror the app release tag onto the CLI's Go module path. The CLI lives in
-      # a subdirectory (module github.com/jentic/jentic-one/cli), so `go get
-      # .../cli@vX.Y.Z` only resolves if a `cli/vX.Y.Z` git tag exists. We point it
-      # at the SAME commit as the app's vX.Y.Z tag, so the module version and the
-      # app release are always lockstep-identical. Uses GITHUB_TOKEN's checkout
-      # creds; the `cli/v*` tag can't match this workflow's `v*.*.*` trigger, so
-      # there's no recursive release run.
-      - name: Tag the CLI Go module at the release version
-        run: |
-          set -euo pipefail
-          CLI_TAG="cli/${GITHUB_REF_NAME}"
-          if git rev-parse -q --verify "refs/tags/${CLI_TAG}" >/dev/null; then
-            echo "${CLI_TAG} already exists — nothing to do"
-          else
-            git tag -a "${CLI_TAG}" -m "${CLI_TAG}" "${GITHUB_SHA}"
-            git push origin "${CLI_TAG}"
-          fi
       - uses: actions/setup-go@v7
         with:
           go-version-file: cli/go.mod
@@ -158,3 +141,24 @@ jobs:
           # can be pushed cross-repo (GITHUB_TOKEN is scoped to THIS repo only).
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           COSIGN_YES: "true"
+      # Mirror the app release tag onto the CLI's Go module path. The CLI lives in
+      # a subdirectory (module github.com/jentic/jentic-one/cli), so `go get
+      # .../cli@vX.Y.Z` only resolves if a `cli/vX.Y.Z` git tag exists. We point it
+      # at the SAME commit as the app's vX.Y.Z tag, so the module version and the
+      # app release are always lockstep-identical. Runs LAST so a tagging hiccup
+      # never blocks GoReleaser publishing the binaries. The `cli/v*` tag can't
+      # match this workflow's `v*.*.*` trigger, so there's no recursive release run.
+      - name: Tag the CLI Go module at the release version
+        run: |
+          set -euo pipefail
+          CLI_TAG="cli/${GITHUB_REF_NAME}"
+          if git rev-parse -q --verify "refs/tags/${CLI_TAG}" >/dev/null; then
+            echo "${CLI_TAG} already exists — nothing to do"
+          else
+            # Annotated tags need a committer identity; runners have none. Attribute
+            # to GitHub's Actions bot (matches the convention for CI-created objects).
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "${CLI_TAG}" -m "${CLI_TAG}" "${GITHUB_SHA}"
+            git push origin "${CLI_TAG}"
+          fi


### PR DESCRIPTION
## Summary

The `cli/vX.Y.Z` tagging step (added in #706) **broke the v0.14.2 release**:

- It failed with `fatal: empty ident name` — annotated tags need a committer identity that GitHub runners don't have.
- It ran **before** GoReleaser, so the failure **skipped GoReleaser**. `v0.14.2` shipped with **0 release assets** (no signed binaries, no Homebrew cask) and no `cli/v0.14.2` tag.

This fixes it two ways:
- Set a `github-actions[bot]` git identity before the annotated tag.
- **Move the step to the end** of the release job, so a tagging hiccup can never block GoReleaser publishing the binaries again.

## Recovery for v0.14.2

Merging this fixes future releases. `v0.14.2` itself still needs its assets — I'll re-run the release workflow on the `v0.14.2` tag once this is merged (see comment).

## Test plan

- [ ] Merge.
- [ ] Re-run `release.yml` for `v0.14.2`; confirm GoReleaser publishes assets and `cli/v0.14.2` tag is created.
- [ ] `go get github.com/jentic/jentic-one/cli@v0.14.2` resolves.

Made with [Cursor](https://cursor.com)