### PR TITLE
fix(ui): use a dedicated muted token for input placeholder text

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -22,6 +22,9 @@
 	--color-muted: hsl(var(--muted));
 	--color-muted-foreground: hsl(var(--muted-foreground));
 
+	/* Form placeholder — a muted grey, clearly lighter than entered text */
+	--color-input-placeholder: hsl(var(--input-placeholder));
+
 	/* Card */
 	--color-card: hsl(var(--card));
 	--color-card-foreground: hsl(var(--card-foreground));
@@ -165,6 +168,10 @@
 	--foreground-lighter: var(--primary-100); /* #E4EAEB */
 	--muted: var(--primary-850); /* #193238 */
 	--muted-foreground: var(--primary-100); /* #E4EAEB */
+
+	/* Placeholder text — deliberately a muted grey so empty fields read as
+	   empty and don't look identical to entered (near-white) text (#673). */
+	--input-placeholder: var(--primary-500); /* #689296 */
 
 	/* Brand */
 	--primary: var(--primary-300); /* #A3CACC */

--- a/ui/src/shared/app/rail/DenyReasonField.tsx
+++ b/ui/src/shared/app/rail/DenyReasonField.tsx
@@ -29,7 +29,7 @@ export function DenyReasonField({ id, value, onChange, autoFocus }: DenyReasonFi
 				rows={2}
 				autoFocus={autoFocus}
 				placeholder="Why is this being denied?"
-				className="border-border bg-background focus:border-primary w-full resize-none rounded border px-2 py-1 text-[11px] outline-none"
+				className="border-border bg-background focus:border-primary placeholder:text-input-placeholder w-full resize-none rounded border px-2 py-1 text-[11px] outline-none"
 			/>
 		</div>
 	);

--- a/ui/src/shared/ui/Input.tsx
+++ b/ui/src/shared/ui/Input.tsx
@@ -43,7 +43,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(function Inp
 					aria-describedby={errorId}
 					aria-invalid={error ? true : undefined}
 					className={cn(
-						'bg-card border-border text-foreground placeholder:text-muted-foreground w-full rounded-lg border transition-colors',
+						'bg-card border-border text-foreground placeholder:text-input-placeholder w-full rounded-lg border transition-colors',
 						'focus:border-primary focus:outline-hidden',
 						sizeClasses[size],
 						startIcon && 'pl-9',

--- a/ui/src/shared/ui/Textarea.tsx
+++ b/ui/src/shared/ui/Textarea.tsx
@@ -31,7 +31,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(fun
 				aria-describedby={errorId}
 				aria-invalid={error ? true : undefined}
 				className={cn(
-					'bg-card border-border text-foreground placeholder:text-muted-foreground w-full rounded-lg border px-4 py-2 text-sm transition-colors',
+					'bg-card border-border text-foreground placeholder:text-input-placeholder w-full rounded-lg border px-4 py-2 text-sm transition-colors',
 					'focus:border-primary focus:outline-hidden',
 					resizeClasses[resizable],
 					error && 'border-danger focus:border-danger',


### PR DESCRIPTION
## Summary

Placeholder text in form fields rendered the same near-white colour as entered
text, so empty and filled fields looked identical app-wide. Placeholders
inherited the `--muted-foreground` token (`#E4EAEB`), which is nearly
indistinguishable from the `#FFFFFF` foreground used for entered text.

This introduces a **dedicated placeholder token** so only placeholder text is
affected. `--muted-foreground` is intentionally left unchanged — it is consumed
by many components for general muted text (table headers, the app rail, badges,
captions, pagination), and darkening it would be the wrong blast radius.

## Related issue

Closes #673

## Changes

- `ui/src/index.css`: add a semantic `--input-placeholder` token (`#689296`,
  `primary-500` — a muted grey clearly lighter than entered text) and register a
  matching `--color-input-placeholder` Tailwind colour in the `@theme inline`
  block. `--muted-foreground` is left untouched at `#E4EAEB`.
- `ui/src/shared/ui/Input.tsx`: placeholder utility
  `placeholder:text-muted-foreground` → `placeholder:text-input-placeholder`.
- `ui/src/shared/ui/Textarea.tsx`: same placeholder utility change.

## Testing

- `npm run lint` (in `ui/`) — clean.
- `npm run build` (in `ui/`) — succeeds; Tailwind compiles the new
  `text-input-placeholder` utility with no "unknown utility class" error.
- Verified the compiled CSS emits
  `::placeholder{color:hsl(var(--input-placeholder))}` resolving to `#689296`,
  distinct from the `#FFFFFF` entered text.
- Manual check: placeholder text now reads as a muted grey and is clearly
  distinct from typed text; other `text-muted-foreground` surfaces (table
  headers, rail, badges, captions) are unchanged.

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] `make check` passes (lint, type check, secrets audit, arch tests)
- [ ] Tests added/updated for the change
- [x] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included