### PR TITLE
fix(broker): parse permission-rule JSON columns on the SQLite read path

### DIFF
--- a/src/jentic_one/broker/repos/rule_evaluator.py
+++ b/src/jentic_one/broker/repos/rule_evaluator.py
@@ -11,6 +11,7 @@ Performance: the rule list per (toolkit, credential) pair is short-TTL cached
 
 from __future__ import annotations
 
+import json
 import re
 import time
 from collections import OrderedDict
@@ -61,6 +62,30 @@ def _compile_path(raw: str | None) -> re.Pattern[str] | None:
         return re.compile(raw)
     except re.error:
         return None
+
+
+def _coerce_json_list(value: object) -> list[str] | None:
+    """Coerce a JSON column value into a list of strings (or None).
+
+    The evaluator reads rules via raw ``text()`` SQL, which bypasses the ORM's
+    ``json_variant()`` deserialization. On PostgreSQL the JSONB driver still
+    decodes the column into native lists, but on SQLite (JSON stored as TEXT)
+    the raw string comes straight through — e.g. ``'["GET", "POST"]'`` or the
+    literal ``'null'``. Parse the string form here so both backends yield the
+    same list; a non-string list (already decoded) passes through unchanged.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    return None
 
 
 def _normalize_methods(raw: list[str] | None) -> frozenset[str] | None:
@@ -197,9 +222,11 @@ class RuleEvaluator:
         return [
             PermissionRule(
                 effect=row[0],
-                methods=_normalize_methods(row[1]),
+                methods=_normalize_methods(_coerce_json_list(row[1])),
                 path=_compile_path(row[2]),
-                operations=tuple(row[3]) if row[3] is not None else None,
+                operations=(
+                    tuple(ops) if (ops := _coerce_json_list(row[3])) is not None else None
+                ),
             )
             for row in rows
         ]

--- a/src/jentic_one/broker/repos/rule_evaluator.py
+++ b/src/jentic_one/broker/repos/rule_evaluator.py
@@ -224,9 +224,7 @@ class RuleEvaluator:
                 effect=row[0],
                 methods=_normalize_methods(_coerce_json_list(row[1])),
                 path=_compile_path(row[2]),
-                operations=(
-                    tuple(ops) if (ops := _coerce_json_list(row[3])) is not None else None
-                ),
+                operations=(tuple(ops) if (ops := _coerce_json_list(row[3])) is not None else None),
             )
             for row in rows
         ]

--- a/tests/unit/broker/test_rule_evaluator.py
+++ b/tests/unit/broker/test_rule_evaluator.py
@@ -10,6 +10,7 @@ import pytest
 from jentic_one.broker.repos.rule_evaluator import (
     PermissionRule,
     RuleEvaluator,
+    _coerce_json_list,
     _compile_path,
     _normalize_methods,
     _rule_matches,
@@ -108,6 +109,34 @@ def test_normalize_methods_none() -> None:
 def test_normalize_methods_uppercases() -> None:
     result = _normalize_methods(["get", "Post", "DELETE"])
     assert result == frozenset({"GET", "POST", "DELETE"})
+
+
+# ---------------------------------------------------------------------------
+# JSON-column coercion (raw-SQL read path — SQLite returns JSON as TEXT)
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_json_list_none() -> None:
+    assert _coerce_json_list(None) is None
+
+
+def test_coerce_json_list_passes_through_decoded_list() -> None:
+    """Postgres JSONB is already decoded to a list — returned unchanged."""
+    assert _coerce_json_list(["GET", "POST"]) == ["GET", "POST"]
+
+
+def test_coerce_json_list_parses_sqlite_json_string() -> None:
+    """SQLite returns the column as a raw JSON string via ``text()`` SQL."""
+    assert _coerce_json_list('["GET", "POST", "PUT"]') == ["GET", "POST", "PUT"]
+
+
+def test_coerce_json_list_json_null_string_is_none() -> None:
+    """A SQLite ``operations='null'`` column must decode to None, not ['n','u','l','l']."""
+    assert _coerce_json_list("null") is None
+
+
+def test_coerce_json_list_invalid_json_is_none() -> None:
+    assert _coerce_json_list("not-json") is None
 
 
 # ---------------------------------------------------------------------------
@@ -254,6 +283,38 @@ async def test_evaluator_empty_rules_denies() -> None:
         toolkit_id="tk_1", method="GET", path="/x", operation_id=None, api_vendor="acme"
     )
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_evaluator_coerces_sqlite_json_string_methods() -> None:
+    """Regression: SQLite returns ``methods``/``operations`` as raw JSON strings.
+
+    The evaluator reads rules via raw ``text()`` SQL, bypassing the ORM's JSON
+    deserialization. On SQLite ``methods`` arrives as ``'["GET", ...]'`` and
+    ``operations`` as ``'null'``; without coercion these get iterated
+    character-by-character, so a legitimate ``allow`` rule silently fails to
+    match. Feed the SQLite wire form and assert the method still matches.
+    """
+    mock_db = MagicMock()
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.all.return_value = [
+        ("allow", '["GET", "POST", "PUT", "PATCH", "DELETE"]', ".*", "null")
+    ]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_db.session = MagicMock(return_value=_AsyncCtx(mock_session))
+
+    evaluator = RuleEvaluator(mock_db, cache_ttl_seconds=300.0)
+    allowed = await evaluator.evaluate(
+        toolkit_id="tk_1", method="POST", path="/v1/things", operation_id=None, api_vendor="acme"
+    )
+    assert allowed is True
+
+    # A method outside the (correctly parsed) set must NOT match.
+    denied = await evaluator.evaluate(
+        toolkit_id="tk_1", method="OPTIONS", path="/v1/things", operation_id=None, api_vendor="acme"
+    )
+    assert denied is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


<!--
Thanks for contributing to Jentic One!
Keep PRs focused and reviewable. Do not include secrets or credentials.
-->

## Summary

<!-- What does this change and why? -->
The rule evaluator reads toolkit_permission_rules via raw text() SQL, which bypasses the ORM's json_variant() deserialization. On PostgreSQL the JSONB driver still decodes methods/operations into native lists, but on SQLite (JSON stored as TEXT) the raw string comes straight through — e.g. '["GET", "POST"]' or the literal 'null'. _normalize_methods / tuple() then iterate the string character-by-character, so a legitimate allow rule silently fails to match and every operation is wrongly denied.

## Related issue

<!-- e.g. Closes #123 -->

## Changes

Add _coerce_json_list to parse the string form (mirroring _as_scope_list in token_resolver), so both backends yield the same list. An already-decoded list passes through unchanged; 'null'/invalid maps to None (no constraint).

## Testing

<!-- How did you verify this? `make check` output, new/updated tests, manual steps. -->

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] `make check` passes (lint, type check, secrets audit, arch tests)
- [x] Tests added/updated for the change
- [ ] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included
