### PR TITLE
fix(registry): restore operation inputs (parameters + requestBody) on import

### DIFF
--- a/src/jentic_one/registry/ingest/parsers/openapi.py
+++ b/src/jentic_one/registry/ingest/parsers/openapi.py
@@ -31,6 +31,9 @@ class OpenAPIOperationParser:
                     continue
 
                 path_servers: list[dict[str, Any]] = path_item.get("servers", [])
+                path_parameters: list[dict[str, Any]] = [
+                    p for p in path_item.get("parameters", []) if isinstance(p, dict)
+                ]
 
                 for method, operation in path_item.items():
                     if method not in HTTP_METHODS:
@@ -38,7 +41,9 @@ class OpenAPIOperationParser:
                     if not isinstance(operation, dict):
                         continue
 
-                    op = self._process_operation(path, method, operation, path_servers)
+                    op = self._process_operation(
+                        path, method, operation, path_servers, path_parameters
+                    )
                     operations.append(op)
 
         logger.debug("operations_extracted", count=len(operations))
@@ -50,12 +55,24 @@ class OpenAPIOperationParser:
         method: str,
         operation: dict[str, Any],
         path_servers: list[dict[str, Any]],
+        path_parameters: list[dict[str, Any]],
     ) -> dict[str, Any]:
-        """Process a single operation into the canonical output shape."""
+        """Process a single operation into the canonical output shape.
+
+        Retains ``parameters`` (query/header/path) and ``requestBody`` so the
+        stored ``raw_operation`` records what inputs an operation accepts —
+        without these, imported operations expose only path params and every
+        write / header-bearing call is uncallable (issue #768).
+
+        Path-item-level ``parameters`` apply to every operation on the path;
+        they are merged in here with operation-level entries taking precedence
+        on the same ``(name, in)`` key, mirroring the OpenAPI merge semantics
+        already used by the catalogue preview projector.
+        """
         operation_servers: list[dict[str, Any]] = operation.get("servers", [])
         servers = operation_servers if operation_servers else path_servers
 
-        return {
+        result: dict[str, Any] = {
             "operation_id": operation.get("operationId"),
             "path": path,
             "method": method.upper(),
@@ -64,3 +81,34 @@ class OpenAPIOperationParser:
             "tags": operation.get("tags", []),
             "servers": servers,
         }
+
+        merged_parameters = self._merge_parameters(path_parameters, operation.get("parameters", []))
+        if merged_parameters:
+            result["parameters"] = merged_parameters
+
+        if "requestBody" in operation:
+            result["requestBody"] = operation["requestBody"]
+
+        return result
+
+    @staticmethod
+    def _merge_parameters(
+        path_parameters: list[dict[str, Any]],
+        operation_parameters: Any,
+    ) -> list[dict[str, Any]]:
+        """Merge path-item and operation parameters.
+
+        Operation-level parameters override path-level ones on the same
+        ``(name, in)`` key. Non-dict entries (malformed specs) are skipped. A
+        ``$ref`` parameter has neither ``name`` nor ``in`` in scope here, so it
+        cannot participate in the override key — it is retained verbatim.
+        """
+        op_params = [p for p in operation_parameters if isinstance(p, dict)]
+        op_keys = {(p.get("name"), p.get("in")) for p in op_params if "name" in p and "in" in p}
+        merged: list[dict[str, Any]] = list(op_params)
+        for param in path_parameters:
+            key = (param.get("name"), param.get("in"))
+            if "name" in param and "in" in param and key in op_keys:
+                continue
+            merged.append(param)
+        return merged

--- a/src/jentic_one/registry/services/inspect/formatters/markdown.py
+++ b/src/jentic_one/registry/services/inspect/formatters/markdown.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import json
-from typing import Any
 
-from jentic_one.registry.services.inspect.models import OperationInspectResult
+from jentic_one.registry.services.inspect.models import (
+    OperationInputs,
+    OperationInspectResult,
+    OperationParameter,
+    RequestBodySchema,
+)
 
 
 def render_markdown(result: OperationInspectResult) -> str:
@@ -34,11 +38,8 @@ def _render_operation_markdown(result: OperationInspectResult) -> str:
         lines.append(f"> {result.api.description}")
     lines.append("")
 
-    if result.parameters:
-        lines.append("## Parameters")
-        lines.append("")
-        _describe_params(lines, result.parameters)
-        lines.append("")
+    if result.inputs:
+        _describe_inputs(lines, result.inputs)
 
     if result.response_schema:
         lines.append("## Response Schema")
@@ -64,23 +65,52 @@ def _render_operation_markdown(result: OperationInspectResult) -> str:
     return "\n".join(lines)
 
 
-def _describe_params(lines: list[str], params: dict[str, object]) -> None:
-    for name, schema in params.items():
-        type_str = _schema_type(schema) if isinstance(schema, dict) else "unknown"
-        desc = ""
-        if isinstance(schema, dict):
-            desc = _describe_field(schema)
-        lines.append(f"- `{name}` ({type_str}){desc}")
+def _describe_inputs(lines: list[str], inputs: OperationInputs) -> None:
+    groups = (
+        ("Path Parameters", inputs.path),
+        ("Query Parameters", inputs.query),
+        ("Header Parameters", inputs.header),
+    )
+    if any(params for _, params in groups):
+        lines.append("## Parameters")
+        lines.append("")
+        for heading, params in groups:
+            if not params:
+                continue
+            lines.append(f"### {heading}")
+            lines.append("")
+            _describe_params(lines, params)
+            lines.append("")
+
+    if inputs.body is not None:
+        _describe_body(lines, inputs.body)
 
 
-def _describe_field(schema: dict[str, Any]) -> str:
-    desc = schema.get("description", "")
-    if desc:
-        return f" — {desc}"
-    return ""
+def _describe_params(lines: list[str], params: list[OperationParameter]) -> None:
+    for param in params:
+        type_str = _schema_type(param.schema_)
+        required = " (required)" if param.required else ""
+        desc = f" — {param.description}" if param.description else ""
+        lines.append(f"- `{param.name}` ({type_str}){required}{desc}")
 
 
-def _schema_type(schema: Any) -> str:
+def _describe_body(lines: list[str], body: RequestBodySchema) -> None:
+    lines.append("## Request Body")
+    lines.append("")
+    if body.content_type:
+        lines.append(f"**Content-Type:** `{body.content_type}`")
+    lines.append(f"**Required:** {'yes' if body.required else 'no'}")
+    if body.description:
+        lines.append(f"> {body.description}")
+    lines.append("")
+    if body.schema_:
+        lines.append("```json")
+        lines.append(json.dumps(body.schema_, indent=2))
+        lines.append("```")
+        lines.append("")
+
+
+def _schema_type(schema: dict[str, object] | None) -> str:
     if isinstance(schema, dict):
         return str(schema.get("type", "object"))
     return "unknown"

--- a/src/jentic_one/registry/services/inspect/formatters/openapi.py
+++ b/src/jentic_one/registry/services/inspect/formatters/openapi.py
@@ -7,7 +7,10 @@ from urllib.parse import urlparse
 
 import yaml
 
-from jentic_one.registry.services.inspect.models import OperationInspectResult
+from jentic_one.registry.services.inspect.models import (
+    OperationInputs,
+    OperationInspectResult,
+)
 
 
 def render_openapi_yaml(result: OperationInspectResult) -> str:
@@ -20,14 +23,13 @@ def render_openapi_yaml(result: OperationInspectResult) -> str:
         operation["description"] = result.description
     operation["operationId"] = result.operation_id
 
-    if result.parameters:
-        params: list[dict[str, Any]] = []
-        for name, schema in result.parameters.items():
-            param: dict[str, Any] = {"name": name, "in": "query"}
-            if isinstance(schema, dict):
-                param["schema"] = schema
-            params.append(param)
-        operation["parameters"] = params
+    if result.inputs:
+        params = _render_parameters(result.inputs)
+        if params:
+            operation["parameters"] = params
+        request_body = _render_request_body(result.inputs)
+        if request_body is not None:
+            operation["requestBody"] = request_body
 
     if result.response_schema:
         operation["responses"] = {
@@ -56,6 +58,42 @@ def render_openapi_yaml(result: OperationInspectResult) -> str:
         spec["servers"] = [{"url": result.server}]
 
     return yaml.dump(spec, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+
+def _render_parameters(inputs: OperationInputs) -> list[dict[str, Any]]:
+    """Emit OpenAPI parameter objects with their true ``in`` location."""
+    params: list[dict[str, Any]] = []
+    for location, entries in (
+        ("path", inputs.path),
+        ("query", inputs.query),
+        ("header", inputs.header),
+    ):
+        for param in entries:
+            entry: dict[str, Any] = {"name": param.name, "in": location}
+            if param.required:
+                entry["required"] = True
+            if param.description:
+                entry["description"] = param.description
+            if param.schema_ is not None:
+                entry["schema"] = param.schema_
+            params.append(entry)
+    return params
+
+
+def _render_request_body(inputs: OperationInputs) -> dict[str, Any] | None:
+    """Emit an OpenAPI requestBody object from the projected body schema."""
+    body = inputs.body
+    if body is None:
+        return None
+    request_body: dict[str, Any] = {}
+    if body.required:
+        request_body["required"] = True
+    if body.description:
+        request_body["description"] = body.description
+    if body.schema_ is not None:
+        media_type = body.content_type or "application/json"
+        request_body["content"] = {media_type: {"schema": body.schema_}}
+    return request_body or None
 
 
 def _extract_path(url: str, server: str | None) -> str:

--- a/src/jentic_one/registry/services/inspect/inputs.py
+++ b/src/jentic_one/registry/services/inspect/inputs.py
@@ -1,0 +1,107 @@
+"""Project a stored ``raw_operation`` into structured, grouped inputs.
+
+Spec import stores the operation's ``parameters`` and ``requestBody`` verbatim
+in ``raw_operation`` (issue #768). This module turns that raw blob into the
+``OperationInputs`` view — query / header / path parameters grouped by their
+location plus a single request-body schema — so a client can build a complete
+request rather than only supplying path parameters.
+
+This is a pure projection over the stored operation dict. Any ``$ref`` inside a
+parameter or request body cannot be resolved here (the surrounding components
+document is not stored alongside the operation), so a ref-only parameter is
+skipped and a ref-only body schema is passed through as-is.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jentic_one.registry.services.inspect.models import (
+    OperationInputs,
+    OperationParameter,
+    RequestBodySchema,
+)
+
+_PARAM_LOCATIONS = ("path", "query", "header")
+
+
+def build_operation_inputs(raw_operation: dict[str, Any] | None) -> OperationInputs:
+    """Build the grouped inputs view from a stored ``raw_operation`` dict."""
+    if not isinstance(raw_operation, dict):
+        return OperationInputs()
+
+    grouped: dict[str, list[OperationParameter]] = {loc: [] for loc in _PARAM_LOCATIONS}
+    for raw_param in raw_operation.get("parameters") or []:
+        projected = _project_parameter(raw_param)
+        if projected is None:
+            continue
+        location, param = projected
+        grouped[location].append(param)
+
+    body = _project_request_body(raw_operation.get("requestBody"))
+
+    return OperationInputs(
+        path=grouped["path"],
+        query=grouped["query"],
+        header=grouped["header"],
+        body=body,
+    )
+
+
+def _project_parameter(raw_param: Any) -> tuple[str, OperationParameter] | None:
+    """Project one OpenAPI parameter; return ``(location, param)`` or ``None``.
+
+    Returns ``None`` for a malformed parameter, a location we don't group
+    (e.g. ``cookie``), or a ``$ref``-only entry that can't be resolved without
+    the components document.
+    """
+    if not isinstance(raw_param, dict):
+        return None
+    name = raw_param.get("name")
+    location = raw_param.get("in")
+    if not isinstance(name, str) or location not in _PARAM_LOCATIONS:
+        return None
+    schema = raw_param.get("schema")
+    return location, OperationParameter(
+        name=name,
+        required=bool(raw_param.get("required", False)),
+        description=raw_param.get("description"),
+        schema_=schema if isinstance(schema, dict) else None,
+    )
+
+
+def _project_request_body(raw_body: Any) -> RequestBodySchema | None:
+    """Project an OpenAPI ``requestBody`` to a single preferred-media schema.
+
+    JSON media types are preferred; otherwise the first declared content entry
+    is used. When no content is declared but a body block exists, its
+    ``required``/``description`` still surface so a client knows a body is
+    expected.
+    """
+    if not isinstance(raw_body, dict):
+        return None
+
+    content = raw_body.get("content")
+    content_type: str | None = None
+    schema: dict[str, Any] | None = None
+    if isinstance(content, dict) and content:
+        content_type = _select_media_type(content)
+        media = content.get(content_type) if content_type else None
+        if isinstance(media, dict):
+            candidate = media.get("schema")
+            schema = candidate if isinstance(candidate, dict) else None
+
+    return RequestBodySchema(
+        required=bool(raw_body.get("required", False)),
+        description=raw_body.get("description"),
+        content_type=content_type,
+        schema_=schema,
+    )
+
+
+def _select_media_type(content: dict[str, Any]) -> str:
+    """Pick the media type to project: prefer JSON, else the first declared."""
+    for media_type in content:
+        if isinstance(media_type, str) and "json" in media_type.lower():
+            return media_type
+    return next(iter(content))

--- a/src/jentic_one/registry/services/inspect/models.py
+++ b/src/jentic_one/registry/services/inspect/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 @dataclass(frozen=True)
@@ -55,6 +55,42 @@ class InspectLinks(BaseModel):
     self_link: str
 
 
+class OperationParameter(BaseModel):
+    """A single declared parameter (query / header / path)."""
+
+    name: str
+    required: bool = False
+    description: str | None = None
+    schema_: dict[str, object] | None = Field(default=None, serialization_alias="schema")
+
+
+class RequestBodySchema(BaseModel):
+    """The request body an operation accepts, projected to a single schema.
+
+    ``content_type`` records which media type the ``schema`` was taken from
+    (JSON is preferred when the spec offers several).
+    """
+
+    required: bool = False
+    description: str | None = None
+    content_type: str | None = None
+    schema_: dict[str, object] | None = Field(default=None, serialization_alias="schema")
+
+
+class OperationInputs(BaseModel):
+    """Declared inputs for an operation, grouped by where they belong.
+
+    Restores the query / header / path parameters and request body that spec
+    import used to drop, so a client can construct a complete request rather
+    than only supplying path parameters (issue #768).
+    """
+
+    path: list[OperationParameter] = []
+    query: list[OperationParameter] = []
+    header: list[OperationParameter] = []
+    body: RequestBodySchema | None = None
+
+
 class OperationInspectResult(BaseModel):
     """Full structural detail for a resolved operation."""
 
@@ -65,7 +101,7 @@ class OperationInspectResult(BaseModel):
     name: str | None = None
     description: str | None = None
     api: ApiContext
-    parameters: dict[str, object] | None = None
+    inputs: OperationInputs | None = None
     response_schema: dict[str, object] | None = None
     auth: list[AuthInstruction] | None = None
     server: str | None = None

--- a/src/jentic_one/registry/services/inspect/service.py
+++ b/src/jentic_one/registry/services/inspect/service.py
@@ -11,6 +11,7 @@ from jentic_one.registry.repos.operation_repo import OperationRepository
 from jentic_one.registry.repos.security_repo import SecurityRepository
 from jentic_one.registry.services.errors import OperationNotFoundError
 from jentic_one.registry.services.inspect.auth import translate_security_schemes
+from jentic_one.registry.services.inspect.inputs import build_operation_inputs
 from jentic_one.registry.services.inspect.models import (
     ApiContext,
     AuthInstruction,
@@ -84,6 +85,7 @@ class InspectService:
 
         api_context = self._build_api_context(operation)
         links = _build_links(method, url, self._base_url)
+        inputs = build_operation_inputs(operation.raw_operation)
 
         return OperationInspectResult(
             operation_id=operation.id,
@@ -92,7 +94,7 @@ class InspectService:
             name=operation.summary,
             description=operation.description,
             api=api_context,
-            parameters=None,
+            inputs=inputs,
             response_schema=None,
             auth=auth,
             server=server,

--- a/tests/unit/registry/ingest/test_openapi_parser.py
+++ b/tests/unit/registry/ingest/test_openapi_parser.py
@@ -180,3 +180,102 @@ def test_empty_servers_when_none_defined() -> None:
     }
     ops = parser.extract_operations(spec)
     assert ops[0]["servers"] == []
+
+
+def test_retains_parameters_and_request_body() -> None:
+    # Regression for #768: header/query parameters and the request body must
+    # survive import — without them every write / header-bearing operation is
+    # uncallable because the stored operation declares no inputs.
+    parser = OpenAPIOperationParser()
+    spec: dict[str, Any] = {
+        "paths": {
+            "/v1/pages": {
+                "post": {
+                    "operationId": "createPage",
+                    "parameters": [
+                        {"name": "Notion-Version", "in": "header", "required": True},
+                        {"name": "filter", "in": "query"},
+                    ],
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": {"type": "object", "properties": {"parent": {}}}
+                            }
+                        },
+                    },
+                },
+            },
+        },
+    }
+    ops = parser.extract_operations(spec)
+    assert len(ops) == 1
+    op = ops[0]
+    param_names = {p["name"] for p in op["parameters"]}
+    assert param_names == {"Notion-Version", "filter"}
+    assert op["requestBody"]["required"] is True
+    assert op["requestBody"]["content"]["application/json"]["schema"]["type"] == "object"
+
+
+def test_omits_parameters_and_body_keys_when_absent() -> None:
+    # Operations with no declared inputs must not sprout empty keys — the
+    # stored blob stays lean and the absence is unambiguous.
+    parser = OpenAPIOperationParser()
+    spec: dict[str, Any] = {
+        "paths": {
+            "/things": {
+                "get": {"operationId": "listThings"},
+            },
+        },
+    }
+    ops = parser.extract_operations(spec)
+    assert "parameters" not in ops[0]
+    assert "requestBody" not in ops[0]
+
+
+def test_merges_path_level_parameters() -> None:
+    # Path-item-level parameters apply to every operation on the path.
+    parser = OpenAPIOperationParser()
+    spec: dict[str, Any] = {
+        "paths": {
+            "/v1/pages/{page_id}": {
+                "parameters": [
+                    {"name": "page_id", "in": "path", "required": True},
+                    {"name": "Notion-Version", "in": "header", "required": True},
+                ],
+                "get": {
+                    "operationId": "getPage",
+                    "parameters": [{"name": "filter", "in": "query"}],
+                },
+            },
+        },
+    }
+    ops = parser.extract_operations(spec)
+    assert len(ops) == 1
+    param_index = {(p["name"], p["in"]) for p in ops[0]["parameters"]}
+    assert param_index == {
+        ("filter", "query"),
+        ("page_id", "path"),
+        ("Notion-Version", "header"),
+    }
+
+
+def test_operation_parameters_override_path_level_on_same_key() -> None:
+    # When an operation redeclares a path-level parameter (same name + in),
+    # the operation-level definition wins and there is no duplicate.
+    parser = OpenAPIOperationParser()
+    spec: dict[str, Any] = {
+        "paths": {
+            "/items": {
+                "parameters": [{"name": "limit", "in": "query", "required": False}],
+                "get": {
+                    "operationId": "listItems",
+                    "parameters": [{"name": "limit", "in": "query", "required": True}],
+                },
+            },
+        },
+    }
+    ops = parser.extract_operations(spec)
+    limit_params = [p for p in ops[0]["parameters"] if p["name"] == "limit"]
+    assert len(limit_params) == 1
+    assert limit_params[0]["required"] is True

--- a/tests/unit/registry/services/test_inspect_formatters.py
+++ b/tests/unit/registry/services/test_inspect_formatters.py
@@ -10,7 +10,10 @@ from jentic_one.registry.services.inspect.models import (
     ApiContext,
     AuthInstruction,
     InspectLinks,
+    OperationInputs,
     OperationInspectResult,
+    OperationParameter,
+    RequestBodySchema,
 )
 
 
@@ -18,7 +21,7 @@ def _make_result(
     *,
     server: str | None = "https://api.example.com",
     auth: list[AuthInstruction] | None = None,
-    parameters: dict[str, object] | None = None,
+    inputs: OperationInputs | None = None,
     response_schema: dict[str, object] | None = None,
 ) -> OperationInspectResult:
     return OperationInspectResult(
@@ -33,7 +36,7 @@ def _make_result(
             version="v1",
             description="A pet management API",
         ),
-        parameters=parameters,
+        inputs=inputs,
         response_schema=response_schema,
         auth=auth,
         server=server,
@@ -73,10 +76,54 @@ def test_render_markdown_includes_description() -> None:
 
 
 def test_render_markdown_includes_parameters() -> None:
-    result = _make_result(parameters={"limit": {"type": "integer", "description": "Max items"}})
+    result = _make_result(
+        inputs=OperationInputs(
+            query=[
+                OperationParameter(
+                    name="limit",
+                    schema_={"type": "integer", "description": "Max items"},
+                    description="Max items",
+                )
+            ]
+        )
+    )
     md = render_markdown(result)
     assert "`limit`" in md
     assert "integer" in md
+    assert "Query Parameters" in md
+
+
+def test_render_markdown_groups_parameters_by_location() -> None:
+    result = _make_result(
+        inputs=OperationInputs(
+            path=[OperationParameter(name="page_id", required=True)],
+            query=[OperationParameter(name="page_size", schema_={"type": "integer"})],
+            header=[OperationParameter(name="Notion-Version", required=True)],
+        )
+    )
+    md = render_markdown(result)
+    assert "Path Parameters" in md
+    assert "Query Parameters" in md
+    assert "Header Parameters" in md
+    assert "`page_id`" in md
+    assert "`Notion-Version`" in md
+    assert "(required)" in md
+
+
+def test_render_markdown_includes_request_body() -> None:
+    result = _make_result(
+        inputs=OperationInputs(
+            body=RequestBodySchema(
+                required=True,
+                content_type="application/json",
+                schema_={"type": "object", "properties": {"parent": {"type": "object"}}},
+            )
+        )
+    )
+    md = render_markdown(result)
+    assert "Request Body" in md
+    assert "application/json" in md
+    assert '"parent"' in md
 
 
 def test_render_markdown_includes_response_schema() -> None:
@@ -140,3 +187,39 @@ def test_render_openapi_yaml_no_server_omits_servers() -> None:
     output = render_openapi_yaml(result)
     parsed = yaml.safe_load(output)
     assert "servers" not in parsed
+
+
+def test_render_openapi_yaml_emits_parameters_with_correct_location() -> None:
+    result = _make_result(
+        inputs=OperationInputs(
+            path=[OperationParameter(name="page_id", required=True)],
+            query=[OperationParameter(name="page_size", schema_={"type": "integer"})],
+            header=[OperationParameter(name="Notion-Version", required=True)],
+        )
+    )
+    output = render_openapi_yaml(result)
+    parsed = yaml.safe_load(output)
+    params = parsed["paths"]["/v1/pets"]["get"]["parameters"]
+    by_name = {p["name"]: p for p in params}
+    assert by_name["page_id"]["in"] == "path"
+    assert by_name["page_size"]["in"] == "query"
+    assert by_name["page_size"]["schema"] == {"type": "integer"}
+    assert by_name["Notion-Version"]["in"] == "header"
+    assert by_name["Notion-Version"]["required"] is True
+
+
+def test_render_openapi_yaml_emits_request_body() -> None:
+    result = _make_result(
+        inputs=OperationInputs(
+            body=RequestBodySchema(
+                required=True,
+                content_type="application/json",
+                schema_={"type": "object"},
+            )
+        )
+    )
+    output = render_openapi_yaml(result)
+    parsed = yaml.safe_load(output)
+    request_body = parsed["paths"]["/v1/pets"]["get"]["requestBody"]
+    assert request_body["required"] is True
+    assert request_body["content"]["application/json"]["schema"] == {"type": "object"}

--- a/tests/unit/registry/services/test_inspect_inputs.py
+++ b/tests/unit/registry/services/test_inspect_inputs.py
@@ -1,0 +1,100 @@
+"""Unit tests for the inspect inputs projector (issue #768)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jentic_one.registry.services.inspect.inputs import build_operation_inputs
+
+
+def test_groups_parameters_by_location() -> None:
+    raw: dict[str, Any] = {
+        "parameters": [
+            {"name": "page_id", "in": "path", "required": True},
+            {"name": "page_size", "in": "query", "schema": {"type": "integer"}},
+            {"name": "Notion-Version", "in": "header", "required": True},
+        ]
+    }
+    inputs = build_operation_inputs(raw)
+    assert [p.name for p in inputs.path] == ["page_id"]
+    assert [p.name for p in inputs.query] == ["page_size"]
+    assert [p.name for p in inputs.header] == ["Notion-Version"]
+    assert inputs.query[0].schema_ == {"type": "integer"}
+    assert inputs.path[0].required is True
+
+
+def test_extracts_json_request_body_schema() -> None:
+    raw: dict[str, Any] = {
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {"schema": {"type": "object", "properties": {"parent": {}}}}
+            },
+        }
+    }
+    inputs = build_operation_inputs(raw)
+    assert inputs.body is not None
+    assert inputs.body.required is True
+    assert inputs.body.content_type == "application/json"
+    assert inputs.body.schema_ == {"type": "object", "properties": {"parent": {}}}
+
+
+def test_prefers_json_media_type_over_others() -> None:
+    raw: dict[str, Any] = {
+        "requestBody": {
+            "content": {
+                "text/plain": {"schema": {"type": "string"}},
+                "application/json": {"schema": {"type": "object"}},
+            }
+        }
+    }
+    inputs = build_operation_inputs(raw)
+    assert inputs.body is not None
+    assert inputs.body.content_type == "application/json"
+    assert inputs.body.schema_ == {"type": "object"}
+
+
+def test_falls_back_to_first_media_type_when_no_json() -> None:
+    raw: dict[str, Any] = {
+        "requestBody": {
+            "content": {"text/csv": {"schema": {"type": "string"}}},
+        }
+    }
+    inputs = build_operation_inputs(raw)
+    assert inputs.body is not None
+    assert inputs.body.content_type == "text/csv"
+
+
+def test_body_without_content_still_surfaces_required() -> None:
+    raw: dict[str, Any] = {"requestBody": {"required": True}}
+    inputs = build_operation_inputs(raw)
+    assert inputs.body is not None
+    assert inputs.body.required is True
+    assert inputs.body.schema_ is None
+
+
+def test_empty_or_missing_raw_operation_yields_empty_inputs() -> None:
+    values: list[Any] = [None, {}, [], "not-a-dict"]
+    for value in values:
+        inputs = build_operation_inputs(value)
+        assert inputs.path == []
+        assert inputs.query == []
+        assert inputs.header == []
+        assert inputs.body is None
+
+
+def test_skips_malformed_and_unresolvable_parameters() -> None:
+    raw: dict[str, Any] = {
+        "parameters": [
+            {"name": "ok", "in": "query"},
+            {"in": "query"},  # missing name
+            {"name": "no_location"},  # missing in
+            {"$ref": "#/components/parameters/Shared"},  # unresolvable here
+            {"name": "session", "in": "cookie"},  # location we don't group
+            "not-a-dict",
+        ]
+    }
+    inputs = build_operation_inputs(raw)
+    assert [p.name for p in inputs.query] == ["ok"]
+    assert inputs.path == []
+    assert inputs.header == []

--- a/tests/web/registry/test_inspect.py
+++ b/tests/web/registry/test_inspect.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping
 
 import pytest
 from fastapi.testclient import TestClient
@@ -44,6 +44,7 @@ async def _seed_operation(
     server_url: str = "https://api.example.com",
     index_host: str = "api.example.com",
     spec_operation_id: str | None = None,
+    raw_operation: Mapping[str, object] | None = None,
 ) -> tuple[Api, ApiRevision, str]:
     """Seed an API, revision, operation, server, and URL index entry.
 
@@ -90,6 +91,7 @@ async def _seed_operation(
             summary="List pets",
             description="Returns all pets",
             tags=["pets"],
+            raw_operation=raw_operation,
         )
         session.add(operation)
         await session.flush()
@@ -277,3 +279,60 @@ async def test_inspect_accept_unsupported_returns_406(
 async def test_inspect_without_auth_returns_401(unauthed_client: TestClient) -> None:
     resp = unauthed_client.get("/inspect", params={"operation_id": "op_abc", "detail": "summary"})
     assert resp.status_code == 401
+
+
+async def test_inspect_surfaces_header_query_path_and_body_inputs(
+    authed_client: TestClient, web_context: Context
+) -> None:
+    """Regression for #768: imported operations must expose their header,
+    query, path, and body inputs — not only path params — so a client can
+    build a complete, callable request."""
+    raw_operation = {
+        "operation_id": "createPage",
+        "path": "/v1/pages/{page_id}",
+        "method": "POST",
+        "parameters": [
+            {"name": "page_id", "in": "path", "required": True},
+            {"name": "page_size", "in": "query", "schema": {"type": "integer"}},
+            {"name": "Notion-Version", "in": "header", "required": True},
+        ],
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "schema": {"type": "object", "properties": {"parent": {"type": "object"}}}
+                }
+            },
+        },
+    }
+    _, _, op_id = await _seed_operation(
+        web_context,
+        path="/v1/pages/{page_id}",
+        method="POST",
+        raw_operation=raw_operation,
+    )
+    resp = authed_client.get("/inspect", params={"operation_id": op_id, "detail": "summary"})
+    assert resp.status_code == 200
+    inputs = resp.json()["inputs"]
+
+    assert [p["name"] for p in inputs["path"]] == ["page_id"]
+    assert [p["name"] for p in inputs["query"]] == ["page_size"]
+    assert [p["name"] for p in inputs["header"]] == ["Notion-Version"]
+    assert inputs["body"]["required"] is True
+    assert inputs["body"]["content_type"] == "application/json"
+    assert inputs["body"]["schema"]["type"] == "object"
+
+
+async def test_inspect_no_raw_operation_yields_empty_inputs(
+    authed_client: TestClient, web_context: Context
+) -> None:
+    """An operation stored without a raw_operation blob still inspects cleanly
+    with empty input groups (backwards compatibility)."""
+    _, _, op_id = await _seed_operation(web_context, raw_operation=None)
+    resp = authed_client.get("/inspect", params={"operation_id": op_id, "detail": "summary"})
+    assert resp.status_code == 200
+    inputs = resp.json()["inputs"]
+    assert inputs["path"] == []
+    assert inputs["query"] == []
+    assert inputs["header"] == []
+    assert inputs["body"] is None


### PR DESCRIPTION
## Summary

Fixes #768. Imported operations exposed **only their path parameters** — header, query, and request-body inputs were dropped during OpenAPI ingestion, making every write operation (and every Notion operation, which needs a required `Notion-Version` header) uncallable.

The root cause was two gaps, not one:

1. `OpenAPIOperationParser._process_operation` built the canonical operation dict and **dropped** `parameters` and `requestBody` before it was persisted as `raw_operation`.
2. Even once persisted, **nothing read `raw_operation` back** — `InspectService._build_result` hardcoded `parameters=None`, so the `/inspect` surface (the local analogue of `load_execution_info`) told clients the operation had no inputs, and they stripped everything.

The broker `execute` path is a transparent proxy that forwards the client-built request, so no broker change is needed — the fix is entirely in ingest (persist the data) and inspect (surface it).

## Changes

- **Parser** (`registry/ingest/parsers/openapi.py`): `_process_operation` retains `parameters` and `requestBody`, merging path-item-level parameters (operation-level wins on the same `(name, in)` key). Keys are omitted when absent.
- **Inputs projector** (new `registry/services/inspect/inputs.py`): turns a stored `raw_operation` into structured `path`/`query`/`header` groups plus a single request-body schema (JSON preferred). Malformed and unresolvable `$ref` parameters are skipped.
- **Result model** (`registry/services/inspect/models.py`): replaced the flat `parameters: dict` with a structured `inputs: OperationInputs` (backed by `OperationParameter` / `RequestBodySchema`).
- **Inspect service** (`registry/services/inspect/service.py`): populates `inputs` from `operation.raw_operation`.
- **Formatters**: markdown groups params by location and adds a Request Body section; OpenAPI-YAML emits parameters with their true `in` location and a real `requestBody` (no longer forcing `in: query`).

## Testing

- Added unit tests for the parser (retention, path-level merge, override, absence), the inputs projector (grouping, JSON body extraction, media-type preference, malformed/`$ref` skipping), and both formatters.
- Added `/inspect` integration tests asserting header/query/path/body inputs surface (the exact regression from the ticket) and that a missing `raw_operation` yields empty inputs.
- `make openapi` produces no drift; unit suite, lint, and mypy pass. The `/inspect` integration tests could not be run in my environment (test Postgres fixtures collide with a running dev DB on port 5432); the serialization shape they assert was verified in-process.

## Out of scope
- Broker-side backstop injection of required constant-valued headers.
- `response_schema` population and `$ref` component inlining.
- Any cloud-side (`api.jentic.com`) code.

Please **squash + merge**.

Made with [Cursor](https://cursor.com)