### PR TITLE
ci(release): force patch release to republish v0.14.2 artifacts

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -26,6 +26,27 @@ Releases are automated with [release-please](https://github.com/googleapis/relea
 The pre-1.0 baseline is the restored `v0.1.0`…`v0.13.2` tag line; the next
 release is `v0.14.0` (we continue the `0.x` line — see `VERSIONING.md`).
 
+### Forcing or recovering a release
+
+release-please only opens a Release PR when there are user-facing commits since
+the last release (`ci`, `chore`, `test` and other hidden types don't trigger a
+bump). To force a release anyway — e.g. to recover a release whose `release.yml`
+run failed before GoReleaser published its assets — land a commit on `main`
+whose footer sets the version explicitly:
+
+```
+ci(release): force patch release to republish artifacts
+
+Release-As: 0.14.3
+```
+
+release-please then opens a `chore(main): release 0.14.3` PR; merging it cuts the
+tag and re-runs `release.yml` (now from the fixed workflow on `main`), producing
+a complete set of signed binaries + the Homebrew cask. A failed release version
+is simply superseded by the next one — every release rebuilds all artifacts from
+scratch, so nothing is lost by skipping it.
+
+
 ## One-time setup (repo/org admin)
 
 The automation is inert until these are provisioned:


### PR DESCRIPTION
## Summary

`v0.14.2` shipped with **zero release assets** — its `release.yml` run failed at the cli-tagging step before GoReleaser ran (empty git identity), and the step ran before GoReleaser so it took the whole publish job down with it. The fixes are now on `main`:

- #708 — cli-tag identity + moved the step to run *after* GoReleaser
- #709 — Homebrew cask links both `jenticctl` and `jentic`

Since only `ci` commits have landed since `v0.14.2`, release-please won't auto-propose a new version. This commit carries a `Release-As` footer to force one.

## IMPORTANT — merge instructions

This repo squash-merges. **The squash commit message MUST retain this footer** or release-please won't force the version:

```
Release-As: 0.14.3
```

(Please leave it in the squash commit body when merging.)

## What happens after merge

1. release-please opens `chore(main): release 0.14.3`.
2. Merging that PR tags `v0.14.3` and runs the **fixed** `release.yml`, which publishes signed binaries + Homebrew cask (both binaries) and creates `cli/v0.14.3`.
3. `v0.14.2` stays asset-less and is effectively superseded — every release rebuilds all artifacts, so nothing is lost.

## Test plan

- [ ] Merge (footer retained) → release-please opens the 0.14.3 Release PR.
- [ ] Merge that PR → `release.yml` succeeds end-to-end; `v0.14.3` GitHub Release has assets; `cli/v0.14.3` tag exists.
- [ ] `go get github.com/jentic/jentic-one/cli@v0.14.3` resolves; `brew upgrade jentic` links both binaries.

Made with [Cursor](https://cursor.com)