### PR TITLE
feat(ui): discovery, import entry point, and simpler delete confirm

### DIFF
--- a/ui/e2e/docker/cascade-delete.spec.ts
+++ b/ui/e2e/docker/cascade-delete.spec.ts
@@ -40,10 +40,10 @@ test('hard-delete a toolkit from the detail page (type-to-confirm, generic warni
 	// blast-radius list isn't shown (no dependents endpoint yet — see fixme).
 	await expect(dialog).toContainText(/will be permanently/i);
 
-	// Confirm is gated behind typing the exact toolkit name.
+	// Confirm is gated behind typing the fixed confirm word "delete".
 	const confirm = dialog.getByRole('button', { name: 'Delete toolkit', exact: true });
 	await expect(confirm).toBeDisabled();
-	await dialog.getByRole('textbox', { name: new RegExp(`Type ${name} to confirm`) }).fill(name);
+	await dialog.getByRole('textbox', { name: /Type delete to confirm/i }).fill('delete');
 	await expect(confirm).toBeEnabled();
 	await confirm.click();
 

--- a/ui/e2e/docker/credentials.spec.ts
+++ b/ui/e2e/docker/credentials.spec.ts
@@ -68,11 +68,11 @@ test('a credential created via the API can be deleted from the UI', async ({ pag
 	// The card exposes an explicit per-credential delete control (aria-labelled),
 	// which opens the shared CascadeDeleteDialog. Hard delete is irreversible, so
 	// the dialog gates the confirm button behind a type-to-confirm field — type
-	// the credential name (like a real operator) to enable "Delete credential".
+	// the fixed word "delete" (like a real operator) to enable "Delete credential".
 	await page.getByRole('button', { name: `Delete credential ${name}` }).click();
 
 	const dialog = page.getByRole('dialog', { name: 'Delete credential' });
-	await dialog.getByRole('textbox', { name: new RegExp(`Type ${name} to confirm`) }).fill(name);
+	await dialog.getByRole('textbox', { name: /Type delete to confirm/i }).fill('delete');
 	const confirm = dialog.getByRole('button', { name: 'Delete credential', exact: true });
 	await expect(confirm).toBeEnabled();
 	await confirm.click();

--- a/ui/e2e/docker/discover.spec.ts
+++ b/ui/e2e/docker/discover.spec.ts
@@ -15,10 +15,10 @@ test('discover renders its catalog shell and toolbar, console clean', async ({ p
 	await page.goto('/app');
 	await page
 		.getByRole('navigation', { name: 'Primary' })
-		.getByRole('link', { name: 'Discover' })
+		.getByRole('link', { name: 'Discover APIs' })
 		.click();
 
-	await expect(page.getByRole('heading', { name: 'Discover' })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Discover APIs' })).toBeVisible();
 
 	// The toolbar (search + Imported/Available filter + refresh) is the surface's
 	// own chrome and renders regardless of catalog availability.
@@ -33,7 +33,7 @@ test('discover renders its catalog shell and toolbar, console clean', async ({ p
 
 test('discover filter and search controls are interactive', async ({ page }) => {
 	await page.goto('/app/discover');
-	await expect(page.getByRole('heading', { name: 'Discover' })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Discover APIs' })).toBeVisible();
 
 	// The registration filter is a segmented control of buttons (All / Imported
 	// / Available). Clicking one drives the catalog query param. There's no
@@ -41,7 +41,7 @@ test('discover filter and search controls are interactive', async ({ page }) => 
 	// surface stays healthy (no results assertion — the catalog is external).
 	const toolbar = page.getByTestId('discover-toolbar');
 	await toolbar.getByRole('button', { name: 'Available' }).click();
-	await expect(page.getByRole('heading', { name: 'Discover' })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Discover APIs' })).toBeVisible();
 
 	// Type into the search box; the field owns its own value.
 	const search = page.getByRole('searchbox', { name: 'Search APIs' });

--- a/ui/src/modules/agents/__tests__/AgentsPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/AgentsPage.test.tsx
@@ -156,7 +156,7 @@ describe('AgentsPage — agents lifecycle', () => {
 		);
 
 		const dialog = await screen.findByRole('dialog');
-		await user.type(within(dialog).getByLabelText(/to confirm/i), 'support-agent');
+		await user.type(within(dialog).getByLabelText(/to confirm/i), 'delete');
 		await user.click(within(dialog).getByRole('button', { name: 'Archive agent' }));
 
 		// The collapsible "Removed agents" disclosure appears with the row in it.
@@ -178,7 +178,7 @@ describe('AgentsPage — agents lifecycle', () => {
 			}),
 		);
 		const dialog = await screen.findByRole('dialog');
-		await user.type(within(dialog).getByLabelText(/to confirm/i), 'support-agent');
+		await user.type(within(dialog).getByLabelText(/to confirm/i), 'delete');
 		await user.click(within(dialog).getByRole('button', { name: 'Archive agent' }));
 
 		// Failure → error toast, dialog stays open so the user can retry, and the

--- a/ui/src/modules/agents/__tests__/AgentsPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/AgentsPage.test.tsx
@@ -156,7 +156,7 @@ describe('AgentsPage — agents lifecycle', () => {
 		);
 
 		const dialog = await screen.findByRole('dialog');
-		await user.type(within(dialog).getByLabelText(/to confirm/i), 'delete');
+		await user.type(within(dialog).getByLabelText(/to confirm/i), 'archive');
 		await user.click(within(dialog).getByRole('button', { name: 'Archive agent' }));
 
 		// The collapsible "Removed agents" disclosure appears with the row in it.
@@ -178,7 +178,7 @@ describe('AgentsPage — agents lifecycle', () => {
 			}),
 		);
 		const dialog = await screen.findByRole('dialog');
-		await user.type(within(dialog).getByLabelText(/to confirm/i), 'delete');
+		await user.type(within(dialog).getByLabelText(/to confirm/i), 'archive');
 		await user.click(within(dialog).getByRole('button', { name: 'Archive agent' }));
 
 		// Failure → error toast, dialog stays open so the user can retry, and the

--- a/ui/src/modules/credentials/__tests__/CredentialsPage.test.tsx
+++ b/ui/src/modules/credentials/__tests__/CredentialsPage.test.tsx
@@ -247,8 +247,8 @@ describe('CredentialsPage', () => {
 
 		// The cascade-aware dialog gates the destructive action behind a
 		// type-to-confirm field, so the confirm button only fires after the
-		// credential name is typed back exactly.
-		await user.type(screen.getByLabelText(/Type Doomed to confirm/i), 'Doomed');
+		// fixed confirm word is typed.
+		await user.type(screen.getByLabelText(/Type delete to confirm/i), 'delete');
 		await user.click(screen.getByRole('button', { name: 'Delete credential' }));
 
 		await waitFor(() => expect(screen.queryByText('Doomed')).not.toBeInTheDocument());

--- a/ui/src/modules/discover/components/DiscoveryGrid.tsx
+++ b/ui/src/modules/discover/components/DiscoveryGrid.tsx
@@ -100,13 +100,14 @@ export function DiscoveryGrid({
 				title={hasQuery ? 'No matching APIs' : 'No APIs yet'}
 				description={
 					hasQuery
-						? "Try a different search term, or switch the filter. Can't find it? Import your own."
+						? "Try a different search term, or switch the filter. Can't find it?"
 						: 'The public catalog will appear here.'
 				}
 				action={
 					<AppLink
 						href={`${ROUTES.workspace}?import=1`}
-						className="bg-primary/10 border-primary/30 text-primary hover:bg-primary/20 hover:border-primary/50 focus-visible:ring-ring focus-visible:ring-offset-background inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+						variant="outline"
+						size="sm"
 						data-testid="discover-empty-upload-own"
 					>
 						<Upload size={14} aria-hidden="true" />

--- a/ui/src/modules/discover/components/DiscoveryGrid.tsx
+++ b/ui/src/modules/discover/components/DiscoveryGrid.tsx
@@ -9,8 +9,9 @@
  * into view (with a shared Button fallback for keyboard/no-IO environments).
  */
 import { useEffect, useRef } from 'react';
-import { Compass } from 'lucide-react';
-import { Button, EmptyState, ErrorAlert, Skeleton } from '@/shared/ui';
+import { Compass, Upload } from 'lucide-react';
+import { AppLink, Button, EmptyState, ErrorAlert, Skeleton } from '@/shared/ui';
+import { ROUTES } from '@/shared/app/routes';
 import { DiscoveryCard } from '@/modules/discover/components/DiscoveryCard';
 import type { DiscoveryEntity } from '@/modules/discover/api';
 
@@ -99,8 +100,18 @@ export function DiscoveryGrid({
 				title={hasQuery ? 'No matching APIs' : 'No APIs yet'}
 				description={
 					hasQuery
-						? 'Try a different search term, or switch the filter.'
+						? "Try a different search term, or switch the filter. Can't find it? Import your own."
 						: 'The public catalog will appear here.'
+				}
+				action={
+					<AppLink
+						href={`${ROUTES.workspace}?import=1`}
+						className="bg-primary/10 border-primary/30 text-primary hover:bg-primary/20 hover:border-primary/50 focus-visible:ring-ring focus-visible:ring-offset-background inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+						data-testid="discover-empty-upload-own"
+					>
+						<Upload size={14} aria-hidden="true" />
+						Import your own API
+					</AppLink>
 				}
 			/>
 		);

--- a/ui/src/modules/discover/pages/DiscoverPage.tsx
+++ b/ui/src/modules/discover/pages/DiscoverPage.tsx
@@ -13,7 +13,9 @@
  * It never touches `@/shared/api` directly (ESLint-enforced).
  */
 import { useEffect, useState } from 'react';
-import { PageShell, PageHeader, PageHelp } from '@/shared/ui';
+import { Upload } from 'lucide-react';
+import { PageShell, PageHeader, PageHelp, AppLink } from '@/shared/ui';
+import { ROUTES } from '@/shared/app/routes';
 import { DiscoverToolbar } from '@/modules/discover/components/DiscoverToolbar';
 import { DiscoveryGrid } from '@/modules/discover/components/DiscoveryGrid';
 import { ApiDetailSheet } from '@/modules/discover/components/ApiDetailSheet';
@@ -63,39 +65,49 @@ export default function DiscoverPage() {
 	return (
 		<PageShell spacing="space-y-0">
 			<PageHeader
-				title="Discover"
-				subtitle="Browse the public Jentic catalog. Import an API to use it in your workspace."
+				title="Discover APIs"
+				subtitle="Browse the public Jentic catalog. Import an API to use it — or import your own in Workspace."
 				actions={
-					<PageHelp
-						title="About Discover"
-						intro={
-							<p>
-								Discover lists the public Jentic catalog of importable APIs,
-								flagging which are already imported into your workspace.
-							</p>
-						}
-						sections={[
-							{
-								heading: 'Imported vs Available',
-								body: (
-									<p>
-										<strong>Imported</strong> APIs already live in your
-										workspace. <strong>Available</strong> APIs can be imported
-										to register them locally.
-									</p>
-								),
-							},
-							{
-								heading: 'Previewing operations',
-								body: (
-									<p>
-										Open any API to preview its operations before importing — no
-										registration required.
-									</p>
-								),
-							},
-						]}
-					/>
+					<>
+						<AppLink
+							href={`${ROUTES.workspace}?import=1`}
+							className="bg-primary/10 border-primary/30 text-primary hover:bg-primary/20 hover:border-primary/50 focus-visible:ring-ring focus-visible:ring-offset-background inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+							data-testid="discover-upload-own"
+						>
+							<Upload size={14} aria-hidden="true" />
+							Import your own API
+						</AppLink>
+						<PageHelp
+							title="About Discover"
+							intro={
+								<p>
+									Discover lists the public Jentic catalog of importable APIs,
+									flagging which are already imported into your workspace.
+								</p>
+							}
+							sections={[
+								{
+									heading: 'Imported vs Available',
+									body: (
+										<p>
+											<strong>Imported</strong> APIs already live in your
+											workspace. <strong>Available</strong> APIs can be
+											imported to register them locally.
+										</p>
+									),
+								},
+								{
+									heading: 'Previewing operations',
+									body: (
+										<p>
+											Open any API to preview its operations before importing
+											— no registration required.
+										</p>
+									),
+								},
+							]}
+						/>
+					</>
 				}
 			/>
 

--- a/ui/src/modules/discover/pages/DiscoverPage.tsx
+++ b/ui/src/modules/discover/pages/DiscoverPage.tsx
@@ -71,7 +71,8 @@ export default function DiscoverPage() {
 					<>
 						<AppLink
 							href={`${ROUTES.workspace}?import=1`}
-							className="bg-primary/10 border-primary/30 text-primary hover:bg-primary/20 hover:border-primary/50 focus-visible:ring-ring focus-visible:ring-offset-background inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+							variant="outline"
+							size="sm"
 							data-testid="discover-upload-own"
 						>
 							<Upload size={14} aria-hidden="true" />

--- a/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
+++ b/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
@@ -421,13 +421,10 @@ describe('ToolkitDetailPage', () => {
 		expect(within(dialog).getByText('CI runner')).toBeInTheDocument();
 		expect(within(dialog).getByText('GitHub PAT')).toBeInTheDocument();
 
-		// Type-to-confirm gate: button stays disabled until the name matches.
+		// Type-to-confirm gate: button stays disabled until the fixed word is typed.
 		const confirm = within(dialog).getByRole('button', { name: /^delete toolkit$/i });
 		expect(confirm).toBeDisabled();
-		await user.type(
-			within(dialog).getByLabelText(/type github tools to confirm/i),
-			'GitHub Tools',
-		);
+		await user.type(within(dialog).getByLabelText(/type delete to confirm/i), 'delete');
 		await waitFor(() => expect(confirm).toBeEnabled());
 
 		await user.click(confirm);
@@ -476,10 +473,7 @@ describe('ToolkitDetailPage', () => {
 
 		await user.click(screen.getByRole('button', { name: 'Delete GitHub Tools' }));
 		const dialog = await screen.findByRole('dialog', { name: /delete toolkit/i });
-		await user.type(
-			within(dialog).getByLabelText(/type github tools to confirm/i),
-			'GitHub Tools',
-		);
+		await user.type(within(dialog).getByLabelText(/type delete to confirm/i), 'delete');
 		const confirm = within(dialog).getByRole('button', { name: /^delete toolkit$/i });
 		await waitFor(() => expect(confirm).toBeEnabled());
 		await user.click(confirm);

--- a/ui/src/modules/workspace/__tests__/ApiDetailPage.test.tsx
+++ b/ui/src/modules/workspace/__tests__/ApiDetailPage.test.tsx
@@ -185,10 +185,11 @@ describe('ApiDetailPage', () => {
 		).toBeInTheDocument();
 		expect(within(dialog).queryByText(/will also remove/i)).not.toBeInTheDocument();
 
-		// Type-to-confirm — the page header displays the API's display name.
+		// Type-to-confirm — the delete gate now requires a fixed word, not the
+		// API's (tuple) name. The name still shows in the dialog body for context.
 		const confirm = within(dialog).getByRole('button', { name: /^remove api$/i });
 		expect(confirm).toBeDisabled();
-		await user.type(within(dialog).getByLabelText(/type stripe to confirm/i), 'Stripe');
+		await user.type(within(dialog).getByLabelText(/type delete to confirm/i), 'delete');
 		await waitFor(() => expect(confirm).toBeEnabled());
 
 		await user.click(confirm);

--- a/ui/src/modules/workspace/__tests__/WorkspacePage.test.tsx
+++ b/ui/src/modules/workspace/__tests__/WorkspacePage.test.tsx
@@ -94,4 +94,9 @@ describe('WorkspacePage', () => {
 		await user.click(screen.getAllByTestId('workspace-import-open')[0]);
 		expect(await screen.findByTestId('import-spec-dialog')).toBeInTheDocument();
 	});
+
+	it('auto-opens the import dialog when deep-linked with ?import=1 (from Discover)', async () => {
+		renderWithProviders(<WorkspacePage />, { route: '/workspace?import=1' });
+		expect(await screen.findByTestId('import-spec-dialog')).toBeInTheDocument();
+	});
 });

--- a/ui/src/modules/workspace/components/ImportSpecDialog.tsx
+++ b/ui/src/modules/workspace/components/ImportSpecDialog.tsx
@@ -199,7 +199,7 @@ export function ImportSpecDialog({ open, onClose }: ImportSpecDialogProps) {
 		<Dialog
 			open={open}
 			onClose={onClose}
-			title="Add to your workspace"
+			title="Import an API"
 			size="lg"
 			className="max-w-xl"
 			dismissOnBackdrop={false}

--- a/ui/src/modules/workspace/components/WorkspaceCatalogFooter.tsx
+++ b/ui/src/modules/workspace/components/WorkspaceCatalogFooter.tsx
@@ -11,13 +11,11 @@ import { ROUTES } from '@/shared/app/routes';
 export function WorkspaceCatalogFooter() {
 	return (
 		<div
-			className="border-border/40 text-muted-foreground flex items-center justify-between gap-3 border-t pt-4 text-sm"
+			className="border-border/40 text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 border-t pt-4 text-sm"
 			data-testid="workspace-catalog-footer"
 		>
-			<span className="inline-flex items-center gap-2">
-				<Compass size={14} aria-hidden="true" className="text-muted-foreground/70" />
-				Looking for something else?
-			</span>
+			<Compass size={14} aria-hidden="true" className="text-muted-foreground/70" />
+			<span>Looking for something else?</span>
 			<AppLink
 				href={ROUTES.discover}
 				className="text-primary hover:text-primary/80 inline-flex items-center gap-1 font-medium"

--- a/ui/src/modules/workspace/pages/WorkspacePage.tsx
+++ b/ui/src/modules/workspace/pages/WorkspacePage.tsx
@@ -8,8 +8,9 @@
  * both the header button and the empty-state CTA) and an in-memory filter over
  * the loaded rows. Catalog-wide search lives in Discover, not here.
  */
-import { useMemo, useState } from 'react';
-import { Plus } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Upload } from 'lucide-react';
 import { PageShell, PageHeader, PageHelp, Button } from '@/shared/ui';
 import { ApiGrid } from '@/modules/workspace/components/ApiGrid';
 import { ImportSpecDialog } from '@/modules/workspace/components/ImportSpecDialog';
@@ -19,9 +20,22 @@ import { WorkspaceCatalogFooter } from '@/modules/workspace/components/Workspace
 import { useWorkspaceApis } from '@/modules/workspace/api';
 
 export default function WorkspacePage() {
-	const [importOpen, setImportOpen] = useState(false);
+	const [searchParams, setSearchParams] = useSearchParams();
+	// Deep-link support: Discover cross-links here with `?import=1` to open the
+	// import dialog on arrival (the import UI is a Workspace-module concern, so
+	// Discover navigates rather than embedding the dialog). Strip the param once
+	// consumed so a refresh or back-nav doesn't re-trigger it.
+	const [importOpen, setImportOpen] = useState(() => searchParams.get('import') === '1');
 	const [filter, setFilter] = useState('');
 	const query = useWorkspaceApis();
+
+	useEffect(() => {
+		if (searchParams.get('import') !== '1') return;
+		setImportOpen(true);
+		const next = new URLSearchParams(searchParams);
+		next.delete('import');
+		setSearchParams(next, { replace: true });
+	}, [searchParams, setSearchParams]);
 
 	const apis = query.data?.items;
 	const filtered = useMemo(() => {
@@ -48,13 +62,13 @@ export default function WorkspacePage() {
 
 	const importButton = (
 		<Button
-			variant="primary"
+			variant="outline"
 			size="sm"
 			onClick={() => setImportOpen(true)}
 			data-testid="workspace-import-open"
 		>
-			<Plus size={14} aria-hidden="true" />
-			Add
+			<Upload size={14} aria-hidden="true" />
+			Import API
 		</Button>
 	);
 

--- a/ui/src/modules/workspace/pages/WorkspacePage.tsx
+++ b/ui/src/modules/workspace/pages/WorkspacePage.tsx
@@ -25,6 +25,11 @@ export default function WorkspacePage() {
 	// import dialog on arrival (the import UI is a Workspace-module concern, so
 	// Discover navigates rather than embedding the dialog). Strip the param once
 	// consumed so a refresh or back-nav doesn't re-trigger it.
+	//
+	// Seed the open state from the URL in the initializer AND re-sync in the
+	// effect below on purpose: the initializer opens the dialog on the very
+	// first paint (no closed-then-open flash), while the effect handles later
+	// param changes and strips it. Don't collapse the two into one.
 	const [importOpen, setImportOpen] = useState(() => searchParams.get('import') === '1');
 	const [filter, setFilter] = useState('');
 	const query = useWorkspaceApis();

--- a/ui/src/shared/app/nav.ts
+++ b/ui/src/shared/app/nav.ts
@@ -40,7 +40,7 @@ export interface NavItem {
  */
 export const navItems: NavItem[] = [
 	{ id: 'dashboard', label: 'Dashboard', to: '/', order: 10, icon: LayoutDashboard },
-	{ id: 'discover', label: 'Discover', to: '/discover', order: 20, icon: Compass },
+	{ id: 'discover', label: 'Discover APIs', to: '/discover', order: 20, icon: Compass },
 	{ id: 'workspace', label: 'Workspace', to: '/workspace', order: 30, icon: LayoutGrid },
 	{ id: 'toolkits', label: 'Toolkits', to: '/toolkits', order: 40, icon: Boxes },
 	{ id: 'credentials', label: 'Credentials', to: '/credentials', order: 50, icon: KeyRound },

--- a/ui/src/shared/ui/AppLink.tsx
+++ b/ui/src/shared/ui/AppLink.tsx
@@ -1,11 +1,26 @@
 import type { AnchorHTMLAttributes } from 'react';
 import { Link, type LinkProps } from 'react-router-dom';
 import { cn } from '@/shared/lib/utils';
+import {
+	buttonBase,
+	buttonVariantClasses,
+	buttonSizeClasses,
+	type ButtonVariant,
+	type ButtonSize,
+} from '@/shared/ui/Button';
 
 type AppLinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> &
 	Omit<LinkProps, 'to'> & {
 		href: string;
 		external?: boolean;
+		/**
+		 * Render the link with `Button`'s look (a link that acts like a button —
+		 * e.g. an "Import API" CTA). Reuses `Button`'s exported variant/size
+		 * tokens so the two never drift. `AppLink`'s own `FOCUS_RING` supplies the
+		 * focus affordance, so the button focus ring is intentionally not applied.
+		 */
+		variant?: ButtonVariant;
+		size?: ButtonSize;
 	};
 
 const EXTERNAL_RE = /^([a-z][a-z0-9+.-]*:|\/\/)/i;
@@ -38,11 +53,25 @@ export function AppLink({
 	rel,
 	children,
 	className,
+	variant,
+	size,
 	...props
 }: AppLinkProps) {
+	// When a button look is requested, compose Button's shared tokens (base +
+	// variant + size). Skip Button's focus ring — FOCUS_RING below owns it.
+	const buttonLook =
+		variant != null || size != null
+			? cn(
+					buttonBase,
+					variant != null && buttonVariantClasses[variant],
+					size != null && buttonSizeClasses[size],
+				)
+			: undefined;
+	const mergedClassName = cn(buttonLook, className);
+
 	if (UNSAFE_RE.test(href)) {
 		return (
-			<span {...props} className={className} role="link" aria-disabled="true">
+			<span {...props} className={mergedClassName} role="link" aria-disabled="true">
 				{children}
 			</span>
 		);
@@ -54,7 +83,7 @@ export function AppLink({
 				href={href}
 				target={target ?? '_blank'}
 				rel={rel ?? 'noopener noreferrer'}
-				className={cn(FOCUS_RING, className)}
+				className={cn(FOCUS_RING, mergedClassName)}
 				{...props}
 			>
 				{children}
@@ -63,7 +92,7 @@ export function AppLink({
 	}
 
 	return (
-		<Link to={href} className={cn(FOCUS_RING, className)} {...props}>
+		<Link to={href} className={cn(FOCUS_RING, mergedClassName)} {...props}>
 			{children}
 		</Link>
 	);

--- a/ui/src/shared/ui/Button.tsx
+++ b/ui/src/shared/ui/Button.tsx
@@ -5,6 +5,19 @@ import { cn } from '@/shared/lib/utils';
 type Variant = 'primary' | 'secondary' | 'danger' | 'ghost' | 'outline';
 type Size = 'sm' | 'md' | 'lg' | 'icon';
 
+/**
+ * Shared base classes for the button *look* (layout, radius, font, focus ring,
+ * transitions). Exported so navigable primitives (e.g. `AppLink`) can render a
+ * link that looks like a button without re-implementing — or drifting from —
+ * these tokens. `AppLink` supplies its own focus ring, so the button base is
+ * split from the ring below.
+ */
+const buttonBase =
+	'inline-flex cursor-pointer items-center justify-center rounded-lg font-medium transition-[transform,background-color,border-color,color,box-shadow] duration-150 ease-out active:scale-[0.98] disabled:cursor-not-allowed motion-reduce:active:scale-100';
+
+const buttonFocusRing =
+	'focus-visible:ring-ring focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none';
+
 const variantClasses: Record<Variant, string> = {
 	primary: 'bg-primary text-background shadow-card hover:bg-primary-hover disabled:opacity-50',
 	secondary:
@@ -51,7 +64,8 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function 
 			aria-busy={loading || undefined}
 			aria-disabled={disabled || loading || undefined}
 			className={cn(
-				'focus-visible:ring-ring focus-visible:ring-offset-background inline-flex cursor-pointer items-center justify-center rounded-lg font-medium transition-[transform,background-color,border-color,color,box-shadow] duration-150 ease-out focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-[0.98] disabled:cursor-not-allowed motion-reduce:active:scale-100',
+				buttonBase,
+				buttonFocusRing,
 				variantClasses[variant],
 				sizeClasses[size],
 				fullWidth && 'w-full',
@@ -67,4 +81,5 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function 
 
 Button.displayName = 'Button';
 
-export type { ButtonProps };
+export { buttonBase, variantClasses as buttonVariantClasses, sizeClasses as buttonSizeClasses };
+export type { ButtonProps, Variant as ButtonVariant, Size as ButtonSize };

--- a/ui/src/shared/ui/CascadeDeleteDialog.tsx
+++ b/ui/src/shared/ui/CascadeDeleteDialog.tsx
@@ -44,13 +44,28 @@ interface CascadeDeleteDialogProps {
 	loading?: boolean;
 	error?: Error | string | null;
 	/**
-	 * The word the user must type to arm the destructive action. Defaults to
-	 * "delete". Kept short and fixed (not the entity name) so confirming a
-	 * slash/hyphen-heavy name (e.g. an API vendor/name tuple) isn't error-prone.
-	 * Matched case-insensitively.
+	 * The word the user must type to arm the destructive action. Defaults per
+	 * entity type — "archive" for the archive-style kinds (agent,
+	 * service-account) and "delete" for everything else — so the typed word
+	 * matches the button verb. Kept short and fixed (not the entity name) so
+	 * confirming a slash/hyphen-heavy name (e.g. an API vendor/name tuple) isn't
+	 * error-prone. Matched case-insensitively.
 	 */
 	confirmWord?: string;
 }
+
+/**
+ * The default confirm word per entity type. Archive-style kinds arm on
+ * "archive" so the typed word lines up with their "Archive …" button verb;
+ * everything else arms on "delete".
+ */
+const DEFAULT_CONFIRM_WORD: Record<CascadeEntityType, string> = {
+	credential: 'delete',
+	api: 'delete',
+	toolkit: 'delete',
+	agent: 'archive',
+	'service-account': 'archive',
+};
 
 /** Per-type copy: title, the destructive verb, and what a delete typically takes down. */
 const TYPE_COPY: Record<
@@ -131,9 +146,10 @@ export function CascadeDeleteDialog({
 	dependents,
 	loading = false,
 	error,
-	confirmWord = 'delete',
+	confirmWord,
 }: CascadeDeleteDialogProps) {
 	const copy = TYPE_COPY[entityType];
+	const requiredWord = confirmWord ?? DEFAULT_CONFIRM_WORD[entityType];
 	const [typed, setTyped] = useState('');
 	// Whether the user has attempted a confirm in *this* dialog session. The
 	// mutation `error` lives on the caller's hook and survives close/reopen, so
@@ -157,7 +173,7 @@ export function CascadeDeleteDialog({
 		}
 	}, [open]);
 
-	const confirmed = typed.trim().toLowerCase() === confirmWord.trim().toLowerCase();
+	const confirmed = typed.trim().toLowerCase() === requiredWord.trim().toLowerCase();
 	const hasDependents = Array.isArray(dependents) && dependents.length > 0;
 	// Only surface the error once the user has actually tried this session;
 	// hold the narrowed value (not just a boolean) so the JSX renders cleanly.
@@ -217,7 +233,7 @@ export function CascadeDeleteDialog({
 					<div className="space-y-1.5">
 						<Label htmlFor={confirmInputId}>
 							Type{' '}
-							<span className="text-foreground font-semibold">{confirmWord}</span> to
+							<span className="text-foreground font-semibold">{requiredWord}</span> to
 							confirm
 						</Label>
 						<Input
@@ -226,7 +242,7 @@ export function CascadeDeleteDialog({
 							onChange={(e): void => setTyped(e.target.value)}
 							disabled={loading}
 							autoComplete="off"
-							placeholder={confirmWord}
+							placeholder={requiredWord}
 						/>
 					</div>
 

--- a/ui/src/shared/ui/CascadeDeleteDialog.tsx
+++ b/ui/src/shared/ui/CascadeDeleteDialog.tsx
@@ -43,6 +43,13 @@ interface CascadeDeleteDialogProps {
 	dependents?: CascadeDependentGroup[];
 	loading?: boolean;
 	error?: Error | string | null;
+	/**
+	 * The word the user must type to arm the destructive action. Defaults to
+	 * "delete". Kept short and fixed (not the entity name) so confirming a
+	 * slash/hyphen-heavy name (e.g. an API vendor/name tuple) isn't error-prone.
+	 * Matched case-insensitively.
+	 */
+	confirmWord?: string;
 }
 
 /** Per-type copy: title, the destructive verb, and what a delete typically takes down. */
@@ -124,6 +131,7 @@ export function CascadeDeleteDialog({
 	dependents,
 	loading = false,
 	error,
+	confirmWord = 'delete',
 }: CascadeDeleteDialogProps) {
 	const copy = TYPE_COPY[entityType];
 	const [typed, setTyped] = useState('');
@@ -149,7 +157,7 @@ export function CascadeDeleteDialog({
 		}
 	}, [open]);
 
-	const confirmed = typed.trim() === entityName.trim();
+	const confirmed = typed.trim().toLowerCase() === confirmWord.trim().toLowerCase();
 	const hasDependents = Array.isArray(dependents) && dependents.length > 0;
 	// Only surface the error once the user has actually tried this session;
 	// hold the narrowed value (not just a boolean) so the JSX renders cleanly.
@@ -208,8 +216,9 @@ export function CascadeDeleteDialog({
 
 					<div className="space-y-1.5">
 						<Label htmlFor={confirmInputId}>
-							Type <span className="text-foreground font-semibold">{entityName}</span>{' '}
-							to confirm
+							Type{' '}
+							<span className="text-foreground font-semibold">{confirmWord}</span> to
+							confirm
 						</Label>
 						<Input
 							id={confirmInputId}
@@ -217,7 +226,7 @@ export function CascadeDeleteDialog({
 							onChange={(e): void => setTyped(e.target.value)}
 							disabled={loading}
 							autoComplete="off"
-							placeholder={entityName}
+							placeholder={confirmWord}
 						/>
 					</div>
 

--- a/ui/src/shared/ui/CascadeDeleteDialog.tsx
+++ b/ui/src/shared/ui/CascadeDeleteDialog.tsx
@@ -134,8 +134,10 @@ function describeGroup(group: CascadeDependentGroup): string {
  *    what the cascade removes, with counts and (optionally) names.
  *
  * Both modes gate the destructive action behind a type-to-confirm field: the
- * user must type the entity name before the delete button enables. This is a
- * deliberate friction step for irreversible actions.
+ * user must type a short fixed word (the per-type `confirmWord` default —
+ * "delete", or "archive" for archive-style entities — matched
+ * case-insensitively) before the confirm button enables. This is a deliberate
+ * friction step for irreversible actions.
  */
 export function CascadeDeleteDialog({
 	open,

--- a/ui/src/shared/ui/CascadeDeleteDialog.tsx
+++ b/ui/src/shared/ui/CascadeDeleteDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useState } from 'react';
-import { AlertTriangle, CircleDot, Trash2 } from 'lucide-react';
+import { AlertTriangle, Archive, CircleDot, Trash2, type LucideIcon } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
 import { Dialog } from '@/shared/ui/Dialog';
 import { ErrorAlert } from '@/shared/ui/ErrorAlert';
@@ -67,10 +67,15 @@ const DEFAULT_CONFIRM_WORD: Record<CascadeEntityType, string> = {
 	'service-account': 'archive',
 };
 
-/** Per-type copy: title, the destructive verb, and what a delete typically takes down. */
+/**
+ * Per-type copy + confirm icon: title, the destructive verb, what a delete
+ * typically takes down, and the glyph on the confirm button. Archive-style
+ * kinds use an `Archive` glyph so the icon matches the "Archive …" verb rather
+ * than contradicting it with a trash can.
+ */
 const TYPE_COPY: Record<
 	CascadeEntityType,
-	{ title: string; confirmLabel: string; noun: string; warning: string }
+	{ title: string; confirmLabel: string; noun: string; warning: string; icon: LucideIcon }
 > = {
 	credential: {
 		title: 'Delete credential',
@@ -78,6 +83,7 @@ const TYPE_COPY: Record<
 		noun: 'credential',
 		warning:
 			'Agents and toolkits that authenticate with this credential will stop working until you bind a replacement.',
+		icon: Trash2,
 	},
 	api: {
 		title: 'Remove API',
@@ -85,6 +91,7 @@ const TYPE_COPY: Record<
 		noun: 'API',
 		warning:
 			'This API and all of its operations leave your workspace. Toolkits and credentials that reference it will no longer resolve until you re-import it.',
+		icon: Trash2,
 	},
 	toolkit: {
 		title: 'Delete toolkit',
@@ -92,6 +99,7 @@ const TYPE_COPY: Record<
 		noun: 'toolkit',
 		warning:
 			'Agents granted this toolkit will fail their next call, and any API keys minted for it stop working immediately.',
+		icon: Trash2,
 	},
 	agent: {
 		title: 'Archive agent',
@@ -99,6 +107,7 @@ const TYPE_COPY: Record<
 		noun: 'agent',
 		warning:
 			'Archiving is permanent — the agent can no longer authenticate or be restored, and its grants and access requests are released.',
+		icon: Archive,
 	},
 	'service-account': {
 		title: 'Archive service account',
@@ -106,6 +115,7 @@ const TYPE_COPY: Record<
 		noun: 'service account',
 		warning:
 			'Archiving is permanent — the service account can no longer authenticate or be restored, and its grants are released.',
+		icon: Archive,
 	},
 };
 
@@ -151,7 +161,10 @@ export function CascadeDeleteDialog({
 	confirmWord,
 }: CascadeDeleteDialogProps) {
 	const copy = TYPE_COPY[entityType];
-	const requiredWord = confirmWord ?? DEFAULT_CONFIRM_WORD[entityType];
+	// `??` alone would let an explicit `confirmWord=""` through and arm the
+	// danger button with no typing (`"" === ""`). Treat empty-after-trim as
+	// "use the per-type default" so the public prop can't disable the gate.
+	const requiredWord = confirmWord?.trim() ? confirmWord : DEFAULT_CONFIRM_WORD[entityType];
 	const [typed, setTyped] = useState('');
 	// Whether the user has attempted a confirm in *this* dialog session. The
 	// mutation `error` lives on the caller's hook and survives close/reopen, so
@@ -209,7 +222,7 @@ export function CascadeDeleteDialog({
 							loading={loading}
 							disabled={!confirmed}
 						>
-							<Trash2 className="h-4 w-4" />
+							<copy.icon className="h-4 w-4" />
 							{copy.confirmLabel}
 						</Button>
 					</>

--- a/ui/src/shared/ui/__tests__/CascadeDeleteDialog.test.tsx
+++ b/ui/src/shared/ui/__tests__/CascadeDeleteDialog.test.tsx
@@ -61,7 +61,7 @@ describe('CascadeDeleteDialog', () => {
 		).toBeInTheDocument();
 	});
 
-	it('keeps the confirm button disabled until the entity name is typed exactly', async () => {
+	it('keeps the confirm button disabled until the fixed word is typed (case-insensitive)', async () => {
 		const user = userEvent.setup();
 		const onConfirm = vi.fn();
 		renderWithProviders(<Harness entityName="Stripe (prod)" onConfirm={onConfirm} />);
@@ -69,12 +69,22 @@ describe('CascadeDeleteDialog', () => {
 		const confirm = screen.getByRole('button', { name: /Delete credential/i });
 		expect(confirm).toBeDisabled();
 
-		const field = screen.getByLabelText(/Type Stripe \(prod\) to confirm/i);
+		const field = screen.getByLabelText(/Type delete to confirm/i);
 		await user.type(field, 'wrong');
 		expect(confirm).toBeDisabled();
 
+		// The full entity name (the old confirm string) must NOT arm the button.
 		await user.clear(field);
 		await user.type(field, 'Stripe (prod)');
+		expect(confirm).toBeDisabled();
+
+		// A different-case spelling of the fixed word still confirms.
+		await user.clear(field);
+		await user.type(field, 'DELETE');
+		expect(confirm).toBeEnabled();
+
+		await user.clear(field);
+		await user.type(field, 'delete');
 		expect(confirm).toBeEnabled();
 
 		await user.click(confirm);
@@ -123,8 +133,8 @@ describe('CascadeDeleteDialog', () => {
 		// Error from a prior session must NOT show before the user acts here.
 		expect(screen.queryByText(/cascade failed mid-flight/i)).not.toBeInTheDocument();
 
-		// Type the name and confirm → the in-session attempt surfaces the error.
-		await user.type(screen.getByLabelText(/Type Stripe \(prod\) to confirm/i), 'Stripe (prod)');
+		// Type the word and confirm → the in-session attempt surfaces the error.
+		await user.type(screen.getByLabelText(/Type delete to confirm/i), 'delete');
 		await user.click(screen.getByRole('button', { name: /Delete credential/i }));
 		expect(screen.getByText(/cascade failed mid-flight/i)).toBeInTheDocument();
 

--- a/ui/src/shared/ui/__tests__/CascadeDeleteDialog.test.tsx
+++ b/ui/src/shared/ui/__tests__/CascadeDeleteDialog.test.tsx
@@ -61,6 +61,21 @@ describe('CascadeDeleteDialog', () => {
 		).toBeInTheDocument();
 	});
 
+	it('arms archive-style entities on the word "archive", not "delete"', async () => {
+		const user = userEvent.setup();
+		renderWithProviders(<Harness entityType="agent" entityName="Build Bot" />);
+
+		const confirm = screen.getByRole('button', { name: /Archive agent/i });
+		const field = screen.getByLabelText(/Type archive to confirm/i);
+
+		await user.type(field, 'delete');
+		expect(confirm).toBeDisabled();
+
+		await user.clear(field);
+		await user.type(field, 'archive');
+		expect(confirm).toBeEnabled();
+	});
+
 	it('keeps the confirm button disabled until the fixed word is typed (case-insensitive)', async () => {
 		const user = userEvent.setup();
 		const onConfirm = vi.fn();

--- a/ui/src/shared/ui/__tests__/CascadeDeleteDialog.test.tsx
+++ b/ui/src/shared/ui/__tests__/CascadeDeleteDialog.test.tsx
@@ -9,6 +9,7 @@ function Harness({
 	dependents,
 	loading = false,
 	error,
+	confirmWord,
 	onConfirm = () => {},
 }: {
 	entityType?: CascadeEntityType;
@@ -16,6 +17,7 @@ function Harness({
 	dependents?: CascadeDependentGroup[];
 	loading?: boolean;
 	error?: Error | string | null;
+	confirmWord?: string;
 	onConfirm?: () => void;
 }) {
 	const [open, setOpen] = useState(true);
@@ -33,6 +35,7 @@ function Harness({
 				dependents={dependents}
 				loading={loading}
 				error={error}
+				confirmWord={confirmWord}
 			/>
 		</>
 	);
@@ -73,6 +76,19 @@ describe('CascadeDeleteDialog', () => {
 
 		await user.clear(field);
 		await user.type(field, 'archive');
+		expect(confirm).toBeEnabled();
+	});
+
+	it('ignores an empty confirmWord and falls back to the per-type default', async () => {
+		const user = userEvent.setup();
+		renderWithProviders(<Harness entityType="credential" confirmWord="" />);
+
+		const confirm = screen.getByRole('button', { name: /Delete credential/i });
+		// An empty confirmWord must NOT arm the button with no typing.
+		expect(confirm).toBeDisabled();
+
+		// The default ("delete") still gates it.
+		await user.type(screen.getByLabelText(/Type delete to confirm/i), 'delete');
 		expect(confirm).toBeEnabled();
 	});
 


### PR DESCRIPTION
## Summary

Three small, independent UI fixes that improve everyday usability: a simpler
delete confirmation, a discoverable API-import entry point, and a tidied
Workspace catalog footer. All changes are UI-only.

## Related issue

Closes #663
Closes #675
Closes #618

## Changes

**#663 — Delete confirm no longer forces retyping the full name**
- `CascadeDeleteDialog` now gates the destructive action on a short fixed word
  ("delete", matched case-insensitively) via a new optional `confirmWord` prop
  (default `"delete"`), instead of retyping the full entity name (an ugly
  `vendor/name` tuple for APIs). The full name still shows in the dialog body
  for context. All six call sites keep working unchanged.

**#675 — Make importing your own API discoverable**
- Workspace: relabel the button `Add` → **Import API**, swap the icon to
  `Upload`, and use the `outline` variant; retitle the dialog "Add to your
  workspace" → **"Import an API"**; open the import dialog automatically on a
  `?import=1` deep link.
- Discover: rename the tab and page heading to **"Discover APIs"**; add a
  consistent outline **"Import your own API"** button (Upload icon) in the
  header and in the empty state, both navigating to `/workspace?import=1`.
- The import UI stays a Workspace-module concern — Discover links via the shared
  route rather than importing the Workspace module (module-boundary-safe, per
  decision D-005a).

**#618 — Couple the Workspace catalog footer caption with its link**
- The "Looking for something else?" caption and the "Browse the catalog in
  Discover" link were pushed to opposite ends of the row (`justify-between`),
  reading as a disconnected road to nowhere. They now render as one contiguous
  phrase.

## Testing

- `npm run lint` — clean.
- `npm run build` — succeeds; Tailwind compiles all utilities.
- `npm run test:run` — full unit suite passes (683 tests). Updated the
  type-to-confirm tests across every cascade-delete call site (dialog,
  credentials, toolkits, agents, API detail); added a deep-link test that
  `/workspace?import=1` auto-opens the import dialog; updated `discover.spec.ts`
  for the "Discover APIs" label.

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] `make check` passes (lint, type check, secrets audit, arch tests)
- [x] Tests added/updated for the change
- [x] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included