### PR TITLE
fix(control): let a bound agent write to its toolkit and 403 (not 404) when scope-hidden

### DIFF
--- a/src/jentic_one/control/services/toolkits/errors.py
+++ b/src/jentic_one/control/services/toolkits/errors.py
@@ -15,6 +15,24 @@ class ToolkitNotFoundError(ToolkitServiceError):
         self.toolkit_id = toolkit_id
 
 
+class ToolkitAccessDeniedError(ToolkitServiceError):
+    """Raised when a toolkit exists but is hidden from the caller by owner scoping.
+
+    Distinguishes an authorization outcome from a missing row: the toolkit is
+    real, but the caller neither owns it, is bound to it, nor holds ``org:admin``,
+    so a write is refused. Surfacing this as ``403`` (rather than a misleading
+    ``404 toolkit_not_found``) names the real requirement to the caller. See
+    issue #682.
+    """
+
+    def __init__(self, toolkit_id: str) -> None:
+        super().__init__(
+            f"Toolkit '{toolkit_id}' exists but is not accessible; write access requires "
+            "a binding to it, matching ownership, or org:admin"
+        )
+        self.toolkit_id = toolkit_id
+
+
 class ToolkitKeyNotFoundError(ToolkitServiceError):
     """Raised when a toolkit key identified by ID does not exist."""
 

--- a/src/jentic_one/control/services/toolkits/service.py
+++ b/src/jentic_one/control/services/toolkits/service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import NoReturn
+
 import structlog
 
 from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
@@ -19,6 +21,7 @@ from jentic_one.control.scoping.filters import build_access_filters
 from jentic_one.control.services.toolkits.errors import (
     BindingNotFoundError,
     DuplicateBindingError,
+    ToolkitAccessDeniedError,
     ToolkitKeyNotFoundError,
     ToolkitNotFoundError,
 )
@@ -56,6 +59,22 @@ class ToolkitService:
             return await PrerequisiteRepository.list_toolkit_ids_for_agent(
                 session, agent_id=identity.sub
             )
+
+    async def _raise_toolkit_unavailable(self, toolkit_id: str) -> NoReturn:
+        """Raise the right error when a scoped toolkit lookup came back empty.
+
+        A write handler that resolved the toolkit under access filters and found
+        nothing can mean one of two things: the toolkit id is genuinely unknown
+        (``404``), or it exists but this caller isn't allowed to see it — not the
+        owner, not bound, not ``org:admin`` (``403``). An unscoped existence probe
+        tells the two apart so we stop reporting an authorization outcome as a
+        misleading ``404 toolkit_not_found`` (issue #682).
+        """
+        async with self._ctx.control_db.session() as session:
+            exists = await ToolkitRepository.get_by_id(session, toolkit_id)
+        if exists is not None:
+            raise ToolkitAccessDeniedError(toolkit_id)
+        raise ToolkitNotFoundError(toolkit_id)
 
     async def _emit_telemetry(self, *, type: str, summary: str, identity: Identity) -> None:
         """Emit a telemetry event on the admin DB (best-effort).
@@ -225,13 +244,15 @@ class ToolkitService:
         description: str | None = None,
         active: bool | None = None,
     ) -> Toolkit:
-        access_filters = build_access_filters(identity, Toolkit)
+        access_filters = build_access_filters(
+            identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+        )
         async with self._ctx.control_db.transaction() as session:
             existing = await ToolkitRepository.get_by_id(
                 session, toolkit_id, filters=access_filters
             )
             if existing is None:
-                raise ToolkitNotFoundError(toolkit_id)
+                await self._raise_toolkit_unavailable(toolkit_id)
             before_name = existing.name
             before_active = existing.active
             toolkit = await ToolkitRepository.update(
@@ -257,11 +278,13 @@ class ToolkitService:
         return toolkit
 
     async def delete(self, toolkit_id: str, *, identity: Identity) -> None:
-        access_filters = build_access_filters(identity, Toolkit)
+        access_filters = build_access_filters(
+            identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+        )
         async with self._ctx.control_db.transaction() as session:
             toolkit = await ToolkitRepository.get_by_id(session, toolkit_id, filters=access_filters)
             if toolkit is None:
-                raise ToolkitNotFoundError(toolkit_id)
+                await self._raise_toolkit_unavailable(toolkit_id)
             await ToolkitRepository.delete(session, toolkit_id)
 
         async with self._ctx.admin_db.transaction() as session:
@@ -291,12 +314,14 @@ class ToolkitService:
     ) -> tuple[ToolkitKey, str]:
         """Create an additional API key. Returns (key, plaintext)."""
         plaintext, hashed, preview, lookup = generate_toolkit_key()
-        access_filters = build_access_filters(identity, Toolkit)
+        access_filters = build_access_filters(
+            identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+        )
 
         async with self._ctx.control_db.transaction() as session:
             toolkit = await ToolkitRepository.get_by_id(session, toolkit_id, filters=access_filters)
             if toolkit is None:
-                raise ToolkitNotFoundError(toolkit_id)
+                await self._raise_toolkit_unavailable(toolkit_id)
             key = await ToolkitKeyRepository.create(
                 session,
                 toolkit_id=toolkit_id,
@@ -368,11 +393,13 @@ class ToolkitService:
         allowed_ips: list[str] | None = None,
         revoked: bool | None = None,
     ) -> ToolkitKey:
-        access_filters = build_access_filters(identity, Toolkit)
+        access_filters = build_access_filters(
+            identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+        )
         async with self._ctx.control_db.transaction() as session:
             toolkit = await ToolkitRepository.get_by_id(session, toolkit_id, filters=access_filters)
             if toolkit is None:
-                raise ToolkitNotFoundError(toolkit_id)
+                await self._raise_toolkit_unavailable(toolkit_id)
             key = await ToolkitKeyRepository.get_by_id(session, key_id)
             if key is None or key.toolkit_id != toolkit_id:
                 raise ToolkitKeyNotFoundError(key_id)
@@ -397,11 +424,13 @@ class ToolkitService:
         return updated
 
     async def delete_key(self, toolkit_id: str, key_id: str, *, identity: Identity) -> None:
-        access_filters = build_access_filters(identity, Toolkit)
+        access_filters = build_access_filters(
+            identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+        )
         async with self._ctx.control_db.transaction() as session:
             toolkit = await ToolkitRepository.get_by_id(session, toolkit_id, filters=access_filters)
             if toolkit is None:
-                raise ToolkitNotFoundError(toolkit_id)
+                await self._raise_toolkit_unavailable(toolkit_id)
             key = await ToolkitKeyRepository.get_by_id(session, key_id)
             if key is None or key.toolkit_id != toolkit_id:
                 raise ToolkitKeyNotFoundError(key_id)
@@ -428,11 +457,13 @@ class ToolkitService:
         identity: Identity,
         permissions: list[dict[str, object]] | None = None,
     ) -> ToolkitCredentialBinding:
-        access_filters = build_access_filters(identity, Toolkit)
+        access_filters = build_access_filters(
+            identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+        )
         async with self._ctx.control_db.transaction() as session:
             toolkit = await ToolkitRepository.get_by_id(session, toolkit_id, filters=access_filters)
             if toolkit is None:
-                raise ToolkitNotFoundError(toolkit_id)
+                await self._raise_toolkit_unavailable(toolkit_id)
             existing = await ToolkitBindingRepository.get(session, toolkit_id, credential_id)
             if existing is not None:
                 raise DuplicateBindingError(toolkit_id, credential_id)
@@ -505,11 +536,13 @@ class ToolkitService:
     async def unbind_credential(
         self, toolkit_id: str, credential_id: str, *, identity: Identity
     ) -> None:
-        access_filters = build_access_filters(identity, Toolkit)
+        access_filters = build_access_filters(
+            identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+        )
         async with self._ctx.control_db.transaction() as session:
             toolkit = await ToolkitRepository.get_by_id(session, toolkit_id, filters=access_filters)
             if toolkit is None:
-                raise ToolkitNotFoundError(toolkit_id)
+                await self._raise_toolkit_unavailable(toolkit_id)
             deleted = await ToolkitBindingRepository.unbind(session, toolkit_id, credential_id)
             if not deleted:
                 raise BindingNotFoundError(toolkit_id, credential_id)
@@ -559,11 +592,13 @@ class ToolkitService:
         *,
         identity: Identity,
     ) -> list[ToolkitPermissionRule]:
-        access_filters = build_access_filters(identity, Toolkit)
+        access_filters = build_access_filters(
+            identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+        )
         async with self._ctx.control_db.transaction() as session:
             toolkit = await ToolkitRepository.get_by_id(session, toolkit_id, filters=access_filters)
             if toolkit is None:
-                raise ToolkitNotFoundError(toolkit_id)
+                await self._raise_toolkit_unavailable(toolkit_id)
             binding = await ToolkitBindingRepository.get(session, toolkit_id, credential_id)
             if binding is None:
                 raise BindingNotFoundError(toolkit_id, credential_id)
@@ -597,11 +632,13 @@ class ToolkitService:
         add: list[dict[str, object]] | None = None,
         remove: list[int] | None = None,
     ) -> list[ToolkitPermissionRule]:
-        access_filters = build_access_filters(identity, Toolkit)
+        access_filters = build_access_filters(
+            identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+        )
         async with self._ctx.control_db.transaction() as session:
             toolkit = await ToolkitRepository.get_by_id(session, toolkit_id, filters=access_filters)
             if toolkit is None:
-                raise ToolkitNotFoundError(toolkit_id)
+                await self._raise_toolkit_unavailable(toolkit_id)
             binding = await ToolkitBindingRepository.get(session, toolkit_id, credential_id)
             if binding is None:
                 raise BindingNotFoundError(toolkit_id, credential_id)

--- a/src/jentic_one/control/web/errors.py
+++ b/src/jentic_one/control/web/errors.py
@@ -33,6 +33,7 @@ from jentic_one.control.services.toolkits.errors import (
     BindingNotFoundError,
     DuplicateBindingError,
     KeyAlreadyRevokedError,
+    ToolkitAccessDeniedError,
     ToolkitKeyNotFoundError,
     ToolkitNotFoundError,
 )
@@ -49,6 +50,7 @@ credential_service_error_handler = make_service_error_handler(_ERROR_MAP)
 
 _TOOLKIT_ERROR_MAP: dict[type[Exception], tuple[int, str]] = {
     ToolkitNotFoundError: (404, "toolkit_not_found"),
+    ToolkitAccessDeniedError: (403, "toolkit_access_denied"),
     ToolkitKeyNotFoundError: (404, "toolkit_key_not_found"),
     BindingNotFoundError: (404, "binding_not_found"),
     DuplicateBindingError: (409, "duplicate_binding"),

--- a/tests/unit/control/test_toolkit_delete.py
+++ b/tests/unit/control/test_toolkit_delete.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from jentic_one.control.services.toolkits.errors import ToolkitNotFoundError
+from jentic_one.control.services.toolkits.errors import (
+    ToolkitAccessDeniedError,
+    ToolkitNotFoundError,
+)
 from jentic_one.control.services.toolkits.service import ToolkitService
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.models import ActorType
@@ -30,9 +33,13 @@ def _make_ctx() -> MagicMock:
     control_session = AsyncMock()
     ctx.control_db.transaction.return_value.__aenter__ = AsyncMock(return_value=control_session)
     ctx.control_db.transaction.return_value.__aexit__ = AsyncMock(return_value=False)
+    ctx.control_db.session.return_value.__aenter__ = AsyncMock(return_value=control_session)
+    ctx.control_db.session.return_value.__aexit__ = AsyncMock(return_value=False)
     admin_session = AsyncMock()
     ctx.admin_db.transaction.return_value.__aenter__ = AsyncMock(return_value=admin_session)
     ctx.admin_db.transaction.return_value.__aexit__ = AsyncMock(return_value=False)
+    ctx.admin_db.session.return_value.__aenter__ = AsyncMock(return_value=admin_session)
+    ctx.admin_db.session.return_value.__aexit__ = AsyncMock(return_value=False)
     return ctx
 
 
@@ -122,14 +129,56 @@ async def test_delete_removes_agent_bindings(
 @patch(f"{_SVC_MODULE}.PrerequisiteRepository")
 @patch(f"{_SVC_MODULE}.ToolkitRepository")
 @patch(f"{_SVC_MODULE}.build_access_filters")
-async def test_delete_non_owner_raises_not_found(
+async def test_delete_non_owner_raises_access_denied(
     mock_filters: MagicMock,
     mock_repo: MagicMock,
     mock_prereq: MagicMock,
     mock_audit: AsyncMock,
 ) -> None:
+    """A non-owner, non-bound, non-admin caller gets 403 (access denied), not 404.
+
+    The scoped lookup returns nothing, but an unscoped existence probe finds the
+    toolkit, so the write is refused as an authorization outcome rather than a
+    misleading ``toolkit_not_found`` (issue #682).
+    """
     mock_filters.return_value = ["some_filter"]
+    # First call: scoped lookup misses. Second call (unscoped probe): row exists.
+    mock_repo.get_by_id = AsyncMock(side_effect=[None, _make_toolkit()])
+    mock_prereq.list_toolkit_ids_for_agent = AsyncMock(return_value=[])
+
+    ctx = _make_ctx()
+    svc = ToolkitService(ctx)
+    non_owner = Identity(
+        sub="other_user",
+        email="other@example.com",
+        permissions=["toolkits:write"],
+        actor_type=ActorType.USER,
+        parent_actor_id=None,
+    )
+
+    with pytest.raises(ToolkitAccessDeniedError):
+        await svc.delete("tk_abc123", identity=non_owner)
+
+    mock_repo.delete.assert_not_called()
+    mock_audit.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch(f"{_SVC_MODULE}.record_audit_best_effort", new_callable=AsyncMock)
+@patch(f"{_SVC_MODULE}.PrerequisiteRepository")
+@patch(f"{_SVC_MODULE}.ToolkitRepository")
+@patch(f"{_SVC_MODULE}.build_access_filters")
+async def test_delete_non_owner_missing_toolkit_raises_not_found(
+    mock_filters: MagicMock,
+    mock_repo: MagicMock,
+    mock_prereq: MagicMock,
+    mock_audit: AsyncMock,
+) -> None:
+    """A genuinely missing toolkit still raises ``ToolkitNotFoundError`` (404)."""
+    mock_filters.return_value = ["some_filter"]
+    # Both the scoped lookup and the unscoped existence probe miss.
     mock_repo.get_by_id = AsyncMock(return_value=None)
+    mock_prereq.list_toolkit_ids_for_agent = AsyncMock(return_value=[])
 
     ctx = _make_ctx()
     svc = ToolkitService(ctx)
@@ -142,7 +191,7 @@ async def test_delete_non_owner_raises_not_found(
     )
 
     with pytest.raises(ToolkitNotFoundError):
-        await svc.delete("tk_abc123", identity=non_owner)
+        await svc.delete("tk_gone", identity=non_owner)
 
     mock_repo.delete.assert_not_called()
     mock_audit.assert_not_called()

--- a/tests/web/control/conftest.py
+++ b/tests/web/control/conftest.py
@@ -183,6 +183,57 @@ def bound_orphan_client(
         yield tc
 
 
+# A bound orphan that ALSO holds toolkits:write (issue #682, write path): it owns
+# nothing but is bound to tk_target, so a write to that toolkit must succeed —
+# not 404 as owner-only scoping produced before the fix.
+BOUND_ORPHAN_WRITER_IDENTITY = Identity(
+    sub=FILER_SUB,
+    email="orphan-writer@test.local",
+    permissions=["toolkits:write", "owner:toolkits:read", "owner:credentials:read"],
+    actor_type=ActorType.AGENT,
+    parent_actor_id=None,
+)
+
+# A writer that neither owns nor is bound to tk_target and is not org:admin. A
+# write to tk_target (which exists, owned by OWNER_SUB) must be 403 — naming the
+# real requirement — not a misleading 404 (issue #682).
+UNBOUND_WRITER_IDENTITY = Identity(
+    sub="usr_webtest_unbound_writer",
+    email="unbound-writer@test.local",
+    permissions=["toolkits:write"],
+)
+
+
+@pytest.fixture()
+def bound_orphan_writer_client(
+    web_context: Context, seed_binding: None, clean_access_requests: None
+) -> Iterator[TestClient]:
+    """TestClient as a bound-but-orphaned agent that holds toolkits:write."""
+    app = _build_app(web_context, BOUND_ORPHAN_WRITER_IDENTITY)
+    with TestClient(app) as tc:
+        yield tc
+
+
+@pytest.fixture()
+def unbound_writer_client(
+    web_context: Context, seed_binding: None, clean_access_requests: None
+) -> Iterator[TestClient]:
+    """TestClient holding toolkits:write but neither owning nor bound to tk_target."""
+    app = _build_app(web_context, UNBOUND_WRITER_IDENTITY)
+    with TestClient(app) as tc:
+        yield tc
+
+
+@pytest.fixture()
+def admin_writer_client(
+    web_context: Context, seed_binding: None, clean_access_requests: None
+) -> Iterator[TestClient]:
+    """TestClient as org:admin against the seed_binding toolkit (tk_target)."""
+    app = _build_app(web_context, ADMIN_IDENTITY)
+    with TestClient(app) as tc:
+        yield tc
+
+
 @pytest.fixture()
 def filer_client(
     web_context: Context, seed_binding: None, clean_access_requests: None

--- a/tests/web/control/test_toolkits.py
+++ b/tests/web/control/test_toolkits.py
@@ -152,6 +152,68 @@ def test_orphaned_agent_denied_unbound_toolkit(bound_orphan_client: TestClient) 
     assert resp.status_code == 404
 
 
+# --- Bound-agent WRITE access (issue #682) ---
+
+
+def test_bound_orphan_writer_can_bind_credential(bound_orphan_writer_client: TestClient) -> None:
+    """A bound agent with toolkits:write can write to its bound toolkit.
+
+    Reproduces #682: before the fix the write path scoped to owner-only, so a
+    bound-but-orphaned agent got 404 on a toolkit it is actively bound to.
+    """
+    resp = bound_orphan_writer_client.post(
+        "/toolkits/tk_target/credentials",
+        json={"credential_id": "cred_001"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["toolkit_id"] == "tk_target"
+    assert body["credential_id"] == "cred_001"
+
+
+def test_bound_orphan_writer_can_create_key(bound_orphan_writer_client: TestClient) -> None:
+    """The same bound agent can issue a key on its bound toolkit."""
+    resp = bound_orphan_writer_client.post(
+        "/toolkits/tk_target/keys",
+        json={"label": "bound-orphan-key"},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["api_key"].startswith("jntc_live_")
+
+
+def test_unbound_writer_denied_with_403_not_404(unbound_writer_client: TestClient) -> None:
+    """A writer that is neither owner, bound, nor admin gets 403 (not a misleading 404).
+
+    The toolkit exists (owned by another operator); reporting it as
+    ``404 toolkit_not_found`` hid an authorization outcome. Issue #682.
+    """
+    resp = unbound_writer_client.post(
+        "/toolkits/tk_target/credentials",
+        json={"credential_id": "cred_001"},
+    )
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["type"] == "toolkit_access_denied"
+
+
+def test_unbound_writer_genuine_missing_toolkit_is_404(unbound_writer_client: TestClient) -> None:
+    """A truly non-existent toolkit id still returns 404, not 403."""
+    resp = unbound_writer_client.post(
+        "/toolkits/tk_does_not_exist/credentials",
+        json={"credential_id": "cred_001"},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+def test_admin_writer_bypasses_scoping(admin_writer_client: TestClient) -> None:
+    """org:admin can still write to any toolkit regardless of ownership/binding."""
+    resp = admin_writer_client.post(
+        "/toolkits/tk_target/credentials",
+        json={"credential_id": "cred_001"},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["toolkit_id"] == "tk_target"
+
+
 # --- Keys ---
 
 


### PR DESCRIPTION
## Summary

An agent holding `toolkits:write` and **already bound** to a toolkit still got `404 toolkit_not_found` on every write (bind/unbind credential, update, delete, key CRUD, permission rules). The write methods in `ToolkitService` scoped to owner-only (`Toolkit.created_by == self`), unlike the read methods which already widen visibility with the caller's bound-toolkit ids. Owner-scoping silently hid a toolkit the agent legitimately operates on, and an authorization outcome masqueraded as a missing row.

This is the write-side twin of the read fix (#665/#686/#718); it stays scoped to the write path.

## Changes

- **`control/services/toolkits/service.py`** — every write method (`bind_credential`, `unbind_credential`, `update`, `delete`, `create_key`, `update_key`, `delete_key`, `replace_permissions`, `patch_permissions`) now passes `bound_toolkit_ids=await self._bound_toolkit_ids(identity)` to `build_access_filters`, mirroring the read path so a bound-but-orphaned agent can act within its bindings.
- **`control/services/toolkits/errors.py`** — new `ToolkitAccessDeniedError`. A shared `_raise_toolkit_unavailable` helper does an unscoped existence probe when the scoped lookup misses: toolkit exists → `403`; genuinely absent → `404`.
- **`control/web/errors.py`** — maps `ToolkitAccessDeniedError` → `403 toolkit_access_denied`. (The generic `403` is already advertised on every authenticated operation in the OpenAPI spec, so there is no spec drift.)
- **Tests** — web tests: bound agent write succeeds; unbound non-owner non-admin gets `403` (not `404`); genuine missing id stays `404`; `org:admin` still bypasses. Unit `test_toolkit_delete` updated for the new 404-vs-403 distinction.

## Test plan

- [x] `make test-fast` (unit + arch) — 2112 passed
- [x] `tests/web/control/` against Postgres — 52 passed (incl. 5 new)
- [x] `make lint` (ruff + mypy) — clean
- [x] `make openapi` — no spec drift
- [ ] Reviewer: confirm the 404→403 change is desired for genuinely scope-hidden toolkits

Closes #682

> Merge with **squash + merge**.

Made with [Cursor](https://cursor.com)