### PR TITLE
fix(build): exclude generated src/jentic_one/static from Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,6 +61,12 @@ node_modules/
 **/node_modules/
 ui/dist/
 
+# Generated UI bundle — gitignored build output, never a build input. The wheel
+# force-includes `ui/dist` -> `jentic_one/static` (pyproject.toml), so a stale
+# local `src/jentic_one/static/` copied via `COPY src/ src/` would collide with
+# that force-include and fail the wheel build (issue #654).
+src/jentic_one/static/
+
 # Editors / OS
 .idea/
 .vscode/

--- a/deploy/docker/python-base.Dockerfile
+++ b/deploy/docker/python-base.Dockerfile
@@ -19,6 +19,9 @@ COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 WORKDIR /build
 COPY pyproject.toml uv.lock README.md ./
+# `src/jentic_one/static/` (generated UI bundle) is excluded from the build
+# context via `.dockerignore` — the wheel gets it solely from the force-include
+# of `ui/dist` below, so a stale local copy can't collide with it (issue #654).
 COPY src/ src/
 COPY openapi/ openapi/
 # Built SPA must be present before `uv build` so force-include packages it.


### PR DESCRIPTION
## Summary

Building the app image from a dev checkout that had previously run the UI build failed in the wheel step with:

```
ValueError: A second file is being added to the wheel archive at the same path: `jentic_one/static/apple-touch-icon.png`.
```

A clean checkout built fine — classic "works on CI, fails on my machine".

**Root cause:** `src/jentic_one/static/` is gitignored generated UI output. The wheel force-includes `ui/dist` → `jentic_one/static` (`pyproject.toml`). `.dockerignore` excluded `ui/dist/` but **not** `src/jentic_one/static/`, so `COPY src/ src/` (`deploy/docker/python-base.Dockerfile`) carried a stale local `src/jentic_one/static/` into the build context. hatchling then also force-included the freshly built `ui/dist` at the same target path → duplicate-file error.

## Changes

- **`.dockerignore`**: exclude `src/jentic_one/static/` so the packaged bundle is sourced solely from the `ui/dist` force-include (it's build output, never a build input).
- **`deploy/docker/python-base.Dockerfile`**: comment near `COPY src/ src/` documenting the intentional exclusion.

No behavior change to runtime static serving (`static.py` untouched) — the dev-only `ui/dist` fallback from #652/#727 is unaffected.

## Test plan

Verified locally with Docker 28.1.1, building `--target builder` of `deploy/docker/python-base.Dockerfile`:

- **Stale-static repro (the bug):** created `src/jentic_one/static/{apple-touch-icon.png,index.html,stale-marker.txt}` with dummy contents.
  - **Without the fix** (`.dockerignore` lacking the new line): build fails with the exact `ValueError: A second file is being added ... jentic_one/static/apple-touch-icon.png` from the issue. ✅ reproduced.
  - **With the fix**: build succeeds. ✅
- **Fresh SPA is still packaged:** inspected the built wheel inside the image — `jentic_one/static/` contains the freshly built SPA (real `index.html`, real PNG `apple-touch-icon.png`), and the stale `stale-marker.txt` is **absent**. ✅
- **No regression on clean checkout:** the force-include of `ui/dist` remains the sole source of the packaged bundle.

Squash-merge please.

Closes #654

Made with [Cursor](https://cursor.com)