### PR TITLE
fix(registry): reload API view after promote-over-live to avoid MissingGreenlet

### DIFF
--- a/src/jentic_one/registry/repos/api_repo.py
+++ b/src/jentic_one/registry/repos/api_repo.py
@@ -50,6 +50,10 @@ class ApiRepository:
                 joinedload(Api.current_revision).selectinload(ApiRevision.security_schemes),
                 joinedload(Api.current_revision).selectinload(ApiRevision.servers),
             )
+            # Force eager-loaded relationships to overwrite any stale identity-map
+            # state so a caller that mutated rows via bulk UPDATEs (e.g. promote)
+            # never triggers an async lazy load on a cached instance. See #642.
+            .execution_options(populate_existing=True)
         )
         return result.unique().scalar_one_or_none()
 

--- a/src/jentic_one/registry/repos/revision_repo.py
+++ b/src/jentic_one/registry/repos/revision_repo.py
@@ -114,6 +114,9 @@ class ApiRevisionRepository:
                 ApiRevision.state == ApiRevisionState.IMPORTED,
             )
             .values(state=ApiRevisionState.ARCHIVED, archived_at=now)
+            # Keep in-session ApiRevision instances consistent with the bulk
+            # UPDATE so callers that later read them don't see stale state. See #642.
+            .execution_options(synchronize_session="fetch")
         )
         await session.flush()
 
@@ -205,7 +208,12 @@ class ApiRevisionRepository:
         result = cast(
             "CursorResult[Any]",
             await session.execute(
-                update(ApiRevision).where(ApiRevision.id == revision_id).values(**values)
+                update(ApiRevision)
+                .where(ApiRevision.id == revision_id)
+                .values(**values)
+                # Keep the in-session instance consistent with the bulk UPDATE so
+                # callers that later read it don't see stale state. See #642.
+                .execution_options(synchronize_session="fetch")
             ),
         )
         await session.flush()

--- a/src/jentic_one/registry/services/revision_service.py
+++ b/src/jentic_one/registry/services/revision_service.py
@@ -235,6 +235,16 @@ class RevisionService:
             )
             await ApiRepository.set_current_revision(session, api.id, revision_uuid)
 
+            # The demote path above mutates revision rows via bulk UPDATEs and
+            # repoints ``Api.current_revision_id``. Bulk updates do not sync the
+            # ORM identity map, so the cached ``Api`` (and its ``current_revision``,
+            # which is ``lazy="joined"``) is now stale. Expire everything so
+            # ``_fetch_api_view`` re-reads fresh rows and its eager-load options
+            # populate the relationships, instead of triggering an async lazy load
+            # on a stale instance (which raises MissingGreenlet). See #642.
+            await session.flush()
+            session.expire_all()
+
             view = await ApiService._fetch_api_view(session, vendor, name, version)
 
         await record_audit_best_effort(

--- a/src/jentic_one/registry/web/app.py
+++ b/src/jentic_one/registry/web/app.py
@@ -10,6 +10,7 @@ from jentic_one.registry.services.errors import RegistryServiceError
 from jentic_one.registry.web.errors import service_error_handler
 from jentic_one.registry.web.routers import apis, catalog, inspect, notes, overlays, search
 from jentic_one.shared.context import Context
+from jentic_one.shared.db.errors import DatabaseConsistencyError
 from jentic_one.shared.web.app_factory import create_surface_app
 from jentic_one.shared.web.health import make_health_router
 
@@ -33,6 +34,11 @@ def get_exception_handlers() -> list[tuple[type[Exception], Any]]:
     """Return registry-specific exception handlers for the combined app."""
     return [
         (RegistryServiceError, service_error_handler),
+        # Belt-and-braces: catch an accidental async lazy load (MissingGreenlet,
+        # mapped by the DB transaction wrapper to DatabaseConsistencyError) so it
+        # maps to a known, logged 500 rather than escaping as an opaque unhandled
+        # traceback. See #642.
+        (DatabaseConsistencyError, service_error_handler),
     ]
 
 

--- a/src/jentic_one/registry/web/errors.py
+++ b/src/jentic_one/registry/web/errors.py
@@ -26,6 +26,7 @@ from jentic_one.registry.services.errors import (
     SpecFileMissingError,
     TooManyCandidatesError,
 )
+from jentic_one.shared.db.errors import DatabaseConsistencyError
 from jentic_one.shared.web.errors import make_service_error_handler
 
 _ERROR_MAP: dict[type[Exception], tuple[int, str]] = {
@@ -48,6 +49,19 @@ _ERROR_MAP: dict[type[Exception], tuple[int, str]] = {
     SearchUnavailableError: (501, "search_unsupported"),
     SpecFileMissingError: (500, "spec_file_missing"),
     CatalogUnavailableError: (502, "catalog_unavailable"),
+    # Belt-and-braces: an accidental async lazy load (e.g. on a stale, bulk-updated
+    # ORM instance) raises sqlalchemy MissingGreenlet, which the DB transaction
+    # wrapper maps to DatabaseConsistencyError. Map it to a known 500 with a
+    # generic client detail so it is logged as a recognised class instead of
+    # escaping as an opaque traceback. See #642.
+    DatabaseConsistencyError: (500, "internal_error"),
+}
+
+# Never surface raw SQLAlchemy internals (SQL, state, connection details) to the
+# client for the defensively-mapped DatabaseConsistencyError; the raw message is
+# still logged server-side (see make_service_error_handler).
+_SAFE_DETAILS: dict[type[Exception], str] = {
+    DatabaseConsistencyError: "An unexpected error occurred",
 }
 
 
@@ -60,4 +74,6 @@ def _add_allow_header(
     return response
 
 
-service_error_handler = make_service_error_handler(_ERROR_MAP, response_hook=_add_allow_header)
+service_error_handler = make_service_error_handler(
+    _ERROR_MAP, response_hook=_add_allow_header, safe_details=_SAFE_DETAILS
+)

--- a/src/jentic_one/shared/db/errors.py
+++ b/src/jentic_one/shared/db/errors.py
@@ -15,3 +15,18 @@ class DatabaseUnavailableError(Exception):
     def __init__(self, detail: str = "") -> None:
         super().__init__(detail)
         self.detail = detail
+
+
+class DatabaseConsistencyError(Exception):
+    """Raised when an ORM operation hits an invalid-state/consistency failure.
+
+    Wraps ``sqlalchemy.exc.InvalidRequestError`` (the parent of
+    ``MissingGreenlet``) so that an accidental async lazy load on a stale or
+    detached instance surfaces as a known, mappable domain error with a generic
+    client message rather than an opaque unhandled traceback. The raw SQLAlchemy
+    message is preserved in ``detail`` for server-side diagnosis. See #642.
+    """
+
+    def __init__(self, detail: str = "") -> None:
+        super().__init__(detail)
+        self.detail = detail

--- a/src/jentic_one/shared/db/session.py
+++ b/src/jentic_one/shared/db/session.py
@@ -9,7 +9,12 @@ from typing import TypeVar
 
 import structlog
 from sqlalchemy.engine import URL
-from sqlalchemy.exc import DisconnectionError, IntegrityError, OperationalError
+from sqlalchemy.exc import (
+    DisconnectionError,
+    IntegrityError,
+    InvalidRequestError,
+    OperationalError,
+)
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -24,7 +29,11 @@ from jentic_one.shared.db.backends import (
     get_backend,
 )
 from jentic_one.shared.db.backends.base import DatabaseBackend
-from jentic_one.shared.db.errors import DatabaseIntegrityError, DatabaseUnavailableError
+from jentic_one.shared.db.errors import (
+    DatabaseConsistencyError,
+    DatabaseIntegrityError,
+    DatabaseUnavailableError,
+)
 
 T = TypeVar("T")
 
@@ -131,6 +140,13 @@ class DatabaseSession:
             except (OperationalError, DisconnectionError) as exc:
                 await sess.rollback()
                 raise DatabaseUnavailableError(str(exc)) from exc
+            except InvalidRequestError as exc:
+                # Belt-and-braces for an accidental async lazy load (MissingGreenlet
+                # is an InvalidRequestError) on a stale/detached ORM instance: map it
+                # to a known domain error so it surfaces as a logged 500 with a
+                # generic client message instead of an opaque traceback. See #642.
+                await sess.rollback()
+                raise DatabaseConsistencyError(str(exc)) from exc
             except BaseException:
                 await sess.rollback()
                 raise

--- a/tests/integration/registry/services/test_revision_promote.py
+++ b/tests/integration/registry/services/test_revision_promote.py
@@ -1,0 +1,198 @@
+"""Integration tests for ``RevisionService.promote`` against a real registry DB.
+
+Regression coverage for jentic/jentic-one#642: promoting a draft revision when
+another revision is already live must return the refreshed API view (host +
+security schemes of the newly-live revision) and must not raise
+``MissingGreenlet`` from an async lazy load on a stale, bulk-updated instance.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy import delete, update
+
+from jentic_one.registry.core.schema.api_revisions import ApiRevision
+from jentic_one.registry.core.schema.apis import Api
+from jentic_one.registry.core.schema.security_schemes import SecurityScheme
+from jentic_one.registry.core.schema.servers import Server
+from jentic_one.registry.services.errors import RevisionStateConflictError
+from jentic_one.registry.services.revision_service import RevisionService
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.context import Context
+from jentic_one.shared.db.session import DatabaseSession
+from jentic_one.shared.models import ApiRevisionState
+
+pytestmark = pytest.mark.integration
+
+_IDENTITY = Identity(sub="usr_test", email="test@example.com")
+
+
+@pytest.fixture()
+async def clean_registry(registry_db: DatabaseSession) -> AsyncGenerator[None, None]:
+    """Truncate the registry tables this module touches, before and after each test."""
+
+    async def _truncate() -> None:
+        async with registry_db.session() as session:
+            await session.execute(delete(SecurityScheme))
+            await session.execute(delete(Server))
+            await session.execute(update(Api).values(current_revision_id=None))
+            await session.execute(delete(ApiRevision))
+            await session.execute(delete(Api))
+            await session.commit()
+
+    await _truncate()
+    yield
+    await _truncate()
+
+
+async def _create_revision(
+    session,
+    *,
+    api_id: uuid.UUID,
+    state: str,
+    spec_digest: str,
+    host: str | None = None,
+    scheme_type: str | None = None,
+) -> uuid.UUID:
+    """Create a revision (optionally with a server host and security scheme)."""
+    revision = ApiRevision(
+        api_id=api_id,
+        state=state,
+        spec_digest=spec_digest,
+        source_type="url",
+        source_url="https://example.com/spec.yaml",
+        created_by="usr_test",
+    )
+    session.add(revision)
+    await session.flush()
+    if host is not None:
+        session.add(Server(revision_id=revision.id, url=f"https://{host}", created_by="usr_test"))
+    if scheme_type is not None:
+        session.add(
+            SecurityScheme(
+                revision_id=revision.id,
+                name="default",
+                type=scheme_type,
+                raw_scheme={"type": scheme_type},
+                created_by="usr_test",
+            )
+        )
+    await session.flush()
+    return revision.id
+
+
+@pytest.fixture()
+async def api_with_live_and_draft(
+    registry_db: DatabaseSession, clean_registry: None
+) -> tuple[str, str, str, uuid.UUID, uuid.UUID, uuid.UUID]:
+    """Seed an API with a live (published) revision A and a draft revision B.
+
+    Returns ``(vendor, name, version, api_id, live_id, draft_id)``.
+    """
+    api = Api(vendor="acme.com", name="widget", version="v1", created_by="usr_test")
+    async with registry_db.session() as session:
+        session.add(api)
+        await session.flush()
+        live_id = await _create_revision(
+            session,
+            api_id=api.id,
+            state=ApiRevisionState.PUBLISHED,
+            spec_digest="sha256:live",
+            host="old.acme.com",
+            scheme_type="apiKey",
+        )
+        draft_id = await _create_revision(
+            session,
+            api_id=api.id,
+            state=ApiRevisionState.DRAFT,
+            spec_digest="sha256:draft",
+            host="new.acme.com",
+            scheme_type="http",
+        )
+        api.current_revision_id = live_id
+        await session.commit()
+    return api.vendor, api.name, api.version, api.id, live_id, draft_id
+
+
+async def test_promote_over_live_returns_refreshed_view(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    api_with_live_and_draft: tuple[str, str, str, uuid.UUID, uuid.UUID, uuid.UUID],
+) -> None:
+    """Promoting a draft over a live revision succeeds and returns the new live view.
+
+    Before the #642 fix this raised ``sqlalchemy.exc.MissingGreenlet`` because
+    ``_fetch_api_view`` accessed relationships on a stale, bulk-updated ``Api``.
+    """
+    vendor, name, version, api_id, live_id, draft_id = api_with_live_and_draft
+
+    svc = RevisionService(integration_context)
+    view = await svc.promote(vendor, name, version, str(draft_id), identity=_IDENTITY)
+
+    # The view reflects the newly-live draft, not the previously-live revision.
+    assert view.current_revision_id == str(draft_id)
+    assert view.host == "new.acme.com"
+    assert view.security_schemes == ["http"]
+
+    # Persisted state: draft is now published/live, old live is archived.
+    async with registry_db.session() as session:
+        api = await session.get(Api, api_id)
+        assert api is not None
+        assert api.current_revision_id == draft_id
+
+        new_live = await session.get(ApiRevision, draft_id)
+        old_live = await session.get(ApiRevision, live_id)
+        assert new_live is not None
+        assert old_live is not None
+        assert new_live.state == ApiRevisionState.PUBLISHED
+        assert new_live.promoted_at is not None
+        assert old_live.state == ApiRevisionState.ARCHIVED
+        assert old_live.archived_at is not None
+
+
+async def test_promote_first_revision_no_live_still_works(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    clean_registry: None,
+) -> None:
+    """Promoting the first-ever revision (no live yet) still works (no regression)."""
+    api = Api(vendor="acme.com", name="gadget", version="v1", created_by="usr_test")
+    async with registry_db.session() as session:
+        session.add(api)
+        await session.flush()
+        draft_id = await _create_revision(
+            session,
+            api_id=api.id,
+            state=ApiRevisionState.DRAFT,
+            spec_digest="sha256:first",
+            host="first.acme.com",
+            scheme_type="apiKey",
+        )
+        await session.commit()
+
+    svc = RevisionService(integration_context)
+    view = await svc.promote(api.vendor, api.name, api.version, str(draft_id), identity=_IDENTITY)
+
+    assert view.current_revision_id == str(draft_id)
+    assert view.host == "first.acme.com"
+    assert view.security_schemes == ["apiKey"]
+
+    async with registry_db.session() as session:
+        loaded = await session.get(ApiRevision, draft_id)
+        assert loaded is not None
+        assert loaded.state == ApiRevisionState.PUBLISHED
+
+
+async def test_promote_already_published_raises_conflict(
+    integration_context: Context,
+    api_with_live_and_draft: tuple[str, str, str, uuid.UUID, uuid.UUID, uuid.UUID],
+) -> None:
+    """Promoting an already-published revision is a state conflict, not a 500."""
+    vendor, name, version, _api_id, live_id, _draft_id = api_with_live_and_draft
+
+    svc = RevisionService(integration_context)
+    with pytest.raises(RevisionStateConflictError):
+        await svc.promote(vendor, name, version, str(live_id), identity=_IDENTITY)

--- a/tests/unit/registry/services/test_revision_lifecycle.py
+++ b/tests/unit/registry/services/test_revision_lifecycle.py
@@ -22,6 +22,9 @@ _IDENTITY = Identity(sub="usr_test", email="test@example.com")
 def _make_ctx() -> MagicMock:
     ctx = MagicMock()
     mock_session = AsyncMock()
+    # expire_all is a synchronous AsyncSession method; keep it sync so the mock
+    # doesn't emit "coroutine never awaited" warnings when promote calls it.
+    mock_session.expire_all = MagicMock()
     ctx.registry_db.transaction.return_value.__aenter__ = AsyncMock(return_value=mock_session)
     ctx.registry_db.transaction.return_value.__aexit__ = AsyncMock(return_value=False)
     ctx.registry_db.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
@@ -109,6 +112,11 @@ async def test_promote_draft_succeeds() -> None:
         # Second call promotes the draft
         assert calls[1].args[1] == revision.id
         assert calls[1].args[2] == "published"
+
+        # The stale, bulk-updated identity map is expired before the view is
+        # re-read so _fetch_api_view can't trigger a lazy load. See #642.
+        session = ctx.registry_db.transaction.return_value.__aenter__.return_value
+        session.expire_all.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/registry/web/test_errors.py
+++ b/tests/unit/registry/web/test_errors.py
@@ -1,0 +1,64 @@
+"""Unit tests for the registry web error mapping.
+
+Covers the defensive mapping added for jentic/jentic-one#642: an accidental
+async lazy load surfaces as ``sqlalchemy.exc.MissingGreenlet``, which the DB
+transaction wrapper maps to ``DatabaseConsistencyError``. That must map to a
+known, logged 500 with a generic client detail rather than escaping as an
+opaque unhandled traceback.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+import structlog.testing
+from fastapi import Request
+
+from jentic_one.registry.web.app import get_exception_handlers
+from jentic_one.registry.web.errors import service_error_handler
+from jentic_one.shared.db.errors import DatabaseConsistencyError
+
+
+def _make_request(path: str = "/apis/acme.com/widget/v1/revisions/x/promote") -> MagicMock:
+    request = MagicMock(spec=Request)
+    request.url.path = path
+    return request
+
+
+@pytest.mark.asyncio
+async def test_consistency_error_maps_to_safe_500() -> None:
+    """DatabaseConsistencyError maps to a 500 with a generic (non-leaking) detail."""
+    request = _make_request()
+    exc = DatabaseConsistencyError("greenlet_spawn has not been called; can't call await_only()")
+
+    response = await service_error_handler(request, exc)
+
+    assert response.status_code == 500
+    assert response.media_type == "application/problem+json"
+    body: dict[str, object] = json.loads(bytes(response.body))
+    assert body["type"] == "internal_error"
+    assert body["detail"] == "An unexpected error occurred"
+    assert "greenlet" not in json.dumps(body)
+
+
+@pytest.mark.asyncio
+async def test_consistency_error_logged_with_raw_message() -> None:
+    """The raw SQLAlchemy message is still logged server-side for diagnosis."""
+    request = _make_request()
+    exc = DatabaseConsistencyError("greenlet_spawn has not been called")
+
+    with structlog.testing.capture_logs() as logs:
+        await service_error_handler(request, exc)
+
+    error_logs = [log for log in logs if log["log_level"] == "error"]
+    assert len(error_logs) == 1
+    assert error_logs[0]["event"] == "unhandled_service_error"
+    assert error_logs[0]["type"] == "internal_error"
+
+
+def test_consistency_error_handler_is_registered() -> None:
+    """The registry app registers a handler for DatabaseConsistencyError."""
+    registered = {exc_class for exc_class, _ in get_exception_handlers()}
+    assert DatabaseConsistencyError in registered

--- a/tests/unit/shared/db/test_transaction.py
+++ b/tests/unit/shared/db/test_transaction.py
@@ -10,11 +10,15 @@ from __future__ import annotations
 
 import pytest
 from sqlalchemy import text
-from sqlalchemy.exc import IntegrityError, OperationalError
+from sqlalchemy.exc import IntegrityError, MissingGreenlet, OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from jentic_one.shared.config import DatabaseConfig
-from jentic_one.shared.db.errors import DatabaseIntegrityError, DatabaseUnavailableError
+from jentic_one.shared.db.errors import (
+    DatabaseConsistencyError,
+    DatabaseIntegrityError,
+    DatabaseUnavailableError,
+)
 from jentic_one.shared.db.session import DatabaseSession
 
 
@@ -81,3 +85,18 @@ async def test_run_in_transaction_does_not_retry_integrity_error(
         await sqlite_session.run_in_transaction(fn, backoff_s=0)
 
     assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_transaction_maps_missing_greenlet_to_consistency_error(
+    sqlite_session: DatabaseSession,
+) -> None:
+    """MissingGreenlet (an InvalidRequestError) surfaces as DatabaseConsistencyError.
+
+    Regression guard for #642: an accidental async lazy load inside a
+    transaction must map to a known domain error rather than escaping raw.
+    """
+    with pytest.raises(DatabaseConsistencyError):
+        async with sqlite_session.transaction() as session:
+            await session.execute(text("SELECT 1"))
+            raise MissingGreenlet("greenlet_spawn has not been called")


### PR DESCRIPTION
## Summary

Promoting a draft revision when another revision is already **live** failed with a `500` (`sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called`). Promoting the first-ever revision (no live) worked fine — the failure was specific to the *replace-a-live-revision* branch.

**Root cause:** `RevisionService.promote` demotes the current-live revision with bulk `UPDATE`s (`set_state` / `archive_all_active_imported`) and repoints `Api.current_revision_id`, then calls `ApiService._fetch_api_view` before commit. Bulk updates don't synchronise the ORM identity map, so the cached `Api` (and its `current_revision`, which is `lazy="joined"`) is left stale. `_fetch_api_view` then accesses the stale `current_revision` / its `servers` / `security_schemes`, triggering an async lazy load with no greenlet context → `MissingGreenlet`, which escaped as a bare 500.

## Changes

- **Primary fix** (`revision_service.py`): `flush()` + `session.expire_all()` after the demote/repoint and before re-reading the API view, so the eager-load query returns fresh rows instead of a stale cached instance.
- **Belt-and-braces** (`api_repo.py`): `get_by_identifier_with_current_revision` now uses `populate_existing=True` so eager-loaded relationships overwrite any stale identity-map state.
- **Harden at the source** (`revision_repo.py`): `set_state` and `archive_all_active_imported` bulk updates pass `synchronize_session="fetch"` to keep in-session objects consistent.
- **Defensive net** (`shared/db/session.py`, `registry/web/errors.py`, `registry/web/app.py`): `DatabaseSession.transaction()` maps `sqlalchemy.exc.InvalidRequestError` (parent of `MissingGreenlet`) to a new `DatabaseConsistencyError`; the registry web layer maps that to a logged 500 with a generic client detail (no SQL/internals leaked). This respects the "no sqlalchemy imports in the web layer" arch rule by translating at the DB boundary.
- **Tests**: integration regression (`test_revision_promote.py`) plus unit tests for the transaction mapping and the error handler.

## Test plan

- [x] `make lint` (ruff + format + mypy) — clean
- [x] `make test-fast` (unit + arch) — 2115 passed
- [x] Integration tests on the SQLite backend (`JENTIC_TEST_BACKEND=sqlite`) — registry + shared/db green, including the new promote-over-live test
- [x] Verified the new integration test **reproduces** the original `MissingGreenlet` when the fix is reverted, and passes with it
- [ ] Postgres integration (`make test-integration`) — not run: the shared local Postgres fixture was migrated by a different checkout (`Can't locate revision 'j1e2f3a4b5c6'`), so I avoided mutating the user's shared DB. The same migrations/tests pass on the SQLite backend.

No router/response-model changes, so no OpenAPI spec drift.

This repo uses **squash-merge** — please squash + merge.

Closes #642

Made with [Cursor](https://cursor.com)