### PR TITLE
feat(auth): resolve toolkit binding names in /me whoami (#686)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -324,7 +324,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "2c4ea53d93a5d7661383e1c667d72270f9bf2fb6",
         "is_verified": false,
-        "line_number": 15836
+        "line_number": 15841
       }
     ],
     "release-please-config.json": [
@@ -1553,5 +1553,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-13T14:22:38Z"
+  "generated_at": "2026-07-21T15:18:00Z"
 }

--- a/cli/internal/accessclient/client.go
+++ b/cli/internal/accessclient/client.go
@@ -151,6 +151,7 @@ type ListResult struct {
 // ToolkitBinding is a single agent→toolkit binding from GET /me.
 type ToolkitBinding struct {
 	ToolkitID string    `json:"toolkit_id"`
+	Name      string    `json:"name"`
 	BoundAt   time.Time `json:"bound_at"`
 }
 

--- a/cli/internal/cmd/access.go
+++ b/cli/internal/cmd/access.go
@@ -483,7 +483,11 @@ func (a *App) printMe(me *accessclient.Me) {
 		return
 	}
 	for _, b := range me.ToolkitBindings {
-		fmt.Fprintln(a.Out, "  "+theme.Command.Render(b.ToolkitID))
+		if b.Name != "" {
+			fmt.Fprintln(a.Out, "  "+theme.Command.Render(b.Name)+"  "+theme.Dim.Render(b.ToolkitID))
+		} else {
+			fmt.Fprintln(a.Out, "  "+theme.Command.Render(b.ToolkitID))
+		}
 	}
 }
 

--- a/cli/internal/cmd/access_test.go
+++ b/cli/internal/cmd/access_test.go
@@ -133,6 +133,41 @@ func TestAccessWhoami(t *testing.T) {
 	}
 }
 
+func TestAccessWhoamiRendersToolkitName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/me" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"id":"agnt_test","name":"demo","status":"active",
+			"scopes":["capabilities:execute"],"toolkit_bindings":[
+			{"toolkit_id":"tk_named","name":"Design news radar","bound_at":"2026-01-01T00:00:00Z"},
+			{"toolkit_id":"tk_bare","bound_at":"2026-01-01T00:00:00Z"}]}`))
+	}))
+	defer srv.Close()
+
+	app := testApp(t)
+	seedAccessProfile(t, app, "demo", srv.URL)
+
+	// No --json: exercise the human-readable rendering that shows name (tk_…).
+	out := new(bytes.Buffer)
+	app.Out = out
+	root := newAPIRootCmd(app)
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{"access", "whoami", "--profile", "demo", "--base-url", srv.URL})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("whoami: %v\n%s", err, out.String())
+	}
+	rendered := out.String()
+	if !strings.Contains(rendered, "Design news radar") {
+		t.Errorf("expected toolkit name in output, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "tk_named") || !strings.Contains(rendered, "tk_bare") {
+		t.Errorf("expected both toolkit ids in output, got:\n%s", rendered)
+	}
+}
+
 func TestAccessRequestFiles(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	var gotBody map[string]any

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -4102,6 +4102,11 @@ components:
           format: date-time
           title: Bound At
           type: string
+        name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Name
         toolkit_id:
           title: Toolkit Id
           type: string

--- a/src/jentic_one/__main__.py
+++ b/src/jentic_one/__main__.py
@@ -30,7 +30,10 @@ from jentic_one.shared.web.app_factory import SURFACE_MODULES, create_combined_a
 from jentic_one.wiring import install_broker_registry_resolver as _install_broker_registry_resolver
 
 SURFACE_DB_DEPS: dict[str, set[str]] = {
-    "auth": {"admin"},
+    # Auth reaches the control DB read-only to resolve toolkit-binding names for
+    # the /me whoami response (issue #686): the binding row lives in the admin DB
+    # but the toolkit name lives in the control DB.
+    "auth": {"admin", "control"},
     "broker": {"admin", "control", "registry"},
 }
 

--- a/src/jentic_one/auth/repos/__init__.py
+++ b/src/jentic_one/auth/repos/__init__.py
@@ -1,0 +1,7 @@
+"""Auth-module repositories."""
+
+from __future__ import annotations
+
+from jentic_one.auth.repos.toolkit_name_repo import ToolkitNameRepository
+
+__all__ = ["ToolkitNameRepository"]

--- a/src/jentic_one/auth/repos/toolkit_name_repo.py
+++ b/src/jentic_one/auth/repos/toolkit_name_repo.py
@@ -1,0 +1,45 @@
+"""Cross-database toolkit-name lookup for the auth surface.
+
+Uses raw SQL (``text()``) against the control database so the auth module never
+imports the control ORM — the auth/control module boundary (enforced by
+``tests/arch/test_module_boundaries.py``) forbids a direct cross-module import.
+This mirrors ``control.repos.prerequisite_repo.PrerequisiteRepository``, which
+reaches the *admin* DB from the control side by the same raw-SQL convention.
+
+The only consumer is the ``/me`` whoami assembly (issue #686): an agent can read
+the *id* of a toolkit it is bound to but not its human-readable *name*, because
+the binding row (admin DB) carries only ``toolkit_id`` while ``name`` lives in
+the control DB ``toolkits`` table. Callers resolve names for a set of already
+scope-checked binding ids, so this is read-only and scope-safe by construction —
+it only ever maps ids the caller is already permitted to see.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy import bindparam, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class ToolkitNameRepository:
+    """Resolves toolkit ids to names in the control DB without control imports."""
+
+    @staticmethod
+    async def get_names_for_ids(
+        session: AsyncSession, toolkit_ids: Sequence[str]
+    ) -> dict[str, str]:
+        """Return a ``{toolkit_id: name}`` map for the given ids.
+
+        Ids with no matching toolkit row (e.g. a since-deleted toolkit) are
+        omitted, so callers get a name only when one exists. Runs against a
+        control-DB session.
+        """
+        if not toolkit_ids:
+            return {}
+        unique_ids = list(dict.fromkeys(toolkit_ids))
+        stmt = text("SELECT id, name FROM toolkits WHERE id IN :ids").bindparams(
+            bindparam("ids", expanding=True)
+        )
+        result = await session.execute(stmt, {"ids": unique_ids})
+        return {row[0]: row[1] for row in result.fetchall()}

--- a/src/jentic_one/auth/services/agent_service.py
+++ b/src/jentic_one/auth/services/agent_service.py
@@ -13,6 +13,7 @@ from jentic_one.admin.repos import (
     AgentToolkitBindingRepository,
 )
 from jentic_one.admin.scoping.filters import build_access_filters
+from jentic_one.auth.repos import ToolkitNameRepository
 from jentic_one.auth.services.errors import (
     ActorNotFoundError,
     InvalidOwnerError,
@@ -277,7 +278,19 @@ class AgentService:
         await self.get_agent(agent_id, identity=identity)
         async with self._ctx.admin_db.session() as session:
             bindings = await AgentToolkitBindingRepository.list_for_agent(session, agent_id)
-        return [ToolkitBindingView.model_validate(b) for b in bindings]
+        views = [ToolkitBindingView.model_validate(b) for b in bindings]
+        # Resolve human-readable toolkit names so an agent can map an opaque
+        # `tk_…` id to a name it can show its operator (issue #686). Names live in
+        # the control DB; the bindings above are already scoped to this agent, so
+        # we only ever resolve names for toolkits the caller is bound to. Failure
+        # to reach the control DB is non-fatal — the name is simply left None.
+        toolkit_ids = [v.toolkit_id for v in views]
+        if toolkit_ids and self._ctx.is_db_allowed("control"):
+            async with self._ctx.control_db.session() as session:
+                names = await ToolkitNameRepository.get_names_for_ids(session, toolkit_ids)
+            for view in views:
+                view.name = names.get(view.toolkit_id)
+        return views
 
     async def bind_toolkit(
         self, agent_id: str, *, toolkit_id: str, identity: Identity

--- a/src/jentic_one/auth/services/schemas/agents.py
+++ b/src/jentic_one/auth/services/schemas/agents.py
@@ -43,4 +43,7 @@ class ToolkitBindingView(BaseModel):
     id: str
     agent_id: str
     toolkit_id: str
+    # Human-readable toolkit name resolved from the control DB (issue #686).
+    # None when the toolkit no longer exists or the control DB is unreachable.
+    name: str | None = None
     bound_at: datetime

--- a/src/jentic_one/auth/web/routers/identity.py
+++ b/src/jentic_one/auth/web/routers/identity.py
@@ -98,7 +98,8 @@ async def _resolve_agent(request: Request, identity: Identity, agent_svc: AgentS
         parent_agent_id=agent.parent_agent_id,
         approved_by=agent.approved_by,
         toolkit_bindings=[
-            ToolkitBindingEntry(toolkit_id=tb.toolkit_id, bound_at=tb.bound_at) for tb in toolkits
+            ToolkitBindingEntry(toolkit_id=tb.toolkit_id, name=tb.name, bound_at=tb.bound_at)
+            for tb in toolkits
         ],
     )
 

--- a/src/jentic_one/auth/web/schemas/identity.py
+++ b/src/jentic_one/auth/web/schemas/identity.py
@@ -12,6 +12,10 @@ class ToolkitBindingEntry(BaseModel):
     """Toolkit binding summary for the /me response."""
 
     toolkit_id: str
+    # Human-readable toolkit name, so an agent can map the opaque `tk_…` id to a
+    # name it can present to its operator (issue #686). Null when the toolkit no
+    # longer exists or its name could not be resolved.
+    name: str | None = None
     bound_at: datetime
 
 

--- a/tests/integration/auth/test_toolkit_name_repo.py
+++ b/tests/integration/auth/test_toolkit_name_repo.py
@@ -1,0 +1,66 @@
+"""Integration tests for the cross-DB toolkit-name lookup (issue #686).
+
+``ToolkitNameRepository`` resolves toolkit ids to names in the control DB via raw
+SQL so the auth surface can enrich the /me whoami binding list without importing
+the control ORM. These tests hit a real control database.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy import text
+
+from jentic_one.auth.repos import ToolkitNameRepository
+from jentic_one.shared.db.session import DatabaseSession
+
+pytestmark = pytest.mark.integration
+
+_TK_A = "tk_name_lookup_a"
+_TK_B = "tk_name_lookup_b"
+_TK_MISSING = "tk_name_lookup_missing"
+
+
+@pytest.fixture()
+async def seeded_toolkits(control_db: DatabaseSession) -> AsyncGenerator[None, None]:
+    async with control_db.session() as session:
+        for tk_id, name in ((_TK_A, "Design news radar"), (_TK_B, "Payments toolkit")):
+            await session.execute(
+                text(
+                    "INSERT INTO toolkits (id, name, created_by) "
+                    "VALUES (:id, :name, :created_by) ON CONFLICT DO NOTHING"
+                ),
+                {"id": tk_id, "name": name, "created_by": "usr_name_lookup"},
+            )
+        await session.commit()
+    yield
+    async with control_db.session() as session:
+        await session.execute(
+            text("DELETE FROM toolkits WHERE id IN (:a, :b)"), {"a": _TK_A, "b": _TK_B}
+        )
+        await session.commit()
+
+
+async def test_get_names_for_ids_resolves_known(
+    control_db: DatabaseSession, seeded_toolkits: None
+) -> None:
+    async with control_db.session() as session:
+        names = await ToolkitNameRepository.get_names_for_ids(session, [_TK_A, _TK_B])
+    assert names == {_TK_A: "Design news radar", _TK_B: "Payments toolkit"}
+
+
+async def test_get_names_for_ids_omits_missing(
+    control_db: DatabaseSession, seeded_toolkits: None
+) -> None:
+    async with control_db.session() as session:
+        names = await ToolkitNameRepository.get_names_for_ids(session, [_TK_A, _TK_MISSING])
+    # A since-deleted (or never-existent) toolkit is omitted rather than raising,
+    # so the caller degrades to name=None instead of failing the whole response.
+    assert names == {_TK_A: "Design news radar"}
+    assert _TK_MISSING not in names
+
+
+async def test_get_names_for_ids_empty_input(control_db: DatabaseSession) -> None:
+    async with control_db.session() as session:
+        assert await ToolkitNameRepository.get_names_for_ids(session, []) == {}

--- a/tests/web/auth/test_me.py
+++ b/tests/web/auth/test_me.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncGenerator
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy import delete
+from sqlalchemy import delete, text
 
 from jentic_one.admin.core.schema.agent_toolkit_bindings import AgentToolkitBinding
 from jentic_one.admin.core.schema.agents import Agent
@@ -37,6 +37,13 @@ pytestmark = pytest.mark.integration
 
 ADMIN_EMAIL = "me-test-admin@test.local"
 OWNER_EMAIL = "me-test-owner@test.local"
+
+# A real toolkit (control DB) the agent is bound to — /me must resolve its name
+# (issue #686). ``tk_me_orphan`` is a binding with no toolkit row, exercising the
+# graceful name=None path.
+NAMED_TOOLKIT_ID = "tk_me_named"
+NAMED_TOOLKIT_NAME = "Design news radar"
+ORPHAN_TOOLKIT_ID = "tk_me_orphan"
 
 
 def _build_app(ctx: Context) -> FastAPI:
@@ -165,7 +172,10 @@ async def approved_agent_id(
         )
         await AgentRepository.set_approval(session, agent.id, approved_by=admin_user_id)
         await AgentToolkitBindingRepository.bind(
-            session, agent_id=agent.id, toolkit_id="tk_example", created_by="usr_test"
+            session, agent_id=agent.id, toolkit_id=NAMED_TOOLKIT_ID, created_by="usr_test"
+        )
+        await AgentToolkitBindingRepository.bind(
+            session, agent_id=agent.id, toolkit_id=ORPHAN_TOOLKIT_ID, created_by="usr_test"
         )
         # A live scope grant the presented token won't carry — exercises #673:
         # /me must reflect current grants, not just the token's baked-in scopes.
@@ -177,6 +187,17 @@ async def approved_agent_id(
             granted_by=admin_user_id,
             created_by="usr_test",
         )
+    # The toolkit name lives in the control DB; seed a real row so /me can resolve
+    # NAMED_TOOLKIT_ID → its name (issue #686). ORPHAN_TOOLKIT_ID has no row.
+    async with ctx.control_db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO toolkits (id, name, created_by) "
+                "VALUES (:id, :name, :created_by) ON CONFLICT DO NOTHING"
+            ),
+            {"id": NAMED_TOOLKIT_ID, "name": NAMED_TOOLKIT_NAME, "created_by": owner_user_id},
+        )
+        await session.commit()
     yield agent.id
 
     async with ctx.admin_db.session() as session:
@@ -185,6 +206,9 @@ async def approved_agent_id(
         )
         await ActorScopeGrantRepository.revoke_all(session, agent.id)
         await session.execute(delete(Agent).where(Agent.id == agent.id))
+        await session.commit()
+    async with ctx.control_db.session() as session:
+        await session.execute(text("DELETE FROM toolkits WHERE id = :id"), {"id": NAMED_TOOLKIT_ID})
         await session.commit()
 
 
@@ -282,8 +306,14 @@ def test_me_agent(web_context: Context, approved_agent_id: str) -> None:
     assert body["token_scopes"] == ["toolkits:execute"]
     assert body["parent_agent_id"] is None
     assert body["approved_by"] is not None
-    assert len(body["toolkit_bindings"]) == 1
-    assert body["toolkit_bindings"][0]["toolkit_id"] == "tk_example"
+    bindings = {b["toolkit_id"]: b for b in body["toolkit_bindings"]}
+    assert len(bindings) == 2
+    # The bound toolkit's human-readable name is resolved from the control DB so
+    # the agent can map the opaque id to a name (issue #686)…
+    assert bindings[NAMED_TOOLKIT_ID]["name"] == NAMED_TOOLKIT_NAME
+    # …while a binding whose toolkit row is absent degrades gracefully to null
+    # rather than failing the whole response.
+    assert bindings[ORPHAN_TOOLKIT_ID]["name"] is None
 
 
 async def test_me_agent_opaque_token_surfaces_minted_scopes(

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -6457,6 +6457,17 @@
             "title": "Bound At",
             "type": "string"
           },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
           "toolkit_id": {
             "title": "Toolkit Id",
             "type": "string"


### PR DESCRIPTION
## Summary

An agent can read the opaque `tk_…` id of a toolkit it is bound to via `GET /me` (`jentic access whoami`) but not the toolkit's human-readable **name**, forcing ID-only instructions to its operator (issue #686). This adds the name to each `/me` toolkit-binding entry.

The binding row lives in the **admin** DB (`agent_toolkit_bindings`) while the toolkit name lives in the **control** DB (`toolkits.name`), and the auth↔control module boundary forbids a direct cross-module ORM join. Names are resolved via a boundary-safe raw-SQL helper, scoped to exactly the toolkits the agent is bound to.

This is the read-side counterpart to #665/#682 (which already let a bound agent read a bound toolkit's details via `GET /toolkits/{id}`); here we close the specific gap in the whoami binding list.

## Changes

- **`auth/repos/toolkit_name_repo.py`** — new `ToolkitNameRepository.get_names_for_ids`: raw-SQL `toolkit_id → name` lookup against the control DB without importing control ORM (mirrors control's `PrerequisiteRepository`). Missing rows are omitted.
- **`auth/services/agent_service.py`** — `list_toolkits` resolves names for the agent's already-scoped bindings (scope-safe: only toolkits the agent is bound to). A missing toolkit row, or an auth deployment without control-DB access, degrades gracefully to `name=None`.
- **`auth/services/schemas/agents.py` / `auth/web/schemas/identity.py`** — optional `name` on `ToolkitBindingView` / `ToolkitBindingEntry`; populated in the `/me` router. OpenAPI spec + UI client schema regenerated (`make openapi`).
- **`__main__.py`** — auth surface gains read-only control-DB access (`SURFACE_DB_DEPS`).
- **CLI** — `jentic access whoami` renders `name  tk_…` per binding (falls back to the id when no name).

## Test plan

- [x] `make test-fast` (unit + arch, incl. OpenAPI conformance) — 2111 passed
- [x] `make lint` (ruff + mypy) — clean
- [x] `make openapi` — spec regenerated & committed
- [x] Web `/me` integration tests (Postgres): bound agent's whoami returns each binding's name; a binding with no toolkit row → `name=null`
- [x] Cross-DB `ToolkitNameRepository` integration tests (SQLite): resolves known ids, omits missing, handles empty input
- [x] Go CLI tests (`internal/cmd`, `internal/accessclient`) incl. new whoami name-rendering test; `gofmt`/`go vet` clean

Closes #686

> Please **squash + merge**.

Made with [Cursor](https://cursor.com)