### PR TITLE
fix(cli): make broker default host bare to avoid double scheme

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -274,9 +274,14 @@ organized into sections so other settings can be added over time.
 base_url: http://127.0.0.1:8000   # control plane (auth surface) for register/tokens
 default_profile: default          # profile used when --profile is omitted
 broker:
-  scheme: http
-  host: localhost:4000
+  scheme: http                    # http or https
+  host: localhost:4000            # bare host[:port], no scheme (scheme lives above)
 ```
+
+The broker target is split into `broker.scheme` and `broker.host`: `host` is a
+bare `host[:port]` with no scheme, and the URL is assembled as
+`scheme://host`. A leading scheme in `host` is stripped for tolerance, but the
+canonical form keeps it bare.
 
 Precedence (lowest to highest): built-in defaults -> `config.yaml` -> explicit
 command-line flags.

--- a/cli/internal/cmd/execute.go
+++ b/cli/internal/cmd/execute.go
@@ -90,8 +90,8 @@ func newExecuteCmd(app *App) *cobra.Command {
 	cmd.Flags().StringVar(&opts.dataFile, "data-file", "", "read request body from this file")
 	cmd.Flags().BoolVar(&opts.raw, "raw", false, "stream response body directly to stdout")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "force JSON envelope output")
-	cmd.Flags().StringVar(&opts.brokerScheme, "broker-scheme", config.DefaultBrokerScheme, "broker target scheme")
-	cmd.Flags().StringVar(&opts.brokerHost, "broker-host", config.DefaultBrokerHost, "broker target host")
+	cmd.Flags().StringVar(&opts.brokerScheme, "broker-scheme", config.DefaultBrokerScheme, "broker target scheme (http or https)")
+	cmd.Flags().StringVar(&opts.brokerHost, "broker-host", config.DefaultBrokerHost, "broker target host as host[:port] (no scheme; use --broker-scheme)")
 	cmd.Flags().StringVar(&opts.revision, "revision", "", "pin to a specific revision ID for inspect")
 	ident.bind(cmd)
 

--- a/cli/internal/config/file.go
+++ b/cli/internal/config/file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -12,7 +13,9 @@ import (
 // ConfigName is the CLI's own settings file under ~/.jentic.
 const ConfigName = "config.yaml"
 
-// BrokerConfig is the broker target section of config.yaml.
+// BrokerConfig is the broker target section of config.yaml. Scheme and Host are
+// kept separate: Scheme is "http" or "https"; Host is a bare host[:port] with no
+// scheme (the URL is assembled as scheme + "://" + host).
 type BrokerConfig struct {
 	Scheme string `yaml:"scheme"`
 	Host   string `yaml:"host"`
@@ -81,15 +84,31 @@ func (c *FileConfig) ResolvedBrokerScheme(flag string, flagChanged bool) string 
 	return DefaultBrokerScheme
 }
 
-// ResolvedBrokerHost resolves the (logged) broker target host.
+// ResolvedBrokerHost resolves the (logged) broker target host. The returned
+// value is always a bare host[:port] with no scheme: callers assemble the URL
+// as scheme + "://" + host (see ResolvedBrokerScheme). For tolerance, a leading
+// scheme in a hand-written config (or flag) is stripped so a value like
+// "https://127.0.0.1:8100" still yields a single well-formed URL rather than a
+// doubled scheme.
 func (c *FileConfig) ResolvedBrokerHost(flag string, flagChanged bool) string {
 	if flagChanged {
-		return flag
+		return stripScheme(flag)
 	}
 	if c.Broker.Host != "" {
-		return c.Broker.Host
+		return stripScheme(c.Broker.Host)
 	}
 	return DefaultBrokerHost
+}
+
+// stripScheme removes a leading "scheme://" prefix from a host value so the
+// broker.host field is tolerant of an accidentally-included scheme. The scheme
+// is carried separately in broker.scheme; keeping host bare avoids emitting a
+// doubled scheme (e.g. https://https://…) when the URL is assembled.
+func stripScheme(host string) string {
+	if i := strings.Index(host, "://"); i != -1 {
+		return host[i+len("://"):]
+	}
+	return host
 }
 
 // ResolvedProfileName resolves the profile to act on, in precedence order: the

--- a/cli/internal/config/file_test.go
+++ b/cli/internal/config/file_test.go
@@ -68,6 +68,44 @@ func TestResolvedDefaults(t *testing.T) {
 	}
 }
 
+// TestResolvedBrokerURL guards against issue #657: broker.host is a bare
+// host[:port] and the scheme is carried separately, so assembling
+// scheme + "://" + host must yield a single well-formed URL — never a doubled
+// scheme.
+func TestResolvedBrokerURL(t *testing.T) {
+	brokerURL := func(c *FileConfig) string {
+		return c.ResolvedBrokerScheme("", false) + "://" + c.ResolvedBrokerHost("", false)
+	}
+
+	t.Run("defaults resolve to a single scheme", func(t *testing.T) {
+		cfg := &FileConfig{}
+		if got, want := brokerURL(cfg), "https://127.0.0.1:8100"; got != want {
+			t.Errorf("default broker URL = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("bare host with scheme:http", func(t *testing.T) {
+		cfg := &FileConfig{Broker: BrokerConfig{Scheme: "http", Host: "127.0.0.1:8100"}}
+		if got, want := brokerURL(cfg), "http://127.0.0.1:8100"; got != want {
+			t.Errorf("broker URL = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("host with accidental scheme is stripped", func(t *testing.T) {
+		cfg := &FileConfig{Broker: BrokerConfig{Scheme: "https", Host: "https://127.0.0.1:8100"}}
+		if got, want := brokerURL(cfg), "https://127.0.0.1:8100"; got != want {
+			t.Errorf("broker URL = %q, want single scheme %q", got, want)
+		}
+	})
+
+	t.Run("flag host with accidental scheme is stripped", func(t *testing.T) {
+		cfg := &FileConfig{}
+		if got := cfg.ResolvedBrokerHost("http://example:9000", true); got != "example:9000" {
+			t.Errorf("ResolvedBrokerHost = %q, want scheme stripped", got)
+		}
+	})
+}
+
 func TestResolvedPrecedence(t *testing.T) {
 	cfg := &FileConfig{
 		Broker: BrokerConfig{Scheme: "http", Host: "cfg-host"},

--- a/cli/internal/config/paths.go
+++ b/cli/internal/config/paths.go
@@ -10,8 +10,11 @@ import (
 const (
 	// DefaultBrokerScheme is the scheme of the broker target used by execute.
 	DefaultBrokerScheme = "https"
-	// DefaultBrokerHost is the host of the broker target used by execute.
-	DefaultBrokerHost = "https://127.0.0.1:8100"
+	// DefaultBrokerHost is the host of the broker target used by execute. It is a
+	// bare host[:port] with no scheme — the scheme lives in DefaultBrokerScheme
+	// (and broker.scheme in config.yaml). Callers assemble the URL as
+	// scheme + "://" + host, so embedding a scheme here would double it.
+	DefaultBrokerHost = "127.0.0.1:8100"
 
 	// DefaultBaseURL is the Jentic control-plane (auth surface) base URL used for
 	// agent registration and token minting.

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -869,14 +869,14 @@
             {
               "name": "broker-host",
               "type": "string",
-              "default": "https://127.0.0.1:8100",
-              "usage": "broker target host"
+              "default": "127.0.0.1:8100",
+              "usage": "broker target host as host[:port] (no scheme; use --broker-scheme)"
             },
             {
               "name": "broker-scheme",
               "type": "string",
               "default": "https",
-              "usage": "broker target scheme"
+              "usage": "broker target scheme (http or https)"
             },
             {
               "name": "data",


### PR DESCRIPTION
## Summary

The CLI splits the broker target into `broker.scheme` and `broker.host`, but the compiled-in default `host` embedded a scheme (`https://127.0.0.1:8100`). Since the URL is assembled as `scheme + "://" + host`, a user with no config file fell back to `https://https://127.0.0.1:8100` (double scheme). The installed-config path was already safe (bare host). This fixes the compiled-in default and hardens host resolution.

## Changes

- `cli/internal/config/paths.go`: `DefaultBrokerHost` is now a bare `127.0.0.1:8100` matching the field name and the separate `scheme` field.
- `cli/internal/config/file.go`: `ResolvedBrokerHost` strips a leading `scheme://` for tolerance of hand-written configs/flags; documented the `host[:port]` + separate `scheme` convention on `BrokerConfig`.
- `cli/internal/cmd/execute.go` + `ui/public/cli-reference.json`: clarified `--broker-host` / `--broker-scheme` help text (regenerated reference).
- `cli/README.md`: documented the `broker.host` (bare) + `broker.scheme` split.
- `cli/internal/config/file_test.go`: added `TestResolvedBrokerURL` asserting defaults resolve to a single `https://127.0.0.1:8100`, a bare host + `scheme: http` resolves to `http://127.0.0.1:8100`, and a host with an accidental scheme still resolves to a single well-formed URL.

## Test plan

- [x] `cd cli && go build ./...`
- [x] `cd cli && go test ./...` (all pass, including regenerated `TestCommittedCLIReferenceUpToDate`)
- [x] `gofmt` / `go vet` clean on changed files
- [ ] Reviewer: confirm `jentic execute` with no config now targets `https://127.0.0.1:8100`

Closes #657

> Note: please **squash-merge** this PR.

Made with [Cursor](https://cursor.com)