### PR TITLE
feat(admin): derive expired invite state at read time

### DIFF
--- a/src/jentic_one/admin/repos/invite_token_repo.py
+++ b/src/jentic_one/admin/repos/invite_token_repo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import UTC, datetime
 
 from sqlalchemy import select
@@ -62,3 +63,23 @@ class InviteTokenRepository:
         )
         result = await session.execute(stmt)
         return list(result.scalars().all())
+
+    @staticmethod
+    async def user_ids_with_active_invite(
+        session: AsyncSession, user_ids: Sequence[str]
+    ) -> set[str]:
+        """Return the subset of ``user_ids`` that hold an unredeemed, unexpired invite.
+
+        A single batch query (no N+1) for the roster read path: callers use it to
+        derive an "expired" invite state — a still-``pending`` user absent from
+        this set has only lapsed/redeemed tokens, so their invite has expired.
+        """
+        if not user_ids:
+            return set()
+        stmt = select(InviteToken.user_id).where(
+            InviteToken.user_id.in_(user_ids),
+            InviteToken.redeemed_at.is_(None),
+            InviteToken.expires_at > func.now(),
+        )
+        result = await session.execute(stmt)
+        return {row[0] for row in result}

--- a/src/jentic_one/admin/services/user_service.py
+++ b/src/jentic_one/admin/services/user_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from jentic_one.admin.core.permissions import IMPLICATION_MAP, compute_effective
 from jentic_one.admin.repos import (
     AuditRepository,
+    InviteTokenRepository,
     UserPermissionGrantRepository,
     UserRepository,
     UserSecretRepository,
@@ -30,6 +31,19 @@ from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.context import Context
 from jentic_one.shared.models import InviteState
 from jentic_one.shared.models.audit import AuditAction, AuditTargetType
+
+
+def _derive_invite_state(stored: str, user_id: str, active_invite_user_ids: set[str]) -> str:
+    """Overlay the read-time EXPIRED invite state (never persisted).
+
+    A ``pending`` user with no unredeemed, unexpired invite token has a lapsed
+    invite — surface it as ``expired`` so admins know to regenerate. All other
+    states (redeemed/accepted) pass through unchanged. Mirrors the AccessRequest
+    EXPIRED derivation: the DB keeps ``pending`` and the truth is ``expires_at``.
+    """
+    if stored == InviteState.PENDING and user_id not in active_invite_user_ids:
+        return InviteState.EXPIRED
+    return stored
 
 
 def _build_effective_views(assigned: list[str]) -> list[EffectivePermissionView]:
@@ -94,6 +108,17 @@ class UserService:
         perm_service = PermissionService(self._ctx)
         perms_map = await perm_service.project_for_users(user_ids)
 
+        # Derive the EXPIRED invite state at read time (never persisted, mirroring
+        # AccessRequest's EXPIRED overlay): a still-pending user with no unredeemed,
+        # unexpired token has a lapsed invite. One batch query — no N+1.
+        pending_ids = [u.id for u in users if u.invite_state == InviteState.PENDING]
+        active_invite_ids: set[str] = set()
+        if pending_ids:
+            async with self._ctx.admin_db.session() as session:
+                active_invite_ids = await InviteTokenRepository.user_ids_with_active_invite(
+                    session, pending_ids
+                )
+
         views = [
             UserView(
                 id=u.id,
@@ -103,7 +128,7 @@ class UserService:
                 name=f"{u.first_name} {u.last_name}",
                 active=u.active,
                 auth_provider=u.auth_provider,
-                invite_state=u.invite_state,
+                invite_state=_derive_invite_state(u.invite_state, u.id, active_invite_ids),
                 must_change_password=u.must_change_password,
                 external_subject_id=u.external_subject_id,
                 assigned=perms_map.get(u.id, []),
@@ -178,8 +203,15 @@ class UserService:
     async def get_by_id(self, user_id: str) -> UserView:
         async with self._ctx.admin_db.session() as session:
             user = await UserRepository.get_by_id(session, user_id)
-        if user is None:
-            raise UserNotFoundError(user_id)
+            if user is None:
+                raise UserNotFoundError(user_id)
+            # Derive EXPIRED at read time (see list_all): a pending user with no
+            # active invite token has a lapsed invite.
+            active_invite_ids: set[str] = set()
+            if user.invite_state == InviteState.PENDING:
+                active_invite_ids = await InviteTokenRepository.user_ids_with_active_invite(
+                    session, [user.id]
+                )
 
         perm_service = PermissionService(self._ctx)
         assigned = await perm_service.get_assigned_for_user(user_id)
@@ -191,7 +223,7 @@ class UserService:
             name=f"{user.first_name} {user.last_name}",
             active=user.active,
             auth_provider=user.auth_provider,
-            invite_state=user.invite_state,
+            invite_state=_derive_invite_state(user.invite_state, user.id, active_invite_ids),
             must_change_password=user.must_change_password,
             external_subject_id=user.external_subject_id,
             assigned=assigned,

--- a/src/jentic_one/admin/services/user_service.py
+++ b/src/jentic_one/admin/services/user_service.py
@@ -37,9 +37,11 @@ def _derive_invite_state(stored: str, user_id: str, active_invite_user_ids: set[
     """Overlay the read-time EXPIRED invite state (never persisted).
 
     A ``pending`` user with no unredeemed, unexpired invite token has a lapsed
-    invite — surface it as ``expired`` so admins know to regenerate. All other
-    states (redeemed/accepted) pass through unchanged. Mirrors the AccessRequest
-    EXPIRED derivation: the DB keeps ``pending`` and the truth is ``expires_at``.
+    invite — surface it as ``expired`` so admins know to regenerate. Only
+    ``pending`` is overlaid; every other stored state (``redeemed`` and
+    ``accepted`` — the latter is persisted for external-auth users) passes
+    through unchanged. Mirrors the AccessRequest EXPIRED derivation: the DB keeps
+    ``pending`` and the token's ``expires_at`` is the source of truth.
     """
     if stored == InviteState.PENDING and user_id not in active_invite_user_ids:
         return InviteState.EXPIRED
@@ -91,6 +93,12 @@ class UserService:
         limit: int = 50,
         invite_state: InviteState | None = None,
     ) -> Page[UserView]:
+        # NOTE: the `invite_state` filter matches the STORED column, so it can't
+        # filter by the derived EXPIRED state (never persisted) — `EXPIRED`
+        # returns nothing and `PENDING` may return rows that render as expired.
+        # This mirrors AccessRequestService.list_all, which filters on stored
+        # status and derives EXPIRED only in the view. If filtering by expired is
+        # ever needed, translate it to `PENDING AND user_id NOT IN (active)` here.
         cursor_dt = None
         if cursor is not None:
             cursor_dt, _ = decode_cursor(cursor)

--- a/tests/integration/admin/services/test_user_service.py
+++ b/tests/integration/admin/services/test_user_service.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
 
 import pytest
-from sqlalchemy import delete
+from sqlalchemy import delete, update
 
 from jentic_one.admin.core.schema.invite_tokens import InviteToken
 from jentic_one.admin.core.schema.user_permission_grants import UserPermissionGrant
@@ -329,6 +330,107 @@ async def test_reissue_invite_redeemed_raises(
     service = UserService(ctx)
     with pytest.raises(ConflictError):
         await service.reissue_invite(user_id, identity=Identity(sub="usr_test", email="test@local"))
+
+    # Cleanup
+    async with ctx.admin_db.session() as session:
+        await session.execute(delete(UserSecret).where(UserSecret.user_id == user_id))
+        await session.execute(delete(User).where(User.id == user_id))
+        await session.commit()
+
+
+async def test_get_by_id_derives_expired_for_lapsed_pending_invite(
+    integration_context: Context, admin_user: str
+) -> None:
+    # A pending user whose only invite token has lapsed is derived as EXPIRED,
+    # even though the DB still stores 'pending'.
+    ctx = integration_context
+    service = UserService(ctx)
+    created = await service.create(
+        UserCreatePayload(email="lapsed@test.local", first_name="Lapsed", last_name="User"),
+        identity=Identity(sub=admin_user, email="test@local"),
+    )
+    user_id = created.user.id
+    assert created.user.invite_state == InviteState.PENDING
+
+    # Backdate the issued token so it is expired.
+    async with ctx.admin_db.session() as session:
+        await session.execute(
+            update(InviteToken)
+            .where(InviteToken.user_id == user_id)
+            .values(expires_at=datetime.now(UTC) - timedelta(hours=1))
+        )
+        await session.commit()
+
+    view = await service.get_by_id(user_id)
+    assert view.invite_state == InviteState.EXPIRED
+    # The stored column is untouched (derivation is read-only).
+    async with ctx.admin_db.session() as session:
+        stored = await UserRepository.get_by_id(session, user_id)
+    assert stored is not None and stored.invite_state == InviteState.PENDING
+
+    page = await service.list_all(limit=50)
+    listed = next(u for u in page.data if u.id == user_id)
+    assert listed.invite_state == InviteState.EXPIRED
+
+    # Cleanup
+    async with ctx.admin_db.session() as session:
+        await session.execute(delete(InviteToken).where(InviteToken.user_id == user_id))
+        await session.execute(
+            delete(UserPermissionGrant).where(UserPermissionGrant.user_id == user_id)
+        )
+        await session.execute(delete(UserSecret).where(UserSecret.user_id == user_id))
+        await session.execute(delete(User).where(User.id == user_id))
+        await session.commit()
+
+
+async def test_get_by_id_pending_with_active_invite_not_expired(
+    integration_context: Context, admin_user: str
+) -> None:
+    # A freshly-created (thus active-token) pending user stays 'pending'.
+    ctx = integration_context
+    service = UserService(ctx)
+    created = await service.create(
+        UserCreatePayload(email="fresh-pending@test.local", first_name="Fresh", last_name="User"),
+        identity=Identity(sub=admin_user, email="test@local"),
+    )
+    user_id = created.user.id
+
+    view = await service.get_by_id(user_id)
+    assert view.invite_state == InviteState.PENDING
+
+    # Cleanup
+    async with ctx.admin_db.session() as session:
+        await session.execute(delete(InviteToken).where(InviteToken.user_id == user_id))
+        await session.execute(
+            delete(UserPermissionGrant).where(UserPermissionGrant.user_id == user_id)
+        )
+        await session.execute(delete(UserSecret).where(UserSecret.user_id == user_id))
+        await session.execute(delete(User).where(User.id == user_id))
+        await session.commit()
+
+
+async def test_redeemed_invite_not_derived_as_expired(
+    integration_context: Context, admin_user: str
+) -> None:
+    # A redeemed user is never overlaid (only 'pending' is), even with no active
+    # token — confirms REDEEMED passes through.
+    ctx = integration_context
+    async with ctx.admin_db.session() as session:
+        user = await UserRepository.create(
+            session,
+            email="redeemed-view@test.local",
+            first_name="Redeemed",
+            last_name="View",
+            invite_state=InviteState.REDEEMED,
+            created_by="usr_test",
+        )
+        await UserSecretRepository.create(session, user_id=user.id, created_by="usr_test")
+        await session.commit()
+    user_id = user.id
+
+    service = UserService(ctx)
+    view = await service.get_by_id(user_id)
+    assert view.invite_state == InviteState.REDEEMED
 
     # Cleanup
     async with ctx.admin_db.session() as session:

--- a/tests/integration/admin/test_invite_token_repository.py
+++ b/tests/integration/admin/test_invite_token_repository.py
@@ -202,6 +202,34 @@ async def test_user_ids_with_active_invite_expired_and_redeemed_excluded(
         assert result == set()
 
 
+async def test_user_ids_with_active_invite_reissued_after_expiry_is_active(
+    admin_db: DatabaseSession, test_user: str
+) -> None:
+    # The re-issue path: a user with a lapsed token PLUS a fresh active one is
+    # active (any live token counts). This is what flips a regenerated invite
+    # back from expired to pending in the derived state.
+    async with admin_db.session() as session:
+        await InviteTokenRepository.create(
+            session,
+            user_id=test_user,
+            token_hash="reissue_old_expired",
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+            created_by="usr_test",
+        )
+        await InviteTokenRepository.create(
+            session,
+            user_id=test_user,
+            token_hash="reissue_fresh_active",
+            expires_at=datetime.now(UTC) + timedelta(hours=24),
+            created_by="usr_test",
+        )
+        await session.commit()
+
+    async with admin_db.session() as session:
+        result = await InviteTokenRepository.user_ids_with_active_invite(session, [test_user])
+        assert result == {test_user}
+
+
 async def test_user_ids_with_active_invite_batches_users(
     admin_db: DatabaseSession, clean_invite_tokens: None
 ) -> None:

--- a/tests/integration/admin/test_invite_token_repository.py
+++ b/tests/integration/admin/test_invite_token_repository.py
@@ -142,3 +142,107 @@ async def test_get_active_for_user(admin_db: DatabaseSession, test_user: str) ->
         assert active[0].token_hash == "active_hash_1"
         assert all(t.id != expired_id for t in active)
         assert all(t.id != redeemed_id for t in active)
+
+
+async def test_user_ids_with_active_invite_empty_input(
+    admin_db: DatabaseSession, clean_invite_tokens: None
+) -> None:
+    async with admin_db.session() as session:
+        assert await InviteTokenRepository.user_ids_with_active_invite(session, []) == set()
+
+
+async def test_user_ids_with_active_invite_only_active_counts(
+    admin_db: DatabaseSession, test_user: str
+) -> None:
+    # A user with an unredeemed, unexpired token IS active.
+    async with admin_db.session() as session:
+        await InviteTokenRepository.create(
+            session,
+            user_id=test_user,
+            token_hash="batch_active_1",
+            expires_at=datetime.now(UTC) + timedelta(hours=24),
+            created_by="usr_test",
+        )
+        await session.commit()
+
+    async with admin_db.session() as session:
+        result = await InviteTokenRepository.user_ids_with_active_invite(session, [test_user])
+        assert result == {test_user}
+
+
+async def test_user_ids_with_active_invite_expired_and_redeemed_excluded(
+    admin_db: DatabaseSession, test_user: str
+) -> None:
+    # A user whose only tokens are expired or redeemed is NOT active — this is
+    # what lets the service derive an "expired" invite state.
+    async with admin_db.session() as session:
+        await InviteTokenRepository.create(
+            session,
+            user_id=test_user,
+            token_hash="batch_expired_1",
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+            created_by="usr_test",
+        )
+        redeemed = await InviteTokenRepository.create(
+            session,
+            user_id=test_user,
+            token_hash="batch_redeemed_1",
+            expires_at=datetime.now(UTC) + timedelta(hours=24),
+            created_by="usr_test",
+        )
+        await session.commit()
+        redeemed_id = redeemed.id
+
+    async with admin_db.session() as session:
+        await InviteTokenRepository.redeem(session, redeemed_id)
+        await session.commit()
+
+    async with admin_db.session() as session:
+        result = await InviteTokenRepository.user_ids_with_active_invite(session, [test_user])
+        assert result == set()
+
+
+async def test_user_ids_with_active_invite_batches_users(
+    admin_db: DatabaseSession, clean_invite_tokens: None
+) -> None:
+    # One query resolves many users: only those with a live token come back.
+    async with admin_db.session() as session:
+        active_user = await UserRepository.create(
+            session,
+            email="batch-active@example.com",
+            first_name="Active",
+            last_name="User",
+            created_by="usr_test",
+        )
+        expired_user = await UserRepository.create(
+            session,
+            email="batch-expired@example.com",
+            first_name="Expired",
+            last_name="User",
+            created_by="usr_test",
+        )
+        await session.commit()
+        active_id, expired_id = active_user.id, expired_user.id
+
+    async with admin_db.session() as session:
+        await InviteTokenRepository.create(
+            session,
+            user_id=active_id,
+            token_hash="batch_multi_active",
+            expires_at=datetime.now(UTC) + timedelta(hours=24),
+            created_by="usr_test",
+        )
+        await InviteTokenRepository.create(
+            session,
+            user_id=expired_id,
+            token_hash="batch_multi_expired",
+            expires_at=datetime.now(UTC) - timedelta(hours=1),
+            created_by="usr_test",
+        )
+        await session.commit()
+
+    async with admin_db.session() as session:
+        result = await InviteTokenRepository.user_ids_with_active_invite(
+            session, [active_id, expired_id]
+        )
+        assert result == {active_id}


### PR DESCRIPTION
## Summary

A user's `invite_state` is only ever written `pending` (on create) or `redeemed`
(on redeem) — **never `expired`**. So a lapsed invite shows as `pending` forever
in the admin roster, even though redemption already 410s on an expired token.
Admins had no way to tell an invite had expired (and thus needed regenerating).

This derives `expired` **at read time** in the `UserService` views — never
persisted — exactly mirroring the existing `AccessRequestStatus.EXPIRED` overlay
(`control/services/access_requests/service.py`): a still-`pending` user with no
unredeemed, unexpired invite token has a lapsed invite. The token's `expires_at`
stays the single source of truth.

## Why read-time derivation (not a background sweep)

This matches how the codebase already surfaces a time-based lifecycle status:
- `AccessRequest` derives `EXPIRED` in its view by comparing `expires_at` to now — no persister, no job. This change is the direct analogue.
- The existing background sweeps (`CredentialExpiryScanner`, the worker's job-result sweep) exist only to **emit telemetry events** or **delete rows** — none flips a user-facing status column. Persisting `expired` would introduce staleness/drift that read-derivation avoids.

## Changes

- `InviteTokenRepository.user_ids_with_active_invite(user_ids)` — a single batch query returning which users hold an unredeemed, unexpired token. Keeps the roster read path N+1-free.
- `UserService.list_all` / `get_by_id` — overlay `EXPIRED` for pending users absent from that set, via a small `_derive_invite_state` helper. Other states (`redeemed`/`accepted`) pass through unchanged.

## Notes

- No migration, no new background job, no write-path change.
- `accepted` is an existing enum value that nothing assigns; left untouched.

## Test plan

- [x] `ruff check .` clean; `ruff format --check` clean; `mypy` clean.
- [x] `pytest tests/arch` (258) pass.
- [x] Relevant `pytest tests/unit` (156, `-k user or invite or admin`) pass.
- [x] Added integration tests for the batch query (active counts; expired + redeemed excluded; multi-user batching; empty input). NOTE: couldn't run `@integration` locally (Postgres fixture role setup unavailable in my env) — they mirror the existing passing `test_invite_token_repository.py` tests and will run in CI.
- [ ] CI (Postgres integration) on this PR.

Made with [Cursor](https://cursor.com)