### PR TITLE
fix(control): let a bound agent read its toolkit and its credentials (#665, #682)

### DIFF
--- a/src/jentic_one/control/repos/prerequisite_repo.py
+++ b/src/jentic_one/control/repos/prerequisite_repo.py
@@ -42,6 +42,24 @@ class PrerequisiteRepository:
         return result.scalar_one_or_none() is not None
 
     @staticmethod
+    async def list_toolkit_ids_for_agent(session: AsyncSession, *, agent_id: str) -> list[str]:
+        """Return the ids of every toolkit the agent is actively bound to.
+
+        Used to widen control-surface read scoping: an agent must always be able
+        to see a toolkit (and its credentials) it is bound to, even when the
+        toolkit is owned by someone else — or by no one, as with the orphaned
+        bootstrap agent (issues #665/#682). The binding lives in the admin DB, so
+        this runs against an admin session and returns plain ids the caller feeds
+        into ``build_access_filters`` (the control scoping module must not import
+        admin ORM models or query across databases).
+        """
+        result = await session.execute(
+            text("SELECT toolkit_id FROM agent_toolkit_bindings WHERE agent_id = :agent_id"),
+            {"agent_id": agent_id},
+        )
+        return [row[0] for row in result.fetchall()]
+
+    @staticmethod
     async def delete_agent_toolkit_bindings_for_toolkit(
         session: AsyncSession, *, toolkit_id: str
     ) -> int:

--- a/src/jentic_one/control/scoping/filters.py
+++ b/src/jentic_one/control/scoping/filters.py
@@ -52,13 +52,52 @@ _DELEGATION_SCOPES: dict[type[Any], str] = {
 }
 
 
-def build_access_filters(identity: Identity, model: type[Any]) -> list[ColumnElement[bool]]:
+def _binding_visibility_clause(
+    model: type[Any], bound_toolkit_ids: list[str] | None
+) -> ColumnElement[bool] | None:
+    """Extra visibility a bound-toolkit set grants for ``Toolkit``/``Credential``.
+
+    Returns ``None`` when there is nothing to add (no ids, or a model whose
+    visibility is not widened by bindings). A toolkit is visible directly by id;
+    a credential is visible when it is bound (via ``ToolkitCredentialBinding``) to
+    one of those toolkits. Both stay within the control DB — the ids are supplied
+    by the caller, so no admin table is referenced here.
+    """
+    if not bound_toolkit_ids:
+        return None
+    if model is Toolkit:
+        return Toolkit.id.in_(bound_toolkit_ids)
+    if model is Credential:
+        subq = select(ToolkitCredentialBinding.credential_id).where(
+            ToolkitCredentialBinding.toolkit_id.in_(bound_toolkit_ids),
+            ToolkitCredentialBinding.credential_id == Credential.id,
+        )
+        return exists(subq)
+    return None
+
+
+def build_access_filters(
+    identity: Identity,
+    model: type[Any],
+    *,
+    bound_toolkit_ids: list[str] | None = None,
+) -> list[ColumnElement[bool]]:
     """Build SQLAlchemy filter expressions scoping queries to the caller's visibility.
 
     Rules (evaluated in order):
     1. org:admin -> no restriction (empty list).
     2. Agent with delegation scope + parent_actor_id -> OR filter.
     3. Otherwise -> owner == self.
+
+    ``bound_toolkit_ids`` widens visibility for the ``Toolkit`` and ``Credential``
+    models: a caller may always read a toolkit it is actively bound to — and the
+    credentials attached to that toolkit — regardless of owner scoping (issues
+    #665/#682). This matters for an orphaned agent (``created_by``/owner ``None``)
+    that owns nothing yet is legitimately bound to a toolkit. Binding lives in the
+    admin DB, so the service resolves the ids there (via
+    :meth:`PrerequisiteRepository.list_toolkit_ids_for_agent`) and passes them in;
+    this module stays single-DB and free of admin imports. ``None``/empty leaves
+    the owner-only behaviour unchanged.
 
     Raises ValueError for an unknown model or empty sub.
     """
@@ -76,8 +115,15 @@ def build_access_filters(identity: Identity, model: type[Any]) -> list[ColumnEle
             and delegation_scope in identity.permissions
             and identity.parent_actor_id is not None
         ):
-            return [or_(col == identity.sub, col == identity.parent_actor_id)]
-        return [col == identity.sub]
+            owner_clause: ColumnElement[bool] = or_(
+                col == identity.sub, col == identity.parent_actor_id
+            )
+        else:
+            owner_clause = col == identity.sub
+        binding_clause = _binding_visibility_clause(model, bound_toolkit_ids)
+        if binding_clause is not None:
+            return [or_(owner_clause, binding_clause)]
+        return [owner_clause]
 
     if model in _CHILD_MODELS:
         child_fk, _parent_model, parent_pk, parent_owner = _CHILD_MODELS[model]

--- a/src/jentic_one/control/services/credentials/service.py
+++ b/src/jentic_one/control/services/credentials/service.py
@@ -15,6 +15,7 @@ from jentic_one.control.repos import (
     OAuthClientCredentialRepository,
     TokenValueCredentialRepository,
 )
+from jentic_one.control.repos.prerequisite_repo import PrerequisiteRepository
 from jentic_one.control.scoping.filters import build_access_filters
 from jentic_one.control.services.credentials.errors import (
     CredentialNotFoundError,
@@ -49,6 +50,7 @@ from jentic_one.shared.events import emit_event_best_effort
 from jentic_one.shared.models.credentials import CredentialType, StoredCredentialType
 from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.pagination import decode_cursor_str, encode_cursor
+from jentic_one.shared.scopes import ORG_ADMIN
 from jentic_one.shared.url_validation import validate_upstream_url
 
 logger = structlog.get_logger()
@@ -59,6 +61,22 @@ class CredentialService:
 
     def __init__(self, ctx: Context) -> None:
         self._ctx = ctx
+
+    async def _bound_toolkit_ids(self, identity: Identity) -> list[str]:
+        """Toolkit ids the caller is bound to, widening owner-scoped visibility.
+
+        A credential bound to a toolkit the caller can see must itself be visible
+        to that caller — including an orphaned agent that owns nothing (issues
+        #665/#682). Bindings live in the admin DB, so resolve the ids there and
+        feed them into the control-DB ``build_access_filters``. An ``org:admin``
+        caller is unrestricted already, so skip the lookup.
+        """
+        if ORG_ADMIN in identity.permissions or not identity.sub:
+            return []
+        async with self._ctx.admin_db.session() as session:
+            return await PrerequisiteRepository.list_toolkit_ids_for_agent(
+                session, agent_id=identity.sub
+            )
 
     def list_providers(self) -> list[ProviderDiscoveryEntry]:
         """Return discovery metadata for all configured providers."""
@@ -250,7 +268,9 @@ class CredentialService:
 
     async def get(self, credential_id: str, *, identity: Identity) -> CredentialRedactedView:
         """Get a credential by ID with redacted secrets."""
-        access_filters = build_access_filters(identity, Credential)
+        access_filters = build_access_filters(
+            identity, Credential, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+        )
         async with self._ctx.control_db.session() as session:
             credential = await CredentialRepository.get_by_id(
                 session, credential_id, filters=access_filters
@@ -273,7 +293,9 @@ class CredentialService:
             ts, cid = decode_cursor_str(cursor)
             decoded_cursor = (ts, cid)
 
-        access_filters = build_access_filters(identity, Credential)
+        access_filters = build_access_filters(
+            identity, Credential, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+        )
 
         async with self._ctx.control_db.session() as session:
             rows = await CredentialRepository.list_all(

--- a/src/jentic_one/control/services/toolkits/service.py
+++ b/src/jentic_one/control/services/toolkits/service.py
@@ -30,6 +30,7 @@ from jentic_one.shared.context import Context
 from jentic_one.shared.events import emit_event_best_effort
 from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.pagination import decode_cursor_str, encode_cursor
+from jentic_one.shared.scopes import ORG_ADMIN
 
 logger = structlog.get_logger()
 
@@ -39,6 +40,22 @@ class ToolkitService:
 
     def __init__(self, ctx: Context) -> None:
         self._ctx = ctx
+
+    async def _bound_toolkit_ids(self, identity: Identity) -> list[str]:
+        """Toolkit ids the caller is bound to, widening owner-scoped visibility.
+
+        A caller must always be able to read a toolkit it is actively bound to,
+        even one it doesn't own — including an orphaned agent that owns nothing
+        (issues #665/#682). Bindings live in the admin DB, so resolve the ids
+        there and feed them into the control-DB ``build_access_filters``. An
+        ``org:admin`` caller is unrestricted already, so skip the lookup.
+        """
+        if ORG_ADMIN in identity.permissions or not identity.sub:
+            return []
+        async with self._ctx.admin_db.session() as session:
+            return await PrerequisiteRepository.list_toolkit_ids_for_agent(
+                session, agent_id=identity.sub
+            )
 
     async def _emit_telemetry(self, *, type: str, summary: str, identity: Identity) -> None:
         """Emit a telemetry event on the admin DB (best-effort).
@@ -123,7 +140,8 @@ class ToolkitService:
         return toolkit, plaintext
 
     async def get(self, toolkit_id: str, *, identity: Identity) -> Toolkit:
-        access_filters = build_access_filters(identity, Toolkit)
+        bound_ids = await self._bound_toolkit_ids(identity)
+        access_filters = build_access_filters(identity, Toolkit, bound_toolkit_ids=bound_ids)
         async with self._ctx.control_db.session() as session:
             toolkit = await ToolkitRepository.get_with_relations(
                 session, toolkit_id, filters=access_filters
@@ -141,7 +159,9 @@ class ToolkitService:
             ts, cid = decode_cursor_str(cursor)
             decoded_cursor = (ts, cid)
 
-        access_filters = build_access_filters(identity, Toolkit)
+        access_filters = build_access_filters(
+            identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+        )
         async with self._ctx.control_db.session() as session:
             rows = await ToolkitRepository.list_all(
                 session, cursor=decoded_cursor, limit=limit, filters=access_filters
@@ -167,7 +187,9 @@ class ToolkitService:
         identity: Identity,
     ) -> tuple[list[BoundAgentRow], bool, str | None]:
         """List agents bound to a toolkit. Returns (data, has_more, next_cursor)."""
-        access_filters = build_access_filters(identity, Toolkit)
+        access_filters = build_access_filters(
+            identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+        )
         async with self._ctx.control_db.session() as session:
             toolkit = await ToolkitRepository.get_by_id(session, toolkit_id, filters=access_filters)
             if toolkit is None:
@@ -313,7 +335,11 @@ class ToolkitService:
 
         async with self._ctx.control_db.session() as session:
             toolkit = await ToolkitRepository.get_by_id(
-                session, toolkit_id, filters=build_access_filters(identity, Toolkit)
+                session,
+                toolkit_id,
+                filters=build_access_filters(
+                    identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+                ),
             )
             if toolkit is None:
                 raise ToolkitNotFoundError(toolkit_id)
@@ -446,7 +472,11 @@ class ToolkitService:
 
         async with self._ctx.control_db.session() as session:
             toolkit = await ToolkitRepository.get_by_id(
-                session, toolkit_id, filters=build_access_filters(identity, Toolkit)
+                session,
+                toolkit_id,
+                filters=build_access_filters(
+                    identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+                ),
             )
             if toolkit is None:
                 raise ToolkitNotFoundError(toolkit_id)
@@ -508,7 +538,11 @@ class ToolkitService:
     ) -> list[ToolkitPermissionRule]:
         async with self._ctx.control_db.session() as session:
             toolkit = await ToolkitRepository.get_by_id(
-                session, toolkit_id, filters=build_access_filters(identity, Toolkit)
+                session,
+                toolkit_id,
+                filters=build_access_filters(
+                    identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+                ),
             )
             if toolkit is None:
                 raise ToolkitNotFoundError(toolkit_id)

--- a/tests/unit/control/test_control_scoping.py
+++ b/tests/unit/control/test_control_scoping.py
@@ -152,6 +152,55 @@ def test_child_model_with_delegation_returns_or_in_exists() -> None:
     assert "user_delegator" in sql
 
 
+# --- Bound-toolkit visibility (issues #665 / #682) ---
+
+
+def test_orphaned_agent_sees_bound_toolkit_by_id() -> None:
+    """An orphaned agent (owner_id=None, no org:admin) can read a bound toolkit.
+
+    The owner check still holds (created_by == sub), but the returned filter must
+    additionally OR in an ``id IN (...)`` clause for the toolkits the agent is
+    bound to, so a toolkit it doesn't own is still visible.
+    """
+    identity = _identity(sub="agent_123", permissions=[], actor_type=ActorType.AGENT)
+    filters = build_access_filters(identity, Toolkit, bound_toolkit_ids=["tk_bound_1"])
+    assert len(filters) == 1
+    compiled = filters[0].compile(compile_kwargs={"literal_binds": True})
+    sql = str(compiled)
+    assert "created_by" in sql
+    assert "agent_123" in sql
+    assert "toolkits.id IN" in sql
+    assert "tk_bound_1" in sql
+
+
+def test_bound_toolkit_ids_none_leaves_owner_only_filter() -> None:
+    """Without bound ids the filter is unchanged (plain owner scoping)."""
+    identity = _identity(sub="agent_123", permissions=[], actor_type=ActorType.AGENT)
+    filters = build_access_filters(identity, Toolkit, bound_toolkit_ids=None)
+    assert len(filters) == 1
+    sql = str(filters[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "created_by" in sql
+    assert " IN " not in sql
+
+
+def test_admin_ignores_bound_toolkit_ids() -> None:
+    """org:admin is unrestricted regardless of bound ids."""
+    identity = _identity(permissions=["org:admin"])
+    assert build_access_filters(identity, Toolkit, bound_toolkit_ids=["tk_1"]) == []
+
+
+def test_orphaned_agent_sees_credential_bound_to_bound_toolkit() -> None:
+    """A credential bound to a bound toolkit is visible via an EXISTS subquery."""
+    identity = _identity(sub="agent_123", permissions=[], actor_type=ActorType.AGENT)
+    filters = build_access_filters(identity, Credential, bound_toolkit_ids=["tk_bound_1"])
+    assert len(filters) == 1
+    sql = str(filters[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "created_by" in sql
+    assert "EXISTS" in sql
+    assert "toolkit_credential_bindings" in sql
+    assert "tk_bound_1" in sql
+
+
 # --- AccessRequest model tests ---
 
 

--- a/tests/web/control/conftest.py
+++ b/tests/web/control/conftest.py
@@ -160,6 +160,29 @@ async def clean_access_requests(web_context: Context) -> AsyncGenerator[None, No
         await session.commit()
 
 
+# A bound but orphaned agent (issues #665/#682): it owns nothing (parent_actor_id
+# None, like the jentic-cli-default bootstrap agent) but is bound to tk_target via
+# the seed_binding fixture. It carries the default agent owner-read scopes so it
+# passes the route gate; visibility must then come purely from the binding.
+BOUND_ORPHAN_IDENTITY = Identity(
+    sub=FILER_SUB,
+    email="orphan@test.local",
+    permissions=["owner:toolkits:read", "owner:credentials:read"],
+    actor_type=ActorType.AGENT,
+    parent_actor_id=None,
+)
+
+
+@pytest.fixture()
+def bound_orphan_client(
+    web_context: Context, seed_binding: None, clean_access_requests: None
+) -> Iterator[TestClient]:
+    """TestClient as a bound-but-orphaned agent (owns nothing, bound to tk_target)."""
+    app = _build_app(web_context, BOUND_ORPHAN_IDENTITY)
+    with TestClient(app) as tc:
+        yield tc
+
+
 @pytest.fixture()
 def filer_client(
     web_context: Context, seed_binding: None, clean_access_requests: None

--- a/tests/web/control/test_toolkits.py
+++ b/tests/web/control/test_toolkits.py
@@ -124,6 +124,34 @@ def test_delete_toolkit(tk_admin_client: TestClient) -> None:
     assert resp.status_code == 404
 
 
+# --- Bound-but-orphaned agent visibility (issues #665 / #682) ---
+
+
+def test_orphaned_agent_reads_bound_toolkit(bound_orphan_client: TestClient) -> None:
+    """A bound agent that owns nothing gets 200 (not 404) on its bound toolkit.
+
+    Reproduces #665/#682: previously owner-only scoping returned 404 for an
+    orphaned agent even though it is actively bound to the toolkit.
+    """
+    resp = bound_orphan_client.get("/toolkits/tk_target")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["toolkit_id"] == "tk_target"
+
+
+def test_orphaned_agent_lists_bound_toolkit(bound_orphan_client: TestClient) -> None:
+    """The bound toolkit appears in the orphaned agent's list, not an empty page."""
+    resp = bound_orphan_client.get("/toolkits")
+    assert resp.status_code == 200, resp.text
+    ids = [t["toolkit_id"] for t in resp.json()["data"]]
+    assert "tk_target" in ids
+
+
+def test_orphaned_agent_denied_unbound_toolkit(bound_orphan_client: TestClient) -> None:
+    """Visibility is scoped to bindings — an unbound/unknown toolkit is still 404."""
+    resp = bound_orphan_client.get("/toolkits/tk_not_bound")
+    assert resp.status_code == 404
+
+
 # --- Keys ---
 
 


### PR DESCRIPTION
## Summary

Fixes #665 and #682. An agent bound to a toolkit it did not create — including an **orphaned** agent (`owner_id`/`created_by` `None`, like the `jentic-cli-default` bootstrap agent) — got a 404 from `GET /toolkits/{id}` and an empty list from `GET /toolkits` / `GET /credentials`, because control-surface query scoping was strictly owner-based.

Visibility is now intrinsically linked to **binding**: a caller may always read a toolkit it is actively bound to, plus the credentials attached to that toolkit, regardless of owner scoping.

## Why not the naive subquery

`agent_toolkit_bindings` lives in the **admin** database while `toolkits`/`credentials` live in the **control** database, and the control scoping module is forbidden (by arch tests) from importing admin ORM models or querying across DBs. A single `Toolkit.id.in_(select(AgentToolkitBinding...))` would both break the cross-surface import rule and fail at runtime in a split-DB deployment. Also, `Credential` has no `toolkit_id` — credentials link to toolkits via the `toolkit_credential_bindings` junction table.

## Approach

- `PrerequisiteRepository.list_toolkit_ids_for_agent()` — resolves the agent's bound toolkit ids via raw SQL against the **admin** DB (same pattern as the existing cross-DB prerequisite queries).
- `build_access_filters(identity, model, *, bound_toolkit_ids=None)` — when ids are supplied, ORs the owner check with:
  - `Toolkit.id IN (...)` for `Toolkit`
  - an `EXISTS` over `toolkit_credential_bindings` (scoped to those toolkit ids) for `Credential`
  - This stays single-DB with no admin imports; `None`/empty preserves the prior owner-only behaviour.
- Toolkit & credential services resolve `bound_toolkit_ids` via the admin DB (skipped for `org:admin`) and feed them into the filters on **read** paths only (`get`, `list_all`, `list_keys`, `list_bindings`, `list_permissions`, `list_agents`). Mutation paths remain owner-scoped, so a bound agent still cannot edit/delete a toolkit it doesn't own.

## Test plan

- [x] Unit (`test_control_scoping.py`): compiled SQL for `sub="agent_123"`, owner/parent `None`, no `org:admin` includes `toolkits.id IN (...)`; credential `EXISTS`/junction path; no-op and `org:admin` cases.
- [x] E2E (`test_toolkits.py` + `bound_orphan_client` fixture): orphaned bound agent gets **200** on `GET /toolkits/{id}` and sees it in the list; an unbound toolkit is still **404**. Verified these fail without the fix.
- [x] `make test-fast` (275 unit + arch tests) pass; toolkit web tests (17) pass.
- [x] ruff + mypy clean.

Made with [Cursor](https://cursor.com)