### PR TITLE
chore(dev): add idempotent make dev one-command local bring-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SERVICES := app registry admin control broker
 
 BUILD_DIR := build
 
-.PHONY: help install sync lock upgrade fmt format fix lint typecheck test test-unit test-fast test-integration test-integration-sqlite test-integration-all test-arch test-smoke cov cov-all check score openapi openapi-parity endpoints cli-reference broker-reference hooks clean start-fixtures stop-fixtures destroy-fixtures start-app start-registry start-admin start-control start-broker build-wheel build-base build-all save-all images $(addprefix build-,$(SERVICES)) $(addprefix push-,$(SERVICES)) $(addprefix save-,$(SERVICES))
+.PHONY: help install sync lock upgrade fmt format fix lint typecheck test test-unit test-fast test-integration test-integration-sqlite test-integration-all test-arch test-smoke cov cov-all check score openapi openapi-parity endpoints cli-reference broker-reference hooks clean dev start-fixtures stop-fixtures destroy-fixtures start-app start-registry start-admin start-control start-broker build-wheel build-base build-all save-all images $(addprefix build-,$(SERVICES)) $(addprefix push-,$(SERVICES)) $(addprefix save-,$(SERVICES))
 
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make <target>\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -111,6 +111,13 @@ clean: ## Remove caches and build artifacts
 	find deploy/helm -name "*.tgz" -delete 2>/dev/null || true
 	find deploy/helm -name "Chart.lock" -delete 2>/dev/null || true
 
+JENTIC_CONFIG_FILE ?= config/local.yaml
+export JENTIC_CONFIG_FILE
+
+dev: ## One-command local bring-up (idempotent): fixtures + migrations + UI, then start the app
+	@./scripts/dev-up.sh
+	@$(MAKE) --no-print-directory start-app
+
 start-fixtures: ## Start Docker database fixtures and apply migrations
 	@./scripts/setup.sh
 
@@ -119,9 +126,6 @@ stop-fixtures: ## Stop Docker database fixtures
 
 destroy-fixtures: ## Remove Docker database fixtures and volumes
 	docker compose -f docker/local-setup/docker-compose.yaml down -v
-
-JENTIC_CONFIG_FILE ?= config/local.yaml
-export JENTIC_CONFIG_FILE
 
 start-app: ## Start combined app (all surfaces)
 	uv run python -m jentic_one

--- a/README.md
+++ b/README.md
@@ -81,9 +81,13 @@ Or work from source:
 
 ```bash
 make install   # install dependencies and git hooks
-make check     # lint + typecheck + tests
-make start-app # run the application locally
+make dev        # idempotent local bring-up: fixtures + migrations + UI, then run the app
 ```
+
+`make dev` is the one-command local flow (including after a reboot) — it starts
+Docker fixtures if needed, applies migrations, builds the UI, and runs the app,
+and is safe to re-run. See the [Local development setup](docs/development/local-setup.md)
+guide for details and the individual targets it wraps.
 
 See the [Build & Deploy Guide](deploy/README.md) for full setup instructions.
 See the [Security Hardening Guide](docs/security/hardening.md) for information on securing your deployment.
@@ -115,6 +119,7 @@ Common `make` targets (run `make help` for the full list):
 | Target | Description |
 | ------ | ----------- |
 | `make install` | Full dev setup: sync deps + install git hooks |
+| `make dev` | One-command local bring-up (idempotent): fixtures + migrations + UI, then start the app |
 | `make check` | Lint, score, secrets audit, unit + arch tests |
 | `make fix` | Auto-fix lint issues and reformat code |
 | `make test` | Run unit tests |

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -1,0 +1,67 @@
+# Local development setup
+
+## One command: `make dev`
+
+From a source checkout, the single supported way to bring the stack up locally
+— including **after a machine reboot** — is:
+
+```bash
+make dev
+```
+
+`make dev` is **idempotent**: it is safe to run repeatedly, and each step is a
+no-op when it is already satisfied. It performs, in order:
+
+1. **Docker preflight.** Verifies Docker is installed and running. If Docker is
+   not running it fails fast with an actionable message (start Docker Desktop on
+   macOS / the Docker daemon on Linux) instead of failing deep inside a
+   migration.
+2. **Database fixtures + migrations.** If Postgres is already reachable it just
+   re-applies `alembic upgrade head` for each schema (a no-op when current);
+   otherwise it starts the Docker fixtures and runs the full setup
+   (`scripts/setup.sh` → compose up, create schemas, migrate).
+3. **UI bundle.** If `ui/dist` has no built `index.html` it runs `make ui-build`;
+   otherwise it skips. (If Node is unavailable it warns and continues — the
+   backend API still runs, only the `/app` SPA is unavailable.)
+4. **Start the app.** Runs `make start-app` with `JENTIC_CONFIG_FILE` set
+   automatically, serving all surfaces on `http://127.0.0.1:8000`.
+
+When it finishes, the SPA is reachable at `http://127.0.0.1:8000/app` and the
+site root redirects there.
+
+## What this replaces
+
+Previously, restarting local dev after a reboot took several manual,
+undocumented steps: start Docker, `make start-fixtures`, export
+`JENTIC_CONFIG_FILE=config/local.yaml` by hand, `make ui-build`, then manually
+symlink `ui/dist` → `src/jentic_one/static` so the SPA would be served. Two
+changes remove that friction:
+
+- **`make dev`** orchestrates Docker/DB/UI/app in one idempotent target and sets
+  `JENTIC_CONFIG_FILE` for you.
+- The SPA server now **falls back to `ui/dist`** when running from source (the
+  packaged `jentic_one/static` bundle only exists in a built wheel), so no
+  copy/symlink step is needed. Wheel/production serving is unchanged — the
+  packaged bundle still takes precedence.
+
+## First-time setup
+
+Before your first `make dev`, install dependencies and git hooks once:
+
+```bash
+make install   # sync Python deps, install UI deps, install git hooks
+```
+
+## Related targets
+
+| Target | Description |
+| ------ | ----------- |
+| `make dev` | Idempotent bring-up + start the app (the one-command flow above) |
+| `make start-fixtures` | Start Docker DB fixtures and apply migrations |
+| `make stop-fixtures` | Stop the Docker DB fixtures (keeps volumes) |
+| `make destroy-fixtures` | Remove fixtures **and volumes** (destructive reset) |
+| `make ui-build` | Build the UI bundle into `ui/dist` |
+| `make start-app` | Start the combined app (all surfaces) |
+
+`make dev` never runs the destructive `destroy-fixtures`, so it is safe against
+an existing local Postgres.

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Idempotent local bring-up for Jentic One (issue #652).
+#
+# Safe to run repeatedly and after a machine reboot. It performs only the
+# preflight that a `make start-app` needs — it does NOT start the app itself
+# (the `dev` make target does that once this returns). Each step is a no-op
+# when its target is already satisfied:
+#
+#   1. Verify Docker is running (fail fast with an actionable message).
+#   2. Start the DB fixtures + apply migrations *only if* Postgres is not
+#      already reachable (delegates to the idempotent scripts/setup.sh).
+#   3. Build the UI bundle *only if* ui/dist has no built index.html.
+#
+# Nothing here is destructive: it never runs `down -v` or resets volumes, so it
+# is safe against a shared local Postgres.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Dev config. `make dev` exports this too, but set a default so the script is
+# self-contained when run directly — a raw `uv run python -m jentic_one` /
+# alembic invocation otherwise fails with a missing `databases` field.
+export JENTIC_CONFIG_FILE="${JENTIC_CONFIG_FILE:-config/local.yaml}"
+
+COMPOSE_FILE="docker/local-setup/docker-compose.yaml"
+
+# ── 1. Docker ────────────────────────────────────────────────────────────────
+if ! command -v docker >/dev/null 2>&1; then
+    echo "ERROR: 'docker' not found on PATH. Install Docker Desktop (macOS) or" >&2
+    echo "       the Docker engine (Linux) and try again." >&2
+    exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "ERROR: Docker is installed but not running." >&2
+    case "$(uname -s)" in
+        Darwin) echo "       Start Docker Desktop (e.g. 'open -a Docker'), wait for it to" >&2
+                echo "       report ready, then re-run 'make dev'." >&2 ;;
+        *)      echo "       Start the Docker daemon (e.g. 'sudo systemctl start docker')," >&2
+                echo "       then re-run 'make dev'." >&2 ;;
+    esac
+    exit 1
+fi
+
+# ── 2. Database fixtures + migrations (only if DB unreachable) ───────────────
+db_reachable() {
+    docker compose -f "$COMPOSE_FILE" exec -T db \
+        psql -U postgres -d jentic -tAc 'SELECT 1' >/dev/null 2>&1
+}
+
+if db_reachable; then
+    echo "==> Postgres already reachable — skipping fixtures start."
+    echo "==> Ensuring migrations are up to date…"
+    migration_failed=0
+    for name in registry control admin; do
+        if ! uv run alembic -n "$name" upgrade head; then
+            echo "    ERROR: $name migration failed"
+            migration_failed=1
+        fi
+    done
+    if [ "$migration_failed" -ne 0 ]; then
+        echo "ERROR: One or more migrations failed. See output above." >&2
+        exit 1
+    fi
+else
+    echo "==> Postgres not reachable — starting fixtures…"
+    ./scripts/setup.sh
+fi
+
+# ── 3. UI bundle (only if not already built) ─────────────────────────────────
+if [ -f "ui/dist/index.html" ]; then
+    echo "==> ui/dist already built — skipping UI build."
+elif command -v node >/dev/null 2>&1; then
+    echo "==> ui/dist not built — building the UI bundle…"
+    make ui-build
+else
+    echo "WARNING: node not found and ui/dist is empty — the SPA at /app will" >&2
+    echo "         not be served. Install Node.js and run 'make ui-build' to" >&2
+    echo "         enable the UI (the backend API still runs without it)." >&2
+fi
+
+echo ""
+echo "==> Preflight complete. Starting the app…"

--- a/src/jentic_one/shared/web/static.py
+++ b/src/jentic_one/shared/web/static.py
@@ -1,11 +1,13 @@
 """Same-origin SPA static serving for the admin surface.
 
-The built UI bundle (``ui/dist``) is packaged into the wheel at
-``jentic_one/static`` via ``pyproject.toml`` ``force-include`` — the same
-mechanism used for the bundled OpenAPI specs. At runtime we resolve that
-directory with ``importlib.resources`` and, when present, serve it via
-FastAPI's first-class :meth:`FastAPI.frontend` so the admin surface serves the
-SPA same-origin (no CORS).
+The bundle is packaged into the wheel at ``jentic_one/static`` via
+``pyproject.toml`` ``force-include`` — the same mechanism used for the bundled
+OpenAPI specs. At runtime we resolve that directory with
+``importlib.resources`` and, when present, serve it via FastAPI's first-class
+:meth:`FastAPI.frontend` so the admin surface serves the SPA same-origin (no
+CORS). When running from a source checkout (``make dev``) the packaged copy
+does not exist, so we fall back to the repo's ``ui/dist`` directly — no manual
+``ui/dist`` → ``src/jentic_one/static`` copy step is needed.
 
 The bundle is mounted under :data:`SPA_MOUNT_PATH` (``/app``), NOT the site
 root. This is the key namespace-isolation property: the SPA owns ``/app`` and
@@ -76,20 +78,63 @@ _ROOT_ICON_PROBES = {
 }
 
 
+def _repo_root() -> Path:
+    """Repo root of a source checkout, four parents up from this module.
+
+    ``src/jentic_one/shared/web/static.py`` → repo root. In a wheel install this
+    still resolves to *some* directory under ``site-packages``; callers guard
+    against that via the ``pyproject.toml`` check in :func:`_resolve_dev_static_dir`.
+    """
+    return Path(__file__).resolve().parents[4]
+
+
+def _resolve_dev_static_dir(repo_root: Path | None = None) -> Path | None:
+    """Return ``ui/dist`` from a source checkout if it holds a built SPA.
+
+    Dev-only fallback for running straight from the repo (``make dev`` /
+    ``uv run python -m jentic_one``), where the SPA is **not** packaged under
+    ``jentic_one/static`` — that copy only exists in the built wheel. The
+    ``ui/dist`` bundle is produced by ``make ui-build`` and lives at the repo
+    root. Resolving it here removes the former manual ``ui/dist`` →
+    ``src/jentic_one/static`` symlink step.
+
+    Returns ``None`` when the checkout layout is absent (e.g. a wheel install,
+    where this module lives under ``site-packages`` and there is no sibling
+    ``ui/dist``) or the bundle has not been built, so production/wheel serving
+    is unaffected — the packaged ``static/`` in :func:`_resolve_static_dir`
+    still takes precedence.
+    """
+    root = repo_root if repo_root is not None else _repo_root()
+    if not (root / "pyproject.toml").is_file():
+        # Not a source checkout (e.g. installed under site-packages): bail out
+        # so wheel installs never accidentally resolve an unrelated directory.
+        return None
+
+    dist = root / "ui" / "dist"
+    if not (dist / "index.html").is_file():
+        return None
+    return dist
+
+
 def _resolve_static_dir() -> Path | None:
-    """Return the packaged static dir if it holds a built SPA, else None."""
+    """Return the SPA bundle directory if one holds a built SPA, else None.
+
+    Prefers the packaged ``jentic_one/static`` bundle (wheel/production); when
+    that is absent, falls back to a source checkout's ``ui/dist`` so a dev run
+    from the repo serves the SPA without a manual copy/symlink step.
+    """
     try:
         static_root = importlib.resources.files("jentic_one") / "static"
     except (ModuleNotFoundError, FileNotFoundError):
-        return None
+        static_root = None
 
-    index = static_root / "index.html"
-    if not index.is_file():
-        return None
-    # ``files()`` may return a non-filesystem traversable; ``app.frontend``
-    # needs a real directory path. The wheel install is always on the
-    # filesystem.
-    return Path(str(static_root))
+    if static_root is not None and (static_root / "index.html").is_file():
+        # ``files()`` may return a non-filesystem traversable; ``app.frontend``
+        # needs a real directory path. The wheel install is always on the
+        # filesystem.
+        return Path(str(static_root))
+
+    return _resolve_dev_static_dir()
 
 
 def mount_spa(app: FastAPI, *, health_path: str = "/health") -> bool:

--- a/tests/unit/shared/test_static_spa.py
+++ b/tests/unit/shared/test_static_spa.py
@@ -18,6 +18,7 @@ HTML-accepting browser included. These tests pin:
 
 from __future__ import annotations
 
+import importlib.resources
 from pathlib import Path
 
 import pytest
@@ -25,7 +26,12 @@ from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 
 import jentic_one.shared.web.static as static_mod
-from jentic_one.shared.web.static import APP_CONFIG_PATH, SPA_MOUNT_PATH, mount_spa
+from jentic_one.shared.web.static import (
+    APP_CONFIG_PATH,
+    SPA_MOUNT_PATH,
+    _resolve_dev_static_dir,
+    mount_spa,
+)
 
 # A browser navigating to a deep link sends an HTML-accepting request; that is
 # what triggers the index.html fallback within /app. API clients send JSON.
@@ -42,7 +48,9 @@ def _make_static_bundle(tmp_path: Path) -> Path:
     return static_dir
 
 
-def test_mount_spa_no_op_without_bundle() -> None:
+def test_mount_spa_no_op_without_bundle(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Force "no bundle" regardless of whether a source ui/dist exists locally.
+    monkeypatch.setattr(static_mod, "_resolve_static_dir", lambda: None)
     app = FastAPI()
     assert mount_spa(app) is False
     client = TestClient(app, raise_server_exceptions=False)
@@ -238,3 +246,75 @@ def test_app_config_endpoint_is_not_shadowed_by_frontend(
     resp = client.get(APP_CONFIG_PATH, headers=_HTML_HEADERS)
     assert resp.status_code == 200
     assert resp.json() == {"healthPath": "/health"}
+
+
+def _make_source_checkout(tmp_path: Path, *, with_bundle: bool) -> Path:
+    """Simulate a source checkout: a repo root with pyproject.toml and ui/dist."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    dist = tmp_path / "ui" / "dist"
+    dist.mkdir(parents=True)
+    if with_bundle:
+        (dist / "index.html").write_text("<!doctype html><title>dev</title>", encoding="utf-8")
+    return dist
+
+
+def test_dev_fallback_resolves_built_ui_dist(tmp_path: Path) -> None:
+    """Running from a source checkout resolves ui/dist when it holds a build."""
+    dist = _make_source_checkout(tmp_path, with_bundle=True)
+    assert _resolve_dev_static_dir(repo_root=tmp_path) == dist
+
+
+def test_dev_fallback_none_when_ui_dist_unbuilt(tmp_path: Path) -> None:
+    """A source checkout with an empty ui/dist (placeholder) resolves to None."""
+    _make_source_checkout(tmp_path, with_bundle=False)
+    assert _resolve_dev_static_dir(repo_root=tmp_path) is None
+
+
+def test_dev_fallback_none_when_not_a_source_checkout(tmp_path: Path) -> None:
+    """No pyproject.toml at the root (e.g. a wheel install) resolves to None."""
+    dist = tmp_path / "ui" / "dist"
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_text("<!doctype html>", encoding="utf-8")
+    # No pyproject.toml written: guard must refuse to resolve an unrelated dir.
+    assert _resolve_dev_static_dir(repo_root=tmp_path) is None
+
+
+def test_packaged_static_takes_precedence_over_dev_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the wheel-packaged static/ is present it wins over ui/dist."""
+    packaged = _make_static_bundle(tmp_path / "packaged")
+    dev = _make_source_checkout(tmp_path / "src", with_bundle=True)
+
+    class _FakePackageRoot:
+        """Stands in for ``importlib.resources.files("jentic_one")``.
+
+        ``/ "static"`` yields the real packaged static dir as a filesystem Path,
+        matching what a wheel install returns.
+        """
+
+        def __truediv__(self, other: str) -> Path:
+            assert other == "static"
+            return packaged
+
+    monkeypatch.setattr(importlib.resources, "files", lambda _pkg: _FakePackageRoot())
+    monkeypatch.setattr(static_mod, "_resolve_dev_static_dir", lambda: dev)
+
+    assert static_mod._resolve_static_dir() == packaged
+
+
+def test_dev_fallback_used_when_no_packaged_static(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no packaged static/, the source ui/dist fallback is used."""
+    dev = _make_source_checkout(tmp_path, with_bundle=True)
+
+    class _EmptyTraversable:
+        def __truediv__(self, other: str) -> Path:
+            return tmp_path / "does-not-exist" / other
+
+    monkeypatch.setattr(importlib.resources, "files", lambda _pkg: _EmptyTraversable())
+    monkeypatch.setattr(static_mod, "_resolve_dev_static_dir", lambda: dev)
+
+    assert static_mod._resolve_static_dir() == dev


### PR DESCRIPTION
## Summary

Restarting local dev after a reboot took several manual, undocumented steps: start Docker, `make start-fixtures`, `export JENTIC_CONFIG_FILE=config/local.yaml`, `make ui-build`, then manually symlink `ui/dist` → `src/jentic_one/static` so the SPA would be served. This collapses that into a single **idempotent** entry point and removes the manual symlink.

`Closes #652`

## Changes

- **`make dev`** — one-command local bring-up that orchestrates, in order:
  1. Docker preflight (fail fast with an actionable message if Docker isn't running),
  2. DB fixtures + migrations **only if** Postgres is unreachable (delegates to the existing `scripts/setup.sh`),
  3. UI build **only if** `ui/dist` is unbuilt,
  4. `make start-app` with `JENTIC_CONFIG_FILE` set automatically.
- **`scripts/dev-up.sh`** — the idempotent preflight helper. Reuses `scripts/setup.sh`, defaults `JENTIC_CONFIG_FILE`, and is never destructive (no `down -v` / volume reset), so it's safe against an existing local Postgres.
- **`static.py`** — SPA server now falls back to a source checkout's `ui/dist` when the packaged `jentic_one/static` bundle is absent, so a source run serves the SPA with no copy/symlink step. **Wheel/production serving is unchanged** — the packaged `static/` still takes precedence (guarded by a `pyproject.toml` presence check so wheel installs never resolve an unrelated dir).
- **Docs** — new `docs/development/local-setup.md` documenting the reboot → `make dev` flow; README updated to point at it.
- **Tests** — unit tests cover the dev fallback, precedence over the packaged bundle, and the not-a-source-checkout guard.

## How to use

```bash
make install   # first time only: deps + git hooks
make dev        # after a reboot (or any time): brings the whole stack up
```

Then open http://127.0.0.1:8000/app.

## Test plan

- [x] `make dev` from a cold state (fixtures down, `ui/dist` empty) starts fixtures, migrates, builds the UI, and starts the app.
- [x] Re-running `scripts/dev-up.sh` is a no-op (skips fixtures start and UI build) — idempotent.
- [x] Live: `GET /app/` → 200 (SPA served from `ui/dist`), `GET /` → 307 → `/app/`, `GET /favicon.ico` → 307, `GET /app-config.json` → `{"healthPath":"/admin/health"}`; server log shows `spa_mounted static_dir=…/ui/dist`.
- [x] `JENTIC_CONFIG_FILE` no longer needs to be set by hand.
- [x] `make lint` (ruff + format + mypy), SPA unit tests (23 passed), and arch tests (130 passed) all green.

Please **squash-merge**.

Made with [Cursor](https://cursor.com)