### PR TITLE
fix(registry): make spec re-import idempotent and surface readable errors

### DIFF
--- a/src/jentic_one/registry/ingest/exc.py
+++ b/src/jentic_one/registry/ingest/exc.py
@@ -21,6 +21,19 @@ class IngestJobError(BaseIngestError):
     """Raised when an ingest job fails."""
 
 
+class DuplicateRevisionError(IngestStageError):
+    """Raised when a revision with identical content already exists for the API."""
+
+    _MESSAGE = (
+        "A revision with identical content already exists for this API version "
+        "(a previous import may have completed or failed midway). Re-import under "
+        "a new version, or remove the existing revision"
+    )
+
+    def __init__(self) -> None:
+        super().__init__(self._MESSAGE)
+
+
 class MissingRequiredKeysError(IngestStageError):
     """Raised when required keys are missing from stage context."""
 

--- a/src/jentic_one/registry/ingest/stages/extract_api.py
+++ b/src/jentic_one/registry/ingest/stages/extract_api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 from typing import ClassVar
 
+from jentic_one.registry.ingest.exc import DuplicateRevisionError
 from jentic_one.registry.ingest.pipeline.ctx import PipelineContext
 from jentic_one.registry.ingest.stages.base import BasePipelineStage
 from jentic_one.registry.repos import ApiRepository, ApiRevisionRepository
@@ -39,13 +40,27 @@ class CreateRevisionStage(BasePipelineStage):
     async def _run(self, ctx: PipelineContext) -> None:
         api_id = ctx.require("api_id", uuid.UUID)
         spec = ctx.specification
+        spec_digest = spec.sha or ""
+        # A prior import of identical content may have committed a revision that
+        # was later abandoned (e.g. a sibling source failed, or a subsequent
+        # stage crashed). Re-importing the same (api_id, spec_digest) would then
+        # collide with uq_api_revisions_api_id_spec_digest. Replace a leftover
+        # replaceable revision (draft/archived) so retries are idempotent.
+        await ApiRevisionRepository.delete_replaceable_by_digest(ctx.session, api_id, spec_digest)
+        # Anything still sharing the digest is an active (published/imported)
+        # revision — a genuine conflict. Surface it as a readable error before we
+        # attempt the insert, so callers see a clear message instead of a raw
+        # unique-constraint IntegrityError.
+        existing = await ApiRevisionRepository.get_by_digest(ctx.session, api_id, spec_digest)
+        if existing is not None:
+            raise DuplicateRevisionError()
         if spec.origin is not None:
             await ApiRevisionRepository.archive_active_imported(ctx.session, api_id, spec.origin)
             revision = await ApiRevisionRepository.create_imported(
                 ctx.session,
                 api_id=api_id,
                 origin=spec.origin,
-                spec_digest=spec.sha or "",
+                spec_digest=spec_digest,
                 source_type=spec.source_type or ApiRevisionSourceType.UNKNOWN,
                 source_url=spec.source_url,
                 source_filename=spec.source_filename,
@@ -56,7 +71,7 @@ class CreateRevisionStage(BasePipelineStage):
             revision = await ApiRevisionRepository.create_draft(
                 ctx.session,
                 api_id=api_id,
-                spec_digest=spec.sha or "",
+                spec_digest=spec_digest,
                 source_type=spec.source_type or ApiRevisionSourceType.UNKNOWN,
                 source_url=spec.source_url,
                 source_filename=spec.source_filename,

--- a/src/jentic_one/registry/repos/revision_repo.py
+++ b/src/jentic_one/registry/repos/revision_repo.py
@@ -129,6 +129,32 @@ class ApiRevisionRepository:
         return result.scalar_one_or_none()
 
     @staticmethod
+    async def delete_replaceable_by_digest(
+        session: AsyncSession, api_id: uuid.UUID, spec_digest: str
+    ) -> int:
+        """Delete any leftover, non-active revision with this (api_id, spec_digest).
+
+        Makes re-import idempotent: an abandoned ``draft`` (or an ``archived``
+        revision) sharing the target digest would otherwise collide with
+        ``uq_api_revisions_api_id_spec_digest``. Active ``published``/``imported``
+        revisions are never touched — a live revision with the same content is a
+        genuine conflict that must surface, not be silently overwritten. Child
+        rows cascade via the ``ondelete="CASCADE"`` foreign keys.
+        """
+        result = cast(
+            "CursorResult[Any]",
+            await session.execute(
+                delete(ApiRevision).where(
+                    ApiRevision.api_id == api_id,
+                    ApiRevision.spec_digest == spec_digest,
+                    ApiRevision.state.in_([ApiRevisionState.DRAFT, ApiRevisionState.ARCHIVED]),
+                )
+            ),
+        )
+        await session.flush()
+        return result.rowcount
+
+    @staticmethod
     async def set_operation_count(
         session: AsyncSession, revision_id: uuid.UUID, count: int
     ) -> None:

--- a/src/jentic_one/registry/services/import_service.py
+++ b/src/jentic_one/registry/services/import_service.py
@@ -12,17 +12,33 @@ import structlog
 from pydantic import TypeAdapter
 from structlog.contextvars import bind_contextvars, unbind_contextvars
 
-from jentic_one.registry.ingest.exc import IngestJobError
+from jentic_one.registry.ingest.exc import DuplicateRevisionError, IngestJobError
 from jentic_one.registry.ingest.fetch import IngestSource, load_specification
 from jentic_one.registry.ingest.ingestor import Ingestor
 from jentic_one.shared.audit import AuditAction, AuditTargetType, record_audit_best_effort
 from jentic_one.shared.context import Context
+from jentic_one.shared.db.errors import DatabaseIntegrityError
 from jentic_one.shared.jobs.handlers import JobResultPayload
 from jentic_one.shared.models import ActorType
 
 logger = structlog.get_logger(__name__)
 
 _source_adapter: TypeAdapter[IngestSource] = TypeAdapter(IngestSource)
+
+# The unique constraint that guards one revision per (api_id, spec_digest).
+_DIGEST_CONSTRAINT = "uq_api_revisions_api_id_spec_digest"
+
+
+def _readable_source_error(exc: Exception) -> str:
+    """Map a source-level ingest failure to a message safe to show a user.
+
+    Raw ``IntegrityError`` strings leak SQL and get truncated mid-word in the
+    job record; translate the duplicate-digest collision to a clear message and
+    keep other failures as their (domain) exception text.
+    """
+    if isinstance(exc, DatabaseIntegrityError) and _DIGEST_CONSTRAINT in exc.detail:
+        return DuplicateRevisionError().message
+    return str(exc)
 
 
 class ImportHandler:
@@ -87,7 +103,7 @@ class ImportHandler:
                     )
                 except Exception as exc:
                     logger.exception("import_source_failed", source_index=idx, job_id=job_id)
-                    failures.append(f"source[{idx}]: {exc}")
+                    failures.append(f"source[{idx}]: {_readable_source_error(exc)}")
 
             logger.info(
                 "import_handler_complete",
@@ -99,8 +115,9 @@ class ImportHandler:
 
             # If every source failed, surface it as a failed job rather than
             # masking it behind a "completed" status with an empty result.
-            # (The handler runs in a single transaction, so when nothing
-            # succeeded there is no partial work to preserve by returning.)
+            # Each source runs in its own transaction (see Ingestor.ingest), so
+            # when nothing succeeded there is no committed work to preserve by
+            # returning a "completed" result.
             if failures and not revisions:
                 raise IngestJobError(
                     f"all {len(sources)} import source(s) failed: " + "; ".join(failures)

--- a/tests/integration/registry/services/test_import_handler.py
+++ b/tests/integration/registry/services/test_import_handler.py
@@ -64,6 +64,150 @@ async def _clean_registry(registry_db: DatabaseSession) -> Any:
     await _truncate()
 
 
+async def test_reimport_identical_content_is_idempotent(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    _clean_registry: None,
+) -> None:
+    """Re-importing identical content reuses the draft slot instead of colliding.
+
+    Reproduces #688: the first import commits a draft revision; without the fix
+    a second import of the same (api_id, spec_digest) collides with
+    uq_api_revisions_api_id_spec_digest and fails forever.
+    """
+    handler = ImportHandler(integration_context)
+    payload = {
+        "sources": [
+            {
+                "type": "inline",
+                "content": MINIMAL_OPENAPI,
+                "filename": "openapi.json",
+                "vendor": "dup-vendor",
+                "api_name": "dup-api",
+                "version": "1.0.0",
+            }
+        ]
+    }
+
+    first = await handler.execute(
+        job_id=str(uuid.uuid4()), session=None, payload=payload, created_by="usr_test"
+    )
+    first_revision_id = first.body["revisions"][0]["revision_id"]
+
+    # Re-import the exact same content — must succeed, not raise.
+    second = await handler.execute(
+        job_id=str(uuid.uuid4()), session=None, payload=payload, created_by="usr_test"
+    )
+    second_revision = second.body["revisions"][0]
+    assert second_revision["state"] == "draft"
+    # The leftover draft was replaced, so a fresh revision id is produced.
+    assert second_revision["revision_id"] != first_revision_id
+
+    async with registry_db.session() as session:
+        rows = (await session.execute(select(ApiRevision))).unique().scalars().all()
+        assert len(rows) == 1
+        assert rows[0].state == "draft"
+        assert str(rows[0].id) == second_revision["revision_id"]
+
+
+async def test_reimport_after_sibling_failure_is_idempotent(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    _clean_registry: None,
+) -> None:
+    """A draft left behind by a partially-failed job can be re-imported cleanly.
+
+    First job: one good source (commits a draft) plus one bad source (fails).
+    Second job re-imports the identical good source and must succeed.
+    """
+    handler = ImportHandler(integration_context)
+    good_source = {
+        "type": "inline",
+        "content": MINIMAL_OPENAPI,
+        "filename": "openapi.json",
+        "vendor": "recover-vendor",
+        "api_name": "recover-api",
+        "version": "1.0.0",
+    }
+    bad_source = {
+        "type": "inline",
+        "content": "not valid json or yaml {{{{",
+        "filename": "bad.json",
+    }
+
+    await handler.execute(
+        job_id=str(uuid.uuid4()),
+        session=None,
+        payload={"sources": [good_source, bad_source]},
+        created_by="usr_test",
+    )
+
+    async with registry_db.session() as session:
+        rows = (await session.execute(select(ApiRevision))).unique().scalars().all()
+        assert len(rows) == 1  # the good source's draft survived the sibling failure
+
+    # Re-importing the same good content must not collide.
+    result = await handler.execute(
+        job_id=str(uuid.uuid4()),
+        session=None,
+        payload={"sources": [good_source]},
+        created_by="usr_test",
+    )
+    assert result.body["revisions"][0]["state"] == "draft"
+
+    async with registry_db.session() as session:
+        rows = (await session.execute(select(ApiRevision))).unique().scalars().all()
+        assert len(rows) == 1
+
+
+async def test_reimport_over_active_revision_surfaces_readable_error(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    _clean_registry: None,
+) -> None:
+    """An active revision with identical content yields a readable error, not raw SQL.
+
+    A promoted (published/imported) revision must not be silently overwritten;
+    re-importing identical content collides and the failure message shown to the
+    user must be the human-readable one, not a truncated SQLAlchemy string.
+    """
+    handler = ImportHandler(integration_context)
+    payload = {
+        "sources": [
+            {
+                "type": "inline",
+                "content": MINIMAL_OPENAPI,
+                "filename": "openapi.json",
+                "vendor": "active-vendor",
+                "api_name": "active-api",
+                "version": "1.0.0",
+            }
+        ]
+    }
+
+    first = await handler.execute(
+        job_id=str(uuid.uuid4()), session=None, payload=payload, created_by="usr_test"
+    )
+    revision_id = uuid.UUID(first.body["revisions"][0]["revision_id"])
+
+    # Promote the draft to published so it is no longer a replaceable slot.
+    async with registry_db.session() as session:
+        await session.execute(
+            update(ApiRevision).where(ApiRevision.id == revision_id).values(state="published")
+        )
+        await session.commit()
+
+    with pytest.raises(IngestJobError) as exc_info:
+        await handler.execute(
+            job_id=str(uuid.uuid4()), session=None, payload=payload, created_by="usr_test"
+        )
+
+    message = str(exc_info.value)
+    assert "identical content already exists" in message
+    assert "uq_api_revisions" not in message
+    assert "IntegrityError" not in message
+
+
 async def test_execute_inline_source(
     integration_context: Context,
     registry_db: DatabaseSession,

--- a/tests/unit/registry/services/test_import_error_mapping.py
+++ b/tests/unit/registry/services/test_import_error_mapping.py
@@ -1,0 +1,37 @@
+"""Unit tests for import-source error mapping (readable failure messages)."""
+
+from __future__ import annotations
+
+from jentic_one.registry.ingest.exc import DuplicateRevisionError, IngestStageError
+from jentic_one.registry.services.import_service import _readable_source_error
+from jentic_one.shared.db.errors import DatabaseIntegrityError
+
+
+def test_duplicate_digest_integrity_error_maps_to_readable_message() -> None:
+    """A duplicate-digest IntegrityError surfaces the readable message, not raw SQL."""
+    raw = (
+        "(sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) duplicate key value "
+        'violates unique constraint "uq_api_revisions_api_id_spec_digest"'
+    )
+    exc = DatabaseIntegrityError(raw)
+
+    message = _readable_source_error(exc)
+
+    assert message == DuplicateRevisionError().message
+    assert "identical content already exists" in message
+    assert "uq_api_revisions" not in message
+    assert "sqlalchemy" not in message
+
+
+def test_unrelated_integrity_error_keeps_its_text() -> None:
+    """An integrity error on a different constraint is passed through unchanged."""
+    exc = DatabaseIntegrityError("violates constraint uq_something_else")
+
+    assert _readable_source_error(exc) == "violates constraint uq_something_else"
+
+
+def test_other_exception_is_passed_through() -> None:
+    """Non-integrity failures keep their own message."""
+    exc = IngestStageError("parsing failed at operation X")
+
+    assert _readable_source_error(exc) == "parsing failed at operation X"


### PR DESCRIPTION
## Summary

Local spec import (`POST /apis`, inline/URL source) was **not idempotent**: re-importing identical content failed forever with a raw `IntegrityError`, and that raw SQL string leaked to the job record / UI truncated mid-word.

Root cause: the async import job runs one `Ingestor.ingest` transaction per source. `CreateRevisionStage` commits a `state='draft'` `api_revisions` row per source. If a sibling source failed (or a draft was otherwise abandoned), the committed draft survived, and any re-import of the same `(api_id, spec_digest)` collided with `uq_api_revisions_api_id_spec_digest`. Because `api_id` is deterministic from `vendor/name/version` and `spec_digest` is the sha256 of the content, retrying the same spec at the same version was permanently blocked.

## Changes

- **`registry/ingest/stages/extract_api.py`** — `CreateRevisionStage` now deletes any leftover *replaceable* (`draft`/`archived`) revision sharing the target `(api_id, spec_digest)` before inserting, so retries are idempotent. If an **active** (`published`/`imported`) revision still shares the digest, it raises `DuplicateRevisionError` (readable) rather than blindly inserting and hitting the raw constraint.
- **`registry/repos/revision_repo.py`** — added `delete_replaceable_by_digest` (child rows cascade via `ondelete=CASCADE`); wires in the previously-unused `get_by_digest`.
- **`registry/ingest/exc.py`** — new `DuplicateRevisionError` with a human-readable message.
- **`registry/services/import_service.py`** — maps duplicate-digest `DatabaseIntegrityError` to the readable message (defense-in-depth) and fixes the stale "single transaction" comment (each source has its own transaction).

Recovery CLI/UI path (plan step 5) was **skipped** — the idempotency fix removes the permanent lock-out that made it necessary; noted for a follow-up if standalone orphan cleanup is still wanted.

## Test plan

- [x] `make lint` (ruff + format + mypy) — clean
- [x] `make test-fast` (unit + arch) — 2114 passed
- [x] Integration (real Postgres, no DB mocking):
  - [x] re-import of identical content is idempotent (single revision remains)
  - [x] re-import after a mid-job sibling failure is idempotent
  - [x] active-revision collision surfaces the readable message (no raw SQL / `uq_...` / `IntegrityError`)
- [x] Unit: `_readable_source_error` maps duplicate-digest to readable text, passes others through

Closes #688

Made with [Cursor](https://cursor.com)