### PR TITLE
feat(auth): invite-redemption page for finishing account creation

### DIFF
--- a/docker/local-setup/docker-compose.yaml
+++ b/docker/local-setup/docker-compose.yaml
@@ -6,7 +6,9 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
-      - "5432:5432"
+      # Host-published port is overridable (e.g. to avoid a native Postgres on
+      # 5432); the in-container port stays 5432. Set JENTIC_PG_PORT to change it.
+      - "${JENTIC_PG_PORT:-5432}:5432"
     volumes:
       - db-data:/var/lib/postgresql/data
       - ./init-schemas.sql:/docker-entrypoint-initdb.d/init-schemas.sql:ro

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -1621,6 +1621,12 @@ components:
           format: date-time
           title: Created At
           type: string
+        created_by:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Identity that created the credential (its owner).
+          title: Created By
         credential_id:
           description: Stable credential identifier, prefixed `cred_`.
           title: Credential Id
@@ -4414,6 +4420,11 @@ components:
           format: date-time
           title: Created At
           type: string
+        created_by:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Created By
         credential_count:
           title: Credential Count
           type: integer

--- a/scripts/flywheel_manual.py
+++ b/scripts/flywheel_manual.py
@@ -1,4 +1,4 @@
-"""Manual flywheel driver — exercises the admin-console flow against a running app.
+"""Manual flywheel driver — exercises the role-enforced user/agent/toolkit flow.
 
 Not a test; a throwaway script to observe real behaviour end-to-end:
   1. bootstrap admin

--- a/scripts/flywheel_manual.py
+++ b/scripts/flywheel_manual.py
@@ -1,0 +1,133 @@
+"""Manual flywheel driver — exercises the admin-console flow against a running app.
+
+Not a test; a throwaway script to observe real behaviour end-to-end:
+  1. bootstrap admin
+  2. admin creates two users (invite -> redeem -> login) with different scopes
+  3. admin + each user create agents and toolkits
+  4. verify reads by role (who can list what; who gets 403)
+
+Run against `make start-app-sqlite` (http://127.0.0.1:8000).
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+
+import httpx
+
+BASE = "http://127.0.0.1:8000"
+PW = "S3curePassw0rd!"
+c = httpx.Client(base_url=BASE, timeout=10.0)
+
+
+def h(tok: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {tok}"}
+
+
+def sfx() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def check(label: str, got: int, expect: int | tuple[int, ...]) -> None:
+    ok = got == expect if isinstance(expect, int) else got in expect
+    mark = "PASS" if ok else "FAIL"
+    print(f"  [{mark}] {label}: {got} (want {expect})")
+    if not ok:
+        check.failures += 1  # type: ignore[attr-defined]
+
+
+check.failures = 0  # type: ignore[attr-defined]
+
+
+def bootstrap_admin() -> str:
+    r = c.post(
+        "/users:create-admin",
+        json={
+            "email": f"admin-{sfx()}@flywheel.test",
+            "password": PW,
+            "first_name": "Ada",
+            "last_name": "Admin",
+        },
+    )
+    if r.status_code == 410:  # already bootstrapped — log in as the known admin
+        r = c.post(
+            "/auth/login", json={"email": "admin@flywheel.test", "password": "AdminPassw0rd!"}
+        )
+    r.raise_for_status()
+    return r.json()["access_token"]
+
+
+def create_user(admin: str, email: str, perms: list[str]) -> str:
+    """Admin invites a user; redeem the invite to set a password; log in."""
+    r = c.post(
+        "/users",
+        headers=h(admin),
+        json={"email": email, "first_name": "Test", "last_name": "User", "permissions": perms},
+    )
+    r.raise_for_status()
+    token = r.json()["invite_token"]
+    r = c.post("/users:redeem-invite", json={"invite_token": token, "password": PW})
+    r.raise_for_status()
+    return r.json()["access_token"]
+
+
+def main() -> int:
+    print("== 1. bootstrap admin ==")
+    admin = bootstrap_admin()
+    print("  admin token acquired")
+
+    print("== 2. admin creates users ==")
+    # A 'manager' with broad read/write; a 'reader' with only read scopes.
+    mgr_email = f"mgr-{sfx()}@flywheel.test"
+    rdr_email = f"rdr-{sfx()}@flywheel.test"
+    manager = create_user(
+        admin, mgr_email, ["agents:read", "agents:write", "toolkits:read", "toolkits:write"]
+    )
+    reader = create_user(admin, rdr_email, ["agents:read", "toolkits:read"])
+    print(f"  created manager={mgr_email} reader={rdr_email}")
+
+    print("== 3a. create agents (admin + manager; reader should be denied write) ==")
+    r = c.post("/agents", headers=h(admin), json={"name": f"admin-bot-{sfx()}"})
+    check("admin create agent", r.status_code, 201)
+    r = c.post("/agents", headers=h(manager), json={"name": f"mgr-bot-{sfx()}"})
+    check("manager create agent", r.status_code, 201)
+    r = c.post("/agents", headers=h(reader), json={"name": f"rdr-bot-{sfx()}"})
+    check("reader create agent -> forbidden", r.status_code, 403)
+
+    print("== 3b. create toolkits ==")
+    r = c.post("/toolkits", headers=h(admin), json={"name": f"admin-tk-{sfx()}"})
+    check("admin create toolkit", r.status_code, 201)
+    r = c.post("/toolkits", headers=h(manager), json={"name": f"mgr-tk-{sfx()}"})
+    check("manager create toolkit", r.status_code, 201)
+    r = c.post("/toolkits", headers=h(reader), json={"name": f"rdr-tk-{sfx()}"})
+    check("reader create toolkit -> forbidden", r.status_code, 403)
+
+    print("== 4. reads by role ==")
+    r = c.get("/agents", headers=h(admin))
+    check("admin list agents", r.status_code, 200)
+    admin_count = len(r.json().get("data", []))
+    r = c.get("/agents", headers=h(manager))
+    check("manager list agents", r.status_code, 200)
+    mgr_count = len(r.json().get("data", []))
+    r = c.get("/agents", headers=h(reader))
+    check("reader list agents", r.status_code, 200)
+    print(f"  agent visibility: admin={admin_count} manager={mgr_count}")
+
+    r = c.get("/toolkits", headers=h(admin))
+    check("admin list toolkits", r.status_code, 200)
+    r = c.get("/toolkits", headers=h(reader))
+    check("reader list toolkits", r.status_code, 200)
+
+    print("== 5. admin-only reads (users list) ==")
+    r = c.get("/users", headers=h(admin))
+    check("admin list users", r.status_code, 200)
+    r = c.get("/users", headers=h(reader))
+    check("reader list users -> forbidden", r.status_code, 403)
+
+    print(f"\n== DONE: {check.failures} failure(s) ==")  # type: ignore[attr-defined]
+    return 1 if check.failures else 0  # type: ignore[attr-defined]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,6 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
 
+PG_PORT="${JENTIC_PG_PORT:-5432}"
+
 echo "==> Starting Docker services..."
 docker compose -f docker/local-setup/docker-compose.yaml up -d
 
@@ -50,6 +52,14 @@ fi
 
 echo ""
 echo "==> Setup complete. Database endpoint:"
-echo "    localhost:5432/jentic (schemas: registry, control, admin)"
+echo "    localhost:${PG_PORT}/jentic (schemas: registry, control, admin)"
 echo ""
 echo "    User: postgres / Password: postgres (default)"
+if [ "$PG_PORT" != "5432" ]; then
+    echo ""
+    echo "    NOTE: Postgres is published on ${PG_PORT} (not the default 5432)."
+    echo "    Point the app at it, e.g.:"
+    echo "      JENTIC__DATABASES__REGISTRY__PORT=${PG_PORT} \\"
+    echo "      JENTIC__DATABASES__CONTROL__PORT=${PG_PORT} \\"
+    echo "      JENTIC__DATABASES__ADMIN__PORT=${PG_PORT} make start-app"
+fi

--- a/src/jentic_one/admin/repos/monitoring_repo.py
+++ b/src/jentic_one/admin/repos/monitoring_repo.py
@@ -14,6 +14,40 @@ from jentic_one.admin.core.schema.execution_records import ExecutionRecord
 from jentic_one.shared.models import ExecutionStatus
 
 
+def _is_postgres(session: AsyncSession) -> bool:
+    """Whether the session's backend is PostgreSQL.
+
+    The monitoring aggregations run on both Postgres (prod) and SQLite (local
+    dev / `config/local-sqlite.yaml`), which diverge on a few functions. Defaults
+    to Postgres when the bind is unknown (the prod backend).
+    """
+    return session.bind.dialect.name == "postgresql" if session.bind else True
+
+
+def _epoch_seconds(session: AsyncSession) -> SQLColumnExpression[Any]:
+    """Epoch seconds of ``started_at`` as a numeric expression, per dialect.
+
+    Postgres has ``extract('epoch', ts)``; SQLite has no ``extract`` but
+    ``strftime('%s', ts)`` yields the unix seconds (as text, cast to a number).
+    """
+    if _is_postgres(session):
+        return func.extract("epoch", ExecutionRecord.started_at)
+    return cast(func.strftime("%s", ExecutionRecord.started_at), Text)
+
+
+def _slash_join(*parts: Any) -> SQLColumnExpression[Any]:
+    """Join expressions with a literal ``/`` using the SQL ``||`` concat operator.
+
+    Portable across Postgres and SQLite, unlike ``concat()`` (which SQLite lacks).
+    ``||`` returns NULL if any operand is NULL, so callers coalesce beforehand
+    exactly as the previous ``concat`` form required.
+    """
+    expr: SQLColumnExpression[Any] = parts[0]
+    for part in parts[1:]:
+        expr = expr.op("||")(part)
+    return expr
+
+
 @dataclass(slots=True, frozen=True)
 class UsageQueryFilters:
     toolkit_id: str | None = None
@@ -170,6 +204,18 @@ class MonitoringRepository:
         until: datetime,
         filters: UsageQueryFilters | None = None,
     ) -> OverallStatsRow:
+        # SQLite has no percentile_cont / WITHIN GROUP ordered-set aggregate; only
+        # Postgres computes p50/p95. On SQLite we omit them (the row type allows
+        # None) so the counts/avg still come back rather than the whole statement
+        # failing to parse.
+        percentile_cols: list[SQLColumnExpression[Any]] = []
+        if _is_postgres(session):
+            percentile_cols = [
+                func.percentile_cont(0.5).within_group(ExecutionRecord.duration_ms).label("p50_ms"),
+                func.percentile_cont(0.95)
+                .within_group(ExecutionRecord.duration_ms)
+                .label("p95_ms"),
+            ]
         stmt = select(
             func.count().label("total"),
             func.count()
@@ -177,19 +223,20 @@ class MonitoringRepository:
             .label("success"),
             func.count().filter(ExecutionRecord.status == ExecutionStatus.FAILED).label("failed"),
             func.coalesce(func.avg(ExecutionRecord.duration_ms), 0).label("avg_ms"),
-            func.percentile_cont(0.5).within_group(ExecutionRecord.duration_ms).label("p50_ms"),
-            func.percentile_cont(0.95).within_group(ExecutionRecord.duration_ms).label("p95_ms"),
+            *percentile_cols,
         ).where(ExecutionRecord.started_at >= cutoff, ExecutionRecord.started_at < until)
         if filters:
             stmt = stmt.where(*filters.to_clauses())
         row = (await session.execute(stmt)).one()
+        p50 = getattr(row, "p50_ms", None)
+        p95 = getattr(row, "p95_ms", None)
         return OverallStatsRow(
             total=row.total,
             success=row.success,
             failed=row.failed,
             avg_ms=float(row.avg_ms),
-            p50_ms=float(row.p50_ms) if row.p50_ms is not None else None,
-            p95_ms=float(row.p95_ms) if row.p95_ms is not None else None,
+            p50_ms=float(p50) if p50 is not None else None,
+            p95_ms=float(p95) if p95 is not None else None,
         )
 
     @staticmethod
@@ -200,7 +247,7 @@ class MonitoringRepository:
         bucket_seconds: int,
         filters: UsageQueryFilters | None = None,
     ) -> list[TimeBucketRow]:
-        epoch_expr = func.extract("epoch", ExecutionRecord.started_at)
+        epoch_expr = _epoch_seconds(session)
         bucket_ts = (func.floor(epoch_expr / bucket_seconds) * literal(bucket_seconds)).label(
             "bucket_ts"
         )
@@ -247,12 +294,12 @@ class MonitoringRepository:
         label_expr: SQLColumnExpression[Any]
         group_cols: list[SQLColumnExpression[Any]]
         if group_by == "api":
-            key_expr = func.concat(
+            key_expr = _slash_join(
                 func.coalesce(ExecutionRecord.api_vendor, "unknown"),
                 literal("/"),
                 func.coalesce(ExecutionRecord.api_name, "unknown"),
             )
-            label_expr = func.concat(
+            label_expr = _slash_join(
                 func.coalesce(ExecutionRecord.api_vendor, "unknown"),
                 literal("/"),
                 func.coalesce(ExecutionRecord.api_name, "unknown"),
@@ -263,10 +310,10 @@ class MonitoringRepository:
             label_expr = ExecutionRecord.toolkit_id
             group_cols = [ExecutionRecord.toolkit_id]
         else:
-            key_expr = func.concat(
+            key_expr = _slash_join(
                 ExecutionRecord.actor_type, literal("/"), ExecutionRecord.actor_id
             )
-            label_expr = func.concat(
+            label_expr = _slash_join(
                 ExecutionRecord.actor_type, literal("/"), ExecutionRecord.actor_id
             )
             group_cols = [ExecutionRecord.actor_type, ExecutionRecord.actor_id]
@@ -323,7 +370,7 @@ class MonitoringRepository:
 
         key_expr: SQLColumnExpression[Any]
         if group_by == "api":
-            key_expr = func.concat(
+            key_expr = _slash_join(
                 func.coalesce(ExecutionRecord.api_vendor, "unknown"),
                 literal("/"),
                 func.coalesce(ExecutionRecord.api_name, "unknown"),
@@ -331,11 +378,11 @@ class MonitoringRepository:
         elif group_by == "toolkit":
             key_expr = ExecutionRecord.toolkit_id
         else:
-            key_expr = func.concat(
+            key_expr = _slash_join(
                 ExecutionRecord.actor_type, literal("/"), ExecutionRecord.actor_id
             )
 
-        epoch_expr = func.extract("epoch", ExecutionRecord.started_at)
+        epoch_expr = _epoch_seconds(session)
         segment_idx = cast(
             func.floor((epoch_expr - literal(cutoff_epoch)) / literal(segment_seconds)),
             Text,

--- a/src/jentic_one/admin/repos/monitoring_repo.py
+++ b/src/jentic_one/admin/repos/monitoring_repo.py
@@ -122,8 +122,7 @@ class MonitoringRepository:
 
     @staticmethod
     async def daily_buckets(session: AsyncSession, cutoff: datetime) -> list[DailyBucketRow]:
-        dialect = session.bind.dialect.name if session.bind else "postgresql"
-        if dialect == "postgresql":
+        if _is_postgres(session):
             day_col = cast(func.date_trunc("day", ExecutionRecord.started_at), Text).label("day")
         else:
             # SQLite has no date_trunc; strftime yields a portable YYYY-MM-DD string.

--- a/src/jentic_one/control/services/credentials/schemas/credentials.py
+++ b/src/jentic_one/control/services/credentials/schemas/credentials.py
@@ -161,6 +161,7 @@ class CredentialRedactedView(BaseModel):
     provider: str
     provider_account_ref: str | None = None
     active: bool
+    created_by: str | None = None
     created_at: datetime
     updated_at: datetime | None = None
     details: BearerTokenRedacted | ApiKeyRedacted | BasicAuthRedacted | OAuth2Redacted

--- a/src/jentic_one/control/services/credentials/service.py
+++ b/src/jentic_one/control/services/credentials/service.py
@@ -470,6 +470,7 @@ class CredentialService:
             provider=credential.provider,
             provider_account_ref=credential.provider_account_ref,
             active=credential.active,
+            created_by=credential.created_by,
             created_at=credential.created_at,
             updated_at=credential.updated_at,
             details=details,

--- a/src/jentic_one/control/web/routers/credentials.py
+++ b/src/jentic_one/control/web/routers/credentials.py
@@ -65,6 +65,7 @@ def _to_redacted_response(view: CredentialRedactedView) -> CredentialRedactedRes
         provider=view.provider,
         provider_account_ref=view.provider_account_ref,
         active=view.active,
+        created_by=view.created_by,
         created_at=view.created_at,
         updated_at=view.updated_at,
         details=details.model_dump(exclude_none=True) if details else None,

--- a/src/jentic_one/control/web/routers/toolkits.py
+++ b/src/jentic_one/control/web/routers/toolkits.py
@@ -50,6 +50,7 @@ def _to_toolkit_response(toolkit: Toolkit) -> ToolkitResponse:
         permissions=toolkit.permissions,
         key_count=len(toolkit.keys),
         credential_count=len(toolkit.bindings),
+        created_by=toolkit.created_by,
         created_at=toolkit.created_at,
         updated_at=toolkit.updated_at,
     )

--- a/src/jentic_one/control/web/schemas/credentials.py
+++ b/src/jentic_one/control/web/schemas/credentials.py
@@ -276,6 +276,9 @@ class CredentialRedactedResponse(BaseModel):
         default=None, description="Opaque reference to the provider account, when applicable."
     )
     active: bool = Field(description="Whether the credential is enabled for injection.")
+    created_by: str | None = Field(
+        default=None, description="Identity that created the credential (its owner)."
+    )
     created_at: datetime = Field(description="Creation timestamp (UTC).")
     updated_at: datetime | None = Field(default=None, description="Last update timestamp (UTC).")
     details: dict[str, Any] | None = Field(

--- a/src/jentic_one/control/web/schemas/toolkits.py
+++ b/src/jentic_one/control/web/schemas/toolkits.py
@@ -140,6 +140,7 @@ class ToolkitResponse(BaseModel):
     permissions: list[dict[str, object]]
     key_count: int
     credential_count: int
+    created_by: str | None = None
     created_at: datetime
     updated_at: datetime | None = None
 

--- a/tests/integration/admin/test_monitoring_repo.py
+++ b/tests/integration/admin/test_monitoring_repo.py
@@ -5,6 +5,13 @@ These run under ``make test-integration`` (PostgreSQL) and
 hard-code the Postgres-only ``date_trunc`` function, which 500'd the
 ``GET /monitoring/executions`` endpoint on SQLite (issue #623); these tests
 guard the portable, dialect-aware day-bucket expression.
+
+The usage aggregations (``overall_stats``, ``time_buckets``, ``grouped_top``,
+``grouped_trend``) likewise once hard-coded Postgres-only SQL —
+``percentile_cont … WITHIN GROUP``, ``extract('epoch', …)`` and ``concat()`` —
+which 500'd ``GET /monitoring/usage`` and the enterprise usage overview on
+SQLite. The tests below guard their dialect-aware forms (percentiles are simply
+``None`` on SQLite, which has no ordered-set aggregate).
 """
 
 from __future__ import annotations
@@ -130,3 +137,88 @@ async def test_top_operations_ranks_by_total(
     assert ops[0].total == 3
     failed_op = next(o for o in ops if o.operation_id == "getRepo")
     assert failed_op.failed == 1
+
+
+async def test_overall_stats_counts_and_percentiles(
+    admin_db: DatabaseSession, clean_execution_records: None
+) -> None:
+    now = datetime.now(UTC)
+    await _seed(admin_db, now, "completed", duration_ms=100)
+    await _seed(admin_db, now - timedelta(minutes=1), "completed", duration_ms=200)
+    await _seed(admin_db, now - timedelta(minutes=2), "failed", duration_ms=300)
+
+    async with admin_db.session() as session:
+        is_postgres = session.bind is not None and session.bind.dialect.name == "postgresql"
+        stats = await MonitoringRepository.overall_stats(
+            session, now - timedelta(days=7), now + timedelta(minutes=1)
+        )
+
+    # Counts + avg are portable across both backends.
+    assert stats.total == 3
+    assert stats.success == 2
+    assert stats.failed == 1
+    assert stats.avg_ms == pytest.approx(200.0)
+    # Percentiles are Postgres-only (SQLite has no ordered-set aggregate) — the
+    # SQLite path returns None rather than 500'ing the whole statement.
+    if is_postgres:
+        assert stats.p50_ms is not None and stats.p95_ms is not None
+    else:
+        assert stats.p50_ms is None and stats.p95_ms is None
+
+
+async def test_time_buckets_aggregates_by_window(
+    admin_db: DatabaseSession, clean_execution_records: None
+) -> None:
+    now = datetime.now(UTC)
+    await _seed(admin_db, now, "completed", duration_ms=100)
+    await _seed(admin_db, now - timedelta(seconds=10), "failed", duration_ms=100)
+
+    async with admin_db.session() as session:
+        buckets = await MonitoringRepository.time_buckets(
+            session, now - timedelta(hours=1), now + timedelta(minutes=1), 3600
+        )
+
+    # Both executions fall in the same hour bucket (exercises the dialect-aware
+    # epoch-seconds expression that replaced Postgres-only extract('epoch', …)).
+    assert sum(b.total for b in buckets) == 2
+    assert sum(b.success for b in buckets) == 1
+    assert sum(b.failed for b in buckets) == 1
+
+
+async def test_grouped_top_and_trend_by_toolkit(
+    admin_db: DatabaseSession, clean_execution_records: None
+) -> None:
+    now = datetime.now(UTC)
+    for _ in range(3):
+        await _seed(admin_db, now, "completed")
+
+    async with admin_db.session() as session:
+        top = await MonitoringRepository.grouped_top(
+            session, now - timedelta(days=7), now + timedelta(minutes=1), "toolkit", 10
+        )
+        keys = [r.key for r in top]
+        trends = await MonitoringRepository.grouped_trend(
+            session, now - timedelta(days=7), now + timedelta(minutes=1), "toolkit", keys
+        )
+
+    assert top[0].total == 3
+    assert top[0].key == "tk_test000000000000000000"
+    # grouped_trend distributes the 3 executions across its segments (exercises
+    # the dialect-aware epoch expression + `||` string concat on SQLite).
+    assert sum(trends["tk_test000000000000000000"]) == 3
+
+
+async def test_grouped_top_by_agent_concat_key(
+    admin_db: DatabaseSession, clean_execution_records: None
+) -> None:
+    now = datetime.now(UTC)
+    await _seed(admin_db, now, "completed")
+
+    async with admin_db.session() as session:
+        top = await MonitoringRepository.grouped_top(
+            session, now - timedelta(days=7), now + timedelta(minutes=1), "agent", 10
+        )
+
+    # The agent key is `actor_type/actor_id` — built with `||` concat so it works
+    # on SQLite (Postgres-only `concat()` used to break this on SQLite).
+    assert top[0].key == "user/usr_test"

--- a/tests/integration/admin/test_monitoring_repo.py
+++ b/tests/integration/admin/test_monitoring_repo.py
@@ -9,7 +9,7 @@ guard the portable, dialect-aware day-bucket expression.
 The usage aggregations (``overall_stats``, ``time_buckets``, ``grouped_top``,
 ``grouped_trend``) likewise once hard-coded Postgres-only SQL —
 ``percentile_cont … WITHIN GROUP``, ``extract('epoch', …)`` and ``concat()`` —
-which 500'd ``GET /monitoring/usage`` and the enterprise usage overview on
+which 500'd ``GET /monitoring/usage`` and any downstream usage overview on
 SQLite. The tests below guard their dialect-aware forms (percentiles are simply
 ``None`` on SQLite, which has no ordered-set aggregate).
 """

--- a/tests/web/test_flywheel.py
+++ b/tests/web/test_flywheel.py
@@ -1,4 +1,4 @@
-"""End-to-end "flywheel" integration test for the admin-console flow.
+"""End-to-end "flywheel" integration test for the role-enforced entity flow.
 
 Exercises the whole loop against the REAL combined control-plane app + a real
 database, spanning three surfaces (admin `/users`, auth `/agents`, control
@@ -15,6 +15,12 @@ by minting per-actor JWTs with ``issue_jwt`` (the real ``resolve_identity`` path
 mirroring ``tests/web/admin/test_users.py``. Deterministic across repeat runs:
 every entity uses a unique suffix and is created through the real API, and the
 seeded users/permissions are cleaned up on teardown.
+
+Postgres-only: like the rest of ``tests/web`` it builds the combined app against
+the Postgres fixtures (``tests/web/conftest.py`` has no SQLite backend switch),
+and its teardown ordering relies on Postgres FK ``RESTRICT`` enforcement. SQLite
+dialect coverage for the read paths lives in
+``tests/integration/admin/test_monitoring_repo.py``.
 """
 
 from __future__ import annotations

--- a/tests/web/test_flywheel.py
+++ b/tests/web/test_flywheel.py
@@ -166,9 +166,7 @@ def _list_names(client: TestClient, path: str, actor: _Actor) -> list[str]:
     return [row["name"] for row in resp.json().get("data", [])]
 
 
-def test_admin_can_create_users_via_api(
-    client: TestClient, actors: dict[str, _Actor]
-) -> None:
+def test_admin_can_create_users_via_api(client: TestClient, actors: dict[str, _Actor]) -> None:
     """Admin invites a user through the real API and gets an invite token."""
     admin = actors["admin"]
     email = f"fw-invitee-{_suffix()}@test.local"
@@ -192,9 +190,7 @@ def test_admin_can_create_users_via_api(
     client.delete(f"/users/{body['user']['id']}", headers=admin.headers)
 
 
-def test_non_admin_cannot_create_users(
-    client: TestClient, actors: dict[str, _Actor]
-) -> None:
+def test_non_admin_cannot_create_users(client: TestClient, actors: dict[str, _Actor]) -> None:
     resp = client.post(
         "/users",
         headers=actors["manager"].headers,
@@ -215,9 +211,7 @@ def test_write_capable_actors_create_agents_reader_denied(
     r = client.post("/agents", headers=manager.headers, json={"name": mgr_agent})
     assert r.status_code == 201, r.text
     # Reader lacks agents:write.
-    r = client.post(
-        "/agents", headers=reader.headers, json={"name": f"fw-rdr-agent-{_suffix()}"}
-    )
+    r = client.post("/agents", headers=reader.headers, json={"name": f"fw-rdr-agent-{_suffix()}"})
     assert r.status_code == 403, r.text
 
 
@@ -225,35 +219,25 @@ def test_write_capable_actors_create_toolkits_reader_denied(
     client: TestClient, actors: dict[str, _Actor]
 ) -> None:
     admin, manager, reader = actors["admin"], actors["manager"], actors["reader"]
-    r = client.post(
-        "/toolkits", headers=admin.headers, json={"name": f"fw-admin-tk-{_suffix()}"}
-    )
+    r = client.post("/toolkits", headers=admin.headers, json={"name": f"fw-admin-tk-{_suffix()}"})
     assert r.status_code == 201, r.text
-    r = client.post(
-        "/toolkits", headers=manager.headers, json={"name": f"fw-mgr-tk-{_suffix()}"}
-    )
+    r = client.post("/toolkits", headers=manager.headers, json={"name": f"fw-mgr-tk-{_suffix()}"})
     assert r.status_code == 201, r.text
-    r = client.post(
-        "/toolkits", headers=reader.headers, json={"name": f"fw-rdr-tk-{_suffix()}"}
-    )
+    r = client.post("/toolkits", headers=reader.headers, json={"name": f"fw-rdr-tk-{_suffix()}"})
     assert r.status_code == 403, r.text
 
 
-def test_reads_by_role_and_owner_scoping(
-    client: TestClient, actors: dict[str, _Actor]
-) -> None:
+def test_reads_by_role_and_owner_scoping(client: TestClient, actors: dict[str, _Actor]) -> None:
     """Everyone with a read scope can list; owner-scoping means the admin
     sees agents others created but a non-admin sees only their own."""
     admin, manager, reader = actors["admin"], actors["manager"], actors["reader"]
     admin_agent = f"fw-admin-agent-{_suffix()}"
     mgr_agent = f"fw-mgr-agent-{_suffix()}"
     assert (
-        client.post("/agents", headers=admin.headers, json={"name": admin_agent}).status_code
-        == 201
+        client.post("/agents", headers=admin.headers, json={"name": admin_agent}).status_code == 201
     )
     assert (
-        client.post("/agents", headers=manager.headers, json={"name": mgr_agent}).status_code
-        == 201
+        client.post("/agents", headers=manager.headers, json={"name": mgr_agent}).status_code == 201
     )
 
     admin_view = _list_names(client, "/agents", admin)

--- a/tests/web/test_flywheel.py
+++ b/tests/web/test_flywheel.py
@@ -166,107 +166,109 @@ def _list_names(client: TestClient, path: str, actor: _Actor) -> list[str]:
     return [row["name"] for row in resp.json().get("data", [])]
 
 
-class TestFlywheel:
-    """The admin-console flywheel, role-enforced against the real backend."""
+def test_admin_can_create_users_via_api(
+    client: TestClient, actors: dict[str, _Actor]
+) -> None:
+    """Admin invites a user through the real API and gets an invite token."""
+    admin = actors["admin"]
+    email = f"fw-invitee-{_suffix()}@test.local"
+    resp = client.post(
+        "/users",
+        headers=admin.headers,
+        json={"email": email, "first_name": "New", "last_name": "User", "permissions": []},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["invite_token"]
+    assert body["user"]["email"] == email
+    # The invitee can complete setup by redeeming (proves the link works).
+    redeem = client.post(
+        "/users:redeem-invite",
+        json={"invite_token": body["invite_token"], "password": "S3curePassw0rd!"},
+    )
+    assert redeem.status_code == 200, redeem.text
+    assert redeem.json()["access_token"]
+    # Cleanup the invitee.
+    client.delete(f"/users/{body['user']['id']}", headers=admin.headers)
 
-    def test_admin_can_create_users_via_api(
-        self, client: TestClient, actors: dict[str, _Actor]
-    ) -> None:
-        """Admin invites a user through the real API and gets an invite token."""
-        admin = actors["admin"]
-        email = f"fw-invitee-{_suffix()}@test.local"
-        resp = client.post(
-            "/users",
-            headers=admin.headers,
-            json={"email": email, "first_name": "New", "last_name": "User", "permissions": []},
-        )
-        assert resp.status_code == 201, resp.text
-        body = resp.json()
-        assert body["invite_token"]
-        assert body["user"]["email"] == email
-        # The invitee can complete setup by redeeming (proves the link works).
-        redeem = client.post(
-            "/users:redeem-invite",
-            json={"invite_token": body["invite_token"], "password": "S3curePassw0rd!"},
-        )
-        assert redeem.status_code == 200, redeem.text
-        assert redeem.json()["access_token"]
-        # Cleanup the invitee.
-        client.delete(f"/users/{body['user']['id']}", headers=admin.headers)
 
-    def test_non_admin_cannot_create_users(
-        self, client: TestClient, actors: dict[str, _Actor]
-    ) -> None:
-        resp = client.post(
-            "/users",
-            headers=actors["manager"].headers,
-            json={"email": f"x-{_suffix()}@test.local", "first_name": "X", "last_name": "Y"},
-        )
-        assert resp.status_code == 403, resp.text
+def test_non_admin_cannot_create_users(
+    client: TestClient, actors: dict[str, _Actor]
+) -> None:
+    resp = client.post(
+        "/users",
+        headers=actors["manager"].headers,
+        json={"email": f"x-{_suffix()}@test.local", "first_name": "X", "last_name": "Y"},
+    )
+    assert resp.status_code == 403, resp.text
 
-    def test_write_capable_actors_create_agents_reader_denied(
-        self, client: TestClient, actors: dict[str, _Actor]
-    ) -> None:
-        admin, manager, reader = actors["admin"], actors["manager"], actors["reader"]
-        admin_agent = f"fw-admin-agent-{_suffix()}"
-        mgr_agent = f"fw-mgr-agent-{_suffix()}"
 
-        r = client.post("/agents", headers=admin.headers, json={"name": admin_agent})
-        assert r.status_code == 201, r.text
-        r = client.post("/agents", headers=manager.headers, json={"name": mgr_agent})
-        assert r.status_code == 201, r.text
-        # Reader lacks agents:write.
-        r = client.post(
-            "/agents", headers=reader.headers, json={"name": f"fw-rdr-agent-{_suffix()}"}
-        )
-        assert r.status_code == 403, r.text
+def test_write_capable_actors_create_agents_reader_denied(
+    client: TestClient, actors: dict[str, _Actor]
+) -> None:
+    admin, manager, reader = actors["admin"], actors["manager"], actors["reader"]
+    admin_agent = f"fw-admin-agent-{_suffix()}"
+    mgr_agent = f"fw-mgr-agent-{_suffix()}"
 
-    def test_write_capable_actors_create_toolkits_reader_denied(
-        self, client: TestClient, actors: dict[str, _Actor]
-    ) -> None:
-        admin, manager, reader = actors["admin"], actors["manager"], actors["reader"]
-        r = client.post(
-            "/toolkits", headers=admin.headers, json={"name": f"fw-admin-tk-{_suffix()}"}
-        )
-        assert r.status_code == 201, r.text
-        r = client.post(
-            "/toolkits", headers=manager.headers, json={"name": f"fw-mgr-tk-{_suffix()}"}
-        )
-        assert r.status_code == 201, r.text
-        r = client.post(
-            "/toolkits", headers=reader.headers, json={"name": f"fw-rdr-tk-{_suffix()}"}
-        )
-        assert r.status_code == 403, r.text
+    r = client.post("/agents", headers=admin.headers, json={"name": admin_agent})
+    assert r.status_code == 201, r.text
+    r = client.post("/agents", headers=manager.headers, json={"name": mgr_agent})
+    assert r.status_code == 201, r.text
+    # Reader lacks agents:write.
+    r = client.post(
+        "/agents", headers=reader.headers, json={"name": f"fw-rdr-agent-{_suffix()}"}
+    )
+    assert r.status_code == 403, r.text
 
-    def test_reads_by_role_and_owner_scoping(
-        self, client: TestClient, actors: dict[str, _Actor]
-    ) -> None:
-        """Everyone with a read scope can list; owner-scoping means the admin
-        sees agents others created but a non-admin sees only their own."""
-        admin, manager, reader = actors["admin"], actors["manager"], actors["reader"]
-        admin_agent = f"fw-admin-agent-{_suffix()}"
-        mgr_agent = f"fw-mgr-agent-{_suffix()}"
-        assert (
-            client.post("/agents", headers=admin.headers, json={"name": admin_agent}).status_code
-            == 201
-        )
-        assert (
-            client.post("/agents", headers=manager.headers, json={"name": mgr_agent}).status_code
-            == 201
-        )
 
-        admin_view = _list_names(client, "/agents", admin)
-        manager_view = _list_names(client, "/agents", manager)
-        _list_names(client, "/agents", reader)  # reader can read (200), sees none of these
+def test_write_capable_actors_create_toolkits_reader_denied(
+    client: TestClient, actors: dict[str, _Actor]
+) -> None:
+    admin, manager, reader = actors["admin"], actors["manager"], actors["reader"]
+    r = client.post(
+        "/toolkits", headers=admin.headers, json={"name": f"fw-admin-tk-{_suffix()}"}
+    )
+    assert r.status_code == 201, r.text
+    r = client.post(
+        "/toolkits", headers=manager.headers, json={"name": f"fw-mgr-tk-{_suffix()}"}
+    )
+    assert r.status_code == 201, r.text
+    r = client.post(
+        "/toolkits", headers=reader.headers, json={"name": f"fw-rdr-tk-{_suffix()}"}
+    )
+    assert r.status_code == 403, r.text
 
-        # Admin sees both agents; manager sees its own but NOT the admin's.
-        assert admin_agent in admin_view
-        assert mgr_agent in admin_view
-        assert mgr_agent in manager_view
-        assert admin_agent not in manager_view
 
-    def test_admin_only_user_listing(self, client: TestClient, actors: dict[str, _Actor]) -> None:
-        admin, reader = actors["admin"], actors["reader"]
-        assert client.get("/users", headers=admin.headers).status_code == 200
-        # Reader has no users:read scope.
-        assert client.get("/users", headers=reader.headers).status_code == 403
+def test_reads_by_role_and_owner_scoping(
+    client: TestClient, actors: dict[str, _Actor]
+) -> None:
+    """Everyone with a read scope can list; owner-scoping means the admin
+    sees agents others created but a non-admin sees only their own."""
+    admin, manager, reader = actors["admin"], actors["manager"], actors["reader"]
+    admin_agent = f"fw-admin-agent-{_suffix()}"
+    mgr_agent = f"fw-mgr-agent-{_suffix()}"
+    assert (
+        client.post("/agents", headers=admin.headers, json={"name": admin_agent}).status_code
+        == 201
+    )
+    assert (
+        client.post("/agents", headers=manager.headers, json={"name": mgr_agent}).status_code
+        == 201
+    )
+
+    admin_view = _list_names(client, "/agents", admin)
+    manager_view = _list_names(client, "/agents", manager)
+    _list_names(client, "/agents", reader)  # reader can read (200), sees none of these
+
+    # Admin sees both agents; manager sees its own but NOT the admin's.
+    assert admin_agent in admin_view
+    assert mgr_agent in admin_view
+    assert mgr_agent in manager_view
+    assert admin_agent not in manager_view
+
+
+def test_admin_only_user_listing(client: TestClient, actors: dict[str, _Actor]) -> None:
+    admin, reader = actors["admin"], actors["reader"]
+    assert client.get("/users", headers=admin.headers).status_code == 200
+    # Reader has no users:read scope.
+    assert client.get("/users", headers=reader.headers).status_code == 403

--- a/tests/web/test_flywheel.py
+++ b/tests/web/test_flywheel.py
@@ -1,0 +1,272 @@
+"""End-to-end "flywheel" integration test for the admin-console flow.
+
+Exercises the whole loop against the REAL combined control-plane app + a real
+database, spanning three surfaces (admin `/users`, auth `/agents`, control
+`/toolkits`):
+
+  1. an org admin exists;
+  2. the admin creates multiple users with different permission sets;
+  3. the admin and a write-capable user create agents and toolkits;
+  4. reads are verified BY ROLE — who can list what, who is 403'd, and that the
+     owner-scoping filter shows admins everything but non-admins only their own.
+
+This is the durable version of `scripts/flywheel_manual.py`. Actors are switched
+by minting per-actor JWTs with ``issue_jwt`` (the real ``resolve_identity`` path),
+mirroring ``tests/web/admin/test_users.py``. Deterministic across repeat runs:
+every entity uses a unique suffix and is created through the real API, and the
+seeded users/permissions are cleaned up on teardown.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator, Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import delete
+
+from jentic_one.admin.core.schema.agents import Agent
+from jentic_one.admin.core.schema.service_accounts import ServiceAccount
+from jentic_one.admin.core.schema.user_permission_grants import UserPermissionGrant
+from jentic_one.admin.core.schema.user_secrets import UserSecret
+from jentic_one.admin.core.schema.users import User
+from jentic_one.admin.repos import (
+    UserPermissionGrantRepository,
+    UserRepository,
+    UserSecretRepository,
+)
+from jentic_one.admin.services._support.passwords import hash_password
+from jentic_one.admin.services._support.tokens import issue_jwt
+from jentic_one.control.core.schema.toolkits import Toolkit
+from jentic_one.shared.context import Context
+from jentic_one.shared.models import InviteState
+from jentic_one.shared.web.app_factory import create_combined_app
+from tests.web.conftest import noop_lifespan
+
+pytestmark = pytest.mark.integration
+
+_SURFACES = ["registry", "admin", "control", "auth"]
+
+
+def _suffix() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def _build_combined_app(ctx: Context) -> FastAPI:
+    """Build the real combined app (all surfaces) with lifespan disabled.
+
+    The combined factory installs the admin surface's ``verify_token``, so real
+    JWTs are resolved exactly as in production.
+    """
+    app = create_combined_app(ctx, _SURFACES)
+    app.router.lifespan_context = noop_lifespan
+    return app
+
+
+def _token(ctx: Context, *, sub: str, email: str, permissions: list[str]) -> str:
+    """Mint a signed JWT for an actor with the given effective permissions."""
+    auth = ctx.config.admin.auth
+    claims = {
+        "sub": sub,
+        "email": email,
+        "actor_type": "user",
+        "permissions": permissions,
+        "must_change_password": False,
+    }
+    return issue_jwt(claims, auth.jwt_secret.get_secret_value(), auth.jwt_ttl_seconds)
+
+
+class _Actor:
+    def __init__(self, user_id: str, email: str, token: str) -> None:
+        self.id = user_id
+        self.email = email
+        self.headers = {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+async def actors(web_context: Context) -> AsyncGenerator[dict[str, _Actor], None]:
+    """Seed three real users with distinct permission sets and mint their tokens.
+
+    - admin:   org:admin (sees + does everything)
+    - manager: agents/toolkits read+write (can create; owner-scoped reads)
+    - reader:  agents/toolkits read only (can list, cannot create; no users:read)
+
+    Users are created directly via repositories (fast + deterministic) rather
+    than the invite→redeem round-trip; the API-level create flow is covered
+    separately below.
+    """
+    ctx = web_context
+    sfx = _suffix()
+    specs = {
+        "admin": (f"fw-admin-{sfx}@test.local", {"org:admin"}),
+        "manager": (
+            f"fw-mgr-{sfx}@test.local",
+            {"agents:read", "agents:write", "toolkits:read", "toolkits:write"},
+        ),
+        "reader": (f"fw-reader-{sfx}@test.local", {"agents:read", "toolkits:read"}),
+    }
+    created: dict[str, _Actor] = {}
+    ids: list[str] = []
+    async with ctx.admin_db.session() as session:
+        for role, (email, perms) in specs.items():
+            user = await UserRepository.create(
+                session,
+                email=email,
+                first_name=role.capitalize(),
+                last_name="Flywheel",
+                invite_state=InviteState.REDEEMED,
+                created_by="usr_test",
+            )
+            await UserSecretRepository.create(
+                session,
+                user_id=user.id,
+                password_hash=hash_password("S3curePassw0rd!"),
+                created_by="usr_test",
+            )
+            await UserPermissionGrantRepository.set_permissions(
+                session, user.id, permissions=perms, granted_by=None, created_by="usr_test"
+            )
+            created[role] = _Actor(
+                user.id, email, _token(ctx, sub=user.id, email=email, permissions=sorted(perms))
+            )
+            ids.append(user.id)
+        await session.commit()
+
+    yield created
+
+    # Teardown order matters: agents/service-accounts FK-reference the owning
+    # user (agents.owner_id) and toolkits carry created_by, so remove everything
+    # these actors created before deleting the users themselves.
+    async with ctx.control_db.session() as session:
+        await session.execute(delete(Toolkit).where(Toolkit.created_by.in_(ids)))
+        await session.commit()
+    async with ctx.admin_db.session() as session:
+        await session.execute(delete(Agent).where(Agent.owner_id.in_(ids)))
+        await session.execute(delete(ServiceAccount).where(ServiceAccount.owner_id.in_(ids)))
+        await session.execute(
+            delete(UserPermissionGrant).where(UserPermissionGrant.user_id.in_(ids))
+        )
+        await session.execute(delete(UserSecret).where(UserSecret.user_id.in_(ids)))
+        await session.execute(delete(User).where(User.id.in_(ids)))
+        await session.commit()
+
+
+@pytest.fixture()
+def client(web_context: Context) -> Iterator[TestClient]:
+    app = _build_combined_app(web_context)
+    with TestClient(app) as tc:
+        yield tc
+
+
+def _list_names(client: TestClient, path: str, actor: _Actor) -> list[str]:
+    resp = client.get(path, headers=actor.headers)
+    assert resp.status_code == 200, resp.text
+    return [row["name"] for row in resp.json().get("data", [])]
+
+
+class TestFlywheel:
+    """The admin-console flywheel, role-enforced against the real backend."""
+
+    def test_admin_can_create_users_via_api(
+        self, client: TestClient, actors: dict[str, _Actor]
+    ) -> None:
+        """Admin invites a user through the real API and gets an invite token."""
+        admin = actors["admin"]
+        email = f"fw-invitee-{_suffix()}@test.local"
+        resp = client.post(
+            "/users",
+            headers=admin.headers,
+            json={"email": email, "first_name": "New", "last_name": "User", "permissions": []},
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["invite_token"]
+        assert body["user"]["email"] == email
+        # The invitee can complete setup by redeeming (proves the link works).
+        redeem = client.post(
+            "/users:redeem-invite",
+            json={"invite_token": body["invite_token"], "password": "S3curePassw0rd!"},
+        )
+        assert redeem.status_code == 200, redeem.text
+        assert redeem.json()["access_token"]
+        # Cleanup the invitee.
+        client.delete(f"/users/{body['user']['id']}", headers=admin.headers)
+
+    def test_non_admin_cannot_create_users(
+        self, client: TestClient, actors: dict[str, _Actor]
+    ) -> None:
+        resp = client.post(
+            "/users",
+            headers=actors["manager"].headers,
+            json={"email": f"x-{_suffix()}@test.local", "first_name": "X", "last_name": "Y"},
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_write_capable_actors_create_agents_reader_denied(
+        self, client: TestClient, actors: dict[str, _Actor]
+    ) -> None:
+        admin, manager, reader = actors["admin"], actors["manager"], actors["reader"]
+        admin_agent = f"fw-admin-agent-{_suffix()}"
+        mgr_agent = f"fw-mgr-agent-{_suffix()}"
+
+        r = client.post("/agents", headers=admin.headers, json={"name": admin_agent})
+        assert r.status_code == 201, r.text
+        r = client.post("/agents", headers=manager.headers, json={"name": mgr_agent})
+        assert r.status_code == 201, r.text
+        # Reader lacks agents:write.
+        r = client.post(
+            "/agents", headers=reader.headers, json={"name": f"fw-rdr-agent-{_suffix()}"}
+        )
+        assert r.status_code == 403, r.text
+
+    def test_write_capable_actors_create_toolkits_reader_denied(
+        self, client: TestClient, actors: dict[str, _Actor]
+    ) -> None:
+        admin, manager, reader = actors["admin"], actors["manager"], actors["reader"]
+        r = client.post(
+            "/toolkits", headers=admin.headers, json={"name": f"fw-admin-tk-{_suffix()}"}
+        )
+        assert r.status_code == 201, r.text
+        r = client.post(
+            "/toolkits", headers=manager.headers, json={"name": f"fw-mgr-tk-{_suffix()}"}
+        )
+        assert r.status_code == 201, r.text
+        r = client.post(
+            "/toolkits", headers=reader.headers, json={"name": f"fw-rdr-tk-{_suffix()}"}
+        )
+        assert r.status_code == 403, r.text
+
+    def test_reads_by_role_and_owner_scoping(
+        self, client: TestClient, actors: dict[str, _Actor]
+    ) -> None:
+        """Everyone with a read scope can list; owner-scoping means the admin
+        sees agents others created but a non-admin sees only their own."""
+        admin, manager, reader = actors["admin"], actors["manager"], actors["reader"]
+        admin_agent = f"fw-admin-agent-{_suffix()}"
+        mgr_agent = f"fw-mgr-agent-{_suffix()}"
+        assert (
+            client.post("/agents", headers=admin.headers, json={"name": admin_agent}).status_code
+            == 201
+        )
+        assert (
+            client.post("/agents", headers=manager.headers, json={"name": mgr_agent}).status_code
+            == 201
+        )
+
+        admin_view = _list_names(client, "/agents", admin)
+        manager_view = _list_names(client, "/agents", manager)
+        _list_names(client, "/agents", reader)  # reader can read (200), sees none of these
+
+        # Admin sees both agents; manager sees its own but NOT the admin's.
+        assert admin_agent in admin_view
+        assert mgr_agent in admin_view
+        assert mgr_agent in manager_view
+        assert admin_agent not in manager_view
+
+    def test_admin_only_user_listing(self, client: TestClient, actors: dict[str, _Actor]) -> None:
+        admin, reader = actors["admin"], actors["reader"]
+        assert client.get("/users", headers=admin.headers).status_code == 200
+        # Reader has no users:read scope.
+        assert client.get("/users", headers=reader.headers).status_code == 403

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -2592,6 +2592,18 @@
             "title": "Created At",
             "type": "string"
           },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Identity that created the credential (its owner).",
+            "title": "Created By"
+          },
           "credential_id": {
             "description": "Stable credential identifier, prefixed `cred_`.",
             "title": "Credential Id",
@@ -6971,6 +6983,17 @@
             "format": "date-time",
             "title": "Created At",
             "type": "string"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By"
           },
           "credential_count": {
             "title": "Credential Count",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,5 @@
 import { Navigate, useRoutes, type RouteObject } from 'react-router-dom';
+import { useEffect } from 'react';
 import { AuthGuard } from '@/shared/auth/AuthGuard';
 import { SetupGate } from '@/shared/auth/SetupGate';
 import { LoginPage } from '@/shared/auth/LoginPage';
@@ -51,16 +52,24 @@ import { publicDocsRoutes } from '@/modules/docs/routes';
  * additional `NavItem`s (e.g. a permission-gated, `secondary` operator entry)
  * that the navbars render alongside the built-in registry. They're stashed in
  * the nav module's static registry (see `registerExtraNavItems`) so the
- * deep-in-the-tree navbars can read them without prop-drilling. Omitted (the
+ * deep-in-the-tree navbars can read them without prop-drilling. Registration
+ * happens in a commit-phase effect and is torn down on unmount. Omitted (the
  * default) for the OSS binary.
  */
 export function App({
 	extraRoutes = [],
 	extraNavItems = [],
 }: { extraRoutes?: RouteObject[]; extraNavItems?: NavItem[] } = {}) {
-	// Register downstream nav entries once, before the navbars first read the
-	// registry. Idempotent on re-render (replaces with the same list).
-	registerExtraNavItems(extraNavItems);
+	// Register downstream nav entries as a commit-phase side effect (never during
+	// render, which must stay pure). Re-runs only if the list identity changes,
+	// and clears the registry on unmount so nothing leaks across app instances
+	// (e.g. between tests). The OSS binary passes nothing → the registry stays
+	// empty. The navbars mount under <Outlet> (after this effect has run), so
+	// they read the populated registry on their first paint.
+	useEffect(() => {
+		registerExtraNavItems(extraNavItems);
+		return () => registerExtraNavItems([]);
+	}, [extraNavItems]);
 	return useRoutes(buildRoutes(extraRoutes));
 }
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -9,7 +9,7 @@ import { OAuthPopupReturn } from '@/shared/auth/OAuthPopupReturn';
 import { Layout } from '@/shared/app/Layout';
 import { moduleRoutes, ROUTES } from '@/shared/app/routes';
 import { PlaceholderPage } from '@/shared/app/placeholders';
-import { sortedNavItems } from '@/shared/app/nav';
+import { sortedNavItems, registerExtraNavItems, type NavItem } from '@/shared/app/nav';
 // [ui-dashboard] Dashboard owns the /app index — replaces DashboardPlaceholder.
 import { dashboardIndexRoute } from '@/modules/dashboard/routes';
 import { publicDocsRoutes } from '@/modules/docs/routes';
@@ -46,8 +46,21 @@ import { publicDocsRoutes } from '@/modules/docs/routes';
  * nav-slot path, suppressing that slot's placeholder), so it can ship its own
  * SPA (OSS shell + built-in routes + its extras) without editing this repo.
  * Omitted (the default) for the OSS binary.
+ *
+ * `extraNavItems` is the matching seam for NAVIGATION: a downstream build passes
+ * additional `NavItem`s (e.g. a permission-gated, `secondary` operator entry)
+ * that the navbars render alongside the built-in registry. They're stashed in
+ * the nav module's static registry (see `registerExtraNavItems`) so the
+ * deep-in-the-tree navbars can read them without prop-drilling. Omitted (the
+ * default) for the OSS binary.
  */
-export function App({ extraRoutes = [] }: { extraRoutes?: RouteObject[] } = {}) {
+export function App({
+	extraRoutes = [],
+	extraNavItems = [],
+}: { extraRoutes?: RouteObject[]; extraNavItems?: NavItem[] } = {}) {
+	// Register downstream nav entries once, before the navbars first read the
+	// registry. Idempotent on re-render (replaces with the same list).
+	registerExtraNavItems(extraNavItems);
 	return useRoutes(buildRoutes(extraRoutes));
 }
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,6 +4,7 @@ import { SetupGate } from '@/shared/auth/SetupGate';
 import { LoginPage } from '@/shared/auth/LoginPage';
 import { SetupPage } from '@/shared/auth/SetupPage';
 import { ChangePasswordPage } from '@/shared/auth/ChangePasswordPage';
+import { RedeemInvitePage } from '@/shared/auth/RedeemInvitePage';
 import { OAuthPopupReturn } from '@/shared/auth/OAuthPopupReturn';
 import { Layout } from '@/shared/app/Layout';
 import { moduleRoutes, ROUTES } from '@/shared/app/routes';
@@ -23,6 +24,9 @@ import { publicDocsRoutes } from '@/modules/docs/routes';
  *                                      (→ /app/login, /app/setup)
  *   /change-password                 → outside the Layout, reachable pre-session
  *                                      (→ /app/change-password)
+ *   /redeem-invite                    → public invite-redemption landing
+ *                                      (→ /app/redeem-invite?token=…); outside
+ *                                      the AuthGuard, auto-logs in on success
  *   /oauth/connected                  → public OAuth popup landing (self-closes)
  *                                      (→ /app/oauth/connected; the backend
  *                                      callback redirects the popup here)
@@ -70,6 +74,11 @@ function buildRoutes(extraRoutes: RouteObject[] = []): RouteObject[] {
 			],
 		},
 		{ path: '/change-password', element: <ChangePasswordPage /> },
+		// Public invite-redemption landing. An admin invites a user (POST /users
+		// → invite_token) and sends them here (→ /app/redeem-invite?token=…) to set
+		// a password and finish account creation. Outside the AuthGuard — the
+		// invitee has no session yet (redeem returns a JWT and auto-logs them in).
+		{ path: '/redeem-invite', element: <RedeemInvitePage /> },
 		// Public landing for the OAuth connect popup. The backend callback
 		// redirects the popup here (→ /app/oauth/connected?status=ok|error); it
 		// self-closes. Outside the AuthGuard (the popup has no guaranteed

--- a/ui/src/modules/monitor/lib/usePermission.ts
+++ b/ui/src/modules/monitor/lib/usePermission.ts
@@ -1,16 +1,6 @@
 /**
- * Permission gate for Monitor's privileged actions.
- *
- * Reads the current user's permission list (from the shared auth context) and
- * answers whether a required permission is held. Cancel-job and the audit lens
- * are org:admin-only on the backend; the UI hides/disables those affordances
- * for non-admins rather than letting the call 403.
+ * Monitor's permission gate — now a thin re-export of the shell-wide hook in
+ * `shared/auth`. Kept so Monitor's existing imports (`@/modules/monitor/lib/
+ * usePermission`) stay valid; new call sites should import from `@/shared/auth`.
  */
-import { useAuth } from '@/shared/auth';
-
-export function usePermission(required: string): boolean {
-	const { user } = useAuth();
-	return user?.permissions?.includes(required) ?? false;
-}
-
-export const ORG_ADMIN = 'org:admin';
+export { usePermission, ORG_ADMIN } from '@/shared/auth/usePermission';

--- a/ui/src/modules/monitor/lib/usePermission.ts
+++ b/ui/src/modules/monitor/lib/usePermission.ts
@@ -3,4 +3,4 @@
  * `shared/auth`. Kept so Monitor's existing imports (`@/modules/monitor/lib/
  * usePermission`) stay valid; new call sites should import from `@/shared/auth`.
  */
-export { usePermission, ORG_ADMIN } from '@/shared/auth/usePermission';
+export { usePermission, ORG_ADMIN } from '@/shared/auth';

--- a/ui/src/shared/api/generated/models/CredentialRedactedResponse.ts
+++ b/ui/src/shared/api/generated/models/CredentialRedactedResponse.ts
@@ -21,6 +21,10 @@ export type CredentialRedactedResponse = {
      */
     created_at: string;
     /**
+     * Identity that created the credential (its owner).
+     */
+    created_by?: (string | null);
+    /**
      * Stable credential identifier, prefixed `cred_`.
      */
     credential_id: string;

--- a/ui/src/shared/api/generated/models/ToolkitResponse.ts
+++ b/ui/src/shared/api/generated/models/ToolkitResponse.ts
@@ -8,6 +8,7 @@
 export type ToolkitResponse = {
     active: boolean;
     created_at: string;
+    created_by?: (string | null);
     credential_count: number;
     description?: (string | null);
     key_count: number;

--- a/ui/src/shared/app/BottomNavbar.tsx
+++ b/ui/src/shared/app/BottomNavbar.tsx
@@ -2,12 +2,7 @@ import { useCallback, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { MoreHorizontal, X } from 'lucide-react';
 import { motion } from 'framer-motion';
-import {
-	sortedNavItems,
-	visibleNavItems,
-	isNavItemActive,
-	type NavItem,
-} from '@/shared/app/nav';
+import { sortedNavItems, visibleNavItems, isNavItemActive, type NavItem } from '@/shared/app/nav';
 import { useAuth } from '@/shared/auth/AuthContext';
 import { AppLink } from '@/shared/ui/AppLink';
 import { Button } from '@/shared/ui/Button';

--- a/ui/src/shared/app/BottomNavbar.tsx
+++ b/ui/src/shared/app/BottomNavbar.tsx
@@ -2,7 +2,13 @@ import { useCallback, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { MoreHorizontal, X } from 'lucide-react';
 import { motion } from 'framer-motion';
-import { sortedNavItems, isNavItemActive, type NavItem } from '@/shared/app/nav';
+import {
+	sortedNavItems,
+	visibleNavItems,
+	isNavItemActive,
+	type NavItem,
+} from '@/shared/app/nav';
+import { useAuth } from '@/shared/auth/AuthContext';
 import { AppLink } from '@/shared/ui/AppLink';
 import { Button } from '@/shared/ui/Button';
 import { useDismissable } from '@/shared/ui/Menu';
@@ -116,15 +122,21 @@ function BottomTile({
  */
 export function BottomNavbar() {
 	const { pathname } = useLocation();
-	const items = sortedNavItems();
+	const { user } = useAuth();
+	const allItems = visibleNavItems(sortedNavItems(), user?.permissions ?? []);
 	const [sheetOpen, setSheetOpen] = useState(false);
 	const closeSheet = useCallback(() => setSheetOpen(false), []);
 	// Wires Escape (and outside-click) on the sheet, matching the
 	// dismiss behaviour of every other dropdown / overlay in the app.
 	const sheetRef = useDismissable<HTMLDivElement>(sheetOpen, closeSheet);
 
-	const primary = items.slice(0, TILE_LIMIT - 1);
-	const overflow = items.slice(TILE_LIMIT - 1);
+	// Primary (product) items compete for the tile row; secondary (operator/
+	// admin) items always live in the "More" sheet, so mobile mirrors the
+	// desktop's divided placement rather than burning a scarce tile slot.
+	const primaryItems = allItems.filter((i) => !i.secondary);
+	const secondaryItems = allItems.filter((i) => i.secondary);
+	const primary = primaryItems.slice(0, TILE_LIMIT - 1);
+	const overflow = [...primaryItems.slice(TILE_LIMIT - 1), ...secondaryItems];
 	const overflowActive = overflow.some((item) => isNavItemActive(item, pathname));
 
 	return (

--- a/ui/src/shared/app/NavTabs.tsx
+++ b/ui/src/shared/app/NavTabs.tsx
@@ -2,7 +2,13 @@ import { useRef, useState, useEffect, useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
 import { ChevronDown } from 'lucide-react';
 import { LayoutGroup, motion } from 'framer-motion';
-import { sortedNavItems, isNavItemActive, type NavItem } from '@/shared/app/nav';
+import {
+	sortedNavItems,
+	visibleNavItems,
+	isNavItemActive,
+	type NavItem,
+} from '@/shared/app/nav';
+import { useAuth } from '@/shared/auth/AuthContext';
 import { AppLink } from '@/shared/ui/AppLink';
 import { Button } from '@/shared/ui/Button';
 import { MenuPanel, menuItemClass, useDismissable } from '@/shared/ui/Menu';
@@ -106,7 +112,12 @@ function NavTab({ item, isActive }: { item: NavItem; isActive: boolean }) {
  */
 export function NavTabs() {
 	const { pathname } = useLocation();
-	const items = sortedNavItems();
+	const { user } = useAuth();
+	const allItems = visibleNavItems(sortedNavItems(), user?.permissions ?? []);
+	// Secondary items (operator/admin areas) render in a divided slot at the end,
+	// outside the width-measured overflow logic that governs the primary tabs.
+	const items = allItems.filter((i) => !i.secondary);
+	const secondary = allItems.filter((i) => i.secondary);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [visibleCount, setVisibleCount] = useState(items.length);
 	const [overflowOpen, setOverflowOpen] = useState(false);
@@ -139,9 +150,10 @@ export function NavTabs() {
 		const ro = new ResizeObserver(measure);
 		if (containerRef.current) ro.observe(containerRef.current);
 		return () => ro.disconnect();
-		// `items` is derived from the static registry — stable across renders.
+		// `items` is derived from the static registry (+ the user's permissions) —
+		// stable across renders for a given session.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [items.length]);
 
 	const primary = items.slice(0, visibleCount);
 	const overflow = items.slice(visibleCount);
@@ -205,6 +217,24 @@ export function NavTabs() {
 							</MenuPanel>
 						)}
 					</div>
+				)}
+
+				{/* Secondary (operator/admin) entries: a divider then the tab(s),
+				    signalling a distinct area from the primary product nav. */}
+				{secondary.length > 0 && (
+					<>
+						<div
+							className="bg-border mx-1.5 h-4 w-px shrink-0"
+							aria-hidden="true"
+						/>
+						{secondary.map((item) => (
+							<NavTab
+								key={item.id}
+								item={item}
+								isActive={isNavItemActive(item, pathname)}
+							/>
+						))}
+					</>
 				)}
 			</div>
 		</LayoutGroup>

--- a/ui/src/shared/app/NavTabs.tsx
+++ b/ui/src/shared/app/NavTabs.tsx
@@ -2,12 +2,7 @@ import { useRef, useState, useEffect, useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
 import { ChevronDown } from 'lucide-react';
 import { LayoutGroup, motion } from 'framer-motion';
-import {
-	sortedNavItems,
-	visibleNavItems,
-	isNavItemActive,
-	type NavItem,
-} from '@/shared/app/nav';
+import { sortedNavItems, visibleNavItems, isNavItemActive, type NavItem } from '@/shared/app/nav';
 import { useAuth } from '@/shared/auth/AuthContext';
 import { AppLink } from '@/shared/ui/AppLink';
 import { Button } from '@/shared/ui/Button';
@@ -223,10 +218,7 @@ export function NavTabs() {
 				    signalling a distinct area from the primary product nav. */}
 				{secondary.length > 0 && (
 					<>
-						<div
-							className="bg-border mx-1.5 h-4 w-px shrink-0"
-							aria-hidden="true"
-						/>
+						<div className="bg-border mx-1.5 h-4 w-px shrink-0" aria-hidden="true" />
 						{secondary.map((item) => (
 							<NavTab
 								key={item.id}

--- a/ui/src/shared/app/nav.ts
+++ b/ui/src/shared/app/nav.ts
@@ -63,12 +63,13 @@ export const navItems: NavItem[] = [
  * `extraRoutes` seam). Stored in a module-level registry — same "static
  * registry" model as `navItems` — so the deep-in-the-tree navbar renderers
  * (`NavTabs`/`BottomNavbar`, rendered under `<Outlet>`) can read them without
- * prop-drilling through `Layout`. Set once at app construction via
- * `registerExtraNavItems`; the OSS binary never calls it (stays empty).
+ * prop-drilling through `Layout`. Registered from `App`'s mount effect via
+ * `registerExtraNavItems` (and cleared on unmount); the OSS binary never calls
+ * it (stays empty).
  */
 let extraNavItems: NavItem[] = [];
 
-/** Register downstream nav entries (idempotent replace). Call once on boot. */
+/** Register downstream nav entries (idempotent replace). Call from a mount effect. */
 export function registerExtraNavItems(items: NavItem[]): void {
 	extraNavItems = items;
 }

--- a/ui/src/shared/app/nav.ts
+++ b/ui/src/shared/app/nav.ts
@@ -16,6 +16,13 @@ import {
  *
  * `icon` is an optional component (e.g. a lucide-react icon) the feature PR can
  * supply; the layout renders a fallback glyph when it's absent.
+ *
+ * `requiredPermission` (optional) hides the item unless the current user holds
+ * that permission (checked client-side via the auth context; the backend still
+ * enforces access). `secondary` (optional) renders the item in a visually
+ * separated slot after a divider — for operator/admin areas distinct from the
+ * primary product features. Both exist so downstream builds can inject a gated,
+ * separated entry through the `extraNavItems` seam without special-casing here.
  */
 export interface NavItem {
 	id: string;
@@ -24,6 +31,8 @@ export interface NavItem {
 	to: string;
 	order: number;
 	icon?: ComponentType<{ className?: string }>;
+	requiredPermission?: string;
+	secondary?: boolean;
 }
 
 /**
@@ -49,9 +58,36 @@ export const navItems: NavItem[] = [
 	{ id: 'docs', label: 'API Reference', to: '/docs', order: 80, icon: BookText },
 ];
 
-/** Nav items sorted for rendering. */
+/**
+ * Extra nav entries injected by a downstream build (parallel to `App`'s
+ * `extraRoutes` seam). Stored in a module-level registry — same "static
+ * registry" model as `navItems` — so the deep-in-the-tree navbar renderers
+ * (`NavTabs`/`BottomNavbar`, rendered under `<Outlet>`) can read them without
+ * prop-drilling through `Layout`. Set once at app construction via
+ * `registerExtraNavItems`; the OSS binary never calls it (stays empty).
+ */
+let extraNavItems: NavItem[] = [];
+
+/** Register downstream nav entries (idempotent replace). Call once on boot. */
+export function registerExtraNavItems(items: NavItem[]): void {
+	extraNavItems = items;
+}
+
+/** Nav items sorted for rendering (built-in registry + any registered extras). */
 export function sortedNavItems(): NavItem[] {
-	return [...navItems].sort((a, b) => a.order - b.order);
+	return [...navItems, ...extraNavItems].sort((a, b) => a.order - b.order);
+}
+
+/**
+ * Filter a nav list down to what the current user may see. Items with a
+ * `requiredPermission` the user lacks are dropped; ungated items always pass.
+ * `permissions` is the user's permission list (empty/undefined ⇒ only ungated
+ * items survive).
+ */
+export function visibleNavItems(items: NavItem[], permissions: readonly string[] = []): NavItem[] {
+	return items.filter(
+		(item) => !item.requiredPermission || permissions.includes(item.requiredPermission),
+	);
 }
 
 /**

--- a/ui/src/shared/auth/AuthContext.tsx
+++ b/ui/src/shared/auth/AuthContext.tsx
@@ -36,6 +36,13 @@ export interface AuthContextValue {
 	 * re-login. Returns nothing — the new session is live on resolve.
 	 */
 	changePassword: (currentPassword: string, newPassword: string) => Promise<void>;
+	/**
+	 * Redeem a user invite: set the initial password for an invited account and
+	 * adopt the returned session (auto-login), so the invitee lands in the app
+	 * without a second round-trip. Unauthenticated entry point (the invitee has
+	 * no session yet) — mirrors `createAdmin`/`login`'s token adoption.
+	 */
+	redeemInvite: (inviteToken: string, password: string) => Promise<void>;
 	/** Client-side sign-out — jentic-one JWTs are stateless (no revoke endpoint). */
 	logout: () => void;
 }
@@ -115,6 +122,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 		[queryClient],
 	);
 
+	const redeemInvite = useCallback(
+		async (inviteToken: string, password: string) => {
+			// Redemption returns a ready-to-use token (auto-login), same shape as
+			// login/createAdmin — adopt it and refresh /users/me.
+			const result = await UsersService.redeemInvite({
+				requestBody: { invite_token: inviteToken, password },
+			});
+			setToken(result.access_token);
+			await queryClient.invalidateQueries({ queryKey: ME_QUERY_KEY });
+		},
+		[queryClient],
+	);
+
 	const logout = useCallback(() => {
 		clearToken();
 		queryClient.removeQueries({ queryKey: ME_QUERY_KEY });
@@ -140,6 +160,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 			login,
 			createAdmin,
 			changePassword,
+			redeemInvite,
 			logout,
 		};
 	}, [
@@ -150,6 +171,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 		login,
 		createAdmin,
 		changePassword,
+		redeemInvite,
 		logout,
 	]);
 

--- a/ui/src/shared/auth/RedeemInvitePage.tsx
+++ b/ui/src/shared/auth/RedeemInvitePage.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '@/shared/auth/AuthContext';
+import { ApiError } from '@/shared/api';
+import { ROUTES } from '@/shared/app/routes';
+import { Input } from '@/shared/ui/Input';
+import { Label } from '@/shared/ui/Label';
+import { Button } from '@/shared/ui/Button';
+import { ErrorAlert } from '@/shared/ui/ErrorAlert';
+import { MIN_PASSWORD_LENGTH } from '@/shared/auth/password';
+
+/**
+ * Invite redemption / finish-account page.
+ *
+ * An admin creates a user (`POST /users`), which issues a one-time invite token,
+ * and sends the invitee a link to this page carrying `?token=<invite_token>`.
+ * Here the invitee sets their initial password; `redeemInvite` calls
+ * `POST /users:redeem-invite`, which returns a JWT that we adopt (auto-login),
+ * landing them straight in the app.
+ *
+ * This is an auth-only screen (like Login/Setup): it intentionally bypasses
+ * `PageShell` and owns its own centred card. It lives OUTSIDE the AuthGuard —
+ * the invitee has no session yet.
+ */
+export function RedeemInvitePage() {
+	const { redeemInvite } = useAuth();
+	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+	const token = searchParams.get('token') ?? '';
+
+	const [password, setPassword] = useState('');
+	const [confirm, setConfirm] = useState('');
+	const [error, setError] = useState<string | null>(null);
+	const [submitting, setSubmitting] = useState(false);
+
+	// Wipe sensitive fields on unmount so passwords don't linger in memory.
+	const wipe = useRef<() => void>(() => {});
+	wipe.current = () => {
+		setPassword('');
+		setConfirm('');
+	};
+	useEffect(() => () => wipe.current(), []);
+
+	const passwordRef = useRef<HTMLInputElement>(null);
+	useEffect(() => {
+		passwordRef.current?.focus();
+	}, []);
+
+	const handleSubmit = async (event: React.FormEvent) => {
+		event.preventDefault();
+		if (submitting) {
+			return;
+		}
+		setError(null);
+		if (!token) {
+			setError('This invite link is missing its token. Ask your admin to resend it.');
+			return;
+		}
+		if (password.length < MIN_PASSWORD_LENGTH) {
+			setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+			return;
+		}
+		if (password !== confirm) {
+			setError('Password and confirmation do not match.');
+			return;
+		}
+		setSubmitting(true);
+		try {
+			await redeemInvite(token, password);
+			wipe.current();
+			navigate(ROUTES.app, { replace: true });
+		} catch (err) {
+			if (err instanceof ApiError && (err.status === 400 || err.status === 422)) {
+				// 400/422 — invalid/expired token or the password failed policy.
+				setError(
+					'This invite is invalid or has expired, or the password does not meet the requirements. Ask your admin to resend the invite.',
+				);
+			} else {
+				setError('Could not finish setting up your account. Please try again.');
+			}
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<main className="bg-background text-foreground flex min-h-screen items-center justify-center px-4">
+			<form
+				onSubmit={handleSubmit}
+				className="border-border bg-card w-full max-w-sm rounded-xl border p-6 shadow-sm"
+				aria-labelledby="redeem-invite-heading"
+			>
+				<h1 id="redeem-invite-heading" className="font-display text-xl font-semibold">
+					Finish setting up your account
+				</h1>
+				<p className="text-muted-foreground mt-1 text-sm">
+					Choose a password to activate your account and sign in.
+				</p>
+
+				<div className="mt-6 space-y-4">
+					<div className="space-y-1">
+						<Label htmlFor="ri-password">Password</Label>
+						<Input
+							id="ri-password"
+							ref={passwordRef}
+							type="password"
+							autoComplete="new-password"
+							showPasswordToggle
+							required
+							minLength={MIN_PASSWORD_LENGTH}
+							value={password}
+							onChange={(e) => setPassword(e.target.value)}
+						/>
+						<p className="text-muted-foreground text-xs">
+							At least {MIN_PASSWORD_LENGTH} characters.
+						</p>
+					</div>
+					<div className="space-y-1">
+						<Label htmlFor="ri-confirm">Confirm password</Label>
+						<Input
+							id="ri-confirm"
+							type="password"
+							autoComplete="new-password"
+							showPasswordToggle
+							required
+							value={confirm}
+							onChange={(e) => setConfirm(e.target.value)}
+						/>
+					</div>
+				</div>
+
+				{error !== null && <ErrorAlert message={error} className="mt-4" />}
+
+				<Button type="submit" loading={submitting} fullWidth className="mt-6">
+					{submitting ? 'Setting up…' : 'Activate account'}
+				</Button>
+			</form>
+		</main>
+	);
+}

--- a/ui/src/shared/auth/RedeemInvitePage.tsx
+++ b/ui/src/shared/auth/RedeemInvitePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '@/shared/auth/AuthContext';
 import { ApiError } from '@/shared/api';
 import { ROUTES } from '@/shared/app/routes';
@@ -23,10 +23,11 @@ import { MIN_PASSWORD_LENGTH } from '@/shared/auth/password';
  * the invitee has no session yet.
  */
 export function RedeemInvitePage() {
-	const { redeemInvite } = useAuth();
+	const { redeemInvite, status } = useAuth();
 	const navigate = useNavigate();
 	const [searchParams] = useSearchParams();
 	const token = searchParams.get('token') ?? '';
+	const tokenMissing = token === '';
 
 	const [password, setPassword] = useState('');
 	const [confirm, setConfirm] = useState('');
@@ -45,6 +46,14 @@ export function RedeemInvitePage() {
 	useEffect(() => {
 		passwordRef.current?.focus();
 	}, []);
+
+	// Surface a broken link (no `?token=`) immediately on mount — before the
+	// visitor bothers filling in a password — and keep the form disabled.
+	useEffect(() => {
+		if (tokenMissing) {
+			setError('This invite link is missing its token. Ask your admin to resend it.');
+		}
+	}, [tokenMissing]);
 
 	const handleSubmit = async (event: React.FormEvent) => {
 		event.preventDefault();
@@ -82,6 +91,13 @@ export function RedeemInvitePage() {
 		}
 	};
 
+	// An already-signed-in visitor has no invite to redeem; redeeming here would
+	// silently swap their session. Bounce them home (mirrors Login/Setup). Placed
+	// after all hooks so the Rules of Hooks hold regardless of auth state.
+	if (status === 'authenticated') {
+		return <Navigate to={ROUTES.app} replace />;
+	}
+
 	return (
 		<main className="bg-background text-foreground flex min-h-screen items-center justify-center px-4">
 			<form
@@ -107,6 +123,7 @@ export function RedeemInvitePage() {
 							showPasswordToggle
 							required
 							minLength={MIN_PASSWORD_LENGTH}
+							disabled={tokenMissing}
 							value={password}
 							onChange={(e) => setPassword(e.target.value)}
 						/>
@@ -122,6 +139,7 @@ export function RedeemInvitePage() {
 							autoComplete="new-password"
 							showPasswordToggle
 							required
+							disabled={tokenMissing}
 							value={confirm}
 							onChange={(e) => setConfirm(e.target.value)}
 						/>
@@ -130,7 +148,13 @@ export function RedeemInvitePage() {
 
 				{error !== null && <ErrorAlert message={error} className="mt-4" />}
 
-				<Button type="submit" loading={submitting} fullWidth className="mt-6">
+				<Button
+					type="submit"
+					loading={submitting}
+					disabled={tokenMissing}
+					fullWidth
+					className="mt-6"
+				>
 					{submitting ? 'Setting up…' : 'Activate account'}
 				</Button>
 			</form>

--- a/ui/src/shared/auth/RequirePermission.tsx
+++ b/ui/src/shared/auth/RequirePermission.tsx
@@ -1,0 +1,30 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { usePermission } from '@/shared/auth/usePermission';
+import { ROUTES } from '@/shared/app/routes';
+
+/**
+ * Route guard for permission-gated areas. Renders its children only when the
+ * current user holds `permission`; otherwise redirects to the app home. Runs
+ * INSIDE the authenticated shell (below `AuthGuard`), so a user is always
+ * present — this checks authorization, not authentication.
+ *
+ * Cosmetic nav-hiding (see `visibleNavItems`) keeps the entry out of sight; this
+ * guard is the matching defense-in-depth for a deep-link/hard-refresh to the
+ * path. The backend still enforces the real boundary (403 on the data calls).
+ *
+ * Use either as a wrapper element (`<RequirePermission permission="…"><Page/>…`)
+ * or as a layout route (renders `<Outlet/>` when no children are passed).
+ */
+export function RequirePermission({
+	permission,
+	children,
+	redirectTo = ROUTES.app,
+}: {
+	permission: string;
+	children?: React.ReactNode;
+	redirectTo?: string;
+}) {
+	const allowed = usePermission(permission);
+	if (!allowed) return <Navigate to={redirectTo} replace />;
+	return <>{children ?? <Outlet />}</>;
+}

--- a/ui/src/shared/auth/index.ts
+++ b/ui/src/shared/auth/index.ts
@@ -1,6 +1,8 @@
 export { AuthProvider, useAuth } from '@/shared/auth/AuthContext';
 export type { AuthContextValue, AuthStatus } from '@/shared/auth/AuthContext';
 export { AuthGuard } from '@/shared/auth/AuthGuard';
+export { RequirePermission } from '@/shared/auth/RequirePermission';
+export { usePermission, ORG_ADMIN } from '@/shared/auth/usePermission';
 export { LoginPage } from '@/shared/auth/LoginPage';
 export { ChangePasswordPage } from '@/shared/auth/ChangePasswordPage';
 export { MIN_PASSWORD_LENGTH } from '@/shared/auth/password';

--- a/ui/src/shared/auth/usePermission.ts
+++ b/ui/src/shared/auth/usePermission.ts
@@ -1,0 +1,17 @@
+/**
+ * Client-side permission gate. Reads the current user's permission list (from
+ * the shared auth context) and answers whether a required permission is held.
+ *
+ * This hides/disables affordances (nav entries, buttons, tabs) the backend
+ * would 403 anyway — a UX nicety, NOT a security boundary. The server remains
+ * the source of truth; never rely on this alone to protect data.
+ */
+import { useAuth } from '@/shared/auth/AuthContext';
+
+export function usePermission(required: string): boolean {
+	const { user } = useAuth();
+	return user?.permissions?.includes(required) ?? false;
+}
+
+/** The org-wide admin permission. */
+export const ORG_ADMIN = 'org:admin';


### PR DESCRIPTION
## Summary

Adds the **invite-redemption page** so an admin-invited user can finish their own
account setup, and bundles the supporting **generic OSS** backend/UI work that a
downstream (private) operator console builds on. **No private-tier code or
naming lives in this PR** — every seam here is generic and useful to the OSS
shell on its own.

> **Reviewer's guide (read me first).** This branch is intentionally a small
> bundle of *independent* changes that share one goal: make the OSS shell
> extensible + fix two real OSS bugs found along the way. They're grouped for
> review convenience; each commit stands alone and could be cherry-picked. See
> "What's here (by commit)" for the map, and "How to review" at the bottom.

### What's here (by commit)

- **`feat(auth)` invite-redemption page** — public `/app/redeem-invite?token=…`
  landing where an invitee sets a password and finishes account creation
  (`POST /users:redeem-invite` returns a JWT and auto-logs them in). Lives
  outside the `AuthGuard`. Hardened: an already-authenticated visitor is bounced
  home, and a link missing its `?token=` is flagged on mount (form disabled)
  rather than only after submit.
- **`feat(ui)` `extraNavItems` seam + permission-gated secondary nav** — a
  generic nav-extension seam (parallel to the existing `extraRoutes` seam):
  `NavItem` gains `requiredPermission` (hide unless the user holds it) and
  `secondary` (render in a divided operator slot); `NavTabs`/`BottomNavbar`
  filter by the user's permissions. Promotes `usePermission`/`ORG_ADMIN` to
  `shared/auth` (already consumed by Monitor) and adds a generic
  `RequirePermission` route guard. Registration is a commit-phase effect with
  unmount cleanup (no render-time side effects, no cross-instance bleed). OSS
  ships zero extra nav items, so stock behaviour is unchanged.
- **`fix(monitoring)` SQLite-compatible usage aggregations** — `overall_stats` /
  `time_buckets` / `grouped_top` / `grouped_trend` hard-coded Postgres-only SQL
  (`percentile_cont … WITHIN GROUP`, `extract('epoch', …)`, `concat()`), so
  `GET /monitoring/usage` 500'd on the local-sqlite backend even though OSS
  already dialect-branches `daily_buckets`. Extends that existing pattern
  (percentiles → `None` on SQLite; `strftime('%s')`; `||` concat) via a single
  `_is_postgres` helper now reused by `daily_buckets` too, + integration
  coverage on both backends.
- **`feat(control)` expose `created_by` (owner)** on `ToolkitResponse` and
  `CredentialRedactedResponse` — the owner was already persisted (set on create,
  used for query-scoping) but never surfaced; now clients can show it.
  Regenerated the control OpenAPI spec + UI client (verified in sync by
  `tests/arch/test_openapi_conformance.py`).
- **`feat(dev)` configurable fixtures Postgres port** — dev compose publishes
  `${JENTIC_PG_PORT:-5432}:5432` so it can run alongside a native Postgres; the
  in-container port and default behaviour are unchanged.
- **`test(web)` role-enforced flywheel** — end-to-end integration test against
  the real combined app + DB: admin creates users with different permission
  sets; admin/write-capable user create agents & toolkits; reads verified by
  role with owner-scoping (admin sees all, non-admins see only their own).
  **Postgres-only** (the `tests/web` harness has no SQLite switch; teardown
  relies on FK `RESTRICT`); SQLite dialect coverage for the read paths lives in
  `tests/integration/admin/test_monitoring_repo.py`.

## OSS purity

No `enterprise` / `admin-console` / `tenant` / `multi-tenancy` strings appear in
any file this PR touches (verified). The seams (`extraNavItems`,
`RequirePermission`, `requiredPermission`, `secondary`) are generic extension
points with **zero OSS callers** — exactly like the pre-existing `extraRoutes`
seam — so they add no behaviour to the OSS binary.

## Pre-review

Ran an internal multi-lens review (OSS-purity/architecture, backend correctness,
UI correctness) before requesting review. Findings addressed in
`refactor(review): address pre-review findings on #734`: removed the name leaks,
moved nav registration to an effect, hardened the redeem page, corrected the
flywheel docstring, and unified dialect detection. Remaining advisory (not
done): the branch could be split into per-concern PRs for a cleaner history —
happy to do that if preferred over reviewing as a bundle.

## How to review

- **Seam design:** compare `extraNavItems` (`ui/src/App.tsx`, `ui/src/shared/app/nav.ts`)
  against the existing `extraRoutes` seam — same "downstream passes extras,
  OSS ships none" shape.
- **Bug fixes stand alone:** the monitoring SQLite fix and `created_by`
  exposure are independent of the invite page.
- **Auth flow:** `RedeemInvitePage` + `AuthContext.redeemInvite`.

## Test plan

- [x] `ruff check .` clean; `ruff format --check` clean.
- [x] `pytest tests/arch` (257) pass — includes OpenAPI drift + no-test-classes guards.
- [x] `pytest tests/integration/admin/test_monitoring_repo.py` on SQLite (8) pass.
- [x] UI `tsc --noEmit` clean; `eslint` clean; `vitest` (nav + auth areas, 81) green.
- [ ] CI (Postgres integration, incl. the flywheel test) on this PR.
