### PR TITLE
fix(broker): hint at region/server-variable mismatch on upstream 401/403 (#638)

### DIFF
--- a/src/jentic_one/broker/core/headers.py
+++ b/src/jentic_one/broker/core/headers.py
@@ -20,8 +20,21 @@ class JenticHeader(StrEnum):
     API_VENDOR = "Jentic-Api-Vendor"
     UPSTREAM_STATUS = "Jentic-Upstream-Status"
     ERROR_ORIGIN = "Jentic-Error-Origin"
+    HINT = "Jentic-Hint"
     IDEMPOTENT_REPLAYED = "Idempotent-Replayed"
     IDEMPOTENCY_BODY_OMITTED = "Jentic-Idempotency-Body-Omitted"
+
+
+# Diagnostic hint appended (via the ``Jentic-Hint`` header, never by rewriting
+# the mirrored upstream body — §6b B-002 passthrough invariant) when an upstream
+# 401/403 lands on an API whose spec uses a templated host / server variable
+# (e.g. ``https://{region}.posthog.com``). A valid key that still 401s here is
+# very often a region/server-variable mismatch (#638), so we surface the likely
+# cause without pretending to know the key is valid.
+REGION_MISMATCH_HINT = (
+    "This API requires a specific region or server variable. If your API key is "
+    "valid, ensure your credential is configured for the correct region."
+)
 
 
 # The W3C ``tracestate`` response header — not a ``Jentic-*`` header but a

--- a/src/jentic_one/broker/web/routers/execute.py
+++ b/src/jentic_one/broker/web/routers/execute.py
@@ -43,6 +43,7 @@ from jentic_one.broker.core.exceptions import (
 from jentic_one.broker.core.execution import mint_execution_id
 from jentic_one.broker.core.headers import (
     JENTIC_REVISION_HEADER,
+    REGION_MISMATCH_HINT,
     TRACESTATE_HEADER,
     JenticHeader,
 )
@@ -98,7 +99,7 @@ from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.models.jobs import JobKind
 from jentic_one.shared.schemas import APIReference
 from jentic_one.shared.tracing import JENTIC_TRACESTATE_KEY, pack_jentic_tracestate
-from jentic_one.shared.url import apply_server_variables
+from jentic_one.shared.url import apply_server_variables, has_host_server_variable
 from jentic_one.shared.url_validation import validate_upstream_url
 from jentic_one.shared.web.deps import get_ctx
 
@@ -490,6 +491,10 @@ async def _handle(
         upstream_url=upstream_url, method=method, request=request, resolved=resolved
     )
     ctx_req.pinned_revisions = pinned_revisions
+    # Capture whether the spec's host is templated (server variable) *before*
+    # credential injection substitutes it — this is the signal that drives the
+    # region-mismatch hint on an upstream 401/403 (#638).
+    ctx_req.has_server_variable = has_host_server_variable(upstream_url)
     # Toolkit is derived from the discovered API identity (never the inbound header
     # verbatim); drives credential injection and execution attribution (§03).
     ctx_req.toolkit_id = await select_toolkit(
@@ -671,12 +676,27 @@ async def _handle_streaming(
     )
 
 
+def _region_mismatch_hint(status_code: int, ctx_req: ExecuteRequestContext) -> str | None:
+    """The region-mismatch hint for a templated-host API's upstream 401/403 (#638).
+
+    Returns ``None`` when it does not apply. The hint is surfaced via the
+    ``Jentic-Hint`` response header — the mirrored upstream body is left verbatim
+    (§6b B-002 passthrough invariant).
+    """
+    if status_code in (401, 403) and ctx_req.has_server_variable:
+        return REGION_MISMATCH_HINT
+    return None
+
+
 def _assemble_response(outcome: ExecutionOutcome, ctx_req: ExecuteRequestContext) -> Response:
     result = outcome.result
     metadata = _metadata_headers(ctx_req, outcome.context.execution_id)
     metadata[JenticHeader.UPSTREAM_STATUS.value] = str(result.status_code)
     if outcome.error_origin is not None:
         metadata[JenticHeader.ERROR_ORIGIN.value] = outcome.error_origin.value
+    hint = _region_mismatch_hint(result.status_code, ctx_req)
+    if hint is not None:
+        metadata[JenticHeader.HINT.value] = hint
 
     passthrough = passthrough_response_headers(result.headers)
     return Response(

--- a/src/jentic_one/broker/web/streaming.py
+++ b/src/jentic_one/broker/web/streaming.py
@@ -38,7 +38,7 @@ from jentic_one.broker.adapters.runners.base import (
     StreamingUpstreamRunner,
 )
 from jentic_one.broker.core.exceptions import ErrorOrigin, UpstreamTimeoutError
-from jentic_one.broker.core.headers import JenticHeader
+from jentic_one.broker.core.headers import REGION_MISMATCH_HINT, JenticHeader
 from jentic_one.broker.core.proxy_headers import passthrough_streaming_headers
 from jentic_one.broker.core.schemas import ExecuteRequestContext
 from jentic_one.shared.broker.execution import StreamingOutcome
@@ -130,6 +130,10 @@ def _metadata_headers(
         metadata[JenticHeader.API_VENDOR.value] = ctx_req.api_vendor
     if status_code >= 400:
         metadata[JenticHeader.ERROR_ORIGIN.value] = ErrorOrigin.UPSTREAM.value
+    # Region-mismatch hint for a templated-host API's upstream 401/403 (#638),
+    # surfaced via header — the streamed upstream body stays verbatim.
+    if status_code in (401, 403) and ctx_req.has_server_variable:
+        metadata[JenticHeader.HINT.value] = REGION_MISMATCH_HINT
     return metadata
 
 

--- a/src/jentic_one/shared/broker/schemas.py
+++ b/src/jentic_one/shared/broker/schemas.py
@@ -36,3 +36,8 @@ class ExecuteRequestContext(BaseModel):
     api_version: str | None = None
     prefer: str | None = None
     pinned_revisions: dict[str, Any] | None = None
+    # True when the discovered API's spec uses a templated host / server variable
+    # (e.g. ``https://{region}.posthog.com``). Drives the region-mismatch hint the
+    # broker attaches to an upstream 401/403 (#638) so a valid key hitting the
+    # wrong host is not a dead-end "Invalid Key".
+    has_server_variable: bool = False

--- a/src/jentic_one/shared/url.py
+++ b/src/jentic_one/shared/url.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from urllib.parse import quote
+import re
+from urllib.parse import quote, urlsplit
+
+# A ``{name}`` OpenAPI server-variable placeholder. Names follow the OpenAPI
+# variable-name grammar (letters, digits, underscores, hyphens, dots) so an
+# empty ``{}`` or a stray brace in a query value is not mistaken for one.
+_SERVER_VAR_PLACEHOLDER = re.compile(r"\{[A-Za-z0-9_.-]+\}")
 
 
 def apply_server_variables(url: str, variables: dict[str, str]) -> str:
@@ -17,3 +23,17 @@ def apply_server_variables(url: str, variables: dict[str, str]) -> str:
         placeholder = "{" + name + "}"
         result = result.replace(placeholder, quote(value, safe=""))
     return result
+
+
+def has_host_server_variable(url: str) -> bool:
+    """Whether *url*'s scheme/host carries an unsubstituted ``{name}`` template.
+
+    A region-split API (e.g. ``https://{region}.posthog.com``) reaches the broker
+    with the placeholder still in the **host** because the caller derives the URL
+    from the spec's templated server. Only the scheme + netloc are inspected so an
+    ordinary path parameter (``/users/{id}``) or a ``{...}`` inside the query never
+    triggers a false positive — those are not server variables.
+    """
+    parts = urlsplit(url)
+    host = f"{parts.scheme}://{parts.netloc}" if parts.netloc else url.split("/", 1)[0]
+    return bool(_SERVER_VAR_PLACEHOLDER.search(host))

--- a/tests/unit/broker/test_apply_server_variables.py
+++ b/tests/unit/broker/test_apply_server_variables.py
@@ -1,6 +1,6 @@
 """Unit tests for the shared apply_server_variables() utility."""
 
-from jentic_one.shared.url import apply_server_variables
+from jentic_one.shared.url import apply_server_variables, has_host_server_variable
 
 
 def test_single_variable_substitution() -> None:
@@ -40,3 +40,28 @@ def test_handles_repeated_placeholder() -> None:
     url = "https://{host}.{host}.example.com"
     result = apply_server_variables(url, {"host": "api"})
     assert result == "https://api.api.example.com"
+
+
+def test_has_host_server_variable_detects_templated_host() -> None:
+    assert has_host_server_variable("https://{region}.posthog.com/api/projects") is True
+
+
+def test_has_host_server_variable_detects_templated_subdomain() -> None:
+    assert has_host_server_variable("https://{your-domain}.atlassian.net/rest/api/3") is True
+
+
+def test_has_host_server_variable_false_for_static_host() -> None:
+    assert has_host_server_variable("https://api.posthog.com/api/projects") is False
+
+
+def test_has_host_server_variable_ignores_path_parameters() -> None:
+    # A path parameter is not a server variable — it must not trigger the hint.
+    assert has_host_server_variable("https://api.example.com/users/{id}/items") is False
+
+
+def test_has_host_server_variable_ignores_query_placeholders() -> None:
+    assert has_host_server_variable("https://api.example.com/search?q={term}") is False
+
+
+def test_has_host_server_variable_ignores_empty_braces() -> None:
+    assert has_host_server_variable("https://api.example.com/{}/x") is False

--- a/tests/unit/broker/test_region_mismatch_hint.py
+++ b/tests/unit/broker/test_region_mismatch_hint.py
@@ -1,0 +1,98 @@
+"""Unit tests for the region-mismatch hint on upstream 401/403 (#638).
+
+When an upstream returns 401/403 for an API whose spec uses a templated host /
+server variable (e.g. ``https://{region}.posthog.com``), the broker attaches a
+``Jentic-Hint`` header pointing at a likely region/server-variable mismatch —
+without rewriting the mirrored upstream body (§6b B-002 passthrough invariant).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jentic_one.broker.core.headers import REGION_MISMATCH_HINT, JenticHeader
+from jentic_one.broker.core.schemas import ExecuteRequestContext
+from jentic_one.broker.web.routers.execute import _assemble_response
+from jentic_one.broker.web.streaming import _metadata_headers as _streaming_metadata_headers
+from jentic_one.shared.broker.execution import (
+    ErrorOrigin,
+    ExecutionContext,
+    ExecutionOutcome,
+    RunnerResult,
+)
+
+_HINT_HEADER = JenticHeader.HINT.value
+
+
+def _ctx_req(*, has_server_variable: bool) -> ExecuteRequestContext:
+    return ExecuteRequestContext(
+        upstream_url="https://us.posthog.com/api/projects",
+        method="GET",
+        trace_id="trace-1",
+        operation_id="op-1",
+        api_vendor="posthog.com",
+        api_name="posthog",
+        api_version="v1",
+        has_server_variable=has_server_variable,
+    )
+
+
+def _outcome(status_code: int, body: bytes = b'{"detail":"Invalid Key"}') -> ExecutionOutcome:
+    result = RunnerResult(
+        status_code=status_code,
+        body=body,
+        headers={"content-type": "application/json"},
+        content_type="application/json",
+        duration_ms=1,
+    )
+    context = ExecutionContext(
+        execution_id="exec-1",
+        toolkit_id="tk-1",
+        operation_id="op-1",
+        api=None,
+        trace_id="trace-1",
+    )
+    error_origin = ErrorOrigin.UPSTREAM if status_code >= 400 else None
+    return ExecutionOutcome(result=result, context=context, error_origin=error_origin)
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_hint_added_for_401_403_on_templated_host_api(status_code: int) -> None:
+    response = _assemble_response(_outcome(status_code), _ctx_req(has_server_variable=True))
+    assert response.status_code == status_code
+    assert response.headers[_HINT_HEADER] == REGION_MISMATCH_HINT
+
+
+def test_hint_does_not_rewrite_upstream_body() -> None:
+    body = b'{"type":"authentication_error","detail":"Invalid personal API key."}'
+    response = _assemble_response(_outcome(401, body=body), _ctx_req(has_server_variable=True))
+    # Body is mirrored verbatim — the hint rides on the header, never the body.
+    assert response.body == body
+    assert response.headers[_HINT_HEADER] == REGION_MISMATCH_HINT
+
+
+def test_no_hint_when_api_has_no_server_variable() -> None:
+    response = _assemble_response(_outcome(401), _ctx_req(has_server_variable=False))
+    assert _HINT_HEADER not in response.headers
+
+
+@pytest.mark.parametrize("status_code", [200, 404, 429, 500])
+def test_no_hint_for_non_auth_statuses(status_code: int) -> None:
+    response = _assemble_response(_outcome(status_code), _ctx_req(has_server_variable=True))
+    assert _HINT_HEADER not in response.headers
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_streaming_hint_added_for_401_403_on_templated_host_api(status_code: int) -> None:
+    headers = _streaming_metadata_headers(_ctx_req(has_server_variable=True), "exec-1", status_code)
+    assert headers[_HINT_HEADER] == REGION_MISMATCH_HINT
+
+
+def test_streaming_no_hint_when_api_has_no_server_variable() -> None:
+    headers = _streaming_metadata_headers(_ctx_req(has_server_variable=False), "exec-1", 401)
+    assert _HINT_HEADER not in headers
+
+
+def test_streaming_no_hint_for_non_auth_status() -> None:
+    headers = _streaming_metadata_headers(_ctx_req(has_server_variable=True), "exec-1", 500)
+    assert _HINT_HEADER not in headers


### PR DESCRIPTION
## Summary

Resolves **#638**. When a user's credential is configured for the wrong region on a region-split API (e.g. PostHog's `https://{region}.posthog.com`), the upstream returns a `401`/`403` and the broker mirrors that vendor response verbatim — producing a confusing dead-end "Invalid Key" with no indication that the real cause is a region/host mismatch.

This PR makes the broker attach a **`Jentic-Hint`** response header on an upstream `401`/`403` **when the target API's spec uses a templated host** (a server variable). The hint reads:

> This API requires a specific region or server variable. If your API key is valid, ensure your credential is configured for the correct region.

Key design points:
- The hint rides on a **header**, never the body — the mirrored upstream body stays verbatim, preserving the broker's passthrough invariant (§6b B-002).
- Detection is **self-contained** — no extra registry lookup. The caller-derived (pre-injection) URL still carries the `{name}` template in its **host** when the credential omitted the server variable; `has_host_server_variable()` detects exactly that (host only, so ordinary path params like `/{id}` and query placeholders never false-trigger).
- Applied on both the buffered and streaming response paths.

### Note on #641 (persist `server_variables`)
Investigation found `server_variables` is **already fully wired end-to-end** (wire schema → handler → service → repository → JSONB column, plus the UI form and generated types) and already covered by real-DB round-trip tests in `tests/integration/control/test_credential_service.py`. No changes were needed there, so this PR scopes to #638.

## Changes
- `shared/url.py`: add `has_host_server_variable(url)` (host-only `{name}` template detection).
- `broker/core/headers.py`: add `JenticHeader.HINT` (`Jentic-Hint`) and the `REGION_MISMATCH_HINT` string.
- `shared/broker/schemas.py`: add `has_server_variable: bool` to `ExecuteRequestContext`.
- `broker/web/routers/execute.py`: set the flag from the pre-injection URL; attach the hint in `_assemble_response` for 401/403.
- `broker/web/streaming.py`: same hint on the streaming path.

## Test plan
- [x] `tests/unit/broker/test_apply_server_variables.py` — `has_host_server_variable` (templated host/subdomain true; static host, path params, query placeholders, empty braces false).
- [x] `tests/unit/broker/test_region_mismatch_hint.py` — hint on 401/403 for templated-host APIs (buffered + streaming), body left verbatim, absent for static-host APIs and non-auth statuses (200/404/429/500).
- [x] Full broker unit suite (481 passed), credentials unit tests (144 passed), arch tests (131 passed) — all green.
- [x] Ruff, mypy, commitlint clean (pre-commit hooks); no OpenAPI spec drift.

Made with [Cursor](https://cursor.com)