### PR TITLE
feat(cli): make jenticctl update version/tag-driven and default confirm to Yes

### DIFF
--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -32,11 +32,12 @@ func newUpdateCmd(app *App) *cobra.Command {
 	opts := &updateOptions{}
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update the jentic CLIs (and check the stack) to the latest build",
-		Long: "update reports the installed CLI and server versions, compares the tracked\n" +
-			"git ref against its latest commit on GitHub, and (unless --check) rebuilds\n" +
-			"and replaces the jenticctl and jentic binaries in place, then rebuilds the\n" +
-			"installed stack. Use --cli-only or --stack-only to update just one half.",
+		Short: "Update the jentic CLIs (and check the stack) to the latest release",
+		Long: "update reports the installed CLI and server versions, compares the\n" +
+			"installed version against the latest release tag on GitHub, and (unless\n" +
+			"--check) rebuilds and replaces the jenticctl and jentic binaries in place,\n" +
+			"then rebuilds the installed stack. Use --cli-only or --stack-only to update\n" +
+			"just one half.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return app.updateE(cmd.Context(), opts)
@@ -46,7 +47,7 @@ func newUpdateCmd(app *App) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.cliOnly, "cli-only", false, "update only the CLI binary")
 	cmd.Flags().BoolVar(&opts.stackOnly, "stack-only", false, "update only the stack (not the CLI binary)")
 	cmd.Flags().BoolVar(&opts.yes, "yes", false, "skip the confirmation prompt")
-	cmd.Flags().StringVar(&opts.ref, "ref", "", "git ref to update to (default: the installed ref)")
+	cmd.Flags().StringVar(&opts.ref, "ref", "", "git ref to update to, pinning a specific tag/branch/commit (default: the latest release tag)")
 	cmd.Flags().StringVar(&opts.baseURL, "base-url", "", "Jentic control-plane base URL (for the server probe)")
 	return cmd
 }
@@ -58,26 +59,37 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 	}
 
 	repo := manifest.ResolvedRepo()
-	ref := firstNonEmpty(opts.ref, manifest.Ref, defaultRef(version))
 	installed := firstNonEmpty(manifest.Commit, commit)
 	cliVersion := firstNonEmpty(manifest.CLIVersion, version)
 
 	fmt.Fprint(a.Out, a.brandHeader(opts.baseURL, cliVersion))
 	fmt.Fprintln(a.Out)
 	fmt.Fprintln(a.Out, theme.Field("cli", cliLine(cliVersion, installed)))
-	fmt.Fprintln(a.Out, theme.Field("tracking", repo+"@"+ref))
 	if !found {
 		fmt.Fprintln(a.Out, theme.Dim.Render("  (no install manifest; using build-time metadata)"))
 	}
 
-	remote, remoteErr := update.RemoteCommit(ctx, repo, ref, os.Getenv("GITHUB_TOKEN"))
-	remoteKnown := remoteErr == nil
-	if remoteKnown {
-		fmt.Fprintln(a.Out, theme.Field("latest", remote))
-		a.printVerdict(installed, remote)
+	// Resolve the update target. By default we track the latest release tag; an
+	// explicit --ref pins a specific tag/branch/commit instead.
+	latest, latestErr := update.LatestReleaseTag(ctx, repo, os.Getenv("GITHUB_TOKEN"))
+	latestKnown := latestErr == nil
+
+	ref := opts.ref
+	pinned := ref != ""
+	if !pinned && latestKnown {
+		ref = latest
+	}
+	if ref == "" {
+		ref = firstNonEmpty(manifest.Ref, defaultRef(version))
+	}
+	fmt.Fprintln(a.Out, theme.Field("tracking", repo+"@"+ref))
+
+	if latestKnown {
+		fmt.Fprintln(a.Out, theme.Field("latest", latest))
+		a.printVerdict(cliVersion, latest)
 	} else {
 		fmt.Fprintln(a.Out, theme.Field("latest", "unknown"))
-		fmt.Fprintln(a.Out, theme.Warnf("  %v", remoteErr))
+		fmt.Fprintln(a.Out, theme.Warnf("  %v", latestErr))
 	}
 
 	if opts.check {
@@ -87,11 +99,12 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 	doCLI := !opts.stackOnly
 	doStack := !opts.cliOnly
 
-	// When the tracked ref is already at the installed commit there's nothing to
-	// rebuild for either half. Re-run the installer / `jenticctl install` to force.
-	if remoteKnown && update.SameCommit(installed, remote) {
+	// When the latest release is not newer than what's installed there's nothing
+	// to rebuild. A --ref override always proceeds (the user asked for a specific
+	// build); re-run with --ref to force a rebuild at a pinned version.
+	if !pinned && latestKnown && !update.NewerAvailable(cliVersion, latest) {
 		fmt.Fprintln(a.Out)
-		fmt.Fprintln(a.Out, theme.Successf("Already up to date (%s); nothing to rebuild.", remote))
+		fmt.Fprintln(a.Out, theme.Successf("Already up to date (%s); nothing to rebuild.", latest))
 		return nil
 	}
 
@@ -366,10 +379,13 @@ func confirmApply(doCLI, doStack bool, repo, ref string) (bool, error) {
 	default:
 		what = "the stack"
 	}
-	confirm := false
+	// This prompt is only reached when an update is available, so default the
+	// focused selection to "Yes, update": the user already invoked `update`, so
+	// a reflexive Enter should proceed rather than cancel (#765).
+	confirm := true
 	if err := install.RunConfirm(
 		huh.NewConfirm().
-			Title(fmt.Sprintf("Rebuild %s from %s@%s?", what, repo, ref)).
+			Title(fmt.Sprintf("Update %s to %s@%s?", what, repo, ref)).
 			Affirmative("Yes, update").
 			Negative("Cancel").
 			Value(&confirm),
@@ -382,16 +398,16 @@ func confirmApply(doCLI, doStack bool, repo, ref string) (bool, error) {
 	return confirm, nil
 }
 
-// printVerdict reports up-to-date / update-available based on the installed and
-// latest commits.
-func (a *App) printVerdict(installed, remote string) {
+// printVerdict reports up-to-date / update-available based on the installed CLI
+// version and the latest release tag, compared as semver.
+func (a *App) printVerdict(installed, latest string) {
 	switch {
 	case installed == "" || installed == "none":
-		fmt.Fprintln(a.Out, theme.Warn.Render("Installed commit is unknown; cannot compare. Latest is "+remote+"."))
-	case update.SameCommit(installed, remote):
-		fmt.Fprintln(a.Out, theme.Successf("Up to date (%s).", remote))
+		fmt.Fprintln(a.Out, theme.Warn.Render("Installed version is unknown; cannot compare. Latest is "+latest+"."))
+	case update.NewerAvailable(installed, latest):
+		fmt.Fprintln(a.Out, theme.Accent.Render(fmt.Sprintf("Update available: %s → %s", installed, latest)))
 	default:
-		fmt.Fprintln(a.Out, theme.Accent.Render(fmt.Sprintf("Update available: %s → %s", installed, remote)))
+		fmt.Fprintln(a.Out, theme.Successf("Up to date (%s).", latest))
 	}
 }
 

--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -275,7 +275,7 @@ func (a *App) refreshManifestBinaryPath(target string) {
 
 // binaryVersion runs `<path> --version` and returns its first output line.
 func binaryVersion(path string) (string, error) {
-	out, err := exec.Command(path, "--version").Output()
+	out, err := exec.Command(path, "--version").Output() //nolint:gosec // path is a CLI-internal staged build artifact we just wrote to a temp dir, not user input.
 	if err != nil {
 		return "", err
 	}

--- a/cli/internal/update/update.go
+++ b/cli/internal/update/update.go
@@ -1,131 +1,28 @@
 // Package update backs `jentic update`: it inspects what is installed (via the
-// manifest and build-time metadata) and compares it against the tracked git ref
-// to report whether a newer build is available.
+// manifest and build-time metadata) and compares its version against the latest
+// release tag to report whether a newer build is available, then fetches and
+// swaps in the rebuilt binaries.
 package update
 
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"regexp"
-	"strings"
 )
 
-// shortLen is the number of SHA characters compared/displayed, matching the
-// `git rev-parse --short` length stamped into the binary by the installer.
-const shortLen = 7
-
-// RemoteCommit resolves the current commit of ref in repo using `git ls-remote`,
-// returning the short SHA. A token (GitHub PAT) is sent as an HTTP Basic auth
-// header so private or access-restricted repositories resolve; it mirrors
-// the auth scheme used by tools/install.sh. An empty token queries anonymously.
-//
-// Releases are tagged with a `v` prefix (refs/tags/vX.Y.Z), but the installed
-// build tracks a bare-semver ref (e.g. "0.15.0") stamped from the version. So
-// for a bare-semver ref we also try the fully-qualified release tag; the first
-// candidate that resolves wins. See candidateRefs.
-func RemoteCommit(ctx context.Context, repo, ref, token string) (string, error) {
-	if repo == "" {
-		return "", errors.New("no repository to check")
-	}
-	if ref == "" {
-		return "", errors.New("no ref to check")
-	}
-	if _, err := exec.LookPath("git"); err != nil {
-		return "", errors.New("`git` is required to check for updates but was not found on PATH")
-	}
-
-	var lastErr error
-	for _, cand := range candidateRefs(ref) {
-		sha, err := lsRemote(ctx, repo, cand, token)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		if sha != "" {
-			return short(sha), nil
-		}
-	}
-	if lastErr != nil {
-		return "", lastErr
-	}
-	return "", fmt.Errorf("ref %q not found in %s", ref, repo)
-}
-
-// candidateRefs returns the refs to try, in order, when resolving ref. It always
-// starts with ref as-given (covering branches like "main", full SHAs, and
-// already-`v`-prefixed tags). When ref is a bare semver (starts with a digit and
-// contains a dot), it also appends the fully-qualified release tag
-// "refs/tags/v<ref>" — fully-qualified so `git ls-remote` matches only the
-// canonical release tag and not a similarly-suffixed one (e.g. cli/v0.15.0).
-func candidateRefs(ref string) []string {
-	cands := []string{ref}
-	if bareSemver.MatchString(ref) {
-		cands = append(cands, "refs/tags/v"+ref)
-	}
-	return cands
-}
-
-// bareSemver matches a version without the `v` prefix, e.g. "0.15.0".
-var bareSemver = regexp.MustCompile(`^\d+\.\d+`)
-
-// lsRemote runs `git ls-remote <url> <ref>` and returns the first matching SHA
-// (empty if the ref does not resolve). credential.helper= disables any inherited
-// helper so git can't prompt.
-func lsRemote(ctx context.Context, repo, ref, token string) (string, error) {
-	url := "https://github.com/" + repo + ".git"
-	args := append([]string{"-c", "credential.helper="}, authArgs(token)...)
-	args = append(args, "ls-remote", url, ref)
-
-	cmd := exec.CommandContext(ctx, "git", args...) //nolint:gosec // args are CLI-internal; repo/ref come from the manifest/flags.
-	// Never fall back to an interactive prompt: a missing/invalid token must
-	// fail fast rather than block waiting for a username on the terminal.
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS=true", "GCM_INTERACTIVE=never")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("git ls-remote failed (check the ref %q and, for a private repo, GITHUB_TOKEN): %w", ref, err)
-	}
-	return firstSHA(string(out)), nil
-}
-
 // authArgs returns the `git -c http.extraheader=...` prefix carrying a Basic
-// auth header for token, or nil when no token is set.
+// auth header for token, or nil when no token is set. It mirrors the auth
+// scheme used by tools/install.sh so private repositories resolve.
 func authArgs(token string) []string {
 	if token == "" {
 		return nil
 	}
 	basic := base64.StdEncoding.EncodeToString([]byte("x-access-token:" + token))
 	return []string{"-c", "http.extraheader=Authorization: Basic " + basic}
-}
-
-// firstSHA returns the SHA from the first non-empty `git ls-remote` line, whose
-// format is "<sha>\t<refname>".
-func firstSHA(out string) string {
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) > 0 {
-			return fields[0]
-		}
-	}
-	return ""
-}
-
-// short truncates a full SHA to the comparison/display length.
-func short(sha string) string {
-	if len(sha) > shortLen {
-		return sha[:shortLen]
-	}
-	return sha
 }
 
 // FetchInstaller downloads tools/install.sh for ref from repo's raw content,
@@ -206,19 +103,4 @@ func copyFile(src, dst string, mode os.FileMode) error {
 		return err
 	}
 	return out.Close()
-}
-
-// SameCommit reports whether two (possibly differently-truncated) SHAs refer to
-// the same commit, comparing on the shorter common prefix length.
-func SameCommit(a, b string) bool {
-	a = strings.TrimSpace(a)
-	b = strings.TrimSpace(b)
-	if a == "" || b == "" {
-		return false
-	}
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
-	return strings.EqualFold(a[:n], b[:n])
 }

--- a/cli/internal/update/update_test.go
+++ b/cli/internal/update/update_test.go
@@ -7,37 +7,6 @@ import (
 	"testing"
 )
 
-func TestFirstSHA(t *testing.T) {
-	out := "4ee3bd3c0ffee1234567890abcdef1234567890a\trefs/heads/feat/cli\n"
-	if got := firstSHA(out); got != "4ee3bd3c0ffee1234567890abcdef1234567890a" {
-		t.Errorf("firstSHA = %q", got)
-	}
-	if got := firstSHA("\n  \n"); got != "" {
-		t.Errorf("firstSHA(blank) = %q, want empty", got)
-	}
-}
-
-func TestShortTruncates(t *testing.T) {
-	if got := short("4ee3bd3c0ffee"); got != "4ee3bd3" {
-		t.Errorf("short = %q, want 4ee3bd3", got)
-	}
-	if got := short("abc"); got != "abc" {
-		t.Errorf("short(abc) = %q, want abc", got)
-	}
-}
-
-func TestSameCommitPrefixMatch(t *testing.T) {
-	if !SameCommit("4ee3bd3", "4ee3bd3c0ffee") {
-		t.Errorf("SameCommit should match on common prefix")
-	}
-	if SameCommit("4ee3bd3", "deadbee") {
-		t.Errorf("SameCommit should not match differing SHAs")
-	}
-	if SameCommit("", "4ee3bd3") || SameCommit("4ee3bd3", "") {
-		t.Errorf("SameCommit with empty input should be false")
-	}
-}
-
 func TestReplaceBinaryBacksUpAndSwaps(t *testing.T) {
 	dir := t.TempDir()
 	stageDir := t.TempDir() // separate dir to exercise the copy-then-rename path
@@ -94,37 +63,4 @@ func TestAuthArgs(t *testing.T) {
 	if len(got) != 2 || got[0] != "-c" || !strings.HasPrefix(got[1], "http.extraheader=Authorization: Basic ") {
 		t.Errorf("authArgs(token) = %v, want -c http.extraheader basic auth", got)
 	}
-}
-
-func TestCandidateRefs(t *testing.T) {
-	cases := []struct {
-		ref  string
-		want []string
-	}{
-		// Bare semver also tries the fully-qualified release tag.
-		{"0.15.0", []string{"0.15.0", "refs/tags/v0.15.0"}},
-		{"1.0", []string{"1.0", "refs/tags/v1.0"}},
-		// Branches, already-`v`-prefixed tags, and SHA-like refs are used as-is.
-		{"main", []string{"main"}},
-		{"v0.15.0", []string{"v0.15.0"}},
-		{"abc1234", []string{"abc1234"}},
-	}
-	for _, tc := range cases {
-		got := candidateRefs(tc.ref)
-		if !equalStrings(got, tc.want) {
-			t.Errorf("candidateRefs(%q) = %v, want %v", tc.ref, got, tc.want)
-		}
-	}
-}
-
-func equalStrings(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/cli/internal/update/version.go
+++ b/cli/internal/update/version.go
@@ -1,0 +1,151 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// releaseTag matches a canonical release tag: a `v`-prefixed three-part semver
+// with no pre-release/build suffix (e.g. "v0.15.3"). This deliberately excludes
+// noise tags such as "cli/v0.15.0", pre-releases like "v1.0.0-rc1", and the
+// "^{}" peeled-tag lines that `git ls-remote --tags` also prints.
+var releaseTag = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)$`)
+
+// semver is a parsed three-part version used for ordering release tags. The
+// CLI intentionally ships no third-party semver dependency, so this covers just
+// the major.minor.patch shape the release tags use.
+type semver struct {
+	major, minor, patch int
+}
+
+// parseSemver parses a version string of the form "[v]MAJOR.MINOR.PATCH" into a
+// semver. A leading "v" is optional. Anything that is not a clean three-part
+// numeric version (a branch name, "dev", a SHA, or a pre-release) fails to
+// parse and callers treat that as "unknown".
+func parseSemver(s string) (semver, bool) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return semver{}, false
+	}
+	nums := make([]int, 3)
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return semver{}, false
+		}
+		nums[i] = n
+	}
+	return semver{major: nums[0], minor: nums[1], patch: nums[2]}, true
+}
+
+// compareSemver returns -1, 0, or 1 as a is less than, equal to, or greater
+// than b.
+func compareSemver(a, b semver) int {
+	switch {
+	case a.major != b.major:
+		return cmpInt(a.major, b.major)
+	case a.minor != b.minor:
+		return cmpInt(a.minor, b.minor)
+	default:
+		return cmpInt(a.patch, b.patch)
+	}
+}
+
+func cmpInt(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// NewerAvailable reports whether latest is a newer release than installed.
+//
+// When installed does not parse as a clean semver — e.g. it is "dev", a branch
+// name, or a SHA (an unreleased/source build) — we cannot meaningfully compare,
+// so we conservatively report true so such builds are offered the latest
+// release. When latest itself does not parse we report false: there is nothing
+// sensible to update to.
+func NewerAvailable(installed, latest string) bool {
+	lv, ok := parseSemver(latest)
+	if !ok {
+		return false
+	}
+	iv, ok := parseSemver(installed)
+	if !ok {
+		return true
+	}
+	return compareSemver(lv, iv) > 0
+}
+
+// LatestReleaseTag resolves the highest canonical release tag (vMAJOR.MINOR.PATCH)
+// in repo via `git ls-remote --tags`, returning it with its `v` prefix (e.g.
+// "v0.15.3"). A token (GitHub PAT) authenticates against private repositories,
+// mirroring lsRemote. It errors when git is unavailable or no release tag exists.
+func LatestReleaseTag(ctx context.Context, repo, token string) (string, error) {
+	if repo == "" {
+		return "", errors.New("no repository to check")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		return "", errors.New("`git` is required to check for updates but was not found on PATH")
+	}
+
+	url := "https://github.com/" + repo + ".git"
+	args := append([]string{"-c", "credential.helper="}, authArgs(token)...)
+	args = append(args, "ls-remote", "--tags", url, "v*")
+
+	cmd := exec.CommandContext(ctx, "git", args...) //nolint:gosec // args are CLI-internal; repo comes from the manifest/flags.
+	// Never fall back to an interactive prompt: a missing/invalid token must
+	// fail fast rather than block waiting for a username on the terminal.
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS=true", "GCM_INTERACTIVE=never")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git ls-remote --tags failed (for a private repo, set GITHUB_TOKEN): %w", err)
+	}
+
+	tag, ok := highestReleaseTag(string(out))
+	if !ok {
+		return "", fmt.Errorf("no release tags found in %s", repo)
+	}
+	return tag, nil
+}
+
+// highestReleaseTag scans `git ls-remote --tags` output and returns the highest
+// canonical release tag (with its `v` prefix). Lines have the form
+// "<sha>\trefs/tags/<name>"; non-release and peeled ("^{}") tags are ignored.
+func highestReleaseTag(out string) (string, bool) {
+	var best semver
+	var bestTag string
+	found := false
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 2 {
+			continue
+		}
+		name := strings.TrimPrefix(fields[1], "refs/tags/")
+		if !releaseTag.MatchString(name) {
+			continue
+		}
+		v, ok := parseSemver(name)
+		if !ok {
+			continue
+		}
+		if !found || compareSemver(v, best) > 0 {
+			best = v
+			bestTag = name
+			found = true
+		}
+	}
+	return bestTag, found
+}

--- a/cli/internal/update/version_test.go
+++ b/cli/internal/update/version_test.go
@@ -1,0 +1,107 @@
+package update
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseSemver(t *testing.T) {
+	cases := []struct {
+		in   string
+		want semver
+		ok   bool
+	}{
+		{"0.15.3", semver{0, 15, 3}, true},
+		{"v0.15.3", semver{0, 15, 3}, true},
+		{"  v1.2.0 ", semver{1, 2, 0}, true},
+		{"10.20.30", semver{10, 20, 30}, true},
+		// Non-canonical / not three-part / non-numeric => not parseable.
+		{"0.15", semver{}, false},
+		{"1.2.3.4", semver{}, false},
+		{"v1.0.0-rc1", semver{}, false},
+		{"main", semver{}, false},
+		{"dev", semver{}, false},
+		{"", semver{}, false},
+	}
+	for _, tc := range cases {
+		got, ok := parseSemver(tc.in)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("parseSemver(%q) = (%+v, %v), want (%+v, %v)", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+func TestCompareSemver(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "1.0.0", 0},
+		{"1.0.1", "1.0.0", 1},
+		{"1.0.0", "1.0.1", -1},
+		{"1.1.0", "1.0.9", 1},
+		{"2.0.0", "1.9.9", 1},
+		{"0.9.0", "0.10.0", -1}, // numeric, not lexicographic
+	}
+	for _, tc := range cases {
+		av, _ := parseSemver(tc.a)
+		bv, _ := parseSemver(tc.b)
+		if got := compareSemver(av, bv); got != tc.want {
+			t.Errorf("compareSemver(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestNewerAvailable(t *testing.T) {
+	cases := []struct {
+		installed, latest string
+		want              bool
+	}{
+		{"0.15.2", "0.15.3", true},
+		{"v0.15.2", "v0.15.3", true},
+		{"0.15.3", "0.15.3", false},
+		{"0.16.0", "0.15.3", false},
+		// Unparseable installed (dev/branch/SHA) => offer the latest release.
+		{"dev", "0.15.3", true},
+		{"feat/cli", "v1.0.0", true},
+		// Unparseable latest => nothing sensible to update to.
+		{"0.15.3", "main", false},
+		{"0.15.3", "", false},
+	}
+	for _, tc := range cases {
+		if got := NewerAvailable(tc.installed, tc.latest); got != tc.want {
+			t.Errorf("NewerAvailable(%q, %q) = %v, want %v", tc.installed, tc.latest, got, tc.want)
+		}
+	}
+}
+
+func TestHighestReleaseTag(t *testing.T) {
+	// Mixed ls-remote --tags output: canonical releases, a noise tag, a
+	// pre-release, and a peeled ("^{}") line. Only canonical vX.Y.Z count.
+	out := strings.Join([]string{
+		"aaaaaaa\trefs/tags/v0.15.0",
+		"bbbbbbb\trefs/tags/v0.15.3",
+		"ccccccc\trefs/tags/v0.15.3^{}",
+		"ddddddd\trefs/tags/cli/v0.16.0",
+		"eeeeeee\trefs/tags/v1.0.0-rc1",
+		"fffffff\trefs/tags/v0.9.1",
+	}, "\n")
+
+	got, ok := highestReleaseTag(out)
+	if !ok {
+		t.Fatalf("highestReleaseTag returned ok=false, want a match")
+	}
+	if got != "v0.15.3" {
+		t.Errorf("highestReleaseTag = %q, want v0.15.3", got)
+	}
+}
+
+func TestHighestReleaseTagNoReleases(t *testing.T) {
+	out := "aaaaaaa\trefs/tags/cli/v0.16.0\nbbbbbbb\trefs/tags/nightly\n"
+	if got, ok := highestReleaseTag(out); ok {
+		t.Errorf("highestReleaseTag = (%q, true), want no match", got)
+	}
+	if _, ok := highestReleaseTag(""); ok {
+		t.Errorf("highestReleaseTag(\"\") matched, want no match")
+	}
+}

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -1668,8 +1668,8 @@
           "name": "update",
           "path": "jenticctl update",
           "use": "update",
-          "short": "Update the jentic CLIs (and check the stack) to the latest build",
-          "long": "update reports the installed CLI and server versions, compares the tracked\ngit ref against its latest commit on GitHub, and (unless --check) rebuilds\nand replaces the jenticctl and jentic binaries in place, then rebuilds the\ninstalled stack. Use --cli-only or --stack-only to update just one half.",
+          "short": "Update the jentic CLIs (and check the stack) to the latest release",
+          "long": "update reports the installed CLI and server versions, compares the\ninstalled version against the latest release tag on GitHub, and (unless\n--check) rebuilds and replaces the jenticctl and jentic binaries in place,\nthen rebuilds the installed stack. Use --cli-only or --stack-only to update\njust one half.",
           "group_title": "Setup \u0026 lifecycle",
           "flags": [
             {
@@ -1692,7 +1692,7 @@
             {
               "name": "ref",
               "type": "string",
-              "usage": "git ref to update to (default: the installed ref)"
+              "usage": "git ref to update to, pinning a specific tag/branch/commit (default: the latest release tag)"
             },
             {
               "name": "stack-only",


### PR DESCRIPTION
## Summary

Reworks `jenticctl update` to be driven by **release versions (tags)** rather than commit SHAs, and fixes the confirmation-prompt default (#765) so pressing Enter proceeds with the update.

- Resolves the update target from the **latest release tag** (highest semver `vX.Y.Z`) instead of the tracked git ref's latest commit.
- Compares the installed CLI version against that tag with proper **semver comparison** (only "update available" when latest > installed).
- Flips the confirm prompt default to **"Yes, update"** — it is only ever shown when an update is available, so a reflexive Enter now proceeds instead of cancelling.

## Changes

- Add `LatestReleaseTag` + internal semver `parseSemver`/`compareSemver` + `NewerAvailable` helpers in `internal/update` (no new dependencies), filtering `git ls-remote --tags` output to canonical `vX.Y.Z` release tags (excludes `cli/v*`, pre-releases, and peeled `^{}` lines).
- Rewire `updateE` to track the latest release tag by default (`--ref` still pins a specific tag/branch/commit), use a semver-based verdict, and gate the "already up to date" short-circuit on `NewerAvailable`.
- Default `confirmApply` to Yes and show the target version in the prompt title.
- Update the `update` command's help text and regenerate `ui/public/cli-reference.json`.
- Remove the now-dead commit-based helpers (`RemoteCommit`, `SameCommit`, etc.) and add unit tests for the new semver/tag logic.

## Testing

- `cd cli && go build ./... && go test ./...` — all pass
- `go vet` and `gofmt -l` clean

Closes #765

_Please use **squash + merge**._

Made with [Cursor](https://cursor.com)