### PR TITLE
feat(control): expose public GET /instance backend-identity endpoint (#702)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -371,7 +371,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 16257
+        "line_number": 16342
       }
     ],
     "release-please-config.json": [
@@ -1609,5 +1609,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-29T15:27:47Z"
+  "generated_at": "2026-07-29T18:11:46Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -371,7 +371,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 16337
+        "line_number": 16312
       }
     ],
     "release-please-config.json": [
@@ -1398,6 +1398,15 @@
         "line_number": 50
       }
     ],
+    "tests/unit/shared/test_instance_identity.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "tests/unit/shared/test_instance_identity.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 168
+      }
+    ],
     "tests/unit/test_config.py": [
       {
         "type": "Secret Keyword",
@@ -1609,5 +1618,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-29T18:11:51Z"
+  "generated_at": "2026-07-29T18:12:02Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -371,7 +371,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 16342
+        "line_number": 16337
       }
     ],
     "release-please-config.json": [
@@ -1609,5 +1609,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-29T18:11:46Z"
+  "generated_at": "2026-07-29T18:11:51Z"
 }

--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -281,6 +281,23 @@ need no request — an approved agent already holds `apis:read` and
 `catalog:import` by default, so just import and search again. Don't file an
 access request for a made-up "catalog read" scope.
 
+**Before concluding "the data is gone", confirm which backend you're on.** If
+APIs, credentials, or toolkits you *know* existed appear missing — or IDs look
+unfamiliar — you may be talking to a **different** backend than you expect. The
+hosted Jentic Cloud (`app.jentic.com`) and a local self-hosted install have
+independent registries and credentials, and the CLI, an agent, or an MCP server
+can each be bound to a different one. Check the backend your base URL serves
+before diagnosing data loss:
+
+```
+curl -s "$(jentic config get base-url 2>/dev/null || echo http://127.0.0.1:8000)/instance"
+```
+
+The unauthenticated `/instance` response reports `backend` (`cloud` / `local` /
+`self-hosted`), `canonical_base_url`, and `host`. If it's not the backend you
+meant to use (e.g. an MCP server still on cloud while you imported locally),
+repoint that client at the right base URL rather than importing/searching again.
+
 ### 4. Inspect the operation's contract
 
 Resolve an operation to its method, path, parameters, and schemas before
@@ -391,9 +408,10 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   just imported "doesn't exist", credentials "disappeared", or operation ids
   from one surface don't resolve on the other. Before concluding anything is
   missing or broken, check where each surface points — `jentic profile list`
-  shows this CLI's `base_url`; ask your operator which backend the MCP
-  server was configured against — and stick to one surface for the whole
-  task.
+  shows this CLI's `base_url`, and `curl -s <base-url>/instance` reports
+  which backend serves it (see "confirm which backend you're on" in step 3);
+  ask your operator which backend the MCP server was configured against —
+  and stick to one surface for the whole task.
 - An `execute` failure is not always an access problem. A DNS or TLS error
   means the **broker target** is misconfigured (see step 5); connection
   refused on a **local** target usually means the instance is **stopped** —

--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -290,14 +290,16 @@ bound to a different one. Check the backend your base URL serves before
 diagnosing data loss:
 
 ```
-curl -s "$(jentic config get base-url 2>/dev/null || echo http://127.0.0.1:8000)/instance"
+jentic profile list        # shows each profile's base_url
+curl -s "<base-url>/instance"   # e.g. http://127.0.0.1:8000/instance on a default local install
 ```
 
 The unauthenticated `/instance` response reports `backend` (`local` / `remote` —
-the install's declared `server.backend`), `canonical_base_url`, and `host`. If
-it's not the backend you meant to use (e.g. an MCP server still on a remote
-backend while you imported locally), repoint that client at the right base URL
-rather than importing/searching again.
+the install's declared `server.backend`), `canonical_base_url`, `host`, and an
+opaque `instance_id` (null when telemetry is off). If it's not the backend you
+meant to use (e.g. an MCP server still on a remote backend while you imported
+locally), repoint that client at the right base URL rather than
+importing/searching again.
 
 ### 4. Inspect the operation's contract
 

--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -283,20 +283,21 @@ access request for a made-up "catalog read" scope.
 
 **Before concluding "the data is gone", confirm which backend you're on.** If
 APIs, credentials, or toolkits you *know* existed appear missing — or IDs look
-unfamiliar — you may be talking to a **different** backend than you expect. The
-hosted Jentic Cloud (`app.jentic.com`) and a local self-hosted install have
-independent registries and credentials, and the CLI, an agent, or an MCP server
-can each be bound to a different one. Check the backend your base URL serves
-before diagnosing data loss:
+unfamiliar — you may be talking to a **different** backend than you expect. A
+hosted (`remote`) Jentic install and a `local` self-hosted one have independent
+registries and credentials, and the CLI, an agent, or an MCP server can each be
+bound to a different one. Check the backend your base URL serves before
+diagnosing data loss:
 
 ```
 curl -s "$(jentic config get base-url 2>/dev/null || echo http://127.0.0.1:8000)/instance"
 ```
 
-The unauthenticated `/instance` response reports `backend` (`cloud` / `local` /
-`self-hosted`), `canonical_base_url`, and `host`. If it's not the backend you
-meant to use (e.g. an MCP server still on cloud while you imported locally),
-repoint that client at the right base URL rather than importing/searching again.
+The unauthenticated `/instance` response reports `backend` (`local` / `remote` —
+the install's declared `server.backend`), `canonical_base_url`, and `host`. If
+it's not the backend you meant to use (e.g. an MCP server still on a remote
+backend while you imported locally), repoint that client at the right base URL
+rather than importing/searching again.
 
 ### 4. Inspect the operation's contract
 

--- a/config/production.yaml.example
+++ b/config/production.yaml.example
@@ -46,6 +46,10 @@ server:
   host: 0.0.0.0
   port: 8000
   reload: false
+  # Locality label reported by the public GET /instance identity probe:
+  # "local" (default) for a self-hosted install on your own machine/network,
+  # "remote" for a hosted install run elsewhere.
+  # backend: local
 
 apps:
   - registry

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -776,6 +776,17 @@ uv run python -m tools.deploy down                      # Remove the release
 uv run python -m tools.deploy cluster down              # Destroy the cluster
 ```
 
+> **Cloud / local coexistence.** If you self-host alongside the hosted Jentic
+> Cloud (`app.jentic.com`), a client (the `jentic` CLI, an agent, or an MCP
+> server) is bound to exactly one backend via its own config — the two have
+> independent registries and credentials, so a client pointed at the wrong one
+> looks like data loss. Confirm which backend a base URL serves with the
+> unauthenticated identity probe `curl http://localhost:8000/instance` (returns
+> `backend` = `cloud` / `local` / `self-hosted`, plus `canonical_base_url`,
+> `host`, and `instance_id`). To migrate a client to this install, point *its*
+> backend base URL at your local `canonical_base_url` and re-check `/instance`.
+> See [`docs/context-and-config.md`](../docs/context-and-config.md#cloud--local-coexistence-which-backend-am-i-talking-to).
+
 Add `--otel` to `up` to wire app OTel sidecars to the observability stack
 (requires `obs up` first):
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -776,16 +776,17 @@ uv run python -m tools.deploy down                      # Remove the release
 uv run python -m tools.deploy cluster down              # Destroy the cluster
 ```
 
-> **Cloud / local coexistence.** If you self-host alongside the hosted Jentic
-> Cloud (`app.jentic.com`), a client (the `jentic` CLI, an agent, or an MCP
+> **Local / remote coexistence.** If you self-host alongside a hosted Jentic
+> install (e.g. Jentic Cloud), a client (the `jentic` CLI, an agent, or an MCP
 > server) is bound to exactly one backend via its own config — the two have
 > independent registries and credentials, so a client pointed at the wrong one
 > looks like data loss. Confirm which backend a base URL serves with the
 > unauthenticated identity probe `curl http://localhost:8000/instance` (returns
-> `backend` = `cloud` / `local` / `self-hosted`, plus `canonical_base_url`,
-> `host`, and `instance_id`). To migrate a client to this install, point *its*
-> backend base URL at your local `canonical_base_url` and re-check `/instance`.
-> See [`docs/context-and-config.md`](../docs/context-and-config.md#cloud--local-coexistence-which-backend-am-i-talking-to).
+> `backend` = `local` / `remote` — the operator-declared `server.backend`, default
+> `local` — plus `canonical_base_url`, `host`, and `instance_id`). To migrate a
+> client to this install, point *its* backend base URL at your local
+> `canonical_base_url` and re-check `/instance`.
+> See [`docs/context-and-config.md`](../docs/context-and-config.md#local--remote-coexistence-which-backend-am-i-talking-to).
 
 Add `--otel` to `up` to wire app OTel sidecars to the observability stack
 (requires `obs up` first):

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -783,7 +783,8 @@ uv run python -m tools.deploy cluster down              # Destroy the cluster
 > looks like data loss. Confirm which backend a base URL serves with the
 > unauthenticated identity probe `curl http://localhost:8000/instance` (returns
 > `backend` = `local` / `remote` — the operator-declared `server.backend`, default
-> `local` — plus `canonical_base_url`, `host`, and `instance_id`). To migrate a
+> `local` — plus `canonical_base_url`, `host`, and a telemetry-derived opaque
+> `instance_id`, `null` when telemetry is off). To migrate a
 > client to this install, point *its* backend base URL at your local
 > `canonical_base_url` and re-check `/instance`.
 > See [`docs/context-and-config.md`](../docs/context-and-config.md#local--remote-coexistence-which-backend-am-i-talking-to).

--- a/docs/context-and-config.md
+++ b/docs/context-and-config.md
@@ -122,17 +122,19 @@ Autogenerate compares the target database's base metadata (e.g. `RegistryBase.me
 
 `AppConfig.runtime` holds hot-reloadable flags (debug, log_level, maintenance_mode). Use `config.runtime.reload(overrides)` to produce an updated `RuntimeConfig` from a dict of new values.
 
-## Cloud / local coexistence: which backend am I talking to?
+## Local / remote coexistence: which backend am I talking to?
 
-Jentic can run as the hosted **cloud** platform (`app.jentic.com`) or as a
-**local** self-hosted install. A client — the `jentic` CLI, an agent, or an MCP
-server — is pointed at *one* backend via its own configuration. When both are
-live on the same machine it is easy for two clients to disagree: e.g. an MCP
-server still bound to the cloud while the CLI talks to a fresh local install.
-The two backends have independent registries and credentials, so a tool call
-answered by the *other* backend looks like data loss ("APIs disappeared",
-"credentials vanished", ID-format mismatches) when the systems are simply
-different.
+A `jentic-one` install declares its own locality via `server.backend`: `local`
+for a self-hosted install on your own machine/network, or `remote` for a hosted
+install run elsewhere (e.g. Jentic Cloud). It defaults to `local`; the hosted
+platform sets `remote` in its own config. A client — the `jentic` CLI, an agent,
+or an MCP server — is pointed at *one* backend via its own configuration. When a
+local install and a remote one are both reachable it is easy for two clients to
+disagree: e.g. an MCP server still bound to a remote backend while the CLI talks
+to a fresh local install. The two backends have independent registries and
+credentials, so a tool call answered by the *other* backend looks like data loss
+("APIs disappeared", "credentials vanished", ID-format mismatches) when the
+systems are simply different.
 
 ### The `GET /instance` identity probe
 
@@ -154,11 +156,13 @@ curl -s http://127.0.0.1:8000/instance
 }
 ```
 
-- `backend` is a coarse label derived from the canonical host: `cloud` for a
-  `jentic.com` host, `local` for a loopback/private host, else `self-hosted`.
+- `backend` is the operator-declared locality from `server.backend`: `local` (the
+  default) for a self-hosted install on your own machine/network, `remote` for a
+  hosted install run elsewhere. It is a hint for humans/agents, not an
+  authorization signal.
 - `canonical_base_url` / `host` come from `auth.canonical_base_url` (set in
-  `config/local.yaml` to `http://127.0.0.1:8000` for local runs; the cloud is
-  `https://app.jentic.com`). This is the instance describing *itself*, so it is
+  `config/local.yaml` to `http://127.0.0.1:8000` for local runs; a hosted
+  platform sets its own). This is the instance describing *itself*, so it is
   the value to trust over any client-side assumption.
 - `instance_id` is the opaque telemetry instance id when telemetry has resolved
   one (else `null`); it disambiguates two installs that share a host.
@@ -171,9 +175,9 @@ at the wrong backend.
 
 The per-response backend field is added by the external Jentic MCP server; the
 `jentic-one` side of the contract is the `/instance` endpoint above. To move an
-MCP server (or the CLI) from cloud to a local install, update *that client's*
-backend base URL to your local `canonical_base_url` (e.g.
+MCP server (or the CLI) from a remote backend to a local install, update *that
+client's* backend base URL to your local `canonical_base_url` (e.g.
 `http://127.0.0.1:8000`) and re-check with `GET /instance`. `jentic-one` never
-silently resolves to cloud on its own — a client only reaches cloud because it
-is configured to.
+silently resolves to a remote backend on its own — a client only reaches a
+remote backend because it is configured to.
 

--- a/docs/context-and-config.md
+++ b/docs/context-and-config.md
@@ -151,8 +151,7 @@ curl -s http://127.0.0.1:8000/instance
   "backend": "local",
   "canonical_base_url": "http://127.0.0.1:8000",
   "host": "127.0.0.1:8000",
-  "instance_id": "…",
-  "version": "…"
+  "instance_id": "…"
 }
 ```
 

--- a/docs/context-and-config.md
+++ b/docs/context-and-config.md
@@ -121,3 +121,59 @@ Autogenerate compares the target database's base metadata (e.g. `RegistryBase.me
 ## Runtime configuration
 
 `AppConfig.runtime` holds hot-reloadable flags (debug, log_level, maintenance_mode). Use `config.runtime.reload(overrides)` to produce an updated `RuntimeConfig` from a dict of new values.
+
+## Cloud / local coexistence: which backend am I talking to?
+
+Jentic can run as the hosted **cloud** platform (`app.jentic.com`) or as a
+**local** self-hosted install. A client — the `jentic` CLI, an agent, or an MCP
+server — is pointed at *one* backend via its own configuration. When both are
+live on the same machine it is easy for two clients to disagree: e.g. an MCP
+server still bound to the cloud while the CLI talks to a fresh local install.
+The two backends have independent registries and credentials, so a tool call
+answered by the *other* backend looks like data loss ("APIs disappeared",
+"credentials vanished", ID-format mismatches) when the systems are simply
+different.
+
+### The `GET /instance` identity probe
+
+Every `jentic-one` install exposes an unauthenticated backend-identity endpoint
+so any client can confirm which backend it reached before diagnosing missing
+data:
+
+```bash
+curl -s http://127.0.0.1:8000/instance
+```
+
+```json
+{
+  "backend": "local",
+  "canonical_base_url": "http://127.0.0.1:8000",
+  "host": "127.0.0.1:8000",
+  "instance_id": "…",
+  "version": "…"
+}
+```
+
+- `backend` is a coarse label derived from the canonical host: `cloud` for a
+  `jentic.com` host, `local` for a loopback/private host, else `self-hosted`.
+- `canonical_base_url` / `host` come from `auth.canonical_base_url` (set in
+  `config/local.yaml` to `http://127.0.0.1:8000` for local runs; the cloud is
+  `https://app.jentic.com`). This is the instance describing *itself*, so it is
+  the value to trust over any client-side assumption.
+- `instance_id` is the opaque telemetry instance id when telemetry has resolved
+  one (else `null`); it disambiguates two installs that share a host.
+
+To check which backend a given base URL is bound to, hit `/instance` on that
+URL. If the `backend`/`host` is not the one you expected, the client is pointed
+at the wrong backend.
+
+### Repointing an MCP server (or any client) at a local install
+
+The per-response backend field is added by the external Jentic MCP server; the
+`jentic-one` side of the contract is the `/instance` endpoint above. To move an
+MCP server (or the CLI) from cloud to a local install, update *that client's*
+backend base URL to your local `canonical_base_url` (e.g.
+`http://127.0.0.1:8000`) and re-check with `GET /instance`. `jentic-one` never
+silently resolves to cloud on its own — a client only reaches cloud because it
+is configured to.
+

--- a/docs/context-and-config.md
+++ b/docs/context-and-config.md
@@ -162,9 +162,12 @@ curl -s http://127.0.0.1:8000/instance
 - `canonical_base_url` / `host` come from `auth.canonical_base_url` (set in
   `config/local.yaml` to `http://127.0.0.1:8000` for local runs; a hosted
   platform sets its own). This is the instance describing *itself*, so it is
-  the value to trust over any client-side assumption.
-- `instance_id` is the opaque telemetry instance id when telemetry has resolved
-  one (else `null`); it disambiguates two installs that share a host.
+  the value to trust over any client-side assumption. Any userinfo embedded in
+  the configured URL is stripped before echoing.
+- `instance_id` is an opaque digest *derived from* the telemetry instance id
+  (never the id itself). It only disambiguates two installs sharing a host when
+  both have telemetry enabled — it is `null` whenever telemetry has not
+  resolved an id (e.g. telemetry disabled).
 
 To check which backend a given base URL is bound to, hit `/instance` on that
 URL. If the `backend`/`host` is not the one you expected, the client is pointed

--- a/docs/reference/endpoints.json
+++ b/docs/reference/endpoints.json
@@ -1921,6 +1921,21 @@
       "typical_caller": "agent"
     },
     {
+      "actor_types": [],
+      "auth_note": null,
+      "authenticated": false,
+      "group": "Public (unauthenticated)",
+      "implied_scopes": {},
+      "method": "GET",
+      "operation_id": "getInstance",
+      "path": "/instance",
+      "public": true,
+      "required_scopes": [],
+      "summary": "Backend identity",
+      "surface": "instance",
+      "typical_caller": null
+    },
+    {
       "actor_types": [
         "user",
         "agent",
@@ -4496,5 +4511,5 @@
     ],
     "total": 30
   },
-  "total": 152
+  "total": 153
 }

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -27,7 +27,7 @@ Every API endpoint grouped by its **typical caller**, then by surface, annotated
 
 > The grouping and the _Typical caller_ column are an **advisory hint** at who usually calls a route, inferred from the scope family. They are **not** an enforced restriction: access is gated by the **scope**, not the actor kind, so any actor holding the required scope can call the endpoint.
 
-_Total endpoints: **152**._
+_Total endpoints: **153**._
 
 
 ## Agent-facing (typically agent / service-account / toolkit) (31)
@@ -339,7 +339,7 @@ _Total endpoints: **152**._
 | GET | `/users/me` | _any authenticated_ | any | Get current user |
 | POST | `/users/me:change-password` | _any authenticated_ | any | Change own password |
 
-## Public (unauthenticated) (17)
+## Public (unauthenticated) (18)
 
 
 ### `.well-known`
@@ -391,6 +391,12 @@ _Total endpoints: **152**._
 | Method | Path | Scope(s) | Typical caller | Summary |
 |---|---|---|---|---|
 | GET | `/health` | _public — no auth_ | — | Health |
+
+### `instance`
+
+| Method | Path | Scope(s) | Typical caller | Summary |
+|---|---|---|---|---|
+| GET | `/instance` | _public — no auth_ | — | Backend identity |
 
 ### `oauth`
 

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -2318,15 +2318,10 @@ components:
           - type: 'null'
           description: Opaque telemetry instance id if telemetry has resolved one, else null.
           title: Instance Id
-        version:
-          description: Running jentic-one version.
-          title: Version
-          type: string
       required:
       - backend
       - canonical_base_url
       - host
-      - version
       title: InstanceIdentityResponse
       type: object
     IntrospectRequest:

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -2292,6 +2292,43 @@ components:
       - setup_required
       title: HealthResponse
       type: object
+    InstanceIdentityResponse:
+      description: |-
+        Self-describing identity of the backend serving this request.
+
+        A client can compare ``canonical_base_url``/``host`` against where it *thinks*
+        it is pointed to confirm it is talking to the intended backend (e.g. a local
+        install vs. Jentic Cloud) before diagnosing "missing" data.
+      properties:
+        backend:
+          description: 'Coarse backend label derived from the canonical host: ''cloud'' for a jentic.com host, ''local'' for a loopback/private host, else ''self-hosted''.'
+          title: Backend
+          type: string
+        canonical_base_url:
+          description: The instance's own canonical base URL (auth.canonical_base_url); '' if unset.
+          title: Canonical Base Url
+          type: string
+        host:
+          description: Host (with port) parsed from canonical_base_url; '' if unset.
+          title: Host
+          type: string
+        instance_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Opaque telemetry instance id if telemetry has resolved one, else null.
+          title: Instance Id
+        version:
+          description: Running jentic-one version.
+          title: Version
+          type: string
+      required:
+      - backend
+      - canonical_base_url
+      - host
+      - version
+      title: InstanceIdentityResponse
+      type: object
     IntrospectRequest:
       description: Introspection endpoint request (form body).
       properties:
@@ -11551,6 +11588,54 @@ paths:
       summary: Inspect operation
       tags:
       - Inspect
+  /instance:
+    get:
+      description: |-
+        Return this backend's self-describing identity.
+
+        Unauthenticated and dependency-free so any client (an MCP server, the
+        CLI, an agent) can read which backend it is bound to — cloud vs. a local
+        self-hosted install — and label its responses accordingly.
+      operationId: getInstance
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstanceIdentityResponse'
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security: []
+      summary: Backend identity
+      tags:
+      - System
   /jobs:
     get:
       description: List jobs with optional filters.

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -2296,12 +2296,12 @@ components:
       description: |-
         Self-describing identity of the backend serving this request.
 
-        A client can compare ``canonical_base_url``/``host`` against where it *thinks*
-        it is pointed to confirm it is talking to the intended backend (e.g. a local
-        install vs. Jentic Cloud) before diagnosing "missing" data.
+        A client can compare ``backend``/``canonical_base_url``/``host`` against where
+        it *thinks* it is pointed to confirm it is talking to the intended backend
+        (e.g. a local install vs. a remote one) before diagnosing "missing" data.
       properties:
         backend:
-          description: 'Coarse backend label derived from the canonical host: ''cloud'' for a jentic.com host, ''local'' for a loopback/private host, else ''self-hosted''.'
+          description: 'Operator-declared backend locality (server.backend): ''local'' for a self-hosted install on the operator''s own machine/network, ''remote'' for a hosted install run elsewhere. A hint, not an authorization signal; defaults to ''local''.'
           title: Backend
           type: string
         canonical_base_url:
@@ -11594,8 +11594,8 @@ paths:
         Return this backend's self-describing identity.
 
         Unauthenticated and dependency-free so any client (an MCP server, the
-        CLI, an agent) can read which backend it is bound to — cloud vs. a local
-        self-hosted install — and label its responses accordingly.
+        CLI, an agent) can read which backend it is bound to — local vs. a
+        remote install — and label its responses accordingly.
       operationId: getInstance
       responses:
         '200':

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -2302,21 +2302,24 @@ components:
       properties:
         backend:
           description: 'Operator-declared backend locality (server.backend): ''local'' for a self-hosted install on the operator''s own machine/network, ''remote'' for a hosted install run elsewhere. A hint, not an authorization signal; defaults to ''local''.'
+          enum:
+          - local
+          - remote
           title: Backend
           type: string
         canonical_base_url:
-          description: The instance's own canonical base URL (auth.canonical_base_url); '' if unset.
+          description: The instance's own canonical base URL (auth.canonical_base_url), with any userinfo stripped; '' if unset.
           title: Canonical Base Url
           type: string
         host:
-          description: Host (with port) parsed from canonical_base_url; '' if unset.
+          description: Host (and port, when the canonical base URL declares one) parsed from canonical_base_url; '' if unset or unparseable.
           title: Host
           type: string
         instance_id:
           anyOf:
           - type: string
           - type: 'null'
-          description: Opaque telemetry instance id if telemetry has resolved one, else null.
+          description: Opaque digest derived from the telemetry instance id — stable per install, but not the telemetry id itself. Null when telemetry has not resolved an id (e.g. telemetry disabled).
           title: Instance Id
       required:
       - backend
@@ -11599,34 +11602,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/InstanceIdentityResponse'
           description: Successful Response
-        '400':
-          content:
-            application/problem+json:
-              example: *id001
-              schema:
-                $ref: '#/components/schemas/ProblemDetail'
-          description: Bad Request
-        '422':
-          content:
-            application/problem+json:
-              example: *id002
-              schema:
-                $ref: '#/components/schemas/ProblemDetail'
-          description: Unprocessable Entity
-        '500':
-          content:
-            application/problem+json:
-              example: *id003
-              schema:
-                $ref: '#/components/schemas/ProblemDetail'
-          description: Internal Server Error
-        '503':
-          content:
-            application/problem+json:
-              example: *id004
-              schema:
-                $ref: '#/components/schemas/ProblemDetail'
-          description: Service Unavailable
       security: []
       summary: Backend identity
       tags:

--- a/src/jentic_one/broker/web/app.py
+++ b/src/jentic_one/broker/web/app.py
@@ -197,6 +197,7 @@ def create_app(ctx: Context, container: AppContainer | None = None) -> FastAPI:
         routers=_routers(readiness_saturation_threshold=resilience.readiness_saturation_threshold),
         extra_lifespan=broker_lifespan,
         container=container,
+        include_instance_router=False,
     )
     # One admission gate shared by the shedding middleware and the readiness
     # probe (§05 R5.2), so both observe the same in-flight counter.

--- a/src/jentic_one/shared/config.py
+++ b/src/jentic_one/shared/config.py
@@ -766,6 +766,12 @@ class ServerConfig(BaseModel):
     host: str = "0.0.0.0"
     port: int = 8000
     reload: bool = False
+    backend: Literal["local", "remote"] = "local"
+    """Self-declared backend locality surfaced by ``GET /instance``: ``local`` for
+    a self-hosted install on the operator's own machine/network, ``remote`` for a
+    hosted install run elsewhere (e.g. Jentic Cloud). A hint for clients to tell
+    which backend they reached — not an authorization signal. Defaults to
+    ``local``; the hosted platform sets ``remote`` in its own config."""
 
 
 class TelemetryConfig(BaseModel):

--- a/src/jentic_one/shared/web/app_factory.py
+++ b/src/jentic_one/shared/web/app_factory.py
@@ -37,6 +37,7 @@ from jentic_one.shared.tracing import instrument_inbound_app
 from jentic_one.shared.web.agent_discovery import get_agent_discovery_router
 from jentic_one.shared.web.auth import API_KEY_HEADER
 from jentic_one.shared.web.container import AppContainer
+from jentic_one.shared.web.instance_identity import get_instance_router
 from jentic_one.shared.web.openapi_meta import (
     fastapi_metadata_kwargs,
     install_openapi_metadata,
@@ -358,6 +359,7 @@ def create_surface_app(
     routers: Sequence[tuple[APIRouter, str, list[str]]],
     extra_lifespan: Callable[[FastAPI], AbstractAsyncContextManager[None]] | None = None,
     container: AppContainer | None = None,
+    include_instance_router: bool = True,
 ) -> FastAPI:
     """Create a standalone surface FastAPI app with observability wired.
 
@@ -372,6 +374,12 @@ def create_surface_app(
     ``container`` is the DI seam: when omitted the default is used and behavior is
     unchanged. A caller passes its own container to inject a ``Broker`` (stashed on
     ``app.state``) and mount extra routers after the surface's own.
+
+    ``include_instance_router`` mounts the public backend-identity endpoint
+    (``GET /instance``). It defaults to ``True`` for control-plane surfaces; the
+    broker (a data-plane forward proxy whose only public routes are its
+    liveness/readiness probes) passes ``False`` so it never advertises a
+    control-plane identity surface.
     """
     container = container or AppContainer.default(ctx)
 
@@ -427,6 +435,11 @@ def create_surface_app(
     app.include_router(get_agent_discovery_router())
     for router, _prefix, tags in routers:
         app.include_router(router, tags=list(tags), responses=COMMON_ERROR_RESPONSES)
+    # Public, schema-visible backend-identity endpoint so a client (MCP server,
+    # CLI, agent) can tell which backend it is bound to — cloud vs. local. Off
+    # for the broker data plane (its only public routes are its probes).
+    if include_instance_router:
+        app.include_router(get_instance_router(), responses=COMMON_ERROR_RESPONSES)
     for extra_router, extra_prefix, extra_tags in container.extra_routers:
         app.include_router(
             extra_router,
@@ -521,6 +534,10 @@ def create_combined_app(
     # instead of parsing the OpenAPI document). Registered after all surfaces so
     # the reference it builds covers every included route.
     root.include_router(get_reference_router())
+
+    # Public backend-identity endpoint so a client (MCP server, CLI, agent) can
+    # tell which backend it is bound to — cloud vs. a local self-hosted install.
+    root.include_router(get_instance_router(), responses=COMMON_ERROR_RESPONSES)
 
     # Extension point: injected routers/installers mount after all built-in
     # surfaces (append-only; never shadows a built-in route). No-op by default.

--- a/src/jentic_one/shared/web/app_factory.py
+++ b/src/jentic_one/shared/web/app_factory.py
@@ -439,7 +439,9 @@ def create_surface_app(
     # CLI, agent) can tell which backend it is bound to — cloud vs. local. Off
     # for the broker data plane (its only public routes are its probes).
     if include_instance_router:
-        app.include_router(get_instance_router(), responses=COMMON_ERROR_RESPONSES)
+        # No COMMON_ERROR_RESPONSES: a parameterless public GET can't produce
+        # 400/422 (same posture as /health).
+        app.include_router(get_instance_router())
     for extra_router, extra_prefix, extra_tags in container.extra_routers:
         app.include_router(
             extra_router,
@@ -537,7 +539,9 @@ def create_combined_app(
 
     # Public backend-identity endpoint so a client (MCP server, CLI, agent) can
     # tell which backend it is bound to — cloud vs. a local self-hosted install.
-    root.include_router(get_instance_router(), responses=COMMON_ERROR_RESPONSES)
+    # No COMMON_ERROR_RESPONSES: a parameterless public GET can't produce
+    # 400/422 (same posture as /health).
+    root.include_router(get_instance_router())
 
     # Extension point: injected routers/installers mount after all built-in
     # surfaces (append-only; never shadows a built-in route). No-op by default.

--- a/src/jentic_one/shared/web/content/jentic.md
+++ b/src/jentic_one/shared/web/content/jentic.md
@@ -290,14 +290,16 @@ bound to a different one. Check the backend your base URL serves before
 diagnosing data loss:
 
 ```
-curl -s "$(jentic config get base-url 2>/dev/null || echo http://127.0.0.1:8000)/instance"
+jentic profile list        # shows each profile's base_url
+curl -s "<base-url>/instance"   # e.g. http://127.0.0.1:8000/instance on a default local install
 ```
 
 The unauthenticated `/instance` response reports `backend` (`local` / `remote` —
-the install's declared `server.backend`), `canonical_base_url`, and `host`. If
-it's not the backend you meant to use (e.g. an MCP server still on a remote
-backend while you imported locally), repoint that client at the right base URL
-rather than importing/searching again.
+the install's declared `server.backend`), `canonical_base_url`, `host`, and an
+opaque `instance_id` (null when telemetry is off). If it's not the backend you
+meant to use (e.g. an MCP server still on a remote backend while you imported
+locally), repoint that client at the right base URL rather than
+importing/searching again.
 
 ### 4. Inspect the operation's contract
 

--- a/src/jentic_one/shared/web/content/jentic.md
+++ b/src/jentic_one/shared/web/content/jentic.md
@@ -281,6 +281,24 @@ need no request — an approved agent already holds `apis:read` and
 `catalog:import` by default, so just import and search again. Don't file an
 access request for a made-up "catalog read" scope.
 
+**Before concluding "the data is gone", confirm which backend you're on.** If
+APIs, credentials, or toolkits you *know* existed appear missing — or IDs look
+unfamiliar — you may be talking to a **different** backend than you expect. A
+hosted (`remote`) Jentic install and a `local` self-hosted one have independent
+registries and credentials, and the CLI, an agent, or an MCP server can each be
+bound to a different one. Check the backend your base URL serves before
+diagnosing data loss:
+
+```
+curl -s "$(jentic config get base-url 2>/dev/null || echo http://127.0.0.1:8000)/instance"
+```
+
+The unauthenticated `/instance` response reports `backend` (`local` / `remote` —
+the install's declared `server.backend`), `canonical_base_url`, and `host`. If
+it's not the backend you meant to use (e.g. an MCP server still on a remote
+backend while you imported locally), repoint that client at the right base URL
+rather than importing/searching again.
+
 ### 4. Inspect the operation's contract
 
 Resolve an operation to its method, path, parameters, and schemas before
@@ -391,9 +409,10 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   just imported "doesn't exist", credentials "disappeared", or operation ids
   from one surface don't resolve on the other. Before concluding anything is
   missing or broken, check where each surface points — `jentic profile list`
-  shows this CLI's `base_url`; ask your operator which backend the MCP
-  server was configured against — and stick to one surface for the whole
-  task.
+  shows this CLI's `base_url`, and `curl -s <base-url>/instance` reports
+  which backend serves it (see "confirm which backend you're on" in step 3);
+  ask your operator which backend the MCP server was configured against —
+  and stick to one surface for the whole task.
 - An `execute` failure is not always an access problem. A DNS or TLS error
   means the **broker target** is misconfigured (see step 5); connection
   refused on a **local** target usually means the instance is **stopped** —

--- a/src/jentic_one/shared/web/instance_identity.py
+++ b/src/jentic_one/shared/web/instance_identity.py
@@ -1,0 +1,109 @@
+"""Public ``GET /instance`` — a self-describing backend-identity surface.
+
+When the Jentic Cloud platform (``app.jentic.com`` via its MCP server) and a
+local self-hosted install are both live on the same machine, a client (an MCP
+server, the CLI, an agent) can be pointed at either one. Nothing in a normal
+tool response says *which* backend replied, so a caller draws false conclusions
+("APIs disappeared", "credentials vanished") when the two systems are simply
+different backends.
+
+This endpoint gives any client a cheap, unauthenticated way to read the
+identity of the backend it is talking to, so it can label its responses and a
+human/agent can tell cloud from local at a glance. It intentionally exposes only
+non-sensitive identity metadata: the instance's own canonical base URL / host
+(from ``auth.canonical_base_url``) and, when telemetry has resolved one, the
+opaque telemetry ``instance_id``. Both are values the operator already set or
+that the instance advertises about itself — no secrets.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel, Field
+
+from jentic_one import __version__
+from jentic_one.shared.context import Context
+
+INSTANCE_PATH = "/instance"
+
+
+class InstanceIdentityResponse(BaseModel):
+    """Self-describing identity of the backend serving this request.
+
+    A client can compare ``canonical_base_url``/``host`` against where it *thinks*
+    it is pointed to confirm it is talking to the intended backend (e.g. a local
+    install vs. Jentic Cloud) before diagnosing "missing" data.
+    """
+
+    backend: str = Field(
+        description=(
+            "Coarse backend label derived from the canonical host: 'cloud' for a "
+            "jentic.com host, 'local' for a loopback/private host, else 'self-hosted'."
+        )
+    )
+    canonical_base_url: str = Field(
+        description="The instance's own canonical base URL (auth.canonical_base_url); '' if unset."
+    )
+    host: str = Field(description="Host (with port) parsed from canonical_base_url; '' if unset.")
+    instance_id: str | None = Field(
+        default=None,
+        description="Opaque telemetry instance id if telemetry has resolved one, else null.",
+    )
+    version: str = Field(description="Running jentic-one version.")
+
+
+def _classify_backend(host: str) -> str:
+    """Classify a canonical host into a coarse backend label.
+
+    Deliberately conservative: only hosts under ``jentic.com`` are labelled
+    ``cloud``; loopback/private hosts are ``local``; everything else (including an
+    unset host) is ``self-hosted``. The label is a hint for humans/agents, not an
+    authorization signal.
+    """
+    if not host:
+        return "self-hosted"
+    hostname = host.split(":", 1)[0].lower()
+    if hostname == "jentic.com" or hostname.endswith(".jentic.com"):
+        return "cloud"
+    if hostname in {"localhost", "127.0.0.1", "::1"} or hostname.endswith(".local"):
+        return "local"
+    return "self-hosted"
+
+
+def resolve_instance_identity(ctx: Context) -> InstanceIdentityResponse:
+    """Build the backend-identity payload from the live application ``Context``."""
+    canonical_base_url = ctx.config.auth.canonical_base_url or ""
+    host = urlsplit(canonical_base_url).netloc if canonical_base_url else ""
+    return InstanceIdentityResponse(
+        backend=_classify_backend(host),
+        canonical_base_url=canonical_base_url,
+        host=host,
+        instance_id=ctx.instance_id,
+        version=__version__,
+    )
+
+
+def get_instance_router() -> APIRouter:
+    """Router exposing the public backend-identity endpoint (``GET /instance``)."""
+    router = APIRouter()
+
+    @router.get(
+        INSTANCE_PATH,
+        operation_id="getInstance",
+        summary="Backend identity",
+        tags=["System"],
+        response_model=InstanceIdentityResponse,
+    )
+    async def instance(request: Request) -> InstanceIdentityResponse:
+        """Return this backend's self-describing identity.
+
+        Unauthenticated and dependency-free so any client (an MCP server, the
+        CLI, an agent) can read which backend it is bound to — cloud vs. a local
+        self-hosted install — and label its responses accordingly.
+        """
+        ctx: Context = request.app.state.ctx
+        return resolve_instance_identity(ctx)
+
+    return router

--- a/src/jentic_one/shared/web/instance_identity.py
+++ b/src/jentic_one/shared/web/instance_identity.py
@@ -24,7 +24,6 @@ from urllib.parse import urlsplit
 from fastapi import APIRouter, Request
 from pydantic import BaseModel, Field
 
-from jentic_one import __version__
 from jentic_one.shared.context import Context
 
 INSTANCE_PATH = "/instance"
@@ -54,7 +53,6 @@ class InstanceIdentityResponse(BaseModel):
         default=None,
         description="Opaque telemetry instance id if telemetry has resolved one, else null.",
     )
-    version: str = Field(description="Running jentic-one version.")
 
 
 def resolve_instance_identity(ctx: Context) -> InstanceIdentityResponse:
@@ -66,7 +64,6 @@ def resolve_instance_identity(ctx: Context) -> InstanceIdentityResponse:
         canonical_base_url=canonical_base_url,
         host=host,
         instance_id=ctx.instance_id,
-        version=__version__,
     )
 
 

--- a/src/jentic_one/shared/web/instance_identity.py
+++ b/src/jentic_one/shared/web/instance_identity.py
@@ -1,19 +1,20 @@
 """Public ``GET /instance`` — a self-describing backend-identity surface.
 
-When the Jentic Cloud platform (``app.jentic.com`` via its MCP server) and a
-local self-hosted install are both live on the same machine, a client (an MCP
-server, the CLI, an agent) can be pointed at either one. Nothing in a normal
-tool response says *which* backend replied, so a caller draws false conclusions
-("APIs disappeared", "credentials vanished") when the two systems are simply
-different backends.
+When a hosted (``remote``) Jentic install and a ``local`` self-hosted one are
+both reachable from the same machine, a client (an MCP server, the CLI, an
+agent) can be pointed at either one. Nothing in a normal tool response says
+*which* backend replied, so a caller draws false conclusions ("APIs
+disappeared", "credentials vanished") when the two systems are simply different
+backends.
 
 This endpoint gives any client a cheap, unauthenticated way to read the
 identity of the backend it is talking to, so it can label its responses and a
-human/agent can tell cloud from local at a glance. It intentionally exposes only
-non-sensitive identity metadata: the instance's own canonical base URL / host
-(from ``auth.canonical_base_url``) and, when telemetry has resolved one, the
-opaque telemetry ``instance_id``. Both are values the operator already set or
-that the instance advertises about itself — no secrets.
+human/agent can tell local from remote at a glance. It intentionally exposes
+only non-sensitive identity metadata: the operator-declared ``backend`` locality
+(``server.backend``), the instance's own canonical base URL / host (from
+``auth.canonical_base_url``) and, when telemetry has resolved one, the opaque
+telemetry ``instance_id``. All are values the operator already set or that the
+instance advertises about itself — no secrets.
 """
 
 from __future__ import annotations
@@ -32,15 +33,17 @@ INSTANCE_PATH = "/instance"
 class InstanceIdentityResponse(BaseModel):
     """Self-describing identity of the backend serving this request.
 
-    A client can compare ``canonical_base_url``/``host`` against where it *thinks*
-    it is pointed to confirm it is talking to the intended backend (e.g. a local
-    install vs. Jentic Cloud) before diagnosing "missing" data.
+    A client can compare ``backend``/``canonical_base_url``/``host`` against where
+    it *thinks* it is pointed to confirm it is talking to the intended backend
+    (e.g. a local install vs. a remote one) before diagnosing "missing" data.
     """
 
     backend: str = Field(
         description=(
-            "Coarse backend label derived from the canonical host: 'cloud' for a "
-            "jentic.com host, 'local' for a loopback/private host, else 'self-hosted'."
+            "Operator-declared backend locality (server.backend): 'local' for a "
+            "self-hosted install on the operator's own machine/network, 'remote' for "
+            "a hosted install run elsewhere. A hint, not an authorization signal; "
+            "defaults to 'local'."
         )
     )
     canonical_base_url: str = Field(
@@ -54,30 +57,12 @@ class InstanceIdentityResponse(BaseModel):
     version: str = Field(description="Running jentic-one version.")
 
 
-def _classify_backend(host: str) -> str:
-    """Classify a canonical host into a coarse backend label.
-
-    Deliberately conservative: only hosts under ``jentic.com`` are labelled
-    ``cloud``; loopback/private hosts are ``local``; everything else (including an
-    unset host) is ``self-hosted``. The label is a hint for humans/agents, not an
-    authorization signal.
-    """
-    if not host:
-        return "self-hosted"
-    hostname = host.split(":", 1)[0].lower()
-    if hostname == "jentic.com" or hostname.endswith(".jentic.com"):
-        return "cloud"
-    if hostname in {"localhost", "127.0.0.1", "::1"} or hostname.endswith(".local"):
-        return "local"
-    return "self-hosted"
-
-
 def resolve_instance_identity(ctx: Context) -> InstanceIdentityResponse:
     """Build the backend-identity payload from the live application ``Context``."""
     canonical_base_url = ctx.config.auth.canonical_base_url or ""
     host = urlsplit(canonical_base_url).netloc if canonical_base_url else ""
     return InstanceIdentityResponse(
-        backend=_classify_backend(host),
+        backend=ctx.config.server.backend,
         canonical_base_url=canonical_base_url,
         host=host,
         instance_id=ctx.instance_id,
@@ -100,8 +85,8 @@ def get_instance_router() -> APIRouter:
         """Return this backend's self-describing identity.
 
         Unauthenticated and dependency-free so any client (an MCP server, the
-        CLI, an agent) can read which backend it is bound to — cloud vs. a local
-        self-hosted install — and label its responses accordingly.
+        CLI, an agent) can read which backend it is bound to — local vs. a
+        remote install — and label its responses accordingly.
         """
         ctx: Context = request.app.state.ctx
         return resolve_instance_identity(ctx)

--- a/src/jentic_one/shared/web/instance_identity.py
+++ b/src/jentic_one/shared/web/instance_identity.py
@@ -11,22 +11,31 @@ This endpoint gives any client a cheap, unauthenticated way to read the
 identity of the backend it is talking to, so it can label its responses and a
 human/agent can tell local from remote at a glance. It intentionally exposes
 only non-sensitive identity metadata: the operator-declared ``backend`` locality
-(``server.backend``), the instance's own canonical base URL / host (from
-``auth.canonical_base_url``) and, when telemetry has resolved one, the opaque
-telemetry ``instance_id``. All are values the operator already set or that the
-instance advertises about itself — no secrets.
+(``server.backend``) and the instance's own canonical base URL / host (from
+``auth.canonical_base_url``, with any userinfo stripped before echoing). The
+``instance_id`` is a one-way digest *derived from* the telemetry instance id —
+distinct installs get distinct values, but the durable telemetry identifier
+itself is never published.
 """
 
 from __future__ import annotations
 
-from urllib.parse import urlsplit
+import hashlib
+from typing import Literal
+from urllib.parse import urlsplit, urlunsplit
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
 from jentic_one.shared.context import Context
+from jentic_one.shared.web.deps import get_ctx
 
 INSTANCE_PATH = "/instance"
+
+# Domain-separation prefix so the published digest can't double as a lookup key
+# into anything else keyed by the raw telemetry instance id.
+_INSTANCE_ID_DIGEST_PREFIX = "jentic-instance-identity:"
+_INSTANCE_ID_DIGEST_LENGTH = 16
 
 
 class InstanceIdentityResponse(BaseModel):
@@ -37,7 +46,7 @@ class InstanceIdentityResponse(BaseModel):
     (e.g. a local install vs. a remote one) before diagnosing "missing" data.
     """
 
-    backend: str = Field(
+    backend: Literal["local", "remote"] = Field(
         description=(
             "Operator-declared backend locality (server.backend): 'local' for a "
             "self-hosted install on the operator's own machine/network, 'remote' for "
@@ -46,24 +55,64 @@ class InstanceIdentityResponse(BaseModel):
         )
     )
     canonical_base_url: str = Field(
-        description="The instance's own canonical base URL (auth.canonical_base_url); '' if unset."
+        description=(
+            "The instance's own canonical base URL (auth.canonical_base_url), with "
+            "any userinfo stripped; '' if unset."
+        )
     )
-    host: str = Field(description="Host (with port) parsed from canonical_base_url; '' if unset.")
+    host: str = Field(
+        description=(
+            "Host (and port, when the canonical base URL declares one) parsed from "
+            "canonical_base_url; '' if unset or unparseable."
+        )
+    )
     instance_id: str | None = Field(
         default=None,
-        description="Opaque telemetry instance id if telemetry has resolved one, else null.",
+        description=(
+            "Opaque digest derived from the telemetry instance id — stable per "
+            "install, but not the telemetry id itself. Null when telemetry has not "
+            "resolved an id (e.g. telemetry disabled)."
+        ),
     )
+
+
+def _public_instance_id(instance_id: str | None) -> str | None:
+    """Derive the publishable instance id digest from the telemetry id."""
+    if instance_id is None:
+        return None
+    digest = hashlib.sha256((_INSTANCE_ID_DIGEST_PREFIX + instance_id).encode("utf-8"))
+    return digest.hexdigest()[:_INSTANCE_ID_DIGEST_LENGTH]
+
+
+def _sanitized_url_parts(canonical_base_url: str) -> tuple[str, str]:
+    """Return ``(canonical_base_url, host)`` with any userinfo stripped.
+
+    ``urlsplit().netloc`` retains ``user:password@`` userinfo, so both the echoed
+    URL and the derived host are rebuilt from ``hostname``/``port`` to guarantee
+    credentials embedded in ``auth.canonical_base_url`` are never published.
+    """
+    parts = urlsplit(canonical_base_url)
+    host = parts.hostname or ""
+    if host and parts.port is not None:
+        host = f"{host}:{parts.port}"
+    if parts.username is not None or parts.password is not None:
+        canonical_base_url = urlunsplit(
+            (parts.scheme, host, parts.path, parts.query, parts.fragment)
+        )
+    return canonical_base_url, host
 
 
 def resolve_instance_identity(ctx: Context) -> InstanceIdentityResponse:
     """Build the backend-identity payload from the live application ``Context``."""
     canonical_base_url = ctx.config.auth.canonical_base_url or ""
-    host = urlsplit(canonical_base_url).netloc if canonical_base_url else ""
+    canonical_base_url, host = (
+        _sanitized_url_parts(canonical_base_url) if canonical_base_url else ("", "")
+    )
     return InstanceIdentityResponse(
         backend=ctx.config.server.backend,
         canonical_base_url=canonical_base_url,
         host=host,
-        instance_id=ctx.instance_id,
+        instance_id=_public_instance_id(ctx.instance_id),
     )
 
 
@@ -75,17 +124,15 @@ def get_instance_router() -> APIRouter:
         INSTANCE_PATH,
         operation_id="getInstance",
         summary="Backend identity",
-        tags=["System"],
         response_model=InstanceIdentityResponse,
     )
-    async def instance(request: Request) -> InstanceIdentityResponse:
+    async def instance(ctx: Context = Depends(get_ctx)) -> InstanceIdentityResponse:
         """Return this backend's self-describing identity.
 
         Unauthenticated and dependency-free so any client (an MCP server, the
         CLI, an agent) can read which backend it is bound to — local vs. a
         remote install — and label its responses accordingly.
         """
-        ctx: Context = request.app.state.ctx
         return resolve_instance_identity(ctx)
 
     return router

--- a/src/jentic_one/shared/web/openapi_meta.py
+++ b/src/jentic_one/shared/web/openapi_meta.py
@@ -750,6 +750,8 @@ PUBLIC_OPERATION_IDS: frozenset[str] = frozenset(
     {
         # Health probes (root + per-surface) are dependency-free liveness checks.
         "getHealth",
+        # Backend-identity probe: unauthenticated, self-describing, no secrets.
+        "getInstance",
         "health",
         "controlHealth",
         "adminHealth",
@@ -803,6 +805,7 @@ NON_BEARER_AUTH_OPERATION_IDS: frozenset[str] = frozenset(
 _TAG_RULES: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^/health$"), "System"),
     (re.compile(r"^/[^/]+/health$"), "System"),
+    (re.compile(r"^/instance$"), "System"),
     (re.compile(r"^/admin/config"), "Configuration"),
     (re.compile(r"^/credentials"), "Credentials"),
     (re.compile(r"^/toolkits/[^/]+/keys"), "Toolkit Keys"),

--- a/tests/unit/shared/test_instance_identity.py
+++ b/tests/unit/shared/test_instance_identity.py
@@ -13,7 +13,6 @@ from typing import Any
 
 from fastapi.testclient import TestClient
 
-from jentic_one import __version__
 from jentic_one.broker.web.app import create_app as create_broker_app
 from jentic_one.control.web.app import create_app as create_control_app
 from jentic_one.shared.config import AppConfig
@@ -50,7 +49,6 @@ def test_instance_endpoint_defaults_to_local_backend(sample_config_dict: dict[st
     assert data["backend"] == "local"
     assert data["canonical_base_url"] == "http://127.0.0.1:8000"
     assert data["host"] == "127.0.0.1:8000"
-    assert data["version"] == __version__
     # Telemetry has not resolved an id in this bare app, so it is null.
     assert data["instance_id"] is None
 

--- a/tests/unit/shared/test_instance_identity.py
+++ b/tests/unit/shared/test_instance_identity.py
@@ -1,0 +1,155 @@
+"""Unit tests for the public backend-identity endpoint (``GET /instance``).
+
+The endpoint lets a client (an MCP server, the CLI, an agent) tell which backend
+it is bound to — cloud vs. a local self-hosted install — so it can label its
+responses and avoid mistaking a different backend for data loss (issue #702). It
+reads only config off the live ``Context`` (no DB), so these run as fast units.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from jentic_one import __version__
+from jentic_one.broker.web.app import create_app as create_broker_app
+from jentic_one.control.web.app import create_app as create_control_app
+from jentic_one.shared.config import AppConfig
+from jentic_one.shared.context import Context
+from jentic_one.shared.web.app_factory import create_combined_app
+from jentic_one.shared.web.instance_identity import (
+    InstanceIdentityResponse,
+    resolve_instance_identity,
+)
+
+
+def _ctx(sample_config_dict: dict[str, Any], canonical_base_url: str) -> Context:
+    cfg = dict(sample_config_dict)
+    cfg["auth"] = {**cfg.get("auth", {}), "canonical_base_url": canonical_base_url}
+    return Context(AppConfig.model_validate(cfg))
+
+
+def test_instance_endpoint_reports_local_backend(sample_config_dict: dict[str, Any]) -> None:
+    ctx = _ctx(sample_config_dict, "http://127.0.0.1:8000")
+    client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
+
+    resp = client.get("/instance")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["backend"] == "local"
+    assert data["canonical_base_url"] == "http://127.0.0.1:8000"
+    assert data["host"] == "127.0.0.1:8000"
+    assert data["version"] == __version__
+    # Telemetry has not resolved an id in this bare app, so it is null.
+    assert data["instance_id"] is None
+
+
+def test_instance_endpoint_reports_cloud_backend(sample_config_dict: dict[str, Any]) -> None:
+    ctx = _ctx(sample_config_dict, "https://app.jentic.com")
+    client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
+
+    data = client.get("/instance").json()
+
+    assert data["backend"] == "cloud"
+    assert data["host"] == "app.jentic.com"
+
+
+def test_instance_endpoint_reports_self_hosted_backend(sample_config_dict: dict[str, Any]) -> None:
+    ctx = _ctx(sample_config_dict, "https://jentic.acme.example")
+    client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
+
+    data = client.get("/instance").json()
+
+    assert data["backend"] == "self-hosted"
+    assert data["host"] == "jentic.acme.example"
+
+
+def test_instance_endpoint_unset_base_url_is_self_hosted(
+    sample_config_dict: dict[str, Any],
+) -> None:
+    ctx = _ctx(sample_config_dict, "")
+    client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
+
+    data = client.get("/instance").json()
+
+    assert data["backend"] == "self-hosted"
+    assert data["canonical_base_url"] == ""
+    assert data["host"] == ""
+
+
+def test_instance_endpoint_is_unauthenticated(sample_config_dict: dict[str, Any]) -> None:
+    """No Authorization header is required — it is a public identity probe."""
+    ctx = _ctx(sample_config_dict, "http://127.0.0.1:8000")
+    client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
+
+    assert client.get("/instance").status_code == 200
+
+
+def test_instance_endpoint_present_on_standalone_surface(
+    sample_config_dict: dict[str, Any],
+) -> None:
+    """The identity surface is mounted in standalone surface apps too, not just combined."""
+    ctx = _ctx(sample_config_dict, "http://127.0.0.1:8000")
+    client = TestClient(create_control_app(ctx), raise_server_exceptions=False)
+
+    assert client.get("/instance").status_code == 200
+
+
+def test_instance_endpoint_not_mounted_on_broker(sample_config_dict: dict[str, Any]) -> None:
+    """The broker data plane must not advertise the control-plane identity surface.
+
+    The broker is a forward proxy whose only public routes are its liveness /
+    readiness probes; ``/instance`` belongs to the control plane.
+    """
+    ctx = _ctx(sample_config_dict, "http://127.0.0.1:8000")
+    client = TestClient(create_broker_app(ctx), raise_server_exceptions=False)
+
+    resp = client.get("/instance")
+    # The broker has no /instance route; the path falls through to its auth-gated
+    # forward proxy (401), so it never serves a backend-identity payload.
+    assert resp.status_code != 200
+    assert "backend" not in resp.text
+
+
+def test_instance_endpoint_surfaces_resolved_instance_id(
+    sample_config_dict: dict[str, Any],
+) -> None:
+    ctx = _ctx(sample_config_dict, "http://127.0.0.1:8000")
+    ctx.instance_id = "inst-abc-123"
+    client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
+
+    assert client.get("/instance").json()["instance_id"] == "inst-abc-123"
+
+
+def test_instance_endpoint_hidden_public_in_openapi(sample_config_dict: dict[str, Any]) -> None:
+    """It is a real (schema-visible) route stamped public (no BearerAuth)."""
+    ctx = _ctx(sample_config_dict, "http://127.0.0.1:8000")
+    app = create_combined_app(ctx, ["control"])
+
+    op = app.openapi()["paths"]["/instance"]["get"]
+    assert op["security"] == []
+    assert op["tags"] == ["System"]
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected_backend", "expected_host"),
+    [
+        ("http://localhost:9000", "local", "localhost:9000"),
+        ("http://jentic.local", "local", "jentic.local"),
+        ("https://app.jentic.com/", "cloud", "app.jentic.com"),
+        ("https://jentic.com", "cloud", "jentic.com"),
+    ],
+)
+def test_resolve_instance_identity_classification(
+    sample_config_dict: dict[str, Any],
+    base_url: str,
+    expected_backend: str,
+    expected_host: str,
+) -> None:
+    identity = resolve_instance_identity(_ctx(sample_config_dict, base_url))
+    assert isinstance(identity, InstanceIdentityResponse)
+    assert identity.backend == expected_backend
+    assert identity.host == expected_host

--- a/tests/unit/shared/test_instance_identity.py
+++ b/tests/unit/shared/test_instance_identity.py
@@ -1,16 +1,16 @@
 """Unit tests for the public backend-identity endpoint (``GET /instance``).
 
 The endpoint lets a client (an MCP server, the CLI, an agent) tell which backend
-it is bound to — cloud vs. a local self-hosted install — so it can label its
-responses and avoid mistaking a different backend for data loss (issue #702). It
-reads only config off the live ``Context`` (no DB), so these run as fast units.
+it is bound to — a ``local`` self-hosted install vs. a ``remote`` hosted one — so
+it can label its responses and avoid mistaking a different backend for data loss
+(issue #702). It reads only config off the live ``Context`` (no DB), so these run
+as fast units.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-import pytest
 from fastapi.testclient import TestClient
 
 from jentic_one import __version__
@@ -25,13 +25,21 @@ from jentic_one.shared.web.instance_identity import (
 )
 
 
-def _ctx(sample_config_dict: dict[str, Any], canonical_base_url: str) -> Context:
+def _ctx(
+    sample_config_dict: dict[str, Any],
+    canonical_base_url: str = "http://127.0.0.1:8000",
+    *,
+    backend: str | None = None,
+) -> Context:
     cfg = dict(sample_config_dict)
     cfg["auth"] = {**cfg.get("auth", {}), "canonical_base_url": canonical_base_url}
+    if backend is not None:
+        cfg["server"] = {**cfg.get("server", {}), "backend": backend}
     return Context(AppConfig.model_validate(cfg))
 
 
-def test_instance_endpoint_reports_local_backend(sample_config_dict: dict[str, Any]) -> None:
+def test_instance_endpoint_defaults_to_local_backend(sample_config_dict: dict[str, Any]) -> None:
+    """With no ``server.backend`` set, the instance reports itself as ``local``."""
     ctx = _ctx(sample_config_dict, "http://127.0.0.1:8000")
     client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
 
@@ -47,42 +55,22 @@ def test_instance_endpoint_reports_local_backend(sample_config_dict: dict[str, A
     assert data["instance_id"] is None
 
 
-def test_instance_endpoint_reports_cloud_backend(sample_config_dict: dict[str, Any]) -> None:
-    ctx = _ctx(sample_config_dict, "https://app.jentic.com")
+def test_instance_endpoint_reports_remote_backend(sample_config_dict: dict[str, Any]) -> None:
+    """An operator that declares ``server.backend: remote`` is reported as ``remote``."""
+    ctx = _ctx(sample_config_dict, "https://app.jentic.com", backend="remote")
     client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
 
     data = client.get("/instance").json()
 
-    assert data["backend"] == "cloud"
+    assert data["backend"] == "remote"
+    # canonical_base_url/host are still surfaced independently of the label.
     assert data["host"] == "app.jentic.com"
-
-
-def test_instance_endpoint_reports_self_hosted_backend(sample_config_dict: dict[str, Any]) -> None:
-    ctx = _ctx(sample_config_dict, "https://jentic.acme.example")
-    client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
-
-    data = client.get("/instance").json()
-
-    assert data["backend"] == "self-hosted"
-    assert data["host"] == "jentic.acme.example"
-
-
-def test_instance_endpoint_unset_base_url_is_self_hosted(
-    sample_config_dict: dict[str, Any],
-) -> None:
-    ctx = _ctx(sample_config_dict, "")
-    client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
-
-    data = client.get("/instance").json()
-
-    assert data["backend"] == "self-hosted"
-    assert data["canonical_base_url"] == ""
-    assert data["host"] == ""
+    assert data["canonical_base_url"] == "https://app.jentic.com"
 
 
 def test_instance_endpoint_is_unauthenticated(sample_config_dict: dict[str, Any]) -> None:
     """No Authorization header is required — it is a public identity probe."""
-    ctx = _ctx(sample_config_dict, "http://127.0.0.1:8000")
+    ctx = _ctx(sample_config_dict)
     client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
 
     assert client.get("/instance").status_code == 200
@@ -92,7 +80,7 @@ def test_instance_endpoint_present_on_standalone_surface(
     sample_config_dict: dict[str, Any],
 ) -> None:
     """The identity surface is mounted in standalone surface apps too, not just combined."""
-    ctx = _ctx(sample_config_dict, "http://127.0.0.1:8000")
+    ctx = _ctx(sample_config_dict)
     client = TestClient(create_control_app(ctx), raise_server_exceptions=False)
 
     assert client.get("/instance").status_code == 200
@@ -104,7 +92,7 @@ def test_instance_endpoint_not_mounted_on_broker(sample_config_dict: dict[str, A
     The broker is a forward proxy whose only public routes are its liveness /
     readiness probes; ``/instance`` belongs to the control plane.
     """
-    ctx = _ctx(sample_config_dict, "http://127.0.0.1:8000")
+    ctx = _ctx(sample_config_dict)
     client = TestClient(create_broker_app(ctx), raise_server_exceptions=False)
 
     resp = client.get("/instance")
@@ -117,7 +105,7 @@ def test_instance_endpoint_not_mounted_on_broker(sample_config_dict: dict[str, A
 def test_instance_endpoint_surfaces_resolved_instance_id(
     sample_config_dict: dict[str, Any],
 ) -> None:
-    ctx = _ctx(sample_config_dict, "http://127.0.0.1:8000")
+    ctx = _ctx(sample_config_dict)
     ctx.instance_id = "inst-abc-123"
     client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
 
@@ -126,7 +114,7 @@ def test_instance_endpoint_surfaces_resolved_instance_id(
 
 def test_instance_endpoint_hidden_public_in_openapi(sample_config_dict: dict[str, Any]) -> None:
     """It is a real (schema-visible) route stamped public (no BearerAuth)."""
-    ctx = _ctx(sample_config_dict, "http://127.0.0.1:8000")
+    ctx = _ctx(sample_config_dict)
     app = create_combined_app(ctx, ["control"])
 
     op = app.openapi()["paths"]["/instance"]["get"]
@@ -134,22 +122,23 @@ def test_instance_endpoint_hidden_public_in_openapi(sample_config_dict: dict[str
     assert op["tags"] == ["System"]
 
 
-@pytest.mark.parametrize(
-    ("base_url", "expected_backend", "expected_host"),
-    [
-        ("http://localhost:9000", "local", "localhost:9000"),
-        ("http://jentic.local", "local", "jentic.local"),
-        ("https://app.jentic.com/", "cloud", "app.jentic.com"),
-        ("https://jentic.com", "cloud", "jentic.com"),
-    ],
-)
-def test_resolve_instance_identity_classification(
-    sample_config_dict: dict[str, Any],
-    base_url: str,
-    expected_backend: str,
-    expected_host: str,
-) -> None:
-    identity = resolve_instance_identity(_ctx(sample_config_dict, base_url))
+def test_resolve_instance_identity_defaults_to_local(sample_config_dict: dict[str, Any]) -> None:
+    identity = resolve_instance_identity(_ctx(sample_config_dict, "http://127.0.0.1:8000"))
     assert isinstance(identity, InstanceIdentityResponse)
-    assert identity.backend == expected_backend
-    assert identity.host == expected_host
+    assert identity.backend == "local"
+    assert identity.host == "127.0.0.1:8000"
+
+
+def test_resolve_instance_identity_honours_remote(sample_config_dict: dict[str, Any]) -> None:
+    identity = resolve_instance_identity(
+        _ctx(sample_config_dict, "https://jentic.acme.example", backend="remote")
+    )
+    assert identity.backend == "remote"
+    assert identity.host == "jentic.acme.example"
+
+
+def test_resolve_instance_identity_unset_base_url(sample_config_dict: dict[str, Any]) -> None:
+    identity = resolve_instance_identity(_ctx(sample_config_dict, ""))
+    assert identity.backend == "local"
+    assert identity.canonical_base_url == ""
+    assert identity.host == ""

--- a/tests/unit/shared/test_instance_identity.py
+++ b/tests/unit/shared/test_instance_identity.py
@@ -9,6 +9,7 @@ as fast units.
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any
 
 from fastapi.testclient import TestClient
@@ -100,17 +101,36 @@ def test_instance_endpoint_not_mounted_on_broker(sample_config_dict: dict[str, A
     assert "backend" not in resp.text
 
 
-def test_instance_endpoint_surfaces_resolved_instance_id(
+def test_instance_endpoint_surfaces_resolved_instance_id_as_digest(
     sample_config_dict: dict[str, Any],
 ) -> None:
+    """A resolved telemetry id is published only as a stable one-way digest."""
     ctx = _ctx(sample_config_dict)
     ctx.instance_id = "inst-abc-123"
     client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
 
-    assert client.get("/instance").json()["instance_id"] == "inst-abc-123"
+    published = client.get("/instance").json()["instance_id"]
+
+    expected = hashlib.sha256(b"jentic-instance-identity:inst-abc-123").hexdigest()[:16]
+    assert published == expected
+    # The durable telemetry identifier itself must never appear in the payload.
+    assert published != ctx.instance_id
+    assert ctx.instance_id not in client.get("/instance").text
 
 
-def test_instance_endpoint_hidden_public_in_openapi(sample_config_dict: dict[str, Any]) -> None:
+def test_instance_endpoint_response_has_exactly_the_documented_fields(
+    sample_config_dict: dict[str, Any],
+) -> None:
+    """The contract is exactly four fields — in particular no ``version`` (CWE-200)."""
+    ctx = _ctx(sample_config_dict)
+    client = TestClient(create_combined_app(ctx, ["control"]), raise_server_exceptions=False)
+
+    data = client.get("/instance").json()
+
+    assert set(data) == {"backend", "canonical_base_url", "host", "instance_id"}
+
+
+def test_instance_endpoint_schema_visible_and_public(sample_config_dict: dict[str, Any]) -> None:
     """It is a real (schema-visible) route stamped public (no BearerAuth)."""
     ctx = _ctx(sample_config_dict)
     app = create_combined_app(ctx, ["control"])
@@ -140,3 +160,14 @@ def test_resolve_instance_identity_unset_base_url(sample_config_dict: dict[str, 
     assert identity.backend == "local"
     assert identity.canonical_base_url == ""
     assert identity.host == ""
+
+
+def test_resolve_instance_identity_strips_userinfo(sample_config_dict: dict[str, Any]) -> None:
+    """Credentials embedded in the canonical base URL are never echoed back."""
+    identity = resolve_instance_identity(
+        _ctx(sample_config_dict, "https://user:secret@jentic.acme.example:8443/base")
+    )
+    assert identity.canonical_base_url == "https://jentic.acme.example:8443/base"
+    assert identity.host == "jentic.acme.example:8443"
+    assert "secret" not in identity.canonical_base_url
+    assert "user" not in identity.host

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -397,6 +397,34 @@ def test_broker_jobs_api_base_url_env_override(config_file: Path):
     assert config.broker.jobs_api_base_url == "https://env.example.com"
 
 
+def test_server_backend_defaults_to_local(config_file: Path):
+    config = load_config(config_file)
+    assert config.server.backend == "local"
+
+
+def test_server_backend_from_yaml(tmp_path: Path, sample_config_dict: dict[str, Any]):
+    sample_config_dict["server"] = {"backend": "remote"}
+    path = tmp_path / "cfg.yaml"
+    path.write_text(yaml.dump(sample_config_dict))
+    config = load_config(path)
+    assert config.server.backend == "remote"
+
+
+def test_server_backend_env_override(config_file: Path):
+    env = {"JENTIC__SERVER__BACKEND": "remote"}
+    with patch.dict(os.environ, env, clear=False):
+        config = load_config(config_file)
+    assert config.server.backend == "remote"
+
+
+def test_server_backend_rejects_invalid_value(tmp_path: Path, sample_config_dict: dict[str, Any]):
+    sample_config_dict["server"] = {"backend": "cloud"}
+    path = tmp_path / "cfg.yaml"
+    path.write_text(yaml.dump(sample_config_dict))
+    with pytest.raises(ConfigError):
+        load_config(path)
+
+
 def test_local_yaml_has_valid_encryption_config():
     """config/local.yaml must ship a usable encryption keyset for local dev."""
     local_path = Path(__file__).resolve().parents[2] / "config" / "local.yaml"

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -3627,10 +3627,10 @@
         "type": "object"
       },
       "InstanceIdentityResponse": {
-        "description": "Self-describing identity of the backend serving this request.\n\nA client can compare ``canonical_base_url``/``host`` against where it *thinks*\nit is pointed to confirm it is talking to the intended backend (e.g. a local\ninstall vs. Jentic Cloud) before diagnosing \"missing\" data.",
+        "description": "Self-describing identity of the backend serving this request.\n\nA client can compare ``backend``/``canonical_base_url``/``host`` against where\nit *thinks* it is pointed to confirm it is talking to the intended backend\n(e.g. a local install vs. a remote one) before diagnosing \"missing\" data.",
         "properties": {
           "backend": {
-            "description": "Coarse backend label derived from the canonical host: 'cloud' for a jentic.com host, 'local' for a loopback/private host, else 'self-hosted'.",
+            "description": "Operator-declared backend locality (server.backend): 'local' for a self-hosted install on the operator's own machine/network, 'remote' for a hosted install run elsewhere. A hint, not an authorization signal; defaults to 'local'.",
             "title": "Backend",
             "type": "string"
           },
@@ -21296,7 +21296,7 @@
     },
     "/instance": {
       "get": {
-        "description": "Return this backend's self-describing identity.\n\nUnauthenticated and dependency-free so any client (an MCP server, the\nCLI, an agent) can read which backend it is bound to — cloud vs. a local\nself-hosted install — and label its responses accordingly.",
+        "description": "Return this backend's self-describing identity.\n\nUnauthenticated and dependency-free so any client (an MCP server, the\nCLI, an agent) can read which backend it is bound to — local vs. a\nremote install — and label its responses accordingly.",
         "operationId": "getInstance",
         "responses": {
           "200": {

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -3626,6 +3626,51 @@
         "title": "HealthResponse",
         "type": "object"
       },
+      "InstanceIdentityResponse": {
+        "description": "Self-describing identity of the backend serving this request.\n\nA client can compare ``canonical_base_url``/``host`` against where it *thinks*\nit is pointed to confirm it is talking to the intended backend (e.g. a local\ninstall vs. Jentic Cloud) before diagnosing \"missing\" data.",
+        "properties": {
+          "backend": {
+            "description": "Coarse backend label derived from the canonical host: 'cloud' for a jentic.com host, 'local' for a loopback/private host, else 'self-hosted'.",
+            "title": "Backend",
+            "type": "string"
+          },
+          "canonical_base_url": {
+            "description": "The instance's own canonical base URL (auth.canonical_base_url); '' if unset.",
+            "title": "Canonical Base Url",
+            "type": "string"
+          },
+          "host": {
+            "description": "Host (with port) parsed from canonical_base_url; '' if unset.",
+            "title": "Host",
+            "type": "string"
+          },
+          "instance_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Opaque telemetry instance id if telemetry has resolved one, else null.",
+            "title": "Instance Id"
+          },
+          "version": {
+            "description": "Running jentic-one version.",
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "backend",
+          "canonical_base_url",
+          "host",
+          "version"
+        ],
+        "title": "InstanceIdentityResponse",
+        "type": "object"
+      },
       "IntrospectRequest": {
         "description": "Introspection endpoint request (form body).",
         "properties": {
@@ -21246,6 +21291,103 @@
         "summary": "Inspect operation",
         "tags": [
           "Inspect"
+        ]
+      }
+    },
+    "/instance": {
+      "get": {
+        "description": "Return this backend's self-describing identity.\n\nUnauthenticated and dependency-free so any client (an MCP server, the\nCLI, an agent) can read which backend it is bound to — cloud vs. a local\nself-hosted install — and label its responses accordingly.",
+        "operationId": "getInstance",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstanceIdentityResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The request was malformed or failed a precondition.",
+                  "instance": "/example/path",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "type": "bad_request"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Request validation failed; see errors[] for details.",
+                  "errors": [
+                    {
+                      "detail": "Field 'name' must not be blank.",
+                      "pointer": "#/name"
+                    }
+                  ],
+                  "instance": "/example/path",
+                  "status": 422,
+                  "title": "Unprocessable Entity",
+                  "type": "validation_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "An unexpected error occurred.",
+                  "instance": "/example/path",
+                  "status": 500,
+                  "title": "Internal Server Error",
+                  "type": "server_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The database is temporarily unavailable; please retry.",
+                  "instance": "/example/path",
+                  "status": 503,
+                  "title": "Service Unavailable",
+                  "type": "database_unavailable"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [],
+        "summary": "Backend identity",
+        "tags": [
+          "System"
         ]
       }
     },

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -3655,18 +3655,12 @@
             ],
             "description": "Opaque telemetry instance id if telemetry has resolved one, else null.",
             "title": "Instance Id"
-          },
-          "version": {
-            "description": "Running jentic-one version.",
-            "title": "Version",
-            "type": "string"
           }
         },
         "required": [
           "backend",
           "canonical_base_url",
-          "host",
-          "version"
+          "host"
         ],
         "title": "InstanceIdentityResponse",
         "type": "object"

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -3631,16 +3631,20 @@
         "properties": {
           "backend": {
             "description": "Operator-declared backend locality (server.backend): 'local' for a self-hosted install on the operator's own machine/network, 'remote' for a hosted install run elsewhere. A hint, not an authorization signal; defaults to 'local'.",
+            "enum": [
+              "local",
+              "remote"
+            ],
             "title": "Backend",
             "type": "string"
           },
           "canonical_base_url": {
-            "description": "The instance's own canonical base URL (auth.canonical_base_url); '' if unset.",
+            "description": "The instance's own canonical base URL (auth.canonical_base_url), with any userinfo stripped; '' if unset.",
             "title": "Canonical Base Url",
             "type": "string"
           },
           "host": {
-            "description": "Host (with port) parsed from canonical_base_url; '' if unset.",
+            "description": "Host (and port, when the canonical base URL declares one) parsed from canonical_base_url; '' if unset or unparseable.",
             "title": "Host",
             "type": "string"
           },
@@ -3653,7 +3657,7 @@
                 "type": "null"
               }
             ],
-            "description": "Opaque telemetry instance id if telemetry has resolved one, else null.",
+            "description": "Opaque digest derived from the telemetry instance id — stable per install, but not the telemetry id itself. Null when telemetry has not resolved an id (e.g. telemetry disabled).",
             "title": "Instance Id"
           }
         },
@@ -21302,80 +21306,6 @@
               }
             },
             "description": "Successful Response"
-          },
-          "400": {
-            "content": {
-              "application/problem+json": {
-                "example": {
-                  "detail": "The request was malformed or failed a precondition.",
-                  "instance": "/example/path",
-                  "status": 400,
-                  "title": "Bad Request",
-                  "type": "bad_request"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "422": {
-            "content": {
-              "application/problem+json": {
-                "example": {
-                  "detail": "Request validation failed; see errors[] for details.",
-                  "errors": [
-                    {
-                      "detail": "Field 'name' must not be blank.",
-                      "pointer": "#/name"
-                    }
-                  ],
-                  "instance": "/example/path",
-                  "status": 422,
-                  "title": "Unprocessable Entity",
-                  "type": "validation_error"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          },
-          "500": {
-            "content": {
-              "application/problem+json": {
-                "example": {
-                  "detail": "An unexpected error occurred.",
-                  "instance": "/example/path",
-                  "status": 500,
-                  "title": "Internal Server Error",
-                  "type": "server_error"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Internal Server Error"
-          },
-          "503": {
-            "content": {
-              "application/problem+json": {
-                "example": {
-                  "detail": "The database is temporarily unavailable; please retry.",
-                  "instance": "/example/path",
-                  "status": 503,
-                  "title": "Service Unavailable",
-                  "type": "database_unavailable"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "Service Unavailable"
           }
         },
         "security": [],

--- a/ui/src/shared/api/generated/index.ts
+++ b/ui/src/shared/api/generated/index.ts
@@ -83,7 +83,7 @@ export type { ExecutionResponse } from './models/ExecutionResponse';
 export type { ExecutionStatsResponse } from './models/ExecutionStatsResponse';
 export { GroupBy } from './models/GroupBy';
 export type { HealthResponse } from './models/HealthResponse';
-export type { InstanceIdentityResponse } from './models/InstanceIdentityResponse';
+export { InstanceIdentityResponse } from './models/InstanceIdentityResponse';
 export type { IntrospectRequest } from './models/IntrospectRequest';
 export type { IntrospectResponse } from './models/IntrospectResponse';
 export type { InviteIssuedResponse } from './models/InviteIssuedResponse';

--- a/ui/src/shared/api/generated/index.ts
+++ b/ui/src/shared/api/generated/index.ts
@@ -83,6 +83,7 @@ export type { ExecutionResponse } from './models/ExecutionResponse';
 export type { ExecutionStatsResponse } from './models/ExecutionStatsResponse';
 export { GroupBy } from './models/GroupBy';
 export type { HealthResponse } from './models/HealthResponse';
+export type { InstanceIdentityResponse } from './models/InstanceIdentityResponse';
 export type { IntrospectRequest } from './models/IntrospectRequest';
 export type { IntrospectResponse } from './models/IntrospectResponse';
 export type { InviteIssuedResponse } from './models/InviteIssuedResponse';

--- a/ui/src/shared/api/generated/models/InstanceIdentityResponse.ts
+++ b/ui/src/shared/api/generated/models/InstanceIdentityResponse.ts
@@ -1,0 +1,34 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Self-describing identity of the backend serving this request.
+ *
+ * A client can compare ``backend``/``canonical_base_url``/``host`` against where
+ * it *thinks* it is pointed to confirm it is talking to the intended backend
+ * (e.g. a local install vs. a remote one) before diagnosing "missing" data.
+ */
+export type InstanceIdentityResponse = {
+    /**
+     * Operator-declared backend locality (server.backend): 'local' for a self-hosted install on the operator's own machine/network, 'remote' for a hosted install run elsewhere. A hint, not an authorization signal; defaults to 'local'.
+     */
+    backend: string;
+    /**
+     * The instance's own canonical base URL (auth.canonical_base_url); '' if unset.
+     */
+    canonical_base_url: string;
+    /**
+     * Host (with port) parsed from canonical_base_url; '' if unset.
+     */
+    host: string;
+    /**
+     * Opaque telemetry instance id if telemetry has resolved one, else null.
+     */
+    instance_id?: (string | null);
+    /**
+     * Running jentic-one version.
+     */
+    version: string;
+};
+

--- a/ui/src/shared/api/generated/models/InstanceIdentityResponse.ts
+++ b/ui/src/shared/api/generated/models/InstanceIdentityResponse.ts
@@ -26,9 +26,5 @@ export type InstanceIdentityResponse = {
      * Opaque telemetry instance id if telemetry has resolved one, else null.
      */
     instance_id?: (string | null);
-    /**
-     * Running jentic-one version.
-     */
-    version: string;
 };
 

--- a/ui/src/shared/api/generated/models/InstanceIdentityResponse.ts
+++ b/ui/src/shared/api/generated/models/InstanceIdentityResponse.ts
@@ -13,18 +13,27 @@ export type InstanceIdentityResponse = {
     /**
      * Operator-declared backend locality (server.backend): 'local' for a self-hosted install on the operator's own machine/network, 'remote' for a hosted install run elsewhere. A hint, not an authorization signal; defaults to 'local'.
      */
-    backend: string;
+    backend: InstanceIdentityResponse.backend;
     /**
-     * The instance's own canonical base URL (auth.canonical_base_url); '' if unset.
+     * The instance's own canonical base URL (auth.canonical_base_url), with any userinfo stripped; '' if unset.
      */
     canonical_base_url: string;
     /**
-     * Host (with port) parsed from canonical_base_url; '' if unset.
+     * Host (and port, when the canonical base URL declares one) parsed from canonical_base_url; '' if unset or unparseable.
      */
     host: string;
     /**
-     * Opaque telemetry instance id if telemetry has resolved one, else null.
+     * Opaque digest derived from the telemetry instance id — stable per install, but not the telemetry id itself. Null when telemetry has not resolved an id (e.g. telemetry disabled).
      */
     instance_id?: (string | null);
 };
+export namespace InstanceIdentityResponse {
+    /**
+     * Operator-declared backend locality (server.backend): 'local' for a self-hosted install on the operator's own machine/network, 'remote' for a hosted install run elsewhere. A hint, not an authorization signal; defaults to 'local'.
+     */
+    export enum backend {
+        LOCAL = 'local',
+        REMOTE = 'remote',
+    }
+}
 

--- a/ui/src/shared/api/generated/services/SystemService.ts
+++ b/ui/src/shared/api/generated/services/SystemService.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { HealthResponse } from '../models/HealthResponse';
+import type { InstanceIdentityResponse } from '../models/InstanceIdentityResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -82,6 +83,28 @@ export class SystemService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/health',
+        });
+    }
+    /**
+     * Backend identity
+     * Return this backend's self-describing identity.
+     *
+     * Unauthenticated and dependency-free so any client (an MCP server, the
+     * CLI, an agent) can read which backend it is bound to — local vs. a
+     * remote install — and label its responses accordingly.
+     * @returns InstanceIdentityResponse Successful Response
+     * @throws ApiError
+     */
+    public static getInstance(): CancelablePromise<InstanceIdentityResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/instance',
+            errors: {
+                400: `Bad Request`,
+                422: `Unprocessable Entity`,
+                500: `Internal Server Error`,
+                503: `Service Unavailable`,
+            },
         });
     }
     /**

--- a/ui/src/shared/api/generated/services/SystemService.ts
+++ b/ui/src/shared/api/generated/services/SystemService.ts
@@ -99,12 +99,6 @@ export class SystemService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/instance',
-            errors: {
-                400: `Bad Request`,
-                422: `Unprocessable Entity`,
-                500: `Internal Server Error`,
-                503: `Service Unavailable`,
-            },
         });
     }
     /**


### PR DESCRIPTION
## Summary

When a user has both a hosted (`remote`) Jentic install (e.g. Jentic Cloud) **and** a local self-hosted install reachable at once, MCP tool calls could be silently answered by the other backend with no indication of which one served the request — so "missing" data looked like a bug when it was really a local-vs-remote mismatch.

This adds an explicit, self-describing **backend-identity** surface so any client (an MCP server, the CLI, an agent) can confirm which backend it is bound to before diagnosing missing data.

## Changes

* **New `GET /instance` endpoint** (`src/jentic_one/shared/web/instance_identity.py`): unauthenticated, dependency-free. Returns:
  * `backend` — operator-declared locality from **`server.backend`**: `local` (default) for a self-hosted install on the operator's own machine/network, `remote` for a hosted install run elsewhere. A hint for humans/agents, **not** an authorization signal.
  * `canonical_base_url` — the instance's own `auth.canonical_base_url`, with any userinfo stripped (`""` if unset)
  * `host` — host (and port, when declared) parsed from the canonical base URL
  * `instance_id` — opaque **digest derived from** the telemetry instance id (never the raw durable id), `null` when telemetry has not resolved one
  * *(an earlier revision also returned `version`; it was removed to avoid CWE-200 version fingerprinting)*
* **New config field `server.backend`** (`Literal["local", "remote"]`, default `local`) in `shared/config.py`. Overridable via YAML or `JENTIC__SERVER__BACKEND`. The hosted platform sets `remote` in its own config.
* Mounted on control-plane surfaces via `create_surface_app`/`create_combined_app`; **deliberately not served by the broker data plane** (`create_surface_app(..., include_instance_router=False)`), which only exposes its liveness/readiness probes.
* Marked public + tagged `System` in `openapi_meta.py`; regenerated `openapi/control/control.openapi.yaml`, `ui/openapi.json`, and `docs/reference/endpoints.{json,md}` (the `backend` enum flows into the generated UI client).
* Docs: local/remote coexistence section in `docs/context-and-config.md`, a note in `deploy/README.md`, `server.backend` in `config/production.yaml.example`, and agent guidance in the embedded CLI skill (`cli/internal/skillgen/content/jentic.md`, mirrored to the served copy).

> **Design note:** the label is purely operator-declared (`server.backend`), not derived from the host. An operator who leaves the default on a genuinely remote install reports `local` — the intended cost of dropping host inference, consistent with "hint, not authorization."

### Review-board hardening (pre-merge)

A four-lens review board (security, code quality, product fit, cold-eyes fact check) ran before merge; all findings addressed:

* `instance_id` published as a domain-separated sha256 digest instead of the raw persistent telemetry id (unauthenticated fingerprinting; same rationale as the `version` removal)
* userinfo stripped from the echoed `canonical_base_url`/`host` (credentials in the configured URL can never be published)
* skill doc's probe snippet used a nonexistent CLI command (`jentic config get base-url`) that silently fell back to localhost — replaced with `jentic profile list` + explicit base URL
* `backend` typed as a closed enum end-to-end; handler uses `Depends(get_ctx)`; unreachable 400/422 dropped from the spec (same posture as `/health`)

## Test plan

* `tests/unit/shared/test_instance_identity.py` — covers default-`local`, explicit-`remote`, unset `canonical_base_url`, instance-id digest (raw id never appears in the payload), userinfo stripping, exact four-field contract (no `version` regression), unauthenticated access, standalone + combined mounting, and that the broker does **not** serve `/instance` (real app + `TestClient`, no mocking).
* `tests/unit/test_config.py` — `server.backend` default/YAML/env-override/invalid-value.
* `make test-fast` (incl. arch/endpoint-classification + skill-drift guards) passes.
* `make lint` (ruff + mypy) clean
* `make openapi` / endpoint reference / UI client regenerated with no unexpected drift
* `cd cli && go build ./... && go test ./internal/skillgen/...` passes (embedded skill content)

## Follow-ups (tracked, not this PR)

* Hosted platform must set `server.backend: remote` in its own config — until then cloud reports `local`
* Per-response backend field in the external Jentic MCP server (issue #702's suggestion #1)
* `/health` still returns `__version__` unauthenticated — same CWE-200 concern this PR fixed for `/instance`
* UI could surface "you are on `host`, backend `local`" from the already-generated client

Closes #702

Made with [Cursor](https://cursor.com)
