### PR TITLE
feat(web): serve the onboarding skill over HTTP (#651)

### DIFF
--- a/cli/internal/skillgen/bundled.go
+++ b/cli/internal/skillgen/bundled.go
@@ -9,9 +9,13 @@ import (
 )
 
 // bundledSkill is the canonical "how to use Jentic via the CLI" content shipped
-// in the binary. It is the de-facto source until #277's hosted `GET /skills/*`
-// endpoint exists, and is kept identical to that to-be-hosted markdown so the
-// two never drift.
+// in the binary via go:embed. The very same file is force-included into the
+// backend wheel (see `pyproject.toml` -> `jentic_one/skills/jentic.md`) and
+// served over HTTP at `GET /skills/jentic.md` (alias `GET /SKILL.md`) by
+// `shared/web/skill_router.py`, so a remote agent can fetch the skill from a
+// deployment (issue #651). Because both the embed and the served route read
+// this one committed file, the CLI-embedded copy and the served copy cannot
+// drift; a backend drift-guard test pins that invariant.
 //
 //go:embed content/jentic.md
 var bundledSkill string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,14 +54,22 @@ exclude = ["**/.gitkeep"]
 
 # Bundle OpenAPI specs and the built UI inside the package so they're reachable
 # via importlib.resources.files("jentic_one") / "openapi" and / "static".
+#
+# The onboarding skill is force-included from the *same* physical file the Go
+# CLI embeds (`cli/internal/skillgen/content/jentic.md`), so the served copy and
+# the CLI-embedded copy are byte-for-byte identical and cannot drift. It lands
+# at `jentic_one/skills/jentic.md`, read at runtime via importlib.resources by
+# `shared/web/skill_router.py`.
 [tool.hatch.build.targets.wheel.force-include]
 "openapi" = "jentic_one/openapi"
 "ui/dist" = "jentic_one/static"
+"cli/internal/skillgen/content/jentic.md" = "jentic_one/skills/jentic.md"
 
 [tool.hatch.build.targets.sdist]
 include = [
     "src/jentic_one",
     "openapi",
+    "cli/internal/skillgen/content/jentic.md",
     "README.md",
     "pyproject.toml",
 ]

--- a/src/jentic_one/admin/web/app.py
+++ b/src/jentic_one/admin/web/app.py
@@ -33,6 +33,7 @@ from jentic_one.shared.context import Context
 from jentic_one.shared.db.errors import DatabaseIntegrityError, DatabaseUnavailableError
 from jentic_one.shared.pagination import InvalidCursorError
 from jentic_one.shared.web.app_factory import create_surface_app
+from jentic_one.shared.web.skill_router import get_skill_router
 from jentic_one.shared.web.static import mount_spa
 
 
@@ -60,6 +61,10 @@ def get_routers() -> list[tuple[APIRouter, str, list[str]]]:
         (audit.router, "", []),
         (monitoring.router, "", []),
         (config.router, "", []),
+        # Public, schema-hidden onboarding skill (`GET /skills/jentic.md` +
+        # `/SKILL.md`). Mounted at the root so an agent reaches it at a stable
+        # URL in both standalone and combined deploy modes (issue #651).
+        (get_skill_router(), "", []),
     ]
 
 

--- a/src/jentic_one/shared/web/skill_router.py
+++ b/src/jentic_one/shared/web/skill_router.py
@@ -1,0 +1,121 @@
+"""Public ``GET /skills/jentic.md`` — the onboarding skill served over HTTP.
+
+The onboarding skill (the "how to use Jentic via the CLI" markdown) is embedded
+in the Go CLI via ``//go:embed content/jentic.md`` and written to the local
+device at install time. That only lands the skill on the machine that ran the
+install; a remote agent that can reach the deployment has no first-class way to
+fetch it (issue #651). This router serves the *same* markdown over HTTP so any
+agent reachable to the service reads the exact version the service ships.
+
+**Single source of truth / no drift.** The served bytes come from the *same
+physical file* the CLI embeds — ``cli/internal/skillgen/content/jentic.md``. At
+build time ``pyproject.toml`` force-includes it into the wheel at
+``jentic_one/skills/jentic.md`` (alongside the ``openapi`` / ``static`` bundles),
+so a released service reads it via ``importlib.resources``. In a source checkout
+(editable install, tests) the packaged copy does not exist yet, so we fall back
+to reading the CLI source file directly. Either way there is one committed file,
+so the CLI-embedded and served copies cannot diverge. ``test_skill_router.py``
+adds a belt-and-suspenders drift guard.
+
+Hidden from the OpenAPI schema (``include_in_schema=False``): it is onboarding
+content, not a product API, so it neither advertises in the spec nor requires a
+platform bearer token — an onboarding agent must be able to fetch it before it
+holds any credential.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+from pathlib import Path
+
+from fastapi import APIRouter
+from fastapi.responses import Response
+
+# Path the skill is served at. ``/SKILL.md`` is a convenience alias so an agent
+# can guess the canonical uppercase convention; both return identical bytes.
+SKILL_PATH = "/skills/jentic.md"
+SKILL_ALIAS_PATH = "/SKILL.md"
+
+# Markdown is served as ``text/markdown`` (RFC 7763) with UTF-8 so agents and
+# browsers render it as text rather than downloading it as an octet-stream.
+SKILL_MEDIA_TYPE = "text/markdown; charset=utf-8"
+
+# CLI source file, relative to the repo root, that both the Go embed and (in a
+# source checkout) this router read. Kept in lockstep with the ``force-include``
+# mapping in ``pyproject.toml``.
+_CLI_SKILL_RELPATH = Path("cli/internal/skillgen/content/jentic.md")
+
+_cached_skill: str | None = None
+
+
+def _read_packaged_skill() -> str | None:
+    """Return the force-included skill from the installed wheel, or None.
+
+    Present only in a built wheel (``pyproject.toml`` force-includes the CLI file
+    to ``jentic_one/skills/jentic.md``); absent in a source checkout.
+    """
+    try:
+        resource = importlib.resources.files("jentic_one") / "skills" / "jentic.md"
+    except (ModuleNotFoundError, FileNotFoundError):
+        return None
+    if not resource.is_file():
+        return None
+    return resource.read_text(encoding="utf-8")
+
+
+def _read_source_skill() -> str | None:
+    """Return the CLI source skill from a source checkout, or None.
+
+    Walks up from this module to find the repo root holding the CLI file. Used
+    when running from a source tree (editable install, tests) where the wheel's
+    packaged copy does not exist.
+    """
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / _CLI_SKILL_RELPATH
+        if candidate.is_file():
+            return candidate.read_text(encoding="utf-8")
+    return None
+
+
+def load_skill() -> str:
+    """Load the onboarding skill markdown (cached for the process lifetime).
+
+    Prefers the wheel-packaged copy, falling back to the CLI source file in a
+    checkout. Raises ``FileNotFoundError`` if neither exists, which is a build/
+    packaging error rather than a runtime input problem.
+    """
+    global _cached_skill
+    if _cached_skill is not None:
+        return _cached_skill
+    content = _read_packaged_skill() or _read_source_skill()
+    if content is None:
+        raise FileNotFoundError(
+            "onboarding skill not found: expected the wheel-packaged "
+            "jentic_one/skills/jentic.md or the source cli/internal/skillgen/"
+            "content/jentic.md"
+        )
+    _cached_skill = content
+    return content
+
+
+def get_skill_router() -> APIRouter:
+    """Router exposing the public, schema-hidden onboarding skill."""
+    router = APIRouter()
+
+    async def _serve_skill() -> Response:
+        return Response(content=load_skill(), media_type=SKILL_MEDIA_TYPE)
+
+    router.add_api_route(
+        SKILL_PATH,
+        _serve_skill,
+        methods=["GET"],
+        include_in_schema=False,
+    )
+    router.add_api_route(
+        SKILL_ALIAS_PATH,
+        _serve_skill,
+        methods=["GET"],
+        include_in_schema=False,
+    )
+
+    return router

--- a/tests/unit/shared/web/test_skill_router.py
+++ b/tests/unit/shared/web/test_skill_router.py
@@ -1,0 +1,125 @@
+"""Serving the onboarding skill over HTTP against the real app factories.
+
+Boots the production admin app factories — standalone ``create_app`` and
+``create_combined_app(..., ["admin", ...])`` — and asserts issue #651's
+contract: an agent can fetch the onboarding skill at ``GET /skills/jentic.md``
+(and the ``/SKILL.md`` alias) with a markdown content-type, unauthenticated, in
+both deploy modes; the served bytes are the single source of truth shared with
+the CLI embed and so cannot drift.
+
+No live database is required: ``Context`` is lazy and the app factories don't
+touch the DB at construction; the lifespan (which would connect) is never
+entered (no ``with client:``). This mirrors ``test_static_spa_real_app.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from jentic_one.admin.web.app import create_app as create_admin_app
+from jentic_one.shared.config import AppConfig
+from jentic_one.shared.context import Context
+from jentic_one.shared.web.app_factory import create_combined_app
+from jentic_one.shared.web.skill_router import (
+    SKILL_ALIAS_PATH,
+    SKILL_PATH,
+    load_skill,
+)
+
+# The single committed source of truth the Go CLI embeds via `//go:embed`.
+_CLI_SKILL_FILE = Path("cli/internal/skillgen/content/jentic.md")
+
+
+@pytest.fixture()
+def ctx(sample_config_dict: dict[str, Any]) -> Context:
+    return Context(AppConfig.model_validate(sample_config_dict))
+
+
+def _client(app: FastAPI) -> TestClient:
+    # Never enter the lifespan: no DB connection is made.
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _repo_root() -> Path:
+    """Walk up from this test to the repo root holding the CLI skill file."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / _CLI_SKILL_FILE).is_file():
+            return parent
+    raise AssertionError(f"could not locate {_CLI_SKILL_FILE} above {__file__}")
+
+
+@pytest.fixture()
+def cli_skill_source() -> str:
+    """The exact bytes the Go CLI embeds — the drift-guard reference."""
+    return (_repo_root() / _CLI_SKILL_FILE).read_text(encoding="utf-8")
+
+
+def test_standalone_admin_serves_skill(ctx: Context, cli_skill_source: str) -> None:
+    app = create_admin_app(ctx)
+    client = _client(app)
+
+    resp = client.get(SKILL_PATH)
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "text/markdown; charset=utf-8"
+    assert resp.text == cli_skill_source
+    # It is a real skill, not an empty file or an HTML shell.
+    assert "name: jentic" in resp.text
+    assert "# Using Jentic from the CLI" in resp.text
+
+
+def test_standalone_admin_serves_skill_alias(ctx: Context, cli_skill_source: str) -> None:
+    app = create_admin_app(ctx)
+    client = _client(app)
+
+    resp = client.get(SKILL_ALIAS_PATH)
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "text/markdown; charset=utf-8"
+    assert resp.text == cli_skill_source
+
+
+def test_skill_is_unauthenticated(ctx: Context) -> None:
+    """Onboarding content must be fetchable before an agent holds any token."""
+    app = create_admin_app(ctx)
+    client = _client(app)
+
+    # No Authorization header at all — must still succeed (not 401/403).
+    resp = client.get(SKILL_PATH)
+    assert resp.status_code == 200
+
+
+def test_combined_app_serves_skill(ctx: Context, cli_skill_source: str) -> None:
+    app = create_combined_app(ctx, ["admin", "control", "registry"])
+    client = _client(app)
+
+    for path in (SKILL_PATH, SKILL_ALIAS_PATH):
+        resp = client.get(path)
+        assert resp.status_code == 200, path
+        assert resp.headers["content-type"] == "text/markdown; charset=utf-8", path
+        assert resp.text == cli_skill_source, path
+
+
+def test_skill_excluded_from_openapi_schema(ctx: Context) -> None:
+    """The skill is tooling/onboarding content, not a product API surface."""
+    app = create_combined_app(ctx, ["admin"])
+    client = _client(app)
+
+    spec = client.get("/openapi.json").json()
+    paths = spec.get("paths", {})
+    assert SKILL_PATH not in paths
+    assert SKILL_ALIAS_PATH not in paths
+
+
+def test_served_skill_matches_cli_embedded_source(cli_skill_source: str) -> None:
+    """Drift guard: the served skill is byte-for-byte the CLI-embedded source.
+
+    Both the Go CLI embed and the backend route read the *same* committed file
+    (``cli/internal/skillgen/content/jentic.md``) — packaged into the wheel via
+    ``pyproject.toml`` force-include — so they cannot diverge. This asserts that
+    invariant directly so a future refactor that breaks the wiring fails loudly.
+    """
+    assert load_skill() == cli_skill_source


### PR DESCRIPTION
## Summary

An agent onboarding to Jentic needs the `jentic.md` skill, but it was only embedded in the Go CLI (`//go:embed content/jentic.md`) and written to the local device at install. A remote agent that could reach the deployment had no first-class way to fetch it, and manually-copied copies could drift from the running service. This serves the *same* skill over HTTP so any agent reachable to the deployment reads the exact version the service ships.

## Served URL

- `GET /skills/jentic.md` (canonical)
- `GET /SKILL.md` (alias)

Both return `text/markdown; charset=utf-8`, are **unauthenticated** (an onboarding agent must fetch it before holding any token), and are **schema-hidden** (`include_in_schema=False`) since this is onboarding content, not a product API. Served on the admin surface, so it is reachable at a stable URL in both standalone (`make start-admin`) and combined (`make start-app`) deploy modes.

## Changes

- **`src/jentic_one/shared/web/skill_router.py`** — new public, schema-hidden router serving the onboarding skill (modeled on `reference_router.py`).
- **`src/jentic_one/admin/web/app.py`** — wire the skill router into `get_routers()` (root prefix), so it serves in both standalone and combined modes.
- **`pyproject.toml`** — force-include the *same* file the CLI embeds (`cli/internal/skillgen/content/jentic.md`) into the wheel at `jentic_one/skills/jentic.md` (alongside `openapi`/`static`), plus the sdist. The router reads it via `importlib.resources`, falling back to the CLI source file in a source checkout.
- **`cli/internal/skillgen/bundled.go`** — update the stale comment (the hosted endpoint now exists) to document the shared source of truth.

## Single source of truth / no drift

Both the Go CLI embed and the backend route read **one committed file** (`cli/internal/skillgen/content/jentic.md`). The wheel force-includes that exact file, so the CLI-embedded copy and the served copy are byte-for-byte identical and cannot drift. A drift-guard test pins the invariant directly.

## Test plan

- [x] `test_skill_router.py`: `GET /skills/jentic.md` + `/SKILL.md` return 200 with `text/markdown` content-type and the expected content, in standalone and combined modes.
- [x] Skill route is unauthenticated (fetchable with no `Authorization` header).
- [x] Skill route is excluded from the OpenAPI schema.
- [x] Drift guard: served content == CLI-embedded source file, byte-for-byte.
- [x] `make test-fast` (2117 passed), `make lint` (ruff + mypy clean).
- [x] `make openapi` produces no spec drift (schema-hidden route).
- [x] `cd cli && go build ./... && go test ./...` all pass; `gofmt` clean.
- [x] Built the wheel and verified `jentic_one/skills/jentic.md` is packaged and matches the CLI source.

Please **squash + merge**.

Closes #651

Made with [Cursor](https://cursor.com)