### PR TITLE
feat(control): generic access-filter seam for extension read scoping

### DIFF
--- a/src/jentic_one/control/repos/prerequisite_repo.py
+++ b/src/jentic_one/control/repos/prerequisite_repo.py
@@ -28,6 +28,20 @@ class PrerequisiteRepository:
     """Checks existence of bindings in the admin database without admin imports."""
 
     @staticmethod
+    async def active_user_exists(session: AsyncSession, *, user_id: str) -> bool:
+        """Return True if an active user with this id exists (admin DB).
+
+        A cross-DB existence check that lets a control-side caller validate a
+        user id without importing admin ORM models (e.g. before recording a
+        reference to a user). Returns False for unknown or deactivated users.
+        """
+        result = await session.execute(
+            text("SELECT 1 FROM users WHERE id = :user_id AND active = true LIMIT 1"),
+            {"user_id": user_id},
+        )
+        return result.scalar_one_or_none() is not None
+
+    @staticmethod
     async def agent_toolkit_binding_exists(
         session: AsyncSession, *, agent_id: str, toolkit_id: str
     ) -> bool:

--- a/src/jentic_one/control/scoping/filters.py
+++ b/src/jentic_one/control/scoping/filters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from sqlalchemy import exists, or_, select
@@ -51,6 +52,43 @@ _DELEGATION_SCOPES: dict[type[Any], str] = {
     AccessRequest: OWNER_ACCESS_REQUESTS_READ,
 }
 
+# ---------------------------------------------------------------------------
+# Extra access-filter providers (extension seam).
+#
+# An out-of-tree extension (e.g. the enterprise package) may widen READ-only
+# visibility beyond ownership — e.g. a "shared-with-me" grant — WITHOUT this OSS
+# module importing the extension. A provider is `fn(identity, model) -> clause |
+# None`; it returns an extra OR-clause for a model it widens, or None otherwise.
+# Providers run ONLY on read paths (`include_shared=True`); mutations stay
+# owner-only. OSS ships zero providers, so with no extension present behaviour is
+# byte-for-byte the owner-scoped default. Mirrors `register_telemetry_event`.
+# ---------------------------------------------------------------------------
+AccessFilterProvider = Callable[[Identity, type], "ColumnElement[bool] | None"]
+
+_ACCESS_FILTER_PROVIDERS: list[AccessFilterProvider] = []
+
+
+def register_access_filter_provider(provider: AccessFilterProvider) -> None:
+    """Register an extra READ-only visibility-clause provider (idempotent).
+
+    Call at import time from a registering package (see the enterprise
+    ``register()``). The clause a provider returns is OR-merged into the caller's
+    owner-scoped read filter. Any table the clause references must be readable by
+    the control DB role (i.e. live in the ``control`` schema).
+    """
+    if provider not in _ACCESS_FILTER_PROVIDERS:
+        _ACCESS_FILTER_PROVIDERS.append(provider)
+
+
+def _provider_clauses(identity: Identity, model: type[Any]) -> list[ColumnElement[bool]]:
+    """Collect the non-null clauses every registered provider yields for a model."""
+    clauses: list[ColumnElement[bool]] = []
+    for provider in _ACCESS_FILTER_PROVIDERS:
+        extra = provider(identity, model)
+        if extra is not None:
+            clauses.append(extra)
+    return clauses
+
 
 def _binding_visibility_clause(
     model: type[Any], bound_toolkit_ids: list[str] | None
@@ -81,6 +119,7 @@ def build_access_filters(
     model: type[Any],
     *,
     bound_toolkit_ids: list[str] | None = None,
+    include_shared: bool = False,
 ) -> list[ColumnElement[bool]]:
     """Build SQLAlchemy filter expressions scoping queries to the caller's visibility.
 
@@ -98,6 +137,12 @@ def build_access_filters(
     :meth:`PrerequisiteRepository.list_toolkit_ids_for_agent`) and passes them in;
     this module stays single-DB and free of admin imports. ``None``/empty leaves
     the owner-only behaviour unchanged.
+
+    ``include_shared`` (READ call sites only) invokes any registered
+    access-filter providers (see :func:`register_access_filter_provider`) and
+    OR-merges their clauses — e.g. an extension's "shared-with-me" grant. It must
+    NOT be set on write call sites, so a sharee can see but never mutate. With no
+    providers registered (stock OSS) it is a no-op.
 
     Raises ValueError for an unknown model or empty sub.
     """
@@ -120,10 +165,13 @@ def build_access_filters(
             )
         else:
             owner_clause = col == identity.sub
+        clauses: list[ColumnElement[bool]] = [owner_clause]
         binding_clause = _binding_visibility_clause(model, bound_toolkit_ids)
         if binding_clause is not None:
-            return [or_(owner_clause, binding_clause)]
-        return [owner_clause]
+            clauses.append(binding_clause)
+        if include_shared:
+            clauses.extend(_provider_clauses(identity, model))
+        return [or_(*clauses)] if len(clauses) > 1 else clauses
 
     if model in _CHILD_MODELS:
         child_fk, _parent_model, parent_pk, parent_owner = _CHILD_MODELS[model]

--- a/src/jentic_one/control/services/credentials/service.py
+++ b/src/jentic_one/control/services/credentials/service.py
@@ -286,7 +286,10 @@ class CredentialService:
     async def get(self, credential_id: str, *, identity: Identity) -> CredentialRedactedView:
         """Get a credential by ID with redacted secrets."""
         access_filters = build_access_filters(
-            identity, Credential, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+            identity,
+            Credential,
+            bound_toolkit_ids=await self._bound_toolkit_ids(identity),
+            include_shared=True,
         )
         async with self._ctx.control_db.session() as session:
             credential = await CredentialRepository.get_by_id(
@@ -311,7 +314,10 @@ class CredentialService:
             decoded_cursor = (ts, cid)
 
         access_filters = build_access_filters(
-            identity, Credential, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+            identity,
+            Credential,
+            bound_toolkit_ids=await self._bound_toolkit_ids(identity),
+            include_shared=True,
         )
 
         async with self._ctx.control_db.session() as session:

--- a/src/jentic_one/control/services/toolkits/service.py
+++ b/src/jentic_one/control/services/toolkits/service.py
@@ -187,7 +187,9 @@ class ToolkitService:
 
     async def get(self, toolkit_id: str, *, identity: Identity) -> Toolkit:
         bound_ids = await self._bound_toolkit_ids(identity)
-        access_filters = build_access_filters(identity, Toolkit, bound_toolkit_ids=bound_ids)
+        access_filters = build_access_filters(
+            identity, Toolkit, bound_toolkit_ids=bound_ids, include_shared=True
+        )
         async with self._ctx.control_db.session() as session:
             toolkit = await ToolkitRepository.get_with_relations(
                 session, toolkit_id, filters=access_filters
@@ -206,7 +208,10 @@ class ToolkitService:
             decoded_cursor = (ts, cid)
 
         access_filters = build_access_filters(
-            identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+            identity,
+            Toolkit,
+            bound_toolkit_ids=await self._bound_toolkit_ids(identity),
+            include_shared=True,
         )
         async with self._ctx.control_db.session() as session:
             rows = await ToolkitRepository.list_all(

--- a/tests/unit/control/test_control_scoping.py
+++ b/tests/unit/control/test_control_scoping.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from sqlalchemy import exists, select
+from sqlalchemy import ColumnElement, exists, select
 
 from jentic_one.control.core.schema.access_requests import AccessRequest
 from jentic_one.control.core.schema.credentials import Credential
@@ -212,7 +212,7 @@ def test_orphaned_agent_sees_credential_bound_to_bound_toolkit() -> None:
 def test_include_shared_invokes_registered_provider() -> None:
     """A registered provider's clause is OR-merged on the read path."""
 
-    def _provider(identity: Identity, model: type) -> object | None:
+    def _provider(identity: Identity, model: type) -> ColumnElement[bool] | None:
         if model is Toolkit:
             # A dummy EXISTS keyed on the caller — stands in for a share table.
             return exists(select(Toolkit.id).where(Toolkit.created_by == f"shared:{identity.sub}"))
@@ -234,7 +234,7 @@ def test_include_shared_invokes_registered_provider() -> None:
 def test_include_shared_default_off_ignores_providers() -> None:
     """Without include_shared (the write path), providers are not consulted."""
 
-    def _provider(identity: Identity, model: type) -> object | None:
+    def _provider(identity: Identity, model: type) -> ColumnElement[bool] | None:
         return exists(select(Toolkit.id).where(Toolkit.created_by == "PROVIDER_MARKER"))
 
     register_access_filter_provider(_provider)

--- a/tests/unit/control/test_control_scoping.py
+++ b/tests/unit/control/test_control_scoping.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import exists, select
 
 from jentic_one.control.core.schema.access_requests import AccessRequest
 from jentic_one.control.core.schema.credentials import Credential
 from jentic_one.control.core.schema.toolkit_keys import ToolkitKey
 from jentic_one.control.core.schema.toolkits import Toolkit
-from jentic_one.control.scoping.filters import build_access_filters
+from jentic_one.control.scoping.filters import (
+    _ACCESS_FILTER_PROVIDERS,
+    build_access_filters,
+    register_access_filter_provider,
+)
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.models import ActorType
 from jentic_one.shared.scopes import (
@@ -199,6 +204,63 @@ def test_orphaned_agent_sees_credential_bound_to_bound_toolkit() -> None:
     assert "EXISTS" in sql
     assert "toolkit_credential_bindings" in sql
     assert "tk_bound_1" in sql
+
+
+# --- Read-only sharing seam (register_access_filter_provider) ---
+
+
+def test_include_shared_invokes_registered_provider() -> None:
+    """A registered provider's clause is OR-merged on the read path."""
+
+    def _provider(identity: Identity, model: type) -> object | None:
+        if model is Toolkit:
+            # A dummy EXISTS keyed on the caller — stands in for a share table.
+            return exists(select(Toolkit.id).where(Toolkit.created_by == f"shared:{identity.sub}"))
+        return None
+
+    register_access_filter_provider(_provider)
+    try:
+        identity = _identity(sub="user_share", permissions=[])
+        filters = build_access_filters(identity, Toolkit, include_shared=True)
+        assert len(filters) == 1
+        sql = str(filters[0].compile(compile_kwargs={"literal_binds": True}))
+        assert "created_by" in sql  # owner branch preserved
+        assert "EXISTS" in sql
+        assert "shared:user_share" in sql  # provider clause merged in
+    finally:
+        _ACCESS_FILTER_PROVIDERS.remove(_provider)
+
+
+def test_include_shared_default_off_ignores_providers() -> None:
+    """Without include_shared (the write path), providers are not consulted."""
+
+    def _provider(identity: Identity, model: type) -> object | None:
+        return exists(select(Toolkit.id).where(Toolkit.created_by == "PROVIDER_MARKER"))
+
+    register_access_filter_provider(_provider)
+    try:
+        identity = _identity(sub="user_share", permissions=[])
+        filters = build_access_filters(identity, Toolkit)  # include_shared defaults False
+        sql = str(filters[0].compile(compile_kwargs={"literal_binds": True}))
+        assert "PROVIDER_MARKER" not in sql
+    finally:
+        _ACCESS_FILTER_PROVIDERS.remove(_provider)
+
+
+def test_no_providers_is_owner_only() -> None:
+    """Stock OSS (no providers) yields the plain owner filter even with include_shared."""
+    identity = _identity(sub="user_share", permissions=[])
+    filters = build_access_filters(identity, Toolkit, include_shared=True)
+    assert len(filters) == 1
+    sql = str(filters[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "created_by" in sql
+    assert "EXISTS" not in sql
+
+
+def test_admin_ignores_include_shared() -> None:
+    """org:admin stays unrestricted even with include_shared."""
+    identity = _identity(permissions=["org:admin"])
+    assert build_access_filters(identity, Toolkit, include_shared=True) == []
 
 
 # --- AccessRequest model tests ---


### PR DESCRIPTION
## Summary

Adds a **generic, read-only access-filter seam** to the control-plane query
scoping so an out-of-tree extension (the enterprise package) can widen READ
visibility — e.g. a "shared-with-me" grant — **without any sharing logic living
in OSS**. OSS ships **zero** providers, never imports the extension, and behaves
exactly as before (owner-scoped) on its own.

> This PR previously carried a full OSS sharing implementation; per review, the
> sharing feature belongs in the enterprise tier. It's been reduced to just the
> seam; the tables/service/endpoints move to `jentic-one-enterprise` (with the
> share table living in the `control` schema so the `EXISTS` is readable by the
> control DB role).

## What's here

- **`register_access_filter_provider(fn)`** in `control/scoping/filters.py`
  (mirrors `register_telemetry_event`): a module-level registry of
  `fn(identity, model) -> ColumnElement | None`. On READ paths
  (`include_shared=True`) each provider's clause is OR-merged into the caller's
  owner-scoped filter. Mutations stay owner-only, so an extension can widen
  *read* visibility but never write scope.
- `PrerequisiteRepository.active_user_exists` — a generic cross-DB "is this an
  active user?" check (raw SQL, no admin imports) an extension's share service
  can reuse to validate a grantee.
- Scoping unit tests exercise the seam via a registered provider (clause merged
  on read; ignored on write; no-op when no providers; admin unrestricted).

## Design notes

- **Dependency arrow is extension → OSS only.** OSS never imports the extension;
  the extension calls `register_access_filter_provider` in its `register()`.
  Passes all module-boundary + scoping arch tests.
- **No new API surface.** The seam is invisible in the OpenAPI spec (no share
  endpoints in OSS).
- The provider is active only when the process boots an extension that registers
  one (e.g. the enterprise combined app); stock OSS runs with an empty provider
  list.

## Test plan

- [x] `ruff check` + `ruff format --check` + `mypy` clean.
- [x] Full `tests/arch` suite (257) passes — incl. scoping coverage/boundary and
      module boundaries.
- [x] `tests/unit/control` (308) passes, incl. the reworked seam tests.
- [x] `make openapi` / `make endpoints` regenerated — no share paths.
- [ ] CI.
