### PR TITLE
fix(registry,control,broker): stop stranded credentials colliding on API re-import (#643)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1213,7 +1213,7 @@
         "filename": "tests/unit/broker/test_execute_credential_name.py",
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_verified": false,
-        "line_number": 54
+        "line_number": 55
       }
     ],
     "tests/unit/broker/test_injection.py": [
@@ -1259,21 +1259,21 @@
         "filename": "tests/unit/broker/test_resolver.py",
         "hashed_secret": "e04133b15878189a4e6286d663fe9cd6efae44da",
         "is_verified": false,
-        "line_number": 81
+        "line_number": 84
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/broker/test_resolver.py",
         "hashed_secret": "5b4c85b89922f2b5abe04d69f4795408ec41b2a6",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 109
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/broker/test_resolver.py",
         "hashed_secret": "c346f766f6b424c3f23b40bfbaaa0cc07134ed6c",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 119
       }
     ],
     "tests/unit/conftest.py": [
@@ -1553,5 +1553,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-13T14:22:38Z"
+  "generated_at": "2026-07-21T15:23:55Z"
 }

--- a/docs/credentials-and-toolkits.md
+++ b/docs/credentials-and-toolkits.md
@@ -1,0 +1,51 @@
+# Credentials and toolkits
+
+How stored credentials relate to the APIs they authenticate and the toolkits
+that expose them, and the invariants the platform enforces to keep credential
+resolution unambiguous.
+
+## Model
+
+- A **credential** stores the secret for one API, keyed by the API identity
+  `(api_vendor, api_name, api_version)` (control DB, `credentials`).
+- A **toolkit** groups the credentials an agent may use. A
+  **toolkit-credential binding** (`toolkit_credential_bindings`) associates a
+  toolkit with a credential.
+- At execution time the Broker resolves the **single active** credential for the
+  requested API and injects its secret — the secret never reaches the agent.
+
+Registry (the `apis` table) and Control (`credentials`,
+`toolkit_credential_bindings`) are **separate databases** with no foreign key
+between them; the link is the API identity tuple carried on the credential.
+
+## Invariant: one active credential per API within a toolkit
+
+Within a single toolkit there is **at most one active credential per API
+identity**. Two active credentials for the same API in the same toolkit make
+resolution ambiguous — the Broker cannot tell which secret to inject, so it
+refuses with `409 ambiguous_credential`. The platform prevents that state at
+bind time: binding a second active credential for an API a toolkit already
+covers is rejected with `409 conflicting_api_binding`. Unbind the existing
+credential first to replace it.
+
+A credential may be **reused across toolkits** (e.g. a broad read-only key in
+one toolkit and a scoped key in another) — the one-per-API rule is scoped to a
+single toolkit, not global.
+
+## Deleting an API deactivates its credentials
+
+Because the two databases share no referential integrity, deleting an API from
+the registry does not delete the control-plane credentials that reference it.
+To avoid stranding them — a later re-import plus a new credential would collide
+with `409 ambiguous_credential` — the API delete **deactivates** the matching
+credentials (`active = false`). The rows are preserved (the operator can still
+see and rotate them) but no longer participate in resolution, so a re-import
+starts clean.
+
+## When ambiguity is genuinely surfaced
+
+If two active credentials for one API are ever resolved (the loud, correct
+refusal), the `409 ambiguous_credential` body lists the candidates so the caller
+can pick which to remove. Each candidate carries `id`, `name`, `last4` (the tail
+of the non-secret credential id — never the secret), and `created_at`, so two
+similarly-named credentials remain distinguishable.

--- a/src/jentic_one/broker/services/credentials/errors.py
+++ b/src/jentic_one/broker/services/credentials/errors.py
@@ -2,6 +2,25 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class CredentialCandidate(BaseModel):
+    """A distinguishable ambiguity candidate for a 409 body (issue #643).
+
+    Bare names collide when two credentials share a name, so a candidate also
+    carries its stable ``id``, a ``last4`` display hint (last four chars of the
+    id — never the secret), and ``created_at`` so an operator/agent can tell the
+    two apart and pick which to remove.
+    """
+
+    id: str
+    name: str
+    last4: str
+    created_at: datetime | None = None
+
 
 class CredentialResolutionError(Exception):
     """Base for all credential resolution errors."""
@@ -26,7 +45,7 @@ class AmbiguousCredentialError(CredentialResolutionError):
         name: str,
         version: str,
         count: int,
-        candidates: list[str] | None = None,
+        candidates: list[CredentialCandidate] | None = None,
     ) -> None:
         super().__init__(
             f"Ambiguous: {count} active credentials match api ({vendor}, {name}, {version})"
@@ -35,18 +54,24 @@ class AmbiguousCredentialError(CredentialResolutionError):
         self.name = name
         self.version = version
         self.count = count
-        self.candidates: list[str] = candidates or []
+        self.candidates: list[CredentialCandidate] = candidates or []
 
 
 class CredentialNameNotFoundError(CredentialResolutionError):
     """The requested credential name does not match any active candidate."""
 
     def __init__(
-        self, vendor: str, name: str, version: str, requested_name: str, candidates: list[str]
+        self,
+        vendor: str,
+        name: str,
+        version: str,
+        requested_name: str,
+        candidates: list[CredentialCandidate],
     ) -> None:
+        candidate_names = [c.name for c in candidates]
         super().__init__(
             f"No credential named '{requested_name}' for api ({vendor}, {name}, {version}); "
-            f"available: {candidates}"
+            f"available: {candidate_names}"
         )
         self.vendor = vendor
         self.name = name

--- a/src/jentic_one/broker/services/credentials/orchestrator.py
+++ b/src/jentic_one/broker/services/credentials/orchestrator.py
@@ -120,13 +120,13 @@ class CredentialService:
             raise InvalidCredentialNameError(
                 detail=str(exc),
                 type="credential_name_not_found",
-                extra={"candidates": exc.candidates},
+                extra={"candidates": [c.model_dump(mode="json") for c in exc.candidates]},
             ) from exc
         except AmbiguousCredentialError as exc:
             raise AmbiguousMatchError(
                 detail=str(exc),
                 type="ambiguous_credential",
-                extra={"candidates": exc.candidates},
+                extra={"candidates": [c.model_dump(mode="json") for c in exc.candidates]},
             ) from exc
         except RefreshInvalidGrantError as exc:
             # Jentic-side auth failure: our OAuth refresh against the token

--- a/src/jentic_one/broker/services/credentials/resolver.py
+++ b/src/jentic_one/broker/services/credentials/resolver.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from jentic_one.broker.services.credentials.errors import (
     AmbiguousCredentialError,
+    CredentialCandidate,
     CredentialNameNotFoundError,
     CredentialNotProvisionedError,
 )
@@ -84,19 +85,19 @@ class CredentialResolver:
             if not matches:
                 raise CredentialNotProvisionedError(api.vendor, api.name, api.version)
 
-            candidate_names = [c.name for c in matches]
+            candidate_objs = [self._to_candidate(c) for c in matches]
 
             if credential_name is not None:
                 filtered = [c for c in matches if c.name == credential_name]
                 if not filtered:
                     raise CredentialNameNotFoundError(
-                        api.vendor, api.name, api.version, credential_name, candidate_names
+                        api.vendor, api.name, api.version, credential_name, candidate_objs
                     )
                 matches = filtered
 
             if len(matches) > 1:
                 raise AmbiguousCredentialError(
-                    api.vendor, api.name, api.version, len(matches), candidates=candidate_names
+                    api.vendor, api.name, api.version, len(matches), candidates=candidate_objs
                 )
 
             credential = matches[0]
@@ -104,6 +105,20 @@ class CredentialResolver:
             wire_type = to_wire(stored_type)
 
             return self._build_resolved(credential, wire_type, stored_type)
+
+    @staticmethod
+    def _to_candidate(credential: Credential) -> CredentialCandidate:
+        """Build a distinguishable ambiguity candidate (issue #643).
+
+        ``last4`` is the tail of the non-secret credential id — never the secret
+        — so two same-named credentials render distinctly in the 409 body.
+        """
+        return CredentialCandidate(
+            id=credential.id,
+            name=credential.name,
+            last4=credential.id[-4:],
+            created_at=credential.created_at,
+        )
 
     def _build_resolved(
         self,

--- a/src/jentic_one/control/repos/toolkit_binding_repo.py
+++ b/src/jentic_one/control/repos/toolkit_binding_repo.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.elements import ColumnElement
 
+from jentic_one.control.core.schema.credentials import Credential
 from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
 
 
@@ -84,6 +85,45 @@ class ToolkitBindingRepository:
             for f in filters:
                 stmt = stmt.where(f)
         stmt = stmt.limit(limit + 1)
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def list_active_bound_credentials_for_api(
+        session: AsyncSession,
+        *,
+        toolkit_id: str,
+        api_vendor: str,
+        api_name: str | None,
+        api_version: str | None,
+        exclude_credential_id: str | None = None,
+    ) -> list[Credential]:
+        """Return active credentials bound to a toolkit that match an API identity.
+
+        Used to prevent binding a second active credential for the same API into
+        one toolkit — a guaranteed-ambiguous state the broker resolver later
+        refuses with ``409`` (issue #643). ``api_name`` / ``api_version`` match
+        exactly when given; a ``None`` component matches any value, mirroring the
+        resolver's identity matching.
+        """
+        stmt = (
+            select(Credential)
+            .join(
+                ToolkitCredentialBinding,
+                ToolkitCredentialBinding.credential_id == Credential.id,
+            )
+            .where(
+                ToolkitCredentialBinding.toolkit_id == toolkit_id,
+                Credential.active.is_(True),
+                Credential.api_vendor == api_vendor,
+            )
+        )
+        if api_name is not None:
+            stmt = stmt.where(Credential.api_name == api_name)
+        if api_version is not None:
+            stmt = stmt.where(Credential.api_version == api_version)
+        if exclude_credential_id is not None:
+            stmt = stmt.where(Credential.id != exclude_credential_id)
         result = await session.execute(stmt)
         return list(result.scalars().all())
 

--- a/src/jentic_one/control/services/toolkits/errors.py
+++ b/src/jentic_one/control/services/toolkits/errors.py
@@ -43,6 +43,38 @@ class DuplicateBindingError(ToolkitServiceError):
         self.credential_id = credential_id
 
 
+class ConflictingApiBindingError(ToolkitServiceError):
+    """Raised when a toolkit already has an active credential for the same API.
+
+    Binding a second active credential for one API into one toolkit produces a
+    guaranteed-ambiguous state that the broker later refuses with ``409``
+    (issue #643). Refuse at bind time instead; the caller can unbind the existing
+    credential (``existing_credential_id``) to replace it.
+    """
+
+    def __init__(
+        self,
+        toolkit_id: str,
+        credential_id: str,
+        existing_credential_id: str,
+        api_vendor: str,
+        api_name: str | None,
+        api_version: str | None,
+    ) -> None:
+        api = f"({api_vendor}, {api_name or ''}, {api_version or ''})"
+        super().__init__(
+            f"Toolkit '{toolkit_id}' already has active credential "
+            f"'{existing_credential_id}' for api {api}; unbind it before binding "
+            f"'{credential_id}'"
+        )
+        self.toolkit_id = toolkit_id
+        self.credential_id = credential_id
+        self.existing_credential_id = existing_credential_id
+        self.api_vendor = api_vendor
+        self.api_name = api_name
+        self.api_version = api_version
+
+
 class KeyAlreadyRevokedError(ToolkitServiceError):
     """Raised when trying to revoke a key that is already revoked."""
 

--- a/src/jentic_one/control/services/toolkits/service.py
+++ b/src/jentic_one/control/services/toolkits/service.py
@@ -9,6 +9,7 @@ from jentic_one.control.core.schema.toolkit_keys import ToolkitKey
 from jentic_one.control.core.schema.toolkit_permission_rules import ToolkitPermissionRule
 from jentic_one.control.core.schema.toolkits import Toolkit
 from jentic_one.control.repos import (
+    CredentialRepository,
     ToolkitBindingRepository,
     ToolkitKeyRepository,
     ToolkitPermissionRepository,
@@ -18,6 +19,7 @@ from jentic_one.control.repos.prerequisite_repo import BoundAgentRow, Prerequisi
 from jentic_one.control.scoping.filters import build_access_filters
 from jentic_one.control.services.toolkits.errors import (
     BindingNotFoundError,
+    ConflictingApiBindingError,
     DuplicateBindingError,
     ToolkitKeyNotFoundError,
     ToolkitNotFoundError,
@@ -436,6 +438,25 @@ class ToolkitService:
             existing = await ToolkitBindingRepository.get(session, toolkit_id, credential_id)
             if existing is not None:
                 raise DuplicateBindingError(toolkit_id, credential_id)
+            credential = await CredentialRepository.get_by_id(session, credential_id)
+            if credential is not None:
+                conflicts = await ToolkitBindingRepository.list_active_bound_credentials_for_api(
+                    session,
+                    toolkit_id=toolkit_id,
+                    api_vendor=credential.api_vendor,
+                    api_name=credential.api_name,
+                    api_version=credential.api_version,
+                    exclude_credential_id=credential_id,
+                )
+                if conflicts:
+                    raise ConflictingApiBindingError(
+                        toolkit_id,
+                        credential_id,
+                        conflicts[0].id,
+                        credential.api_vendor,
+                        credential.api_name,
+                        credential.api_version,
+                    )
             binding = await ToolkitBindingRepository.bind(
                 session, toolkit_id=toolkit_id, credential_id=credential_id, created_by=identity.sub
             )

--- a/src/jentic_one/control/web/errors.py
+++ b/src/jentic_one/control/web/errors.py
@@ -31,6 +31,7 @@ from jentic_one.control.services.credentials.errors import (
 )
 from jentic_one.control.services.toolkits.errors import (
     BindingNotFoundError,
+    ConflictingApiBindingError,
     DuplicateBindingError,
     KeyAlreadyRevokedError,
     ToolkitKeyNotFoundError,
@@ -52,6 +53,7 @@ _TOOLKIT_ERROR_MAP: dict[type[Exception], tuple[int, str]] = {
     ToolkitKeyNotFoundError: (404, "toolkit_key_not_found"),
     BindingNotFoundError: (404, "binding_not_found"),
     DuplicateBindingError: (409, "duplicate_binding"),
+    ConflictingApiBindingError: (409, "conflicting_api_binding"),
     KeyAlreadyRevokedError: (409, "key_already_revoked"),
 }
 

--- a/src/jentic_one/registry/repos/control_credential_boundary_repo.py
+++ b/src/jentic_one/registry/repos/control_credential_boundary_repo.py
@@ -44,13 +44,19 @@ class ControlCredentialBoundaryRepository:
         ``toolkit_credential_bindings`` rows survive (they cascade only on
         credential *deletion*); the deactivated credential simply stops resolving.
         """
+        # CAST the nullable parameters to VARCHAR so Postgres (asyncpg) can
+        # determine their type: a bare bind parameter used only in an
+        # ``:param IS NULL`` test has no inferrable type and asyncpg raises
+        # "could not determine data type of parameter". Standard
+        # ``CAST(x AS VARCHAR)`` (not Postgres-specific ``::text``) keeps the
+        # same statement working on both Postgres and SQLite.
         result = await session.execute(
             text(
                 "UPDATE credentials SET active = false "
                 "WHERE active = true "
                 "AND api_vendor = :api_vendor "
-                "AND (:api_name IS NULL OR api_name = :api_name) "
-                "AND (:api_version IS NULL OR api_version = :api_version)"
+                "AND (CAST(:api_name AS VARCHAR) IS NULL OR api_name = :api_name) "
+                "AND (CAST(:api_version AS VARCHAR) IS NULL OR api_version = :api_version)"
             ),
             {
                 "api_vendor": api_vendor,

--- a/src/jentic_one/registry/repos/control_credential_boundary_repo.py
+++ b/src/jentic_one/registry/repos/control_credential_boundary_repo.py
@@ -1,0 +1,61 @@
+"""Cross-database cleanup of control credentials when a registry API is deleted.
+
+Registry and Control are **separate databases** with no referential integrity
+between ``apis`` and ``credentials`` / ``toolkit_credential_bindings``. When an
+API is deleted from the registry, the control-plane credentials that reference it
+by ``(api_vendor, api_name, api_version)`` are left active — a later re-import
+plus a new credential then collides with ``409 ambiguous_credential`` (issue
+#643).
+
+This repository deactivates those stranded credentials. It uses raw SQL
+(``text()``) so the registry module never imports control ORM models — the same
+boundary pattern as ``control/repos/prerequisite_repo.py`` reading the admin DB.
+It is a registry ``repos/`` file, so it is exempt from the no-direct-DB rule and
+runs against a **control-database** session handed in by the caller.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class ControlCredentialBoundaryRepository:
+    """Deactivates control credentials stranded by a registry API delete.
+
+    Runs against a control-DB session (no control ORM imports). ``api_name`` /
+    ``api_version`` are matched exactly when given; a ``None`` component matches
+    any value, mirroring the broker resolver's identity matching.
+    """
+
+    @staticmethod
+    async def deactivate_credentials_for_api(
+        session: AsyncSession,
+        *,
+        api_vendor: str,
+        api_name: str | None,
+        api_version: str | None,
+    ) -> int:
+        """Mark matching active credentials inactive; return the number changed.
+
+        Marking inactive (rather than deleting) preserves the row — the operator
+        can still see and rotate it — while removing it from the broker
+        resolver's active-match set so a re-import can't collide with it. The
+        ``toolkit_credential_bindings`` rows survive (they cascade only on
+        credential *deletion*); the deactivated credential simply stops resolving.
+        """
+        result = await session.execute(
+            text(
+                "UPDATE credentials SET active = false "
+                "WHERE active = true "
+                "AND api_vendor = :api_vendor "
+                "AND (:api_name IS NULL OR api_name = :api_name) "
+                "AND (:api_version IS NULL OR api_version = :api_version)"
+            ),
+            {
+                "api_vendor": api_vendor,
+                "api_name": api_name,
+                "api_version": api_version,
+            },
+        )
+        return int(result.rowcount)  # type: ignore[attr-defined]

--- a/src/jentic_one/registry/services/api_service.py
+++ b/src/jentic_one/registry/services/api_service.py
@@ -8,9 +8,13 @@ from datetime import datetime
 from typing import Any
 from urllib.parse import urlparse
 
+import structlog
 from pydantic import BaseModel
 
 from jentic_one.registry.repos.api_repo import ApiRepository
+from jentic_one.registry.repos.control_credential_boundary_repo import (
+    ControlCredentialBoundaryRepository,
+)
 from jentic_one.registry.services.errors import ApiNotFoundError, NoCurrentRevisionError
 from jentic_one.registry.web.schemas.apis import (
     SecuritySchemeFlowResponse,
@@ -21,6 +25,8 @@ from jentic_one.shared.audit import AuditAction, AuditTargetType, record_audit_b
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.context import Context
 from jentic_one.shared.pagination import decode_cursor, encode_cursor
+
+logger = structlog.get_logger()
 
 
 class ApiPageItem(BaseModel):
@@ -190,6 +196,8 @@ class ApiService:
                 raise ApiNotFoundError(vendor, name, version)
             await ApiRepository.delete(session, api.id)
 
+        deactivated = await self._deactivate_control_credentials(vendor, name, version)
+
         await record_audit_best_effort(
             self._ctx,
             action=AuditAction.DELETE,
@@ -198,8 +206,37 @@ class ApiService:
             actor_type=identity.actor_type,
             actor_id=identity.sub,
             before={"vendor": vendor, "name": name, "version": version},
+            after={"deactivated_credentials": deactivated},
             origin=identity.origin.value,
         )
+
+    async def _deactivate_control_credentials(self, vendor: str, name: str, version: str) -> int:
+        """Deactivate control credentials stranded by this API delete.
+
+        Cross-DB and best-effort: the registry delete has already committed, and
+        the two databases cannot share a transaction (no 2PC). Deactivating (not
+        deleting) removes the credential from the broker resolver's active-match
+        set so a re-import can't collide with it (issue #643), while preserving
+        the row for the operator to see/rotate. When the deployment topology
+        denies this process control-DB access (registry-only parts mode), there
+        is nothing to reconcile here — skip quietly.
+        """
+        if not self._ctx.is_db_allowed("control"):
+            return 0
+        try:
+            async with self._ctx.control_db.transaction() as session:
+                return await ControlCredentialBoundaryRepository.deactivate_credentials_for_api(
+                    session, api_vendor=vendor, api_name=name, api_version=version
+                )
+        except Exception:
+            logger.warning(
+                "control_credential_deactivation_failed",
+                api_vendor=vendor,
+                api_name=name,
+                api_version=version,
+                exc_info=True,
+            )
+            return 0
 
     async def get_security_schemes(
         self, vendor: str, name: str, version: str

--- a/tests/integration/broker/test_credential_service.py
+++ b/tests/integration/broker/test_credential_service.py
@@ -179,6 +179,10 @@ async def test_ambiguous_credential_maps_to_409(
             api_vendor=_VENDOR, api_name=_API_NAME, api_version=_API_VERSION, identity=_IDENTITY
         )
     assert exc.value.type == "ambiguous_credential"
+    candidates = exc.value.extra["candidates"]
+    assert {c["id"] for c in candidates} == {"cred_a", "cred_b"}
+    assert {c["last4"] for c in candidates} == {"ed_a", "ed_b"}
+    assert all("name" in c and "created_at" in c for c in candidates)
 
 
 async def test_resolve_oauth2_credential_eager_loads_token(

--- a/tests/integration/control/test_toolkit_bind_api_conflict.py
+++ b/tests/integration/control/test_toolkit_bind_api_conflict.py
@@ -1,0 +1,145 @@
+"""Integration tests for bind-time API conflict prevention (issue #643).
+
+Binding a second *active* credential for the same API identity into one toolkit
+produces a guaranteed-ambiguous state that the broker resolver later refuses with
+``409``. ``ToolkitService.bind_credential`` refuses it up front with
+``ConflictingApiBindingError`` so the operator resolves it at bind time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy import delete
+
+from jentic_one.control.core.schema.credentials import Credential
+from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
+from jentic_one.control.core.schema.toolkits import Toolkit
+from jentic_one.control.services.toolkits.errors import ConflictingApiBindingError
+from jentic_one.control.services.toolkits.service import ToolkitService
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.context import Context
+from jentic_one.shared.db.ids import generate_ksuid
+from jentic_one.shared.db.session import DatabaseSession
+from jentic_one.shared.models import ActorType
+
+pytestmark = pytest.mark.integration
+
+_VENDOR = "acme643-bind.com"
+_IDENTITY = Identity(sub="usr_test", actor_type=ActorType.USER, permissions=["org:admin"])
+
+
+@pytest.fixture()
+async def clean_tables(control_db: DatabaseSession) -> AsyncGenerator[None, None]:
+    async def _truncate() -> None:
+        async with control_db.session() as session:
+            await session.execute(delete(ToolkitCredentialBinding))
+            await session.execute(delete(Credential).where(Credential.api_vendor == _VENDOR))
+            await session.execute(delete(Toolkit).where(Toolkit.name.like("tk643-%")))
+            await session.commit()
+
+    await _truncate()
+    yield
+    await _truncate()
+
+
+async def _seed_toolkit(control_db: DatabaseSession, name: str) -> str:
+    toolkit = Toolkit(name=name)
+    async with control_db.session() as session:
+        session.add(toolkit)
+        await session.flush()
+        tk_id = toolkit.id
+        await session.commit()
+    return tk_id
+
+
+async def _seed_credential(
+    control_db: DatabaseSession,
+    *,
+    cred_id: str,
+    api_name: str | None,
+    api_version: str | None,
+    active: bool = True,
+) -> str:
+    credential = Credential(
+        id=cred_id,
+        type="token_value",
+        name=f"cred-{cred_id}",
+        api_vendor=_VENDOR,
+        api_name=api_name,
+        api_version=api_version,
+        active=active,
+    )
+    async with control_db.session() as session:
+        session.add(credential)
+        await session.commit()
+    return cred_id
+
+
+async def _bind_directly(control_db: DatabaseSession, tk_id: str, cred_id: str) -> None:
+    async with control_db.session() as session:
+        session.add(
+            ToolkitCredentialBinding(
+                id=generate_ksuid("tcb"), toolkit_id=tk_id, credential_id=cred_id
+            )
+        )
+        await session.commit()
+
+
+async def test_bind_second_credential_for_same_api_conflicts(
+    integration_context: Context,
+    control_db: DatabaseSession,
+    clean_tables: None,
+) -> None:
+    """A toolkit already bound to an active credential for the API refuses a second."""
+    tk_id = await _seed_toolkit(control_db, "tk643-conflict")
+    await _seed_credential(control_db, cred_id="cred_first", api_name="pets", api_version="v1")
+    await _seed_credential(control_db, cred_id="cred_second", api_name="pets", api_version="v1")
+    await _bind_directly(control_db, tk_id, "cred_first")
+
+    svc = ToolkitService(integration_context)
+    with pytest.raises(ConflictingApiBindingError) as exc:
+        await svc.bind_credential(tk_id, "cred_second", identity=_IDENTITY)
+
+    assert exc.value.existing_credential_id == "cred_first"
+
+
+async def test_bind_credential_for_different_api_allowed(
+    integration_context: Context,
+    control_db: DatabaseSession,
+    clean_tables: None,
+) -> None:
+    """A credential for a different API version does not conflict."""
+    tk_id = await _seed_toolkit(control_db, "tk643-ok")
+    await _seed_credential(control_db, cred_id="cred_v1", api_name="pets", api_version="v1")
+    await _seed_credential(control_db, cred_id="cred_v2", api_name="pets", api_version="v2")
+    await _bind_directly(control_db, tk_id, "cred_v1")
+
+    svc = ToolkitService(integration_context)
+    binding = await svc.bind_credential(tk_id, "cred_v2", identity=_IDENTITY)
+
+    assert binding.credential_id == "cred_v2"
+
+
+async def test_bind_credential_when_existing_is_inactive_allowed(
+    integration_context: Context,
+    control_db: DatabaseSession,
+    clean_tables: None,
+) -> None:
+    """A *deactivated* credential for the same API does not block a new binding.
+
+    This is exactly the post-API-delete state (issue #643): the stranded
+    credential is inactive, so re-binding a fresh active credential must succeed.
+    """
+    tk_id = await _seed_toolkit(control_db, "tk643-inactive")
+    await _seed_credential(
+        control_db, cred_id="cred_stale", api_name="pets", api_version="v1", active=False
+    )
+    await _seed_credential(control_db, cred_id="cred_fresh", api_name="pets", api_version="v1")
+    await _bind_directly(control_db, tk_id, "cred_stale")
+
+    svc = ToolkitService(integration_context)
+    binding = await svc.bind_credential(tk_id, "cred_fresh", identity=_IDENTITY)
+
+    assert binding.credential_id == "cred_fresh"

--- a/tests/integration/registry/services/test_api_delete_credential_cleanup.py
+++ b/tests/integration/registry/services/test_api_delete_credential_cleanup.py
@@ -1,0 +1,118 @@
+"""Integration tests for cross-DB credential cleanup on API delete (issue #643).
+
+Deleting an API from the registry must deactivate the control-plane credentials
+that reference it by ``(api_vendor, api_name, api_version)`` — otherwise a later
+re-import plus a new credential collides with ``409 ambiguous_credential`` and
+the stale binding is stranded. Registry and Control are separate databases, so
+the cleanup crosses the boundary via raw SQL (no cross-module ORM import).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy import delete, select
+
+from jentic_one.control.core.schema.credentials import Credential
+from jentic_one.registry.core.schema.apis import Api
+from jentic_one.registry.services.api_service import ApiService
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.context import Context
+from jentic_one.shared.db.session import DatabaseSession
+from jentic_one.shared.models import ActorType, StoredCredentialType
+
+pytestmark = pytest.mark.integration
+
+_VENDOR = "acme643.com"
+_NAME = "pets-api"
+_VERSION = "v1"
+
+_IDENTITY = Identity(sub="usr_test", actor_type=ActorType.USER, permissions=["org:admin"])
+
+
+@pytest.fixture()
+async def clean_state(
+    registry_db: DatabaseSession, control_db: DatabaseSession
+) -> AsyncGenerator[None, None]:
+    async def _truncate() -> None:
+        async with registry_db.session() as session:
+            await session.execute(delete(Api).where(Api.vendor == _VENDOR))
+            await session.commit()
+        async with control_db.session() as session:
+            await session.execute(delete(Credential).where(Credential.api_vendor == _VENDOR))
+            await session.commit()
+
+    await _truncate()
+    yield
+    await _truncate()
+
+
+async def _seed_api(registry_db: DatabaseSession) -> None:
+    async with registry_db.session() as session:
+        session.add(Api(vendor=_VENDOR, name=_NAME, version=_VERSION))
+        await session.commit()
+
+
+async def _seed_credential(
+    control_db: DatabaseSession,
+    *,
+    cred_id: str,
+    api_name: str | None = _NAME,
+    api_version: str | None = _VERSION,
+) -> None:
+    async with control_db.session() as session:
+        session.add(
+            Credential(
+                id=cred_id,
+                type=StoredCredentialType.API_KEY,
+                name=f"cred-{cred_id}",
+                api_vendor=_VENDOR,
+                api_name=api_name,
+                api_version=api_version,
+                created_by="usr_test",
+            )
+        )
+        await session.commit()
+
+
+async def _credential_active(control_db: DatabaseSession, cred_id: str) -> bool:
+    async with control_db.session() as session:
+        result = await session.execute(select(Credential).where(Credential.id == cred_id))
+        cred = result.scalar_one()
+        return cred.active
+
+
+async def test_delete_api_deactivates_matching_credential(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    control_db: DatabaseSession,
+    clean_state: None,
+) -> None:
+    """Deleting an API deactivates a control credential for the same identity."""
+    await _seed_api(registry_db)
+    await _seed_credential(control_db, cred_id="cred_match")
+
+    assert await _credential_active(control_db, "cred_match") is True
+
+    await ApiService(integration_context).delete(_VENDOR, _NAME, _VERSION, identity=_IDENTITY)
+
+    assert await _credential_active(control_db, "cred_match") is False
+
+
+async def test_delete_api_leaves_other_apis_credentials_active(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    control_db: DatabaseSession,
+    clean_state: None,
+) -> None:
+    """Only credentials matching the deleted API identity are deactivated."""
+    await _seed_api(registry_db)
+    await _seed_credential(control_db, cred_id="cred_match")
+    await _seed_credential(control_db, cred_id="cred_other_version", api_version="v2")
+
+    await ApiService(integration_context).delete(_VENDOR, _NAME, _VERSION, identity=_IDENTITY)
+
+    assert await _credential_active(control_db, "cred_match") is False
+    # A credential for a different version of the API is untouched.
+    assert await _credential_active(control_db, "cred_other_version") is True

--- a/tests/unit/broker/test_execute_credential_name.py
+++ b/tests/unit/broker/test_execute_credential_name.py
@@ -12,6 +12,7 @@ import pytest
 from jentic_one.broker.core.exceptions import AmbiguousMatchError, InvalidCredentialNameError
 from jentic_one.broker.services.credentials.errors import (
     AmbiguousCredentialError,
+    CredentialCandidate,
     CredentialNameNotFoundError,
 )
 from jentic_one.broker.services.credentials.orchestrator import CredentialService
@@ -139,8 +140,17 @@ async def test_credential_name_forwarded_when_header_present(
 
 @pytest.mark.asyncio
 async def test_ambiguous_response_contains_candidates(monkeypatch: pytest.MonkeyPatch) -> None:
-    """409 from AmbiguousCredentialError includes candidates list in extra."""
-    exc = AmbiguousCredentialError("stripe", "payments", "v1", 2, candidates=["read-only", "admin"])
+    """409 from AmbiguousCredentialError includes distinguishable candidates in extra."""
+    exc = AmbiguousCredentialError(
+        "stripe",
+        "payments",
+        "v1",
+        2,
+        candidates=[
+            CredentialCandidate(id="cred_1", name="shared", last4="ed_1"),
+            CredentialCandidate(id="cred_2", name="shared", last4="ed_2"),
+        ],
+    )
     resolve = AsyncMock(side_effect=exc)
     monkeypatch.setattr(
         "jentic_one.broker.services.credentials.orchestrator.CredentialResolver",
@@ -155,16 +165,26 @@ async def test_ambiguous_response_contains_candidates(monkeypatch: pytest.Monkey
             identity=_IDENTITY,
         )
 
-    assert raised.value.extra["candidates"] == ["read-only", "admin"]
+    candidates = raised.value.extra["candidates"]
+    assert [c["id"] for c in candidates] == ["cred_1", "cred_2"]
+    assert [c["last4"] for c in candidates] == ["ed_1", "ed_2"]
+    assert {c["name"] for c in candidates} == {"shared"}
 
 
 @pytest.mark.asyncio
 async def test_invalid_credential_name_response_contains_candidates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """400 from CredentialNameNotFoundError includes candidates list in extra."""
+    """400 from CredentialNameNotFoundError includes distinguishable candidates in extra."""
     exc = CredentialNameNotFoundError(
-        "stripe", "payments", "v1", "nonexistent", ["read-only", "admin"]
+        "stripe",
+        "payments",
+        "v1",
+        "nonexistent",
+        [
+            CredentialCandidate(id="cred_1", name="read-only", last4="ed_1"),
+            CredentialCandidate(id="cred_2", name="admin", last4="ed_2"),
+        ],
     )
     resolve = AsyncMock(side_effect=exc)
     monkeypatch.setattr(
@@ -181,5 +201,6 @@ async def test_invalid_credential_name_response_contains_candidates(
             credential_name="nonexistent",
         )
 
-    assert raised.value.extra["candidates"] == ["read-only", "admin"]
+    candidates = raised.value.extra["candidates"]
+    assert [c["name"] for c in candidates] == ["read-only", "admin"]
     assert raised.value.type == "credential_name_not_found"

--- a/tests/unit/broker/test_resolver.py
+++ b/tests/unit/broker/test_resolver.py
@@ -20,6 +20,7 @@ from jentic_one.shared.schemas import APIReference
 def _make_credential(
     *,
     cred_id: str = "cred_abc",
+    name: str = "default",
     type: str = "STATIC_BEARER_TOKEN",
     api_vendor: str = "stripe",
     api_name: str | None = "payments",
@@ -30,6 +31,7 @@ def _make_credential(
 ) -> MagicMock:
     cred = MagicMock()
     cred.id = cred_id
+    cred.name = name
     cred.type = type
     cred.api_vendor = api_vendor
     cred.api_name = api_name
@@ -37,6 +39,7 @@ def _make_credential(
     cred.active = active
     cred.provider = provider
     cred.server_variables = server_variables
+    cred.created_at = None
     cred.token_value_credential = None
     cred.customer_api_key = None
     cred.basic_credential = None

--- a/tests/unit/broker/test_resolver_credential_name.py
+++ b/tests/unit/broker/test_resolver_credential_name.py
@@ -37,6 +37,7 @@ def _make_credential(
     cred.active = active
     cred.provider = provider
     cred.server_variables = None
+    cred.created_at = None
     cred.token_value_credential = MagicMock(encrypted_token_value="enc:tok")
     cred.customer_api_key = None
     cred.basic_credential = None
@@ -90,7 +91,9 @@ async def test_multiple_matches_no_header_raises_ambiguous_with_candidates() -> 
     ):
         await CredentialResolver(ctx).resolve(api=api, caller="caller_1")
 
-    assert set(exc.value.candidates) == {"read-only", "admin"}
+    assert {c.name for c in exc.value.candidates} == {"read-only", "admin"}
+    assert {c.id for c in exc.value.candidates} == {"cred_1", "cred_2"}
+    assert all(c.last4 == c.id[-4:] for c in exc.value.candidates)
 
 
 @pytest.mark.asyncio
@@ -134,7 +137,7 @@ async def test_multiple_matches_with_invalid_header_raises_not_found() -> None:
         )
 
     assert exc.value.requested_name == "nonexistent"
-    assert set(exc.value.candidates) == {"read-only", "admin"}
+    assert {c.name for c in exc.value.candidates} == {"read-only", "admin"}
 
 
 @pytest.mark.asyncio
@@ -174,4 +177,4 @@ async def test_single_match_with_non_matching_header_raises_not_found() -> None:
         await CredentialResolver(ctx).resolve(api=api, caller="caller_1", credential_name="staging")
 
     assert exc.value.requested_name == "staging"
-    assert exc.value.candidates == ["production"]
+    assert [c.name for c in exc.value.candidates] == ["production"]


### PR DESCRIPTION
## Summary

Deleting an API used to strand its control-plane credentials: Registry and Control are separate databases with no FK between `apis` and `credentials`/`toolkit_credential_bindings`, so `registry/services/api_service.py:delete` only touched the registry DB and left the referencing credentials active. On a later re-import + a fresh credential the broker resolver (`broker/services/credentials/resolver.py`) then saw >=2 active matches and refused the call with `409 ambiguous_credential` — and the candidates rendered as identical tuples, so nobody could tell which to remove.

This fixes the issue in three coordinated places and keeps the loud 409 refusal.

## Changes

- **registry — cascade the delete (cross-DB, no ORM import).** New `registry/repos/control_credential_boundary_repo.py` (`ControlCredentialBoundaryRepository`) issues a raw-SQL `UPDATE credentials SET active = false` against a **control-DB** session handed in by the caller, matching `(api_vendor, api_name, api_version)` the same way the resolver does. `ApiService.delete` calls it after the registry delete commits; it is best-effort (the two DBs can't share a transaction) and skipped when `ctx.is_db_allowed("control")` is false. Same boundary pattern as `control/repos/prerequisite_repo.py` reading the admin DB — no cross-module ORM import. The delete count is recorded in the existing audit `after`.
- **control — refuse the ambiguity at bind time.** `ToolkitService.bind_credential` now looks up the credential's API identity and, via `ToolkitBindingRepository.list_active_bound_credentials_for_api`, refuses (`ConflictingApiBindingError` -> `409 conflicting_api_binding`) when the toolkit already has an **active** credential for that same API. A *deactivated* credential (the post-delete state) does not block re-binding, so recovery just works.
- **broker — make the 409 candidates distinguishable.** New `CredentialCandidate` model carries `id`, `name`, `last4` (tail of the non-secret credential id — never the secret) and `created_at`. The resolver builds these for ambiguous/name-not-found matches and the orchestrator serialises them into the problem+json `extra.candidates`.
- **docs** — `docs/credentials-and-toolkits.md` documents the one-active-credential-per-API-per-toolkit invariant and the delete/bind/resolve behaviour.

No OpenAPI drift (`make openapi` produced no diff) — the error bodies are generic problem+json.

## Test plan

- [x] `make test-fast` (unit + arch) — 2111 passed
- [x] `make test-integration-sqlite` — 456 passed (Postgres fixture skipped; see note)
- [x] `make lint` (ruff + format + mypy) — clean
- [x] `make openapi` — no diff
- New real-DB integration tests:
  - `tests/integration/registry/services/test_api_delete_credential_cleanup.py` — delete deactivates the matching credential, leaves other-identity credentials active.
  - `tests/integration/control/test_toolkit_bind_api_conflict.py` — second active credential for the same API conflicts; different version allowed; inactive existing credential does not block re-bind.
  - `tests/integration/broker/test_credential_service.py` — 409 body now asserts `id`/`name`/`last4`/`created_at` per candidate.

## Notes

- Ran integration tests on the **SQLite** backend as advised; the shared local Postgres fixture may be in a mixed migration state from other agents, so I did not touch it.
- No migration added — this uses the existing `credentials.active` column, so there is no control-migration chain to reconcile with #721/#722.

Closes #643

Made with [Cursor](https://cursor.com)