### PR TITLE
fix(admin): generate agent-toolkit-binding ids app-side on SQLite

### DIFF
--- a/src/jentic_one/admin/core/schema/agent_toolkit_bindings.py
+++ b/src/jentic_one/admin/core/schema/agent_toolkit_bindings.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
 from jentic_one.shared.db.base import AdminBase, AuditableMixin
+from jentic_one.shared.db.ids import generate_ksuid
 
 
 class AgentToolkitBinding(AuditableMixin, AdminBase):
@@ -24,6 +25,7 @@ class AgentToolkitBinding(AuditableMixin, AdminBase):
     id: Mapped[str] = mapped_column(
         String(30),
         primary_key=True,
+        default=lambda: generate_ksuid("atb"),
         server_default=func.generate_ksuid("atb"),
     )
     agent_id: Mapped[str] = mapped_column(

--- a/src/jentic_one/migrations/admin/versions/k0l1m2n3o4p5_add_agent_toolkit_bindings.py
+++ b/src/jentic_one/migrations/admin/versions/k0l1m2n3o4p5_add_agent_toolkit_bindings.py
@@ -18,12 +18,19 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    pg = op.get_bind().dialect.name == "postgresql"
     op.create_table(
         "agent_toolkit_bindings",
         sa.Column(
             "id",
             sa.String(30),
-            server_default=sa.func.generate_ksuid("atb"),
+            # Postgres generates the ksuid server-side; SQLite has no such
+            # function so there is no server_default there. Every insert is
+            # expected to go through the ORM model, whose Python-side default
+            # (generate_ksuid("atb")) supplies the id. A *raw* INSERT on SQLite
+            # that omits id would violate NOT NULL — seed/test code must use the
+            # ORM model or pass an explicit id.
+            server_default=sa.func.generate_ksuid("atb") if pg else None,
             nullable=False,
         ),
         sa.Column(


### PR DESCRIPTION

<!--
Thanks for contributing to Jentic One!
Keep PRs focused and reviewable. Do not include secrets or credentials.
-->

## Summary

<!-- What does this change and why? -->

AgentToolkitBinding was the only KSUID-keyed model missing a Python-side default, so on SQLite the id column fell through to the Postgres-only generate_ksuid() server_default and inserts failed with "unknown function: generate_ksuid()". Add the app-side default and guard the migration's server_default with the pg check like the other migrations.

## Related issue

<!-- e.g. Closes #123 -->

## Changes

-

## Testing

<!-- How did you verify this? `make check` output, new/updated tests, manual steps. -->

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] `make check` passes (lint, type check, secrets audit, arch tests)
- [ ] Tests added/updated for the change
- [ ] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included
