### PR TITLE
ci(release): link both jenticctl and jentic in the Homebrew cask

### DIFF
--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -83,6 +83,11 @@ homebrew_casks:
     directory: Casks
     homepage: https://jentic.com
     description: "Jentic One CLIs — jenticctl (installer/lifecycle) + jentic (API client)"
+    # GoReleaser links only the binary matching the cask name (jentic) when this
+    # is omitted, so jenticctl never lands on PATH. List both explicitly.
+    binaries:
+      - jenticctl
+      - jentic
     # Both binaries are auto-installed from the archive (the two-step install:
     # brew install, then jenticctl install).
     # Remove the macOS quarantine attribute so the freshly-downloaded binaries run.


### PR DESCRIPTION
## Summary

Installing the `jentic` cask downloads an archive containing **both** `jentic` and `jenticctl`, but only `jentic` was linked onto PATH — GoReleaser links only the binary matching the cask name when `binaries` is omitted. That left `jenticctl` (the installer/lifecycle CLI) unavailable after `brew install jentic`.

This explicitly lists both binaries in the `homebrew_casks` section so the cask links `jenticctl` and `jentic`.

## Verification

Ran locally:

```bash
cd cli && goreleaser release --snapshot --clean --skip=sign,sbom,publish
```

The generated `dist/homebrew/Casks/jentic.rb` now contains:

```ruby
  binary "jenticctl"
  binary "jentic"
```

(Note: `binaries` plural is the current field — the singular `binary` was deprecated in GoReleaser v2.12.6; we build with `~> v2`.)

## Rollout

Ships with the next release. Subsequent `brew upgrade jentic` will correctly link both binaries on users' machines.

## Test plan

- [ ] Merge; on the next release, confirm the published `Casks/jentic.rb` in `jentic/homebrew-tap` includes both `binary` stanzas.
- [ ] `brew install jentic` (or `brew upgrade`) exposes both `jentic` and `jenticctl` on PATH.

Made with [Cursor](https://cursor.com)