### PR TITLE
fix(auth): add token_endpoint_auth_signing_alg_values_supported to OA…

### DIFF
--- a/src/jentic_one/auth/web/routers/discovery.py
+++ b/src/jentic_one/auth/web/routers/discovery.py
@@ -63,6 +63,7 @@ async def oauth_authorization_server(
         "response_types_supported": ["code"],
         "code_challenge_methods_supported": ["S256"],
         "id_token_signing_alg_values_supported": ["ES256"],
+        "token_endpoint_auth_signing_alg_values_supported": ["EdDSA"],
     }
 
 


### PR DESCRIPTION
fix(auth): add token_endpoint_auth_signing_alg_values_supported to OAuth metadata

OAuth server metadata advertised id_token_signing_alg_values_supported but omitted the RFC 8414 field for client assertion signing algorithms. Clients performing JWT-bearer authentication need to discover that EdDSA is required for token endpoint assertions.

## Summary

OAuth server metadata was missing the `token_endpoint_auth_signing_alg_values_supported` field (RFC 8414). Without it, clients have no way to discover that EdDSA is the required algorithm for JWT-bearer assertions at the token endpoint — distinct from ES256 used for ID token signing.

## Related issue

## Changes

- Add `"token_endpoint_auth_signing_alg_values_supported": ["EdDSA"]` to the metadata dict in `oauth_authorization_server()`

## Testing

- `make check` passes
- Verified `GET /.well-known/oauth-authorization-server` returns the new field

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] `make check` passes (lint, type check, secrets audit, arch tests)
- [ ] Tests added/updated for the change
- [x] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included
