### PR TITLE
fix(broker): make no_toolkit_binding directive recommend credential-first order

### DIFF
--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -66,11 +66,21 @@ branch on the exit code instead of mistaking the 4xx body for success. The
 directive tells you exactly how to recover — which differs by denial:
 
 - **`no_toolkit_binding` (403)** — you're not bound to a toolkit for this API.
-  File an access request and wait for a human to approve it:
+  The directive's `parameters.toolkit_serves_api` tells you which recovery
+  applies:
+  - `toolkit_serves_api: true` — a toolkit already serves this API; you just
+    aren't bound to it. File a binding request and wait for approval:
 
 ```
 jentic access request --toolkit stripe.com/api --wait
 ```
+
+  - `toolkit_serves_api: false` — **no** toolkit serves this API yet, so a
+    toolkit-binding request would be denied ("No toolkit serves API …"). Filing
+    it now is a dead-end. First a credential must be connected (provisioned) and
+    bound to a toolkit — that is what makes a toolkit serve the API. Ask your
+    operator to connect (bind) a credential for this API, then file the
+    `jentic access request --toolkit …` binding and retry.
 
 - **`credential_not_provisioned` (424)** — you're bound to a toolkit, but no
   credential (account) is connected. Filing an access request will **not** fix
@@ -256,10 +266,12 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   means the **broker target** is wrong; on a local install point at the local
   broker. Only a broker **denial** (exit **2**, with an `agent_directive` on
   stderr) is an access/credential issue:
-  - **403 `no_toolkit_binding`** → run the `jentic access request …` it suggests
-    and wait for approval. If it comes back **denied** with "No toolkit serves
-    API …", a toolkit for that API doesn't exist yet — ask your operator to
-    create one and bind a credential, then re-file (you can't self-serve this).
+  - **403 `no_toolkit_binding`** → check the directive's
+    `parameters.toolkit_serves_api`. If `true`, run the `jentic access request …`
+    it suggests and wait for approval. If `false`, no toolkit serves the API yet
+    and a binding request would be denied ("No toolkit serves API …") — ask your
+    operator to connect (bind) a credential for that API first, then file the
+    binding request and retry (you can't self-serve the credential step).
   - **424 `credential_not_provisioned`** → the directive gives a
     `provisioning_url` for your operator to connect an account (an access
     request won't help).

--- a/src/jentic_one/broker/core/exceptions.py
+++ b/src/jentic_one/broker/core/exceptions.py
@@ -233,26 +233,60 @@ def switch_toolkit_directive(status: int) -> AgentDirective:
     )
 
 
-def no_toolkit_binding_directive(*, vendor: str, name: str, version: str) -> AgentDirective:
-    """Directive for a ``no_toolkit_binding`` 403 — ask a human to grant access.
+def no_toolkit_binding_directive(
+    *, vendor: str, name: str, version: str, toolkit_serves_api: bool
+) -> AgentDirective:
+    """Directive for a ``no_toolkit_binding`` 403 — recover the missing binding.
 
-    The caller is authenticated but bound to no toolkit that serves this API, a
-    gap only a human can close (approve a toolkit binding). The directive names
-    the exact CLI command so an autonomous agent can hand it to its operator
-    verbatim instead of reading docs.
+    The caller is authenticated but bound to no toolkit that serves this API. The
+    right recovery depends on whether a toolkit serves the API *at all*:
+
+    - ``toolkit_serves_api=True`` — a toolkit already serves it, the caller just
+      isn't bound to it. Filing a ``toolkit:bind`` access request is the correct,
+      approvable next step.
+    - ``toolkit_serves_api=False`` — **no** toolkit serves it yet (no credential
+      has been provisioned/bound). A ``toolkit:bind`` request here would be a
+      guaranteed dead-end: the approval denies with "no toolkit serves API …"
+      because a toolkit only serves an API once a credential for it is bound
+      (issue #683). So point the caller at credential provisioning first — the
+      step that actually creates a serving toolkit — before the binding request.
+
+    Both variants name the exact next step so an autonomous agent can hand it to
+    its operator verbatim instead of reading docs.
     """
     api = "/".join(part for part in (vendor, name) if part)
-    return AgentDirective(
-        strategy="prompt_human",
-        parameters={
-            "api": {"vendor": vendor, "name": name, "version": version},
-            "suggested_command": f"jentic access request --toolkit {api} --wait",
-        },
-        human_readable_instruction=(
+    parameters: dict[str, Any] = {
+        "api": {"vendor": vendor, "name": name, "version": version},
+        "toolkit_serves_api": toolkit_serves_api,
+    }
+
+    if toolkit_serves_api:
+        parameters["suggested_command"] = f"jentic access request --toolkit {api} --wait"
+        instruction = (
             f"You are not bound to a toolkit for '{api}'. File an access request yourself with "
             f"`jentic access request --toolkit {api} --wait`, then ask your operator to approve "
             f"it — only a human can grant the binding. Once approved, retry this call."
-        ),
+        )
+        return AgentDirective(
+            strategy="prompt_human",
+            parameters=parameters,
+            human_readable_instruction=instruction,
+        )
+
+    # No toolkit serves this API yet: a credential must be provisioned and bound
+    # first (which creates the serving toolkit), then the toolkit binding can be
+    # requested. A bare `toolkit:bind` request now can never be approved.
+    parameters["suggested_command"] = f"jentic access request --toolkit {api} --wait"
+    instruction = (
+        f"No toolkit serves '{api}' yet, so a toolkit-binding request cannot be approved. "
+        f"Ask your operator to connect (provision) a credential for '{api}' and bind it to a "
+        f"toolkit first — that is what makes a toolkit serve the API. Once a toolkit serves it, "
+        f"file `jentic access request --toolkit {api} --wait` to bind yourself, then retry."
+    )
+    return AgentDirective(
+        strategy="prompt_human",
+        parameters=parameters,
+        human_readable_instruction=instruction,
     )
 
 

--- a/src/jentic_one/broker/repos/caching_toolkit_deriver.py
+++ b/src/jentic_one/broker/repos/caching_toolkit_deriver.py
@@ -101,6 +101,15 @@ class CachingToolkitDeriver:
 
         return await self._single_flight.do(key, _load)
 
+    async def any_toolkit_serves_api(self, *, vendor: str, name: str, version: str) -> bool:
+        """Delegate the "any toolkit serves this API" check to the inner deriver.
+
+        Not cached: it is consulted only on the ``no_toolkit_binding`` denial path
+        (to pick the recovery directive), never on the hot success path, so the
+        TTL-LRU that fronts ``derive_toolkits`` would add complexity for no gain.
+        """
+        return await self._inner.any_toolkit_serves_api(vendor=vendor, name=name, version=version)
+
     def _store(self, key: str, entry: _CacheEntry) -> None:
         self._cache[key] = entry
         self._cache.move_to_end(key)

--- a/src/jentic_one/broker/repos/toolkit_binding_resolver.py
+++ b/src/jentic_one/broker/repos/toolkit_binding_resolver.py
@@ -68,3 +68,21 @@ class ToolkitBindingResolver:
         api_toolkits = {row[0] for row in api_rows}
 
         return sorted(agent_toolkits & api_toolkits)
+
+    async def any_toolkit_serves_api(self, *, vendor: str, name: str, version: str) -> bool:
+        """Return whether any toolkit serves the given API (independent of the agent).
+
+        Runs the same control-DB toolkit↔API predicate as :meth:`derive_toolkits`
+        but without intersecting the agent's bindings, so a ``no_toolkit_binding``
+        denial can tell apart "no toolkit exists yet" (provision a credential
+        first) from "a toolkit serves it but this agent isn't bound" (file a
+        toolkit binding). See issue #683.
+        """
+        async with self._control_db.session() as session:
+            api_rows = (
+                await session.execute(
+                    _TOOLKITS_FOR_API,
+                    {"vendor": vendor, "name": name, "version": version},
+                )
+            ).all()
+        return bool(api_rows)

--- a/src/jentic_one/broker/web/routers/execute.py
+++ b/src/jentic_one/broker/web/routers/execute.py
@@ -28,6 +28,7 @@ from jentic_one.broker.adapters.runners.base import (
 )
 from jentic_one.broker.core.exceptions import (
     ActionDeniedError,
+    AgentDirective,
     AmbiguousMatchError,
     IdempotencyConflictError,
     IdempotencyInProgressError,
@@ -253,6 +254,26 @@ def _context_from_discovery(
     )
 
 
+async def _no_toolkit_binding_directive(
+    deriver: ToolkitDeriverProtocol, api: APIReference
+) -> AgentDirective:
+    """Build the ``no_toolkit_binding`` directive with the right recovery step.
+
+    The caller is bound to no toolkit serving ``api``. Whether the right recovery
+    is "provision a credential first" or "file a toolkit binding" depends on
+    whether a toolkit serves the API *at all* — a state the broker can read
+    (independent of the caller's bindings). Consulted only on this denial path,
+    never on the success path, so the extra read costs nothing in the common
+    case. See issue #683.
+    """
+    serves = await deriver.any_toolkit_serves_api(
+        vendor=api.vendor, name=api.name, version=api.version
+    )
+    return no_toolkit_binding_directive(
+        vendor=api.vendor, name=api.name, version=api.version, toolkit_serves_api=serves
+    )
+
+
 async def select_toolkit(
     *,
     deriver: ToolkitDeriverProtocol,
@@ -301,8 +322,8 @@ async def select_toolkit(
             # Recoverable: the agent named a toolkit it isn't bound to. Carry the
             # agent-recovery contract like every other broker denial — point it at
             # the toolkits it *is* bound to (switch_toolkit) or, if it has none,
-            # at filing an access request (prompt_human). A bare Forbidden here
-            # would be a dead-end 403 with no directive (§03 invariant).
+            # at the correct provisioning/binding step (prompt_human). A bare
+            # Forbidden here would be a dead-end 403 with no directive (§03 invariant).
             if candidates:
                 raise ActionDeniedError(
                     f"Not bound to toolkit '{header_toolkit}' for this API",
@@ -314,9 +335,7 @@ async def select_toolkit(
                 f"Not bound to toolkit '{header_toolkit}' for this API",
                 type="no_toolkit_binding",
                 instance=instance,
-                directive=no_toolkit_binding_directive(
-                    vendor=api.vendor, name=api.name, version=api.version
-                ),
+                directive=await _no_toolkit_binding_directive(deriver, api),
             )
         return header_toolkit
 
@@ -325,9 +344,7 @@ async def select_toolkit(
             "No toolkit binding for this API",
             type="no_toolkit_binding",
             instance=instance,
-            directive=no_toolkit_binding_directive(
-                vendor=api.vendor, name=api.name, version=api.version
-            ),
+            directive=await _no_toolkit_binding_directive(deriver, api),
         )
     if len(candidates) > 1:
         raise AmbiguousMatchError(

--- a/src/jentic_one/control/services/access_requests/errors.py
+++ b/src/jentic_one/control/services/access_requests/errors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from jentic_one.shared.access_guidance import no_toolkit_serves_api_reason
 from jentic_one.shared.scopes import GRANTABLE_SCOPES
 
 
@@ -115,10 +116,7 @@ class ToolkitReferenceUnresolvedError(AccessRequestServiceError):
     """
 
     def __init__(self, reference: dict[str, object]) -> None:
-        super().__init__(
-            f"No toolkit serves API {_format_api_reference(reference)}; "
-            "provision and bind a credential for it first"
-        )
+        super().__init__(no_toolkit_serves_api_reason(_format_api_reference(reference)))
         self.reference = reference
 
 

--- a/src/jentic_one/shared/access_guidance.py
+++ b/src/jentic_one/shared/access_guidance.py
@@ -1,0 +1,27 @@
+"""Canonical access-recovery guidance shared across broker and control.
+
+A toolkit only "serves" an API once a credential for it is provisioned and
+bound; only then can an agent be bound to that toolkit. When no toolkit serves
+an API yet, the broker's ``no_toolkit_binding`` recovery directive and the
+control approval-denial reason must recommend the *same* first step — provision
+a credential — instead of contradicting each other (see issue #683).
+
+This module holds the single wording both layers reference so the two messages
+can never drift. It lives under ``shared`` because both the public broker
+(``broker/core/exceptions.py``) and control (``control/services/access_requests``)
+may import ``shared`` but not each other.
+"""
+
+from __future__ import annotations
+
+
+def no_toolkit_serves_api_reason(api: str) -> str:
+    """The canonical denial reason when no toolkit serves ``api`` yet.
+
+    ``api`` is a ``vendor[/name][@version]`` label. Phrased as a statement of the
+    condition plus the recommended first step, matching the broker directive.
+    """
+    return (
+        f"No toolkit serves API {api}; provision and bind a credential for it "
+        "first, then request the toolkit binding"
+    )

--- a/src/jentic_one/shared/broker/protocols.py
+++ b/src/jentic_one/shared/broker/protocols.py
@@ -128,6 +128,18 @@ class ToolkitDeriverProtocol(Protocol):
         self, *, agent_id: str, vendor: str, name: str, version: str
     ) -> list[str]: ...
 
+    async def any_toolkit_serves_api(self, *, vendor: str, name: str, version: str) -> bool:
+        """Return whether *any* toolkit (for any owner) serves the given API.
+
+        A toolkit only "serves" an API once a credential for it is bound. This
+        distinguishes the "no toolkit exists yet — provision a credential first"
+        state from the "a toolkit serves it but this agent isn't bound" state, so
+        a ``no_toolkit_binding`` denial can hand the caller a recovery step that
+        can actually be completed (see issue #683). Unscoped by design: it drives
+        recovery guidance, not authorization.
+        """
+        ...
+
 
 @dataclass(frozen=True, slots=True)
 class IdempotencyClaim:

--- a/tests/integration/broker/test_toolkit_binding_resolver.py
+++ b/tests/integration/broker/test_toolkit_binding_resolver.py
@@ -210,3 +210,39 @@ async def test_derive_toolkits_excludes_unbound_wildcard_toolkit(
 
     assert result == [bound]
     assert unbound_wildcard not in result
+
+
+async def test_any_toolkit_serves_api_true_when_a_toolkit_serves(
+    admin_db: DatabaseSession, control_db: DatabaseSession, clean_tables: None
+) -> None:
+    """A toolkit with a bound credential for the API → serves the API (issue #683).
+
+    Independent of any agent binding: this drives the ``no_toolkit_binding``
+    recovery directive, not authorization.
+    """
+    await _seed_toolkit_with_credential(
+        control_db, toolkit_name="tk-acme", vendor="acme.com", name="pets-api", version="v1"
+    )
+
+    resolver = ToolkitBindingResolver(admin_db, control_db)
+    serves = await resolver.any_toolkit_serves_api(vendor="acme.com", name="pets-api", version="v1")
+
+    assert serves is True
+
+
+async def test_any_toolkit_serves_api_false_when_no_toolkit_serves(
+    admin_db: DatabaseSession, control_db: DatabaseSession, clean_tables: None
+) -> None:
+    """No toolkit bound a credential for the API → does not serve it (issue #683).
+
+    This is the state whose directive must recommend provisioning a credential
+    first rather than an unapprovable toolkit-binding request.
+    """
+    await _seed_toolkit_with_credential(
+        control_db, toolkit_name="tk-other", vendor="other.com", name="x", version="v1"
+    )
+
+    resolver = ToolkitBindingResolver(admin_db, control_db)
+    serves = await resolver.any_toolkit_serves_api(vendor="acme.com", name="pets-api", version="v1")
+
+    assert serves is False

--- a/tests/unit/broker/test_caching_toolkit_deriver_observability.py
+++ b/tests/unit/broker/test_caching_toolkit_deriver_observability.py
@@ -25,6 +25,9 @@ class _CountingDeriver:
         self.calls += 1
         return list(self.result)
 
+    async def any_toolkit_serves_api(self, *, vendor: str, name: str, version: str) -> bool:
+        return bool(self.result)
+
 
 def _get_counter_value(reader: InMemoryMetricReader, name: str) -> int:
     """Extract the cumulative value for a counter from the in-memory reader."""

--- a/tests/unit/broker/test_problem_json.py
+++ b/tests/unit/broker/test_problem_json.py
@@ -42,7 +42,9 @@ def test_directive_factories_emit_known_strategies() -> None:
     in lock-step until the contract is a shared OpenAPI schema (review P1-1)."""
     directives = [
         switch_toolkit_directive(503),
-        no_toolkit_binding_directive(vendor="acme", name="widgets", version="1.0.0"),
+        no_toolkit_binding_directive(
+            vendor="acme", name="widgets", version="1.0.0", toolkit_serves_api=True
+        ),
         ambiguous_toolkit_directive(["tk_a", "tk_b"]),
         action_denied_directive(),
     ]

--- a/tests/unit/broker/test_toolkit_cache.py
+++ b/tests/unit/broker/test_toolkit_cache.py
@@ -26,6 +26,9 @@ class _CountingDeriver:
             await self.gate.wait()
         return list(self.result)
 
+    async def any_toolkit_serves_api(self, *, vendor: str, name: str, version: str) -> bool:
+        return bool(self.result)
+
 
 def test_wrapper_satisfies_protocol() -> None:
     wrapper = CachingToolkitDeriver(_CountingDeriver())

--- a/tests/unit/broker/test_toolkit_select.py
+++ b/tests/unit/broker/test_toolkit_select.py
@@ -10,9 +10,14 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from jentic.problem_details import Forbidden, ProblemDetailException
 
-from jentic_one.broker.core.exceptions import ActionDeniedError, AmbiguousMatchError
+from jentic_one.broker.core.exceptions import (
+    ActionDeniedError,
+    AmbiguousMatchError,
+    no_toolkit_binding_directive,
+)
 from jentic_one.broker.web.errors import install_broker_error_handlers
 from jentic_one.broker.web.routers.execute import select_toolkit
+from jentic_one.shared.access_guidance import no_toolkit_serves_api_reason
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.models import ActorType
 from jentic_one.shared.schemas import APIReference
@@ -22,9 +27,11 @@ _INSTANCE = "/acme.example.com/v1/widgets"
 
 
 class _StubDeriver:
-    def __init__(self, candidates: list[str]) -> None:
+    def __init__(self, candidates: list[str], *, toolkit_serves_api: bool = True) -> None:
         self.candidates = candidates
+        self._toolkit_serves_api = toolkit_serves_api
         self.calls: list[dict[str, str]] = []
+        self.serves_calls: list[dict[str, str]] = []
 
     async def derive_toolkits(
         self, *, agent_id: str, vendor: str, name: str, version: str
@@ -33,6 +40,10 @@ class _StubDeriver:
             {"agent_id": agent_id, "vendor": vendor, "name": name, "version": version}
         )
         return self.candidates
+
+    async def any_toolkit_serves_api(self, *, vendor: str, name: str, version: str) -> bool:
+        self.serves_calls.append({"vendor": vendor, "name": name, "version": version})
+        return self._toolkit_serves_api
 
 
 def _identity(actor_type: str = "agent") -> Identity:
@@ -87,16 +98,37 @@ async def test_single_candidate_no_header_uses_it() -> None:
     assert result == "tk_only"
 
 
-async def test_zero_candidates_no_header_raises_403() -> None:
+async def test_zero_candidates_no_header_toolkit_serves_recommends_binding() -> None:
+    # A toolkit serves this API; the caller just isn't bound. The directive
+    # recommends the (approvable) toolkit-binding request.
     with pytest.raises(ActionDeniedError) as exc:
-        await _select(_StubDeriver([]), header_toolkit=None)
+        await _select(_StubDeriver([], toolkit_serves_api=True), header_toolkit=None)
     assert exc.value.type == "no_toolkit_binding"
     assert exc.value.instance == _INSTANCE
     assert exc.value.directive is not None
     assert exc.value.directive.strategy == "prompt_human"
+    assert exc.value.directive.parameters["toolkit_serves_api"] is True
     assert exc.value.directive.parameters["suggested_command"] == (
         "jentic access request --toolkit acme/widgets --wait"
     )
+
+
+async def test_zero_candidates_no_toolkit_serves_recommends_credential_first() -> None:
+    # No toolkit serves this API yet (issue #683). A bare toolkit-binding request
+    # would be denied, so the directive must point at provisioning a credential
+    # first rather than filing an unapprovable binding request.
+    deriver = _StubDeriver([], toolkit_serves_api=False)
+    with pytest.raises(ActionDeniedError) as exc:
+        await _select(deriver, header_toolkit=None)
+    assert exc.value.type == "no_toolkit_binding"
+    assert exc.value.directive is not None
+    assert exc.value.directive.strategy == "prompt_human"
+    assert exc.value.directive.parameters["toolkit_serves_api"] is False
+    instruction = exc.value.directive.human_readable_instruction
+    assert "credential" in instruction.lower()
+    assert "provision" in instruction.lower()
+    # The broker consulted the "any toolkit serves this API?" predicate.
+    assert deriver.serves_calls == [{"vendor": "acme", "name": "widgets", "version": "1.0.0"}]
 
 
 async def test_multiple_candidates_no_header_raises_409_with_candidates() -> None:
@@ -134,16 +166,29 @@ async def test_header_present_but_not_bound_raises_403() -> None:
 
 
 async def test_header_present_not_bound_and_no_candidates_prompts_human() -> None:
-    # The agent named a toolkit but is bound to none at all: it should be told to
-    # file an access request (prompt_human), not handed a dead-end 403.
+    # The agent named a toolkit but is bound to none at all. When a toolkit does
+    # serve the API it should be told to file the binding request (prompt_human);
+    # it should never be handed a dead-end 403.
     with pytest.raises(ActionDeniedError) as exc:
-        await _select(_StubDeriver([]), header_toolkit="tk_unbound")
+        await _select(_StubDeriver([], toolkit_serves_api=True), header_toolkit="tk_unbound")
     assert exc.value.type == "no_toolkit_binding"
     assert exc.value.directive is not None
     assert exc.value.directive.strategy == "prompt_human"
+    assert exc.value.directive.parameters["toolkit_serves_api"] is True
     assert exc.value.directive.parameters["suggested_command"] == (
         "jentic access request --toolkit acme/widgets --wait"
     )
+
+
+async def test_header_present_not_bound_and_no_toolkit_serves_recommends_credential_first() -> None:
+    # The agent named a toolkit, is bound to none, and no toolkit serves the API:
+    # recover by provisioning a credential first (issue #683), not a binding request.
+    with pytest.raises(ActionDeniedError) as exc:
+        await _select(_StubDeriver([], toolkit_serves_api=False), header_toolkit="tk_unbound")
+    assert exc.value.type == "no_toolkit_binding"
+    assert exc.value.directive is not None
+    assert exc.value.directive.parameters["toolkit_serves_api"] is False
+    assert "credential" in exc.value.directive.human_readable_instruction.lower()
 
 
 async def test_derivation_uses_discovered_api_identity() -> None:
@@ -204,7 +249,7 @@ def test_no_toolkit_binding_body_carries_prompt_human_directive() -> None:
 
     @app.get("/p")
     async def _p() -> None:
-        await _select(_StubDeriver([]), header_toolkit=None)
+        await _select(_StubDeriver([], toolkit_serves_api=True), header_toolkit=None)
 
     resp = TestClient(app, raise_server_exceptions=False).get("/p")
     assert resp.status_code == 403
@@ -214,3 +259,25 @@ def test_no_toolkit_binding_body_carries_prompt_human_directive() -> None:
     assert body["agent_directive"]["parameters"]["suggested_command"] == (
         "jentic access request --toolkit acme/widgets --wait"
     )
+
+
+def test_no_toolkit_binding_credential_first_directive_and_denial_reason_agree() -> None:
+    """The broker directive (no toolkit yet) and the control denial reason agree.
+
+    Regression for issue #683: the ``no_toolkit_binding`` directive must recommend
+    provisioning a credential first, matching the reason the toolkit:bind approval
+    denies with when no toolkit serves the API — so the two never contradict.
+    """
+    directive = no_toolkit_binding_directive(
+        vendor="acme", name="widgets", version="1.0.0", toolkit_serves_api=False
+    )
+    instruction = directive.human_readable_instruction.lower()
+    assert directive.parameters["toolkit_serves_api"] is False
+    assert "credential" in instruction
+    assert "provision" in instruction
+
+    denial_reason = no_toolkit_serves_api_reason("acme/widgets").lower()
+    # Both recommend provisioning/binding a credential as the first step.
+    assert "credential" in denial_reason
+    assert "provision" in denial_reason
+    assert "no toolkit serves" in denial_reason


### PR DESCRIPTION
## Summary

The broker's `no_toolkit_binding` (403) recovery directive unconditionally told
callers to file a `toolkit:bind` access request. But when no toolkit serves the
API yet (no credential provisioned), that request can **never** be approved — the
approval denies with *"No toolkit serves API …; provision and bind a credential
for it first"*. The directive and the denial reason directly contradicted each
other, sending autonomous agents into a guaranteed dead-end (#683).

The real prerequisite chain is **provision credential → creates a serving
toolkit → bind agent**. The directive now reflects that order and distinguishes
the two states, and the control-side denial reason references the same shared
guidance so the two can never drift.

## Changes

- **`shared/broker/protocols.py` + `broker/repos/`**: add
  `ToolkitDeriverProtocol.any_toolkit_serves_api` (implemented in
  `ToolkitBindingResolver` and forwarded by `CachingToolkitDeriver`) so the
  broker can tell *"no toolkit serves this API yet"* from *"a toolkit serves it
  but this agent isn't bound"*. Consulted only on the denial path — never on the
  hot success path.
- **`broker/core/exceptions.py`**: `no_toolkit_binding_directive` now takes
  `toolkit_serves_api`. When `False` it recommends provisioning a credential
  first (the step that actually creates a serving toolkit); when `True` it keeps
  the approvable toolkit-binding request. The state is echoed in
  `parameters.toolkit_serves_api`.
- **`broker/web/routers/execute.py`**: `select_toolkit` looks up the state
  before raising and picks the right directive variant.
- **`shared/access_guidance.py`** (new): single source of truth for the
  "provision a credential first" denial reason, referenced by
  `ToolkitReferenceUnresolvedError` so broker and control agree.
- **`cli/internal/skillgen/content/jentic.md`**: document the credential-first
  order for the `no_toolkit_binding` recovery.

## Test plan

- [x] `make test-fast` (2114 passed)
- [x] `make lint` (ruff + format + mypy clean)
- [x] `make openapi` (no drift)
- [x] `make test-integration` for `test_toolkit_binding_resolver.py` and
      `test_access_request_service.py` (45 passed)
- New tests:
  - directive recommends credential provisioning when no toolkit serves the API
  - directive recommends the binding request when a toolkit already serves it
  - broker directive and the control denial reason recommend the same next step
  - `any_toolkit_serves_api` returns true/false against a real DB

Squash-merge, please.

Closes #683

Made with [Cursor](https://cursor.com)