### PR TITLE
fix(credentials): canonical identity matching across broker/control (#775, #746, #747, #748)

### DIFF
--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -86,6 +86,15 @@ jentic access request --toolkit stripe.com/api --wait
   credential (account) is connected. Filing an access request will **not** fix
   this; the directive carries a `provisioning_url` — hand it to your operator to
   connect the account, then retry.
+- **`credential_identity_mismatch` (403)** — a toolkit *is* bound and a
+  credential *is* connected, but that credential's stored identity doesn't cover
+  this API (e.g. it targets a different name/version, or was stored in a
+  non-canonical form). Filing an access request will **not** fix this — the
+  binding already exists. The directive's `parameters.expected` vs
+  `parameters.found` name the mismatch; if `parameters.would_match_if_normalized`
+  is `true` the credential just needs re-provisioning to canonicalize its
+  identity. Either way, ask your operator to fix or re-provision the credential
+  so it targets `expected`, then retry.
 - **`ambiguous_toolkit` (409)** — multiple toolkits you're bound to serve this
   API. The directive lists `candidates`; resend the same `execute` with
   `--header Jentic-Toolkit-Id=<toolkit_id>` (the directive also gives a
@@ -275,6 +284,10 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   - **424 `credential_not_provisioned`** → the directive gives a
     `provisioning_url` for your operator to connect an account (an access
     request won't help).
+  - **403 `credential_identity_mismatch`** → a bound credential exists but its
+    identity doesn't cover this API (`parameters.expected` vs
+    `parameters.found`). An access request won't help — ask your operator to fix
+    or re-provision the credential so it targets `expected`, then retry.
   Follow the directive; don't keep re-sending the same `execute`.
 - You file and wait for access; you can't approve your own requests.
 - The `operation_id` from `search`/`apis operations` resolves directly; the id

--- a/cli/internal/skillgen/skillgen_test.go
+++ b/cli/internal/skillgen/skillgen_test.go
@@ -69,6 +69,7 @@ func TestRenderBodyIncludesBaseURLAndSections(t *testing.T) {
 		"### 2. Check what you can do, and request access if needed",
 		"jentic access request",
 		"credential_not_provisioned",
+		"credential_identity_mismatch",
 		"provisioning_url",
 		"exits 2",
 		"## Verification",

--- a/src/jentic_one/broker/core/exceptions.py
+++ b/src/jentic_one/broker/core/exceptions.py
@@ -302,6 +302,16 @@ def no_toolkit_binding_directive(
     )
 
 
+def _render_identity(vendor: str, name: str | None, version: str | None) -> str:
+    """Render a ``vendor/name/version`` identity with ``*`` for unset axes.
+
+    Unset (``None`` or empty) name/version become ``*`` so a
+    ``(vendor, None, "1.1")`` identity reads as ``vendor/*/1.1`` rather than the
+    ambiguous ``vendor/1.1`` (which looks like vendor/name).
+    """
+    return "/".join((vendor, name or "*", version or "*"))
+
+
 def credential_identity_mismatch_directive(*, mismatch: IdentityMismatch) -> AgentDirective:
     """Directive for a ``credential_identity_mismatch`` 403 — fix the credential.
 
@@ -311,17 +321,17 @@ def credential_identity_mismatch_directive(*, mismatch: IdentityMismatch) -> Age
     points at re-provisioning/fixing the **credential** and names the concrete
     expected-vs-found identity so the operator has an actionable diagnostic. The
     strategy is the fixed ``prompt_human`` (only a human can fix the credential).
+
+    No ``suggested_command`` is emitted: fixing a credential is an operator
+    action with no single verbatim CLI command an agent can run (there is no
+    ``jentic credentials`` command group), so the prose instruction is the
+    contract. Unset identity axes render as ``*`` (e.g. ``vendor/*/1.1``) so the
+    caller never confuses a missing name for a version.
     """
-    expected = "/".join(
-        part
-        for part in (mismatch.expected_vendor, mismatch.expected_name, mismatch.expected_version)
-        if part
+    expected = _render_identity(
+        mismatch.expected_vendor, mismatch.expected_name, mismatch.expected_version
     )
-    found = "/".join(
-        part
-        for part in (mismatch.found_vendor, mismatch.found_name or "", mismatch.found_version or "")
-        if part
-    )
+    found = _render_identity(mismatch.found_vendor, mismatch.found_name, mismatch.found_version)
     if mismatch.would_match_if_normalized:
         instruction = (
             f"A toolkit is bound for this API, but the bound credential's stored identity "
@@ -351,7 +361,6 @@ def credential_identity_mismatch_directive(*, mismatch: IdentityMismatch) -> Age
                 "version": mismatch.found_version,
             },
             "would_match_if_normalized": mismatch.would_match_if_normalized,
-            "suggested_command": f"jentic credentials provision {expected}",
         },
         human_readable_instruction=instruction,
     )

--- a/src/jentic_one/broker/core/exceptions.py
+++ b/src/jentic_one/broker/core/exceptions.py
@@ -19,6 +19,7 @@ from typing import Any, Literal
 from pydantic import BaseModel
 
 from jentic_one.shared.broker.execution import ErrorOrigin as ErrorOrigin
+from jentic_one.shared.broker.protocols import IdentityMismatch
 
 AgentStrategy = Literal[
     "wait",
@@ -174,6 +175,17 @@ class ActionDeniedError(BrokerError):
     """The request was denied by a toolkit permission rule (403)."""
 
 
+class CredentialIdentityMismatchError(BrokerError):
+    """Bound to a toolkit, but no credential's identity covers this API (403).
+
+    Distinct from :class:`ActionDeniedError` and ``no_toolkit_binding``: the
+    agent *is* bound and a credential *is* bound to a toolkit, but the
+    credential's stored API identity does not cover the resolved operation
+    identity (#747/#748). The recovery is to fix/re-provision the **credential**,
+    not to file an access request (which would auto-deny).
+    """
+
+
 class UpstreamTimeoutError(BrokerError):
     """The upstream did not respond within the deadline (504, §04/§09)."""
 
@@ -286,6 +298,61 @@ def no_toolkit_binding_directive(
     return AgentDirective(
         strategy="prompt_human",
         parameters=parameters,
+        human_readable_instruction=instruction,
+    )
+
+
+def credential_identity_mismatch_directive(*, mismatch: IdentityMismatch) -> AgentDirective:
+    """Directive for a ``credential_identity_mismatch`` 403 — fix the credential.
+
+    The agent is bound and a credential is bound to a toolkit, but the
+    credential's stored API identity does not cover the resolved operation
+    (#747/#748). Filing an access request here auto-denies, so the directive
+    points at re-provisioning/fixing the **credential** and names the concrete
+    expected-vs-found identity so the operator has an actionable diagnostic. The
+    strategy is the fixed ``prompt_human`` (only a human can fix the credential).
+    """
+    expected = "/".join(
+        part
+        for part in (mismatch.expected_vendor, mismatch.expected_name, mismatch.expected_version)
+        if part
+    )
+    found = "/".join(
+        part
+        for part in (mismatch.found_vendor, mismatch.found_name or "", mismatch.found_version or "")
+        if part
+    )
+    if mismatch.would_match_if_normalized:
+        instruction = (
+            f"A toolkit is bound for this API, but the bound credential's stored identity "
+            f"'{found}' only matches '{expected}' after normalization — it was stored in a "
+            f"non-canonical form. Ask your operator to re-provision (or recreate) the "
+            f"credential for '{expected}' so its identity is canonical, then retry. Do not "
+            f"file an access request — the binding already exists."
+        )
+    else:
+        instruction = (
+            f"A toolkit is bound for this API, but its credential's identity '{found}' does "
+            f"not match this API '{expected}'. Ask your operator to fix or re-provision the "
+            f"credential so it targets '{expected}', then retry. Do not file an access "
+            f"request — the binding already exists."
+        )
+    return AgentDirective(
+        strategy="prompt_human",
+        parameters={
+            "expected": {
+                "vendor": mismatch.expected_vendor,
+                "name": mismatch.expected_name,
+                "version": mismatch.expected_version,
+            },
+            "found": {
+                "vendor": mismatch.found_vendor,
+                "name": mismatch.found_name,
+                "version": mismatch.found_version,
+            },
+            "would_match_if_normalized": mismatch.would_match_if_normalized,
+            "suggested_command": f"jentic credentials provision {expected}",
+        },
         human_readable_instruction=instruction,
     )
 

--- a/src/jentic_one/broker/repos/caching_toolkit_deriver.py
+++ b/src/jentic_one/broker/repos/caching_toolkit_deriver.py
@@ -4,7 +4,7 @@ The cross-DB ``derive_toolkits`` lookup (admin agent→toolkit bindings ∩ cont
 toolkit→credential bindings) runs on **every** request that lacks a
 ``Jentic-Toolkit-Id`` header — two DB hits per request. Agent/credential
 bindings change infrequently, so this wraps the authoritative resolver in a
-short-TTL LRU keyed on ``(agent_id, vendor, name, version) → list[toolkit_id]``,
+short-TTL LRU keyed on ``(agent_id, vendor, name, version) → ToolkitDerivation``,
 invalidated on TTL only, and single-flighted (§05 R3.1) so concurrent misses for
 one key collapse to a single Admin+Control lookup.
 
@@ -27,7 +27,7 @@ from dataclasses import dataclass
 import structlog
 
 from jentic_one.broker.core.singleflight import SingleFlight
-from jentic_one.shared.broker.protocols import ToolkitDeriverProtocol
+from jentic_one.shared.broker.protocols import ToolkitDerivation, ToolkitDeriverProtocol
 from jentic_one.shared.metrics import get_meter
 
 logger = structlog.get_logger(__name__)
@@ -48,7 +48,7 @@ DEFAULT_MAX_CACHE_ENTRIES = 10_000
 class _CacheEntry:
     """A cached derivation result with its insertion time (monotonic)."""
 
-    toolkits: list[str]
+    value: ToolkitDerivation
     cached_at: float
 
 
@@ -56,9 +56,15 @@ class CachingToolkitDeriver:
     """TTL-LRU + single-flight wrapper around a :class:`ToolkitDeriverProtocol`.
 
     Implements ``ToolkitDeriverProtocol`` itself so it drops in wherever the raw
-    resolver is used. A hit within ``cache_ttl_seconds`` returns the cached list
-    without touching the DB; concurrent misses for one key are coalesced into a
-    single underlying ``derive_toolkits`` call.
+    resolver is used. A hit within ``cache_ttl_seconds`` returns the cached
+    result without touching the DB; concurrent misses for one key are coalesced
+    into a single underlying ``derive_toolkits`` call.
+
+    The cached :class:`ToolkitDerivation` is a frozen dataclass of tuples, so it
+    is returned directly (no defensive copy). Its ``api_served_toolkits`` and
+    ``identity_mismatch`` are cached under the same TTL as the toolkit list;
+    those drive recovery guidance, never authorization, so bounded staleness is
+    acceptable — the same argument that justifies caching the toolkit list.
     """
 
     def __init__(
@@ -74,12 +80,12 @@ class CachingToolkitDeriver:
         self._cache_ttl_seconds = cache_ttl_seconds
         self._max_entries = max_entries
         self._cache: OrderedDict[str, _CacheEntry] = OrderedDict()
-        self._single_flight: SingleFlight[list[str]] = SingleFlight()
+        self._single_flight: SingleFlight[ToolkitDerivation] = SingleFlight()
 
     async def derive_toolkits(
         self, *, agent_id: str, vendor: str, name: str, version: str
-    ) -> list[str]:
-        """Return the agent's toolkit IDs for the API, served from cache when fresh."""
+    ) -> ToolkitDerivation:
+        """Return the agent's derivation for the API, served from cache when fresh."""
         key = self._make_key(agent_id=agent_id, vendor=vendor, name=name, version=version)
         now = time.monotonic()
 
@@ -87,28 +93,18 @@ class CachingToolkitDeriver:
         if cached is not None and (now - cached.cached_at) < self._cache_ttl_seconds:
             self._cache.move_to_end(key)
             _cache_hits.add(1)
-            # Copy so callers can't mutate the cached list in place.
-            return list(cached.toolkits)
+            return cached.value
 
-        async def _load() -> list[str]:
-            toolkits = await self._inner.derive_toolkits(
+        async def _load() -> ToolkitDerivation:
+            result = await self._inner.derive_toolkits(
                 agent_id=agent_id, vendor=vendor, name=name, version=version
             )
-            self._store(key, _CacheEntry(toolkits=list(toolkits), cached_at=time.monotonic()))
+            self._store(key, _CacheEntry(value=result, cached_at=time.monotonic()))
             _cache_misses.add(1)
             logger.debug("toolkit_cache_miss", agent_id=agent_id, vendor=vendor, name=name)
-            return toolkits
+            return result
 
         return await self._single_flight.do(key, _load)
-
-    async def any_toolkit_serves_api(self, *, vendor: str, name: str, version: str) -> bool:
-        """Delegate the "any toolkit serves this API" check to the inner deriver.
-
-        Not cached: it is consulted only on the ``no_toolkit_binding`` denial path
-        (to pick the recovery directive), never on the hot success path, so the
-        TTL-LRU that fronts ``derive_toolkits`` would add complexity for no gain.
-        """
-        return await self._inner.any_toolkit_serves_api(vendor=vendor, name=name, version=version)
 
     def _store(self, key: str, entry: _CacheEntry) -> None:
         self._cache[key] = entry

--- a/src/jentic_one/broker/repos/toolkit_binding_resolver.py
+++ b/src/jentic_one/broker/repos/toolkit_binding_resolver.py
@@ -16,9 +16,11 @@ from sqlalchemy import bindparam, text
 from jentic_one.shared.broker.protocols import IdentityMismatch, ToolkitDerivation
 from jentic_one.shared.db import DatabaseSession
 from jentic_one.shared.models.api_identity import (
+    CredentialScope,
     canonical_credential_scope,
     credential_coverage_where,
     credential_covers,
+    slugify_api_field,
 )
 
 # admin DB — the toolkits the agent is bound to.
@@ -49,13 +51,33 @@ _TOOLKITS_FOR_API = text(
 # control DB — the stored credential identities bound to a given set of toolkits.
 # Used only on the denial path to compute a nearest-miss diagnostic (#747/#748).
 # Deliberately NOT vendor-scoped: a non-canonical stored vendor is exactly the
-# mismatch we want to surface, so filtering by vendor would hide it.
+# mismatch we want to surface, so filtering by vendor would hide it. Only active
+# credentials are considered so the diagnostic never names a disabled credential,
+# and rows are ordered so the "closest miss" choice is deterministic across
+# backends (SQLite/Postgres row order is otherwise unspecified for DISTINCT).
 _CREDENTIAL_IDENTITIES_FOR_TOOLKITS = text(
     "SELECT DISTINCT c.api_vendor, c.api_name, c.api_version "
     "FROM toolkit_credential_bindings tcb "
     "JOIN credentials c ON c.id = tcb.credential_id "
-    "WHERE tcb.toolkit_id IN :toolkit_ids"
+    "WHERE tcb.toolkit_id IN :toolkit_ids AND c.active "
+    "ORDER BY c.api_vendor, c.api_name, c.api_version"
 ).bindparams(bindparam("toolkit_ids", expanding=True))
+
+
+def _axes_matched(scope: CredentialScope, *, vendor: str, name: str, version: str) -> int:
+    """How many of the operation's axes this scope matches (for ranking near-misses).
+
+    Counts vendor/name/version axes that equal the operation's canonical value.
+    A scope that is unscoped (NULL) on an axis does not *match* a concrete value
+    for ranking purposes — a wildcard would have *covered* the operation and so
+    would never reach the near-miss path. Used only to pick the closest miss
+    deterministically; it is not an authorization signal.
+    """
+    return (
+        int(scope.vendor == slugify_api_field(vendor))
+        + int(scope.name is not None and scope.name == slugify_api_field(name))
+        + int(scope.version is not None and scope.version == version.strip())
+    )
 
 
 class ToolkitBindingResolver:
@@ -89,8 +111,17 @@ class ToolkitBindingResolver:
         api_toolkits = {row[0] for row in api_rows}
 
         intersection = tuple(sorted(agent_toolkits & api_toolkits))
+        # api_served_toolkits carries the actual toolkit ids (not just a bool):
+        # callers currently only need its emptiness (#683 recovery branch), but
+        # the ids let a future directive name *which* toolkit to bind without a
+        # second query. Sorted for a deterministic, cache-stable value.
         served = tuple(sorted(api_toolkits))
 
+        # Nearest-miss diagnostic only when nobody serves the API at all: if any
+        # toolkit serves it (``api_toolkits``), the recovery is "bind to that
+        # toolkit" (#683), not "fix your credential", so a mismatch would send
+        # the wrong signal. Requires the agent to be bound to something (else it
+        # is a plain no-binding case).
         mismatch: IdentityMismatch | None = None
         if not intersection and agent_toolkits and not api_toolkits:
             mismatch = await self._nearest_miss(
@@ -110,11 +141,25 @@ class ToolkitBindingResolver:
         """Find the closest bound-credential identity that fails to cover the API.
 
         The agent is bound but nothing serves the API. Inspect the identities of
-        credentials bound to the agent's own toolkits and report the nearest one,
-        flagging whether it would cover the operation once canonicalized (the
-        #746 legacy-row signal). Returns ``None`` if the agent's toolkits have no
-        bound credentials at all (then it is a genuine provisioning gap, not a
-        mismatch).
+        credentials bound to the agent's own toolkits and report the nearest one
+        *for the same API* — this diagnostic only makes sense when a bound
+        credential is plausibly targeting this vendor:
+
+        - a credential whose canonical vendor equals the expected vendor is a
+          same-vendor near-miss (wrong name/version), or
+        - a credential that ``would_match_if_normalized`` — the #746 legacy
+          non-canonical row that a slug backfill would fix (its stored vendor may
+          differ textually while normalizing to the expected one).
+
+        A credential for an unrelated vendor (agent bound to Slack, calling
+        Stripe) is **not** a mismatch — returning it would wrongly tell the
+        operator to retarget a working credential. In that case, and when the
+        agent's toolkits have no bound credentials at all, return ``None`` so the
+        caller falls through to ``no_toolkit_binding`` (preserving #683).
+
+        Selection is deterministic: rows arrive ordered from the query, and among
+        gated candidates the most actionable wins — ``would_match_if_normalized``
+        first, then the most axes matching the operation.
         """
         async with self._control_db.session() as session:
             rows = (
@@ -126,25 +171,31 @@ class ToolkitBindingResolver:
         if not rows:
             return None
 
+        expected_vendor_slug = slugify_api_field(vendor)
         best: IdentityMismatch | None = None
+        best_rank: tuple[int, int] = (-1, -1)
         for row in rows:
             scope = canonical_credential_scope(
                 vendor=row.api_vendor, name=row.api_name, version=row.api_version
             )
             would_match = credential_covers(scope, vendor=vendor, name=name, version=version)
-            candidate = IdentityMismatch(
-                expected_vendor=vendor,
-                expected_name=name,
-                expected_version=version,
-                found_vendor=row.api_vendor,
-                found_name=row.api_name,
-                found_version=row.api_version,
-                would_match_if_normalized=would_match,
+            # Vendor-affinity gate: only a same-vendor or would-normalize row is a
+            # genuine identity mismatch for *this* API.
+            if scope.vendor != expected_vendor_slug and not would_match:
+                continue
+            rank = (
+                int(would_match),
+                _axes_matched(scope, vendor=vendor, name=name, version=version),
             )
-            # A would-match-after-normalization row is the most actionable signal
-            # (#746), so prefer it; otherwise keep the first candidate seen.
-            if would_match:
-                return candidate
-            if best is None:
-                best = candidate
+            if rank > best_rank:
+                best_rank = rank
+                best = IdentityMismatch(
+                    expected_vendor=vendor,
+                    expected_name=name,
+                    expected_version=version,
+                    found_vendor=row.api_vendor,
+                    found_name=row.api_name,
+                    found_version=row.api_version,
+                    would_match_if_normalized=would_match,
+                )
         return best

--- a/src/jentic_one/broker/repos/toolkit_binding_resolver.py
+++ b/src/jentic_one/broker/repos/toolkit_binding_resolver.py
@@ -11,34 +11,51 @@ Python rather than via a cross-schema JOIN.
 
 from __future__ import annotations
 
-from sqlalchemy import text
+from sqlalchemy import bindparam, text
 
+from jentic_one.shared.broker.protocols import IdentityMismatch, ToolkitDerivation
 from jentic_one.shared.db import DatabaseSession
+from jentic_one.shared.models.api_identity import (
+    canonical_credential_scope,
+    credential_coverage_where,
+    credential_covers,
+)
 
 # admin DB — the toolkits the agent is bound to.
 _AGENT_TOOLKITS = text("SELECT toolkit_id FROM agent_toolkit_bindings WHERE agent_id = :agent_id")
 
-# control DB — toolkits whose bound credential matches the API identity. Empty
-# string for :name / :version means "any" (the credential may not pin name/version).
-# NULL api_name/api_version on the credential means "covers all names/versions for this vendor".
+# control DB — toolkits whose bound credential covers the API identity. The
+# coverage rule (NULL credential axis = "unscoped → covers any"; otherwise
+# equality against the always-concrete operation axis) is the shared seam in
+# shared/models/api_identity.py, so this matcher, the bind-time matcher
+# (control/repos/effects_repo) and the injection-time resolver
+# (broker/services/credentials/resolver) cannot drift apart.
 #
 # NB: this run-time resolver intentionally treats a NULL-wildcard credential
-# binding as a valid match and applies *no* exact-name preference — at execution
-# time we want every toolkit the agent can legitimately use, including
-# wildcard-credential ones. This differs from the *bind-time* resolver
-# (control/repos/effects_repo.resolve_toolkits_for_api), which prefers an exact
-# api_name match so the approver binds the most specific toolkit. The two serve
-# different purposes (credential coverage vs ownership-scoped binding selection),
-# so the asymmetry is deliberate: a bind picks the narrowest toolkit, while an
-# execute accepts any covering one (surfacing ambiguous_toolkit when >1 match).
+# binding as a valid match and applies *no* exact-name preference or specificity
+# narrowing — at execution time we want every toolkit the agent can legitimately
+# use, including wildcard-credential ones (>1 match surfaces as ambiguous_toolkit,
+# which the agent resolves with the Jentic-Toolkit-Id header). This differs from
+# the *bind-time* resolver, which prefers an exact api_name match so the approver
+# binds the most specific toolkit. The two serve different purposes (credential
+# coverage vs ownership-scoped binding selection), so the asymmetry is deliberate.
 _TOOLKITS_FOR_API = text(
     "SELECT DISTINCT tcb.toolkit_id "
     "FROM toolkit_credential_bindings tcb "
     "JOIN credentials c ON c.id = tcb.credential_id "
-    "WHERE c.api_vendor = :vendor "
-    "  AND (:name = '' OR c.api_name IS NULL OR c.api_name = :name) "
-    "  AND (:version = '' OR c.api_version IS NULL OR c.api_version = :version)"
+    f"WHERE {credential_coverage_where()}"
 )
+
+# control DB — the stored credential identities bound to a given set of toolkits.
+# Used only on the denial path to compute a nearest-miss diagnostic (#747/#748).
+# Deliberately NOT vendor-scoped: a non-canonical stored vendor is exactly the
+# mismatch we want to surface, so filtering by vendor would hide it.
+_CREDENTIAL_IDENTITIES_FOR_TOOLKITS = text(
+    "SELECT DISTINCT c.api_vendor, c.api_name, c.api_version "
+    "FROM toolkit_credential_bindings tcb "
+    "JOIN credentials c ON c.id = tcb.credential_id "
+    "WHERE tcb.toolkit_id IN :toolkit_ids"
+).bindparams(bindparam("toolkit_ids", expanding=True))
 
 
 class ToolkitBindingResolver:
@@ -50,13 +67,17 @@ class ToolkitBindingResolver:
 
     async def derive_toolkits(
         self, *, agent_id: str, vendor: str, name: str, version: str
-    ) -> list[str]:
-        """Return the sorted toolkit IDs the agent has that contain the given API."""
+    ) -> ToolkitDerivation:
+        """Derive the agent's toolkits for the API, with the reason for an empty set.
+
+        Returns the intersection (agent bindings ∩ toolkits whose credential
+        covers the API) plus enough context to pick the right denial directive:
+        whether the agent is bound to anything, which toolkits serve the API at
+        all, and — when bound but unresolved — a nearest-miss credential identity.
+        """
         async with self._admin_db.session() as session:
             agent_rows = (await session.execute(_AGENT_TOOLKITS, {"agent_id": agent_id})).all()
         agent_toolkits = {row[0] for row in agent_rows}
-        if not agent_toolkits:
-            return []
 
         async with self._control_db.session() as session:
             api_rows = (
@@ -67,22 +88,63 @@ class ToolkitBindingResolver:
             ).all()
         api_toolkits = {row[0] for row in api_rows}
 
-        return sorted(agent_toolkits & api_toolkits)
+        intersection = tuple(sorted(agent_toolkits & api_toolkits))
+        served = tuple(sorted(api_toolkits))
 
-    async def any_toolkit_serves_api(self, *, vendor: str, name: str, version: str) -> bool:
-        """Return whether any toolkit serves the given API (independent of the agent).
+        mismatch: IdentityMismatch | None = None
+        if not intersection and agent_toolkits and not api_toolkits:
+            mismatch = await self._nearest_miss(
+                agent_toolkits, vendor=vendor, name=name, version=version
+            )
 
-        Runs the same control-DB toolkit↔API predicate as :meth:`derive_toolkits`
-        but without intersecting the agent's bindings, so a ``no_toolkit_binding``
-        denial can tell apart "no toolkit exists yet" (provision a credential
-        first) from "a toolkit serves it but this agent isn't bound" (file a
-        toolkit binding). See issue #683.
+        return ToolkitDerivation(
+            toolkits=intersection,
+            agent_bound_any=bool(agent_toolkits),
+            api_served_toolkits=served,
+            identity_mismatch=mismatch,
+        )
+
+    async def _nearest_miss(
+        self, agent_toolkits: set[str], *, vendor: str, name: str, version: str
+    ) -> IdentityMismatch | None:
+        """Find the closest bound-credential identity that fails to cover the API.
+
+        The agent is bound but nothing serves the API. Inspect the identities of
+        credentials bound to the agent's own toolkits and report the nearest one,
+        flagging whether it would cover the operation once canonicalized (the
+        #746 legacy-row signal). Returns ``None`` if the agent's toolkits have no
+        bound credentials at all (then it is a genuine provisioning gap, not a
+        mismatch).
         """
         async with self._control_db.session() as session:
-            api_rows = (
+            rows = (
                 await session.execute(
-                    _TOOLKITS_FOR_API,
-                    {"vendor": vendor, "name": name, "version": version},
+                    _CREDENTIAL_IDENTITIES_FOR_TOOLKITS,
+                    {"toolkit_ids": list(agent_toolkits)},
                 )
             ).all()
-        return bool(api_rows)
+        if not rows:
+            return None
+
+        best: IdentityMismatch | None = None
+        for row in rows:
+            scope = canonical_credential_scope(
+                vendor=row.api_vendor, name=row.api_name, version=row.api_version
+            )
+            would_match = credential_covers(scope, vendor=vendor, name=name, version=version)
+            candidate = IdentityMismatch(
+                expected_vendor=vendor,
+                expected_name=name,
+                expected_version=version,
+                found_vendor=row.api_vendor,
+                found_name=row.api_name,
+                found_version=row.api_version,
+                would_match_if_normalized=would_match,
+            )
+            # A would-match-after-normalization row is the most actionable signal
+            # (#746), so prefer it; otherwise keep the first candidate seen.
+            if would_match:
+                return candidate
+            if best is None:
+                best = candidate
+        return best

--- a/src/jentic_one/broker/services/credentials/resolver.py
+++ b/src/jentic_one/broker/services/credentials/resolver.py
@@ -16,7 +16,12 @@ from jentic_one.control.core.schema.credentials import Credential
 from jentic_one.control.repos import CredentialRepository
 from jentic_one.control.services.credentials.mapping import to_wire
 from jentic_one.shared.context import Context
-from jentic_one.shared.models.api_identity import slugify_api_field
+from jentic_one.shared.models.api_identity import (
+    CredentialScope,
+    canonical_credential_scope,
+    credential_covers,
+    credential_specificity,
+)
 from jentic_one.shared.models.credentials import (
     CredentialLocation,
     CredentialType,
@@ -75,22 +80,32 @@ class CredentialResolver:
         async with self._ctx.control_db.session() as session:
             candidates = await CredentialRepository.list_by_vendor(session, api.vendor)
 
-            # Normalize both sides before comparing: stored values are slugified
-            # at create time, but historical rows and the incoming registry
-            # identity may differ only by casing/format. Comparing on the shared
-            # slug form prevents a silent default-deny on such mismatches.
-            want_name = slugify_api_field(api.name) if api.name else ""
+            # Coverage + specificity via the shared seam. A credential's stored
+            # scope (canonicalized here so legacy '' / non-slug rows compare on
+            # the same footing) covers the concrete operation when each axis is
+            # either unscoped (NULL → wildcard) or equal. Among covering
+            # credentials, most-specific-wins: a vendor.name.version pin beats a
+            # vendor.name which beats a bare vendor wildcard, so a vendor-wide
+            # credential coexisting with a pin no longer forces a spurious 409.
+            def _scope(c: Credential) -> CredentialScope:
+                return canonical_credential_scope(
+                    vendor=c.api_vendor, name=c.api_name, version=c.api_version
+                )
 
-            matches = [
+            covering = [
                 c
                 for c in candidates
                 if c.active
-                and (not api.name or slugify_api_field(c.api_name or "") == want_name)
-                and (not api.version or c.api_version == api.version)
+                and credential_covers(
+                    _scope(c), vendor=api.vendor, name=api.name, version=api.version
+                )
             ]
 
-            if not matches:
+            if not covering:
                 raise CredentialNotProvisionedError(api.vendor, api.name, api.version)
+
+            best = max(credential_specificity(_scope(c)) for c in covering)
+            matches = [c for c in covering if credential_specificity(_scope(c)) == best]
 
             candidate_objs = [self._to_candidate(c) for c in matches]
 

--- a/src/jentic_one/broker/services/credentials/resolver.py
+++ b/src/jentic_one/broker/services/credentials/resolver.py
@@ -76,6 +76,12 @@ class CredentialResolver:
         Raises CredentialNotProvisionedError if no match.
         Raises AmbiguousCredentialError if >1 match and no credential_name given.
         Raises CredentialNameNotFoundError if credential_name doesn't match any candidate.
+
+        Resolution order: filter to credentials whose stored scope *covers* the
+        API, then — if a ``credential_name`` is given — restrict to that name
+        across **all** covering credentials (an explicit name is the strongest
+        disambiguation signal, so it can select a covering-but-less-specific
+        credential), and only then apply most-specific-wins to break ties.
         """
         async with self._ctx.control_db.session() as session:
             candidates = await CredentialRepository.list_by_vendor(session, api.vendor)
@@ -83,43 +89,53 @@ class CredentialResolver:
             # Coverage + specificity via the shared seam. A credential's stored
             # scope (canonicalized here so legacy '' / non-slug rows compare on
             # the same footing) covers the concrete operation when each axis is
-            # either unscoped (NULL → wildcard) or equal. Among covering
-            # credentials, most-specific-wins: a vendor.name.version pin beats a
-            # vendor.name which beats a bare vendor wildcard, so a vendor-wide
-            # credential coexisting with a pin no longer forces a spurious 409.
-            def _scope(c: Credential) -> CredentialScope:
-                return canonical_credential_scope(
+            # either unscoped (NULL → wildcard) or equal. Precompute (cred, scope)
+            # once so the scope isn't recomputed per predicate below.
+            covering: list[tuple[Credential, CredentialScope]] = []
+            for c in candidates:
+                if not c.active:
+                    continue
+                scope = canonical_credential_scope(
                     vendor=c.api_vendor, name=c.api_name, version=c.api_version
                 )
-
-            covering = [
-                c
-                for c in candidates
-                if c.active
-                and credential_covers(
-                    _scope(c), vendor=api.vendor, name=api.name, version=api.version
-                )
-            ]
+                if credential_covers(scope, vendor=api.vendor, name=api.name, version=api.version):
+                    covering.append((c, scope))
 
             if not covering:
                 raise CredentialNotProvisionedError(api.vendor, api.name, api.version)
 
-            best = max(credential_specificity(_scope(c)) for c in covering)
-            matches = [c for c in covering if credential_specificity(_scope(c)) == best]
-
-            candidate_objs = [self._to_candidate(c) for c in matches]
-
+            # An explicit credential_name is the strongest disambiguation signal,
+            # so it searches *all* covering credentials — including a
+            # covering-but-less-specific one (e.g. the vendor-wide credential
+            # while a pin also exists). Applying it before specificity narrowing
+            # means naming that credential resolves it instead of a spurious
+            # CredentialNameNotFoundError.
             if credential_name is not None:
-                filtered = [c for c in matches if c.name == credential_name]
-                if not filtered:
+                named = [(c, s) for (c, s) in covering if c.name == credential_name]
+                if not named:
                     raise CredentialNameNotFoundError(
-                        api.vendor, api.name, api.version, credential_name, candidate_objs
+                        api.vendor,
+                        api.name,
+                        api.version,
+                        credential_name,
+                        [self._to_candidate(c) for (c, _) in covering],
                     )
-                matches = filtered
+                covering = named
+
+            # Among the remaining covering credentials, most-specific-wins: a
+            # vendor.name.version pin beats a vendor.name which beats a bare
+            # vendor wildcard, so a vendor-wide credential coexisting with a pin
+            # no longer forces a spurious 409.
+            best = max(credential_specificity(s) for (_, s) in covering)
+            matches = [c for (c, s) in covering if credential_specificity(s) == best]
 
             if len(matches) > 1:
                 raise AmbiguousCredentialError(
-                    api.vendor, api.name, api.version, len(matches), candidates=candidate_objs
+                    api.vendor,
+                    api.name,
+                    api.version,
+                    len(matches),
+                    candidates=[self._to_candidate(c) for c in matches],
                 )
 
             credential = matches[0]

--- a/src/jentic_one/broker/web/errors.py
+++ b/src/jentic_one/broker/web/errors.py
@@ -26,6 +26,7 @@ from jentic_one.broker.core.exceptions import (
     AmbiguousMatchError,
     BrokerError,
     CircuitOpenError,
+    CredentialIdentityMismatchError,
     CredentialNeedsReconnectError,
     CredentialNotProvisionedError,
     CredentialRefreshTransientError,
@@ -56,6 +57,7 @@ _PROBLEM_JSON = "application/problem+json"
 # Domain exception → HTTP status (plan.md §7.3 / 02-core-proxy error map).
 STATUS_BY_ERROR: dict[type[BrokerError], int] = {
     ActionDeniedError: 403,
+    CredentialIdentityMismatchError: 403,
     OperationNotFoundError: 404,
     AmbiguousMatchError: 409,
     MethodNotAllowedError: 405,

--- a/src/jentic_one/broker/web/routers/execute.py
+++ b/src/jentic_one/broker/web/routers/execute.py
@@ -28,8 +28,9 @@ from jentic_one.broker.adapters.runners.base import (
 )
 from jentic_one.broker.core.exceptions import (
     ActionDeniedError,
-    AgentDirective,
     AmbiguousMatchError,
+    BrokerError,
+    CredentialIdentityMismatchError,
     IdempotencyConflictError,
     IdempotencyInProgressError,
     OperationNotFoundError,
@@ -38,6 +39,7 @@ from jentic_one.broker.core.exceptions import (
     UpstreamUrlNotAllowedError,
     action_denied_directive,
     ambiguous_toolkit_directive,
+    credential_identity_mismatch_directive,
     no_toolkit_binding_directive,
     switch_toolkit_directive,
 )
@@ -87,6 +89,7 @@ from jentic_one.shared.broker.protocols import (
     RegistryResolverProtocol,
     ResolveResult,
     RuleEvaluatorProtocol,
+    ToolkitDerivation,
     ToolkitDeriverProtocol,
 )
 from jentic_one.shared.config import UpstreamClientConfig
@@ -254,23 +257,35 @@ def _context_from_discovery(
     )
 
 
-async def _no_toolkit_binding_directive(
-    deriver: ToolkitDeriverProtocol, api: APIReference
-) -> AgentDirective:
-    """Build the ``no_toolkit_binding`` directive with the right recovery step.
+def _empty_derivation_denial(
+    d: ToolkitDerivation, api: APIReference, *, detail: str, instance: str
+) -> BrokerError:
+    """Pick the right denial for an empty toolkit derivation (#683 + #747/#748).
 
-    The caller is bound to no toolkit serving ``api``. Whether the right recovery
-    is "provision a credential first" or "file a toolkit binding" depends on
-    whether a toolkit serves the API *at all* — a state the broker can read
-    (independent of the caller's bindings). Consulted only on this denial path,
-    never on the success path, so the extra read costs nothing in the common
-    case. See issue #683.
+    Four cases, distinguished by the structured derivation result:
+
+    - Bound + a bound credential is a near-miss for the API → the credential's
+      identity does not cover the operation (#747/#748). Fix the *credential*,
+      never file an access request (that auto-denies).
+    - Otherwise → ``no_toolkit_binding``, whose recovery (file a bind request vs.
+      provision a credential first) is chosen by ``no_toolkit_binding_directive``
+      from whether any toolkit serves the API at all (#683).
     """
-    serves = await deriver.any_toolkit_serves_api(
-        vendor=api.vendor, name=api.name, version=api.version
-    )
-    return no_toolkit_binding_directive(
-        vendor=api.vendor, name=api.name, version=api.version, toolkit_serves_api=serves
+    serves = bool(d.api_served_toolkits)
+    if d.agent_bound_any and not serves and d.identity_mismatch is not None:
+        return CredentialIdentityMismatchError(
+            detail,
+            type="credential_identity_mismatch",
+            instance=instance,
+            directive=credential_identity_mismatch_directive(mismatch=d.identity_mismatch),
+        )
+    return ActionDeniedError(
+        detail,
+        type="no_toolkit_binding",
+        instance=instance,
+        directive=no_toolkit_binding_directive(
+            vendor=api.vendor, name=api.name, version=api.version, toolkit_serves_api=serves
+        ),
     )
 
 
@@ -284,9 +299,10 @@ async def select_toolkit(
 ) -> str:
     """Derive the toolkit for this execution from the caller's bindings (§03).
 
-    ``0 → 403`` (no binding), ``1 → use it``, ``N → 409`` (caller must disambiguate
-    with ``Jentic-Toolkit-Id``). A supplied header is validated against the derived
-    candidates; never silently honoured or silently picked.
+    ``0 → 403`` (no binding / credential identity mismatch), ``1 → use it``,
+    ``N → 409`` (caller must disambiguate with ``Jentic-Toolkit-Id``). A supplied
+    header is validated against the derived candidates; never silently honoured or
+    silently picked.
 
     Non-agent actors (service accounts, users) currently follow the **same**
     derivation rule — there is no implicit bypass. Broadening this for service
@@ -310,19 +326,20 @@ async def select_toolkit(
             )
         return identity.sub
 
-    candidates = await deriver.derive_toolkits(
+    derivation = await deriver.derive_toolkits(
         agent_id=identity.sub,
         vendor=api.vendor,
         name=api.name,
         version=api.version,
     )
+    candidates = list(derivation.toolkits)
 
     if header_toolkit:
         if header_toolkit not in candidates:
             # Recoverable: the agent named a toolkit it isn't bound to. Carry the
             # agent-recovery contract like every other broker denial — point it at
             # the toolkits it *is* bound to (switch_toolkit) or, if it has none,
-            # at the correct provisioning/binding step (prompt_human). A bare
+            # at the correct provisioning/binding/credential-fix step. A bare
             # Forbidden here would be a dead-end 403 with no directive (§03 invariant).
             if candidates:
                 raise ActionDeniedError(
@@ -331,20 +348,17 @@ async def select_toolkit(
                     instance=instance,
                     directive=ambiguous_toolkit_directive(candidates),
                 )
-            raise ActionDeniedError(
-                f"Not bound to toolkit '{header_toolkit}' for this API",
-                type="no_toolkit_binding",
+            raise _empty_derivation_denial(
+                derivation,
+                api,
+                detail=f"Not bound to toolkit '{header_toolkit}' for this API",
                 instance=instance,
-                directive=await _no_toolkit_binding_directive(deriver, api),
             )
         return header_toolkit
 
     if not candidates:
-        raise ActionDeniedError(
-            "No toolkit binding for this API",
-            type="no_toolkit_binding",
-            instance=instance,
-            directive=await _no_toolkit_binding_directive(deriver, api),
+        raise _empty_derivation_denial(
+            derivation, api, detail="No toolkit binding for this API", instance=instance
         )
     if len(candidates) > 1:
         raise AmbiguousMatchError(

--- a/src/jentic_one/broker/web/routers/execute.py
+++ b/src/jentic_one/broker/web/routers/execute.py
@@ -258,11 +258,14 @@ def _context_from_discovery(
 
 
 def _empty_derivation_denial(
-    d: ToolkitDerivation, api: APIReference, *, detail: str, instance: str
+    d: ToolkitDerivation, api: APIReference, *, instance: str
 ) -> BrokerError:
     """Pick the right denial for an empty toolkit derivation (#683 + #747/#748).
 
-    Four cases, distinguished by the structured derivation result:
+    Two cases, distinguished by the structured derivation result — each with its
+    own ``detail`` so the problem+json ``type`` and ``detail`` never tell
+    different stories (e.g. a ``credential_identity_mismatch`` must not carry a
+    "not bound to toolkit" detail):
 
     - Bound + a bound credential is a near-miss for the API → the credential's
       identity does not cover the operation (#747/#748). Fix the *credential*,
@@ -274,13 +277,13 @@ def _empty_derivation_denial(
     serves = bool(d.api_served_toolkits)
     if d.agent_bound_any and not serves and d.identity_mismatch is not None:
         return CredentialIdentityMismatchError(
-            detail,
+            "A bound credential's identity does not cover this API",
             type="credential_identity_mismatch",
             instance=instance,
             directive=credential_identity_mismatch_directive(mismatch=d.identity_mismatch),
         )
     return ActionDeniedError(
-        detail,
+        "No toolkit binding for this API",
         type="no_toolkit_binding",
         instance=instance,
         directive=no_toolkit_binding_directive(
@@ -326,6 +329,15 @@ async def select_toolkit(
             )
         return identity.sub
 
+    # Invariant: the API identity here is the *discovered* spec identity, which is
+    # always concrete (vendor/name/version all set) — the registry never yields a
+    # wildcard. Derivation and the nearest-miss diagnostic (#748) rely on this
+    # (they slugify and compare each axis), so assert it at the boundary rather
+    # than silently deriving against a blank axis.
+    assert api.vendor and api.name and api.version, (
+        "select_toolkit requires a concrete discovered API identity"
+    )
+
     derivation = await deriver.derive_toolkits(
         agent_id=identity.sub,
         vendor=api.vendor,
@@ -348,18 +360,11 @@ async def select_toolkit(
                     instance=instance,
                     directive=ambiguous_toolkit_directive(candidates),
                 )
-            raise _empty_derivation_denial(
-                derivation,
-                api,
-                detail=f"Not bound to toolkit '{header_toolkit}' for this API",
-                instance=instance,
-            )
+            raise _empty_derivation_denial(derivation, api, instance=instance)
         return header_toolkit
 
     if not candidates:
-        raise _empty_derivation_denial(
-            derivation, api, detail="No toolkit binding for this API", instance=instance
-        )
+        raise _empty_derivation_denial(derivation, api, instance=instance)
     if len(candidates) > 1:
         raise AmbiguousMatchError(
             "Multiple toolkits match this API; resend with the Jentic-Toolkit-Id header.",

--- a/src/jentic_one/control/repos/effects_repo.py
+++ b/src/jentic_one/control/repos/effects_repo.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from jentic_one.control.repos.toolkit_binding_repo import ToolkitBindingRepository
 from jentic_one.shared.db.ids import generate_ksuid
-from jentic_one.shared.models.api_identity import credential_coverage_where
+from jentic_one.shared.models.api_identity import credential_coverage_where, slugify_api_field
 
 
 class BindTargetMissingError(Exception):
@@ -182,14 +182,22 @@ class EffectsRepository:
         (``api_name IS NULL``) credential, an **exact** name/version match is
         preferred: NULL-wildcard credentials only contribute when no exact match
         exists for the requested name.
+
+        The ``vendor``/``name`` reference axes are canonicalized (slugified) here
+        before binding, because stored rows are canonical (the credential service
+        slugifies on write and the backfill migration re-slugs legacy rows). The
+        shared SQL fragment compares bind params verbatim against those canonical
+        rows, so a raw reference like ``GitHub.com`` must be slugified to
+        ``github-com`` here or it would match nothing. ``version`` is trimmed but
+        never slugified, matching ``canonical_credential_scope``.
         """
+        params: dict[str, object] = {"vendor": slugify_api_field(vendor)}
+        if name:
+            params["name"] = slugify_api_field(name)
+        if version:
+            params["version"] = version.strip()
         name_scoped = bool(name)
         version_scoped = bool(version)
-        params: dict[str, object] = {"vendor": vendor}
-        if name_scoped:
-            params["name"] = name
-        if version_scoped:
-            params["version"] = version
         owner_clause = EffectsRepository._owner_in_clause(owner_ids, params, column="tk.created_by")
         if owner_clause is None:
             return []

--- a/src/jentic_one/control/repos/effects_repo.py
+++ b/src/jentic_one/control/repos/effects_repo.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from jentic_one.control.repos.toolkit_binding_repo import ToolkitBindingRepository
 from jentic_one.shared.db.ids import generate_ksuid
+from jentic_one.shared.models.api_identity import credential_coverage_where
 
 
 class BindTargetMissingError(Exception):
@@ -182,24 +183,30 @@ class EffectsRepository:
         preferred: NULL-wildcard credentials only contribute when no exact match
         exists for the requested name.
         """
-        params: dict[str, object] = {
-            "vendor": vendor,
-            "name": name or "",
-            "version": version or "",
-        }
+        name_scoped = bool(name)
+        version_scoped = bool(version)
+        params: dict[str, object] = {"vendor": vendor}
+        if name_scoped:
+            params["name"] = name
+        if version_scoped:
+            params["version"] = version
         owner_clause = EffectsRepository._owner_in_clause(owner_ids, params, column="tk.created_by")
         if owner_clause is None:
             return []
 
+        # Shared coverage rule (see shared/models/api_identity.credential_coverage_where):
+        # a wildcard *reference* axis (empty name/version at bind time) omits that
+        # axis so it matches anything; a scoped axis matches NULL-wildcard or exact.
+        coverage = credential_coverage_where(name_scoped=name_scoped, version_scoped=version_scoped)
+        # Prefer an exact name match only when the reference names one — otherwise
+        # there is no exactness to rank on.
+        name_exact = "(CASE WHEN c.api_name = :name THEN 1 ELSE 0 END)" if name_scoped else "0"
         base_query = (
-            "SELECT DISTINCT tcb.toolkit_id, "
-            "  (CASE WHEN :name <> '' AND c.api_name = :name THEN 1 ELSE 0 END) AS name_exact "
+            f"SELECT DISTINCT tcb.toolkit_id, {name_exact} AS name_exact "
             "FROM toolkit_credential_bindings tcb "
             "JOIN credentials c ON c.id = tcb.credential_id "
             "JOIN toolkits tk ON tk.id = tcb.toolkit_id "
-            "WHERE c.api_vendor = :vendor "
-            "  AND (:name = '' OR c.api_name IS NULL OR c.api_name = :name) "
-            "  AND (:version = '' OR c.api_version IS NULL OR c.api_version = :version) "
+            f"WHERE {coverage} "
             f"{owner_clause}"
         )
         result = await session.execute(text(base_query), params)

--- a/src/jentic_one/control/services/credentials/service.py
+++ b/src/jentic_one/control/services/credentials/service.py
@@ -47,7 +47,7 @@ from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.config import DirectOAuth2ProviderConfig
 from jentic_one.shared.context import Context
 from jentic_one.shared.events import emit_event_best_effort
-from jentic_one.shared.models.api_identity import slugify_api_field
+from jentic_one.shared.models.api_identity import CredentialScope, canonical_credential_scope
 from jentic_one.shared.models.credentials import CredentialType, StoredCredentialType
 from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.pagination import decode_cursor_str, encode_cursor
@@ -114,6 +114,14 @@ class CredentialService:
 
         self._validate_create_fields(payload, managed=provider_obj.managed)
 
+        # Canonicalize the API identity at the service boundary: slug vendor/name,
+        # coerce an unset name/version to NULL (the single wildcard sentinel), and
+        # trim the version. This is what makes credential scoping (vendor /
+        # vendor.name / vendor.name.version) resolve against a concrete operation
+        # identity at execute time (#775), and stores github.com as github-com
+        # rather than a dead-on-arrival identity (#746).
+        api_scope = self._canonical_api_scope(payload.api)
+
         stored_type = to_stored(payload.type, grant_type=payload.grant_type)
         encryption = self._ctx.encryption
 
@@ -122,9 +130,9 @@ class CredentialService:
                 session,
                 type=stored_type.value,
                 name=payload.name,
-                api_vendor=slugify_api_field(payload.api.vendor),
-                api_name=slugify_api_field(payload.api.name),
-                api_version=payload.api.version,
+                api_vendor=api_scope.vendor,
+                api_name=api_scope.name,
+                api_version=api_scope.version,
                 provider=payload.provider,
                 created_by=identity.sub,
                 server_variables=payload.server_variables,
@@ -524,3 +532,19 @@ class CredentialService:
                 raise InvalidCredentialInputError("Field 'client_id' is required for oauth2")
             if not payload.client_secret:
                 raise InvalidCredentialInputError("Field 'client_secret' is required for oauth2")
+
+    @staticmethod
+    def _canonical_api_scope(api: APIReference) -> CredentialScope:
+        """Canonicalize the credential's API scope, rejecting a path-shaped identity.
+
+        A ``name``/``version`` containing a path separator is a strong signal the
+        caller sent a spec *file path* segment rather than an identity (e.g.
+        ``api_version='api.github.com/main/1.1.4'``, #746). Reject it loudly as a
+        400 rather than persisting a credential that can never resolve.
+        """
+        for axis, value in (("name", api.name), ("version", api.version)):
+            if value and "/" in value:
+                raise InvalidCredentialInputError(
+                    f"api.{axis} '{value}' is not an identity — it looks like a spec path"
+                )
+        return canonical_credential_scope(vendor=api.vendor, name=api.name, version=api.version)

--- a/src/jentic_one/migrations/control/versions/k2f3a4b5c6d7_backfill_empty_credential_identity.py
+++ b/src/jentic_one/migrations/control/versions/k2f3a4b5c6d7_backfill_empty_credential_identity.py
@@ -1,0 +1,38 @@
+"""backfill empty-string credential identity axes to NULL
+
+Credential ``api_name``/``api_version`` use ``NULL`` as the single "this axis is
+unscoped (wildcard)" sentinel. Historically the create path stored an unset axis
+as an empty string ``''`` instead, which matches neither ``NULL`` nor a concrete
+operation identity — so a legitimately vendor-/vendor.name-scoped credential
+silently stopped covering its operations and ``execute`` returned
+``no_toolkit_binding`` (#775). The service layer now coerces empty→NULL on write;
+this DML backfill fixes rows written before that.
+
+DML-only (the columns are already nullable). Idempotent — re-running touches no
+rows once the empty strings are gone.
+
+Revision ID: k2f3a4b5c6d7
+Revises: j1e2f3a4b5c6
+Create Date: 2026-07-24
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "k2f3a4b5c6d7"
+down_revision: str | None = "j1e2f3a4b5c6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE credentials SET api_name = NULL WHERE api_name = ''")
+    op.execute("UPDATE credentials SET api_version = NULL WHERE api_version = ''")
+
+
+def downgrade() -> None:
+    # '' vs NULL is not meaningfully reversible: we cannot know which rows were
+    # originally empty-string rather than genuinely unscoped. No-op by design.
+    pass

--- a/src/jentic_one/migrations/control/versions/l3a4b5c6d7e8_reslug_credential_identity.py
+++ b/src/jentic_one/migrations/control/versions/l3a4b5c6d7e8_reslug_credential_identity.py
@@ -1,0 +1,66 @@
+"""re-slug legacy credential api_vendor/api_name to canonical form
+
+Rows created before the credential service slugified the API identity on write
+may store a non-canonical ``api_vendor``/``api_name`` (e.g. ``github.com`` rather
+than ``github-com``), which can never intersect the slugified operation identity
+the registry produces (#746). This narrow, idempotent backfill re-canonicalizes
+only the rows whose value the slug transform would actually change.
+
+Done in Python (not ``regexp_replace``) so it runs identically on Postgres and
+SQLite. The slug rule is inlined as a frozen point-in-time copy: migrations must
+not import evolving application code, and this must keep reproducing the rule as
+it was when the migration was written even if the app helper later changes.
+
+``api_version`` is intentionally left untouched — versions are trimmed, never
+slugified (slugifying ``1.1.4`` → ``1-1-4`` would corrupt it).
+
+DML-only. Idempotent — a canonical value slugifies to itself, so a re-run is a
+no-op.
+
+Revision ID: l3a4b5c6d7e8
+Revises: k2f3a4b5c6d7
+Create Date: 2026-07-24
+
+"""
+
+import re
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "l3a4b5c6d7e8"
+down_revision: str | None = "k2f3a4b5c6d7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Frozen copy of shared.models.api_identity.slugify_api_field as of this revision.
+# Do NOT import the app helper — migrations are point-in-time snapshots.
+_API_FIELD_MAX_LENGTH = 100
+_SLUG_RE = re.compile(r"[^a-z0-9-]+")
+
+
+def _slugify(value: str) -> str:
+    slug = _SLUG_RE.sub("-", value.strip().lower()).strip("-")
+    return slug[:_API_FIELD_MAX_LENGTH]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(sa.text("SELECT id, api_vendor, api_name FROM credentials")).fetchall()
+    for row in rows:
+        cred_id, vendor, name = row.id, row.api_vendor, row.api_name
+        new_vendor = _slugify(vendor) if vendor else vendor
+        new_name = _slugify(name) if name else name
+        if new_vendor == vendor and new_name == name:
+            continue
+        bind.execute(
+            sa.text("UPDATE credentials SET api_vendor = :vendor, api_name = :name WHERE id = :id"),
+            {"vendor": new_vendor, "name": new_name, "id": cred_id},
+        )
+
+
+def downgrade() -> None:
+    # Slug canonicalization is lossy (the original casing/punctuation is gone).
+    # No-op by design.
+    pass

--- a/src/jentic_one/migrations/control/versions/l3a4b5c6d7e8_reslug_credential_identity.py
+++ b/src/jentic_one/migrations/control/versions/l3a4b5c6d7e8_reslug_credential_identity.py
@@ -14,6 +14,15 @@ it was when the migration was written even if the app helper later changes.
 ``api_version`` is intentionally left untouched — versions are trimmed, never
 slugified (slugifying ``1.1.4`` → ``1-1-4`` would corrupt it).
 
+Note: re-slugging can *collapse* two formerly-distinct rows into identical
+scopes (e.g. ``github.com`` and ``github-com`` both become ``github-com``). No
+unique constraint prevents this, so two previously-distinct credentials can end
+up the same identity and surface as a same-specificity ``ambiguous_credential``
+(409) at resolve time. This is accepted: the rows were only ever distinct by a
+non-canonical spelling that could never match the (canonical) operation identity
+anyway. The operator resolves it by deleting/renaming the duplicate, or the
+caller disambiguates with the ``Jentic-Credential-Name`` header.
+
 DML-only. Idempotent — a canonical value slugifies to itself, so a re-run is a
 no-op.
 

--- a/src/jentic_one/shared/broker/protocols.py
+++ b/src/jentic_one/shared/broker/protocols.py
@@ -116,29 +116,60 @@ class ToolkitBindingCheckerProtocol(Protocol):
     async def has_binding(self, agent_id: str, toolkit_id: str) -> bool: ...
 
 
+@dataclass(frozen=True, slots=True)
+class IdentityMismatch:
+    """A nearest-miss credential identity for an unresolved-but-bound API.
+
+    Populated when the agent is bound to toolkit(s) but no credential's stored
+    identity covers the (concrete) operation identity — the #747/#748 case. All
+    fields are plain strings so the directive layer can serialize them directly
+    without touching a pydantic model.
+    """
+
+    expected_vendor: str
+    expected_name: str
+    expected_version: str
+    found_vendor: str
+    found_name: str | None
+    found_version: str | None
+    would_match_if_normalized: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ToolkitDerivation:
+    """Result of toolkit derivation, carrying *why* the toolkit set may be empty.
+
+    ``toolkits`` is the intersection callers use (``()`` → 403, one → use it,
+    many → 409). The remaining fields let the broker distinguish the empty cases
+    and emit the right recovery directive without a second DB round-trip:
+
+    - ``agent_bound_any`` — the agent has at least one toolkit binding at all.
+    - ``api_served_toolkits`` — every toolkit whose bound credential covers the
+      API (independent of the agent). ``()`` means no toolkit serves the API yet;
+      this subsumes the old ``any_toolkit_serves_api`` probe.
+    - ``identity_mismatch`` — a nearest-miss for the diagnostic when the agent is
+      bound but nothing serves the API because a bound credential's identity does
+      not cover the operation.
+    """
+
+    toolkits: tuple[str, ...]
+    agent_bound_any: bool
+    api_served_toolkits: tuple[str, ...]
+    identity_mismatch: IdentityMismatch | None
+
+
 @runtime_checkable
 class ToolkitDeriverProtocol(Protocol):
     """Derives which of an agent's toolkits contain a given API identity.
 
-    ``[]`` → 403, ``[one]`` → use it, ``[many]`` → 409 (caller disambiguates with
-    the ``Jentic-Toolkit-Id`` header).
+    Empty ``toolkits`` → 403, one → use it, many → 409 (caller disambiguates with
+    the ``Jentic-Toolkit-Id`` header). The full :class:`ToolkitDerivation` also
+    carries why an empty set is empty so the denial can pick the right directive.
     """
 
     async def derive_toolkits(
         self, *, agent_id: str, vendor: str, name: str, version: str
-    ) -> list[str]: ...
-
-    async def any_toolkit_serves_api(self, *, vendor: str, name: str, version: str) -> bool:
-        """Return whether *any* toolkit (for any owner) serves the given API.
-
-        A toolkit only "serves" an API once a credential for it is bound. This
-        distinguishes the "no toolkit exists yet — provision a credential first"
-        state from the "a toolkit serves it but this agent isn't bound" state, so
-        a ``no_toolkit_binding`` denial can hand the caller a recovery step that
-        can actually be completed (see issue #683). Unscoped by design: it drives
-        recovery guidance, not authorization.
-        """
-        ...
+    ) -> ToolkitDerivation: ...
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/jentic_one/shared/broker/protocols.py
+++ b/src/jentic_one/shared/broker/protocols.py
@@ -146,7 +146,11 @@ class ToolkitDerivation:
     - ``agent_bound_any`` — the agent has at least one toolkit binding at all.
     - ``api_served_toolkits`` — every toolkit whose bound credential covers the
       API (independent of the agent). ``()`` means no toolkit serves the API yet;
-      this subsumes the old ``any_toolkit_serves_api`` probe.
+      this subsumes the old ``any_toolkit_serves_api`` probe. **These ids can
+      belong to other owners** (the derivation is agent-independent), so only its
+      *truthiness* may be consumed here — the raw ids must not be serialized into
+      a directive/response without owner-scoping, or they'd leak cross-tenant
+      toolkit ids.
     - ``identity_mismatch`` — a nearest-miss for the diagnostic when the agent is
       bound but nothing serves the API because a bound credential's identity does
       not cover the operation.

--- a/src/jentic_one/shared/models/__init__.py
+++ b/src/jentic_one/shared/models/__init__.py
@@ -8,7 +8,15 @@ from jentic_one.shared.models.actors import (
     Origin,
     actor_type_from_id,
 )
-from jentic_one.shared.models.api_identity import API_FIELD_MAX_LENGTH, slugify_api_field
+from jentic_one.shared.models.api_identity import (
+    API_FIELD_MAX_LENGTH,
+    CredentialScope,
+    canonical_credential_scope,
+    credential_coverage_where,
+    credential_covers,
+    credential_specificity,
+    slugify_api_field,
+)
 from jentic_one.shared.models.audit import AuditAction, AuditReason, AuditTargetType
 from jentic_one.shared.models.credentials import (
     CredentialLocation,
@@ -39,6 +47,7 @@ __all__ = [
     "AuditTargetType",
     "AuthProvider",
     "CredentialLocation",
+    "CredentialScope",
     "CredentialType",
     "EventSeverity",
     "EventType",
@@ -50,5 +59,9 @@ __all__ = [
     "OverlayStatus",
     "StoredCredentialType",
     "actor_type_from_id",
+    "canonical_credential_scope",
+    "credential_coverage_where",
+    "credential_covers",
+    "credential_specificity",
     "slugify_api_field",
 ]

--- a/src/jentic_one/shared/models/api_identity.py
+++ b/src/jentic_one/shared/models/api_identity.py
@@ -1,12 +1,23 @@
-"""Canonical normalization for API identity fields (vendor / name).
+"""Canonical normalization and coverage for API identity fields.
 
 The registry slugifies ``vendor``/``name`` on import; any other layer that
 persists or compares those fields must use the *same* normalization, or an
 otherwise-identical identity mismatches on exact string equality and silently
 default-denies. Keep this helper as the single source of truth.
+
+A **spec/operation identity is always concrete** ``(vendor, name, version)`` —
+the registry hard-fails otherwise. A **credential is scoped** at ``vendor`` /
+``vendor.name`` / ``vendor.name.version``; an unset ``name``/``version`` axis is
+``None`` (the single wildcard sentinel — never ``''``). The coverage predicate,
+canonical scope, and the SQL fragment builder below are the one definition of
+"does this credential cover this operation?", shared by all three matchers
+(broker runtime, control bind-time, broker credential resolution).
 """
 
+from __future__ import annotations
+
 import re
+from dataclasses import dataclass
 
 API_FIELD_MAX_LENGTH = 100
 _SLUG_RE = re.compile(r"[^a-z0-9-]+")
@@ -20,3 +31,88 @@ def slugify_api_field(value: str) -> str:
     """
     slug = _SLUG_RE.sub("-", value.strip().lower()).strip("-")
     return slug[:API_FIELD_MAX_LENGTH]
+
+
+@dataclass(frozen=True, slots=True)
+class CredentialScope:
+    """A credential's stored API scope.
+
+    ``name``/``version`` of ``None`` means "this axis is unscoped (wildcard) —
+    covers any". ``vendor`` is always present (a credential is always at least
+    vendor-scoped).
+    """
+
+    vendor: str
+    name: str | None
+    version: str | None
+
+
+def canonical_credential_scope(
+    *, vendor: str, name: str | None, version: str | None
+) -> CredentialScope:
+    """Canonicalize a *credential* scope for storage or comparison.
+
+    - ``vendor``/``name`` slugified (name only when present),
+    - empty string coerced to ``None`` (the single wildcard sentinel),
+    - ``version`` trimmed and empty→``None`` but **never slugified** — slugifying
+      would corrupt a real version (``1.1.4`` → ``1-1-4``).
+
+    Credential-only: do **not** apply the empty→``None`` coercion to spec
+    identities. Specs are always concrete and the registry enforces that
+    separately; coercing there would silently weaken that guarantee.
+    """
+    slug_name = slugify_api_field(name) if name else ""
+    trimmed_version = version.strip() if version else ""
+    return CredentialScope(
+        vendor=slugify_api_field(vendor),
+        name=slug_name or None,
+        version=trimmed_version or None,
+    )
+
+
+def credential_covers(scope: CredentialScope, *, vendor: str, name: str, version: str) -> bool:
+    """Return whether ``scope`` covers the (always concrete) operation identity.
+
+    A ``None`` axis on the scope is an unscoped wildcard (covers any value);
+    otherwise the axis must equal the operation axis in canonical form. The
+    operation identity is normalized here so a legacy non-canonical stored scope
+    and a concrete operation compare on the same footing.
+    """
+    return (
+        scope.vendor == slugify_api_field(vendor)
+        and (scope.name is None or scope.name == slugify_api_field(name))
+        and (scope.version is None or scope.version == version.strip())
+    )
+
+
+def credential_specificity(scope: CredentialScope) -> int:
+    """Rank for most-specific-wins credential selection (M3 only).
+
+    Each pinned axis adds one, so ``vendor.name.version`` (2) beats
+    ``vendor.name`` (1) beats a bare ``vendor`` wildcard (0).
+    """
+    return (scope.name is not None) + (scope.version is not None)
+
+
+def credential_coverage_where(
+    *, alias: str = "c", name_scoped: bool = True, version_scoped: bool = True
+) -> str:
+    """Build the shared SQL coverage fragment (binds ``:vendor``/``:name``/``:version``).
+
+    The one WHERE fragment used by the two raw-SQL matchers (runtime toolkit
+    derivation and bind-time toolkit selection). ``NULL`` on a credential axis is
+    the wildcard; there is no ``= ''`` branch (empty strings are coerced away on
+    write and backfilled, so ``NULL`` is the only wildcard).
+
+    ``name_scoped=False`` / ``version_scoped=False`` omit that axis's comparison
+    entirely — used at bind time when the *reference* is itself a wildcard ("bind
+    all of the vendor"), so the axis matches anything. Only plain comparisons are
+    emitted (no casts / regex), so the fragment is dialect-portable across
+    Postgres and SQLite.
+    """
+    clauses = [f"{alias}.api_vendor = :vendor"]
+    if name_scoped:
+        clauses.append(f"({alias}.api_name IS NULL OR {alias}.api_name = :name)")
+    if version_scoped:
+        clauses.append(f"({alias}.api_version IS NULL OR {alias}.api_version = :version)")
+    return " AND ".join(clauses)

--- a/tests/integration/broker/test_toolkit_binding_resolver.py
+++ b/tests/integration/broker/test_toolkit_binding_resolver.py
@@ -107,7 +107,7 @@ async def test_derive_toolkits_no_overlap_returns_empty(
         agent_id=agent_id, vendor="acme.com", name="pets-api", version="v1"
     )
 
-    assert result == []
+    assert result.toolkits == ()
 
 
 async def test_derive_toolkits_single_match(
@@ -127,7 +127,7 @@ async def test_derive_toolkits_single_match(
         agent_id=agent_id, vendor="acme.com", name="pets-api", version="v1"
     )
 
-    assert result == [matching]
+    assert result.toolkits == (matching,)
 
 
 async def test_derive_toolkits_multiple_matches(
@@ -147,24 +147,26 @@ async def test_derive_toolkits_multiple_matches(
         agent_id=agent_id, vendor="acme.com", name="pets-api", version="v1"
     )
 
-    assert result == sorted([tk_a, tk_b])
+    assert result.toolkits == tuple(sorted([tk_a, tk_b]))
 
 
 async def test_derive_toolkits_wildcard_name_version(
     admin_db: DatabaseSession, control_db: DatabaseSession, clean_tables: None
 ) -> None:
-    """Empty name/version match any credential for the vendor."""
+    """A NULL-name/version credential covers any concrete API for the vendor."""
+    # The credential is vendor-scoped (NULL name/version), so it covers a concrete
+    # operation identity for that vendor.
     tk_id = await _seed_toolkit_with_credential(
-        control_db, toolkit_name="tk-acme", vendor="acme.com", name="pets-api", version="v2"
+        control_db, toolkit_name="tk-acme", vendor="acme.com", name=None, version=None
     )
     agent_id = await _seed_agent_with_toolkits(admin_db, toolkit_ids=[tk_id])
 
     resolver = ToolkitBindingResolver(admin_db, control_db)
     result = await resolver.derive_toolkits(
-        agent_id=agent_id, vendor="acme.com", name="", version=""
+        agent_id=agent_id, vendor="acme.com", name="pets-api", version="v2"
     )
 
-    assert result == [tk_id]
+    assert result.toolkits == (tk_id,)
 
 
 async def test_derive_toolkits_no_agent_bindings_returns_empty(
@@ -181,7 +183,8 @@ async def test_derive_toolkits_no_agent_bindings_returns_empty(
         agent_id=agent_id, vendor="acme.com", name="pets-api", version="v1"
     )
 
-    assert result == []
+    assert result.toolkits == ()
+    assert result.agent_bound_any is False
 
 
 async def test_derive_toolkits_excludes_unbound_wildcard_toolkit(
@@ -208,29 +211,35 @@ async def test_derive_toolkits_excludes_unbound_wildcard_toolkit(
         agent_id=agent_id, vendor="acme.com", name="pets-api", version="v1"
     )
 
-    assert result == [bound]
-    assert unbound_wildcard not in result
+    assert result.toolkits == (bound,)
+    assert unbound_wildcard not in result.toolkits
+    # Both toolkits serve the API (the wildcard covers it too), independent of
+    # the agent's bindings — this drives the recovery directive, not authz.
+    assert set(result.api_served_toolkits) == {bound, unbound_wildcard}
 
 
-async def test_any_toolkit_serves_api_true_when_a_toolkit_serves(
+async def test_derive_toolkits_served_true_when_a_toolkit_serves(
     admin_db: DatabaseSession, control_db: DatabaseSession, clean_tables: None
 ) -> None:
     """A toolkit with a bound credential for the API → serves the API (issue #683).
 
-    Independent of any agent binding: this drives the ``no_toolkit_binding``
-    recovery directive, not authorization.
+    ``api_served_toolkits`` is independent of any agent binding: it drives the
+    ``no_toolkit_binding`` recovery directive, not authorization.
     """
     await _seed_toolkit_with_credential(
         control_db, toolkit_name="tk-acme", vendor="acme.com", name="pets-api", version="v1"
     )
+    agent_id = await _seed_agent_with_toolkits(admin_db, toolkit_ids=[])
 
     resolver = ToolkitBindingResolver(admin_db, control_db)
-    serves = await resolver.any_toolkit_serves_api(vendor="acme.com", name="pets-api", version="v1")
+    result = await resolver.derive_toolkits(
+        agent_id=agent_id, vendor="acme.com", name="pets-api", version="v1"
+    )
 
-    assert serves is True
+    assert result.api_served_toolkits != ()
 
 
-async def test_any_toolkit_serves_api_false_when_no_toolkit_serves(
+async def test_derive_toolkits_served_false_when_no_toolkit_serves(
     admin_db: DatabaseSession, control_db: DatabaseSession, clean_tables: None
 ) -> None:
     """No toolkit bound a credential for the API → does not serve it (issue #683).
@@ -241,8 +250,11 @@ async def test_any_toolkit_serves_api_false_when_no_toolkit_serves(
     await _seed_toolkit_with_credential(
         control_db, toolkit_name="tk-other", vendor="other.com", name="x", version="v1"
     )
+    agent_id = await _seed_agent_with_toolkits(admin_db, toolkit_ids=[])
 
     resolver = ToolkitBindingResolver(admin_db, control_db)
-    serves = await resolver.any_toolkit_serves_api(vendor="acme.com", name="pets-api", version="v1")
+    result = await resolver.derive_toolkits(
+        agent_id=agent_id, vendor="acme.com", name="pets-api", version="v1"
+    )
 
-    assert serves is False
+    assert result.api_served_toolkits == ()

--- a/tests/integration/broker/test_toolkit_binding_resolver.py
+++ b/tests/integration/broker/test_toolkit_binding_resolver.py
@@ -258,3 +258,93 @@ async def test_derive_toolkits_served_false_when_no_toolkit_serves(
     )
 
     assert result.api_served_toolkits == ()
+
+
+async def test_nearest_miss_same_vendor_wrong_name(
+    admin_db: DatabaseSession, control_db: DatabaseSession, clean_tables: None
+) -> None:
+    """Bound to a same-vendor credential with the wrong name → identity mismatch (#748).
+
+    The agent is bound and a credential covers the vendor, but its name doesn't
+    match the operation. This is a genuine credential-identity mismatch, not a
+    provisioning gap.
+    """
+    tk_id = await _seed_toolkit_with_credential(
+        control_db, toolkit_name="tk-billing", vendor="acme-com", name="billing", version="v1"
+    )
+    agent_id = await _seed_agent_with_toolkits(admin_db, toolkit_ids=[tk_id])
+
+    resolver = ToolkitBindingResolver(admin_db, control_db)
+    result = await resolver.derive_toolkits(
+        agent_id=agent_id, vendor="acme-com", name="payments", version="v1"
+    )
+
+    assert result.toolkits == ()
+    assert result.identity_mismatch is not None
+    assert result.identity_mismatch.found_name == "billing"
+    assert result.identity_mismatch.would_match_if_normalized is False
+
+
+async def test_nearest_miss_legacy_non_canonical_would_match(
+    admin_db: DatabaseSession, control_db: DatabaseSession, clean_tables: None
+) -> None:
+    """A legacy non-canonical stored identity flags would_match_if_normalized (#746)."""
+    # Stored verbatim (bypassing the canonicalizing service), as a legacy row.
+    tk_id = await _seed_toolkit_with_credential(
+        control_db, toolkit_name="tk-legacy", vendor="Acme.com", name="Pets-API", version="v1"
+    )
+    agent_id = await _seed_agent_with_toolkits(admin_db, toolkit_ids=[tk_id])
+
+    resolver = ToolkitBindingResolver(admin_db, control_db)
+    # The operation identity is canonical; the stored row only matches once slugged.
+    result = await resolver.derive_toolkits(
+        agent_id=agent_id, vendor="acme-com", name="pets-api", version="v1"
+    )
+
+    assert result.toolkits == ()
+    assert result.identity_mismatch is not None
+    assert result.identity_mismatch.would_match_if_normalized is True
+
+
+async def test_nearest_miss_unrelated_vendor_is_no_mismatch(
+    admin_db: DatabaseSession, control_db: DatabaseSession, clean_tables: None
+) -> None:
+    """Bound only to an unrelated vendor → no mismatch, falls through to #683.
+
+    An agent bound to Slack calling Stripe must NOT be told to retarget its Slack
+    credential. The vendor-affinity gate returns no mismatch, so the caller yields
+    ``no_toolkit_binding`` instead.
+    """
+    tk_id = await _seed_toolkit_with_credential(
+        control_db, toolkit_name="tk-slack", vendor="slack-com", name="chat", version="v1"
+    )
+    agent_id = await _seed_agent_with_toolkits(admin_db, toolkit_ids=[tk_id])
+
+    resolver = ToolkitBindingResolver(admin_db, control_db)
+    result = await resolver.derive_toolkits(
+        agent_id=agent_id, vendor="stripe-com", name="payments", version="v1"
+    )
+
+    assert result.toolkits == ()
+    assert result.identity_mismatch is None
+
+
+async def test_nearest_miss_none_when_no_bound_credentials(
+    admin_db: DatabaseSession, control_db: DatabaseSession, clean_tables: None
+) -> None:
+    """The agent's toolkits have no bound credentials → provisioning gap, not mismatch."""
+    toolkit = Toolkit(name="tk-empty")
+    async with control_db.session() as session:
+        session.add(toolkit)
+        await session.flush()
+        tk_id = toolkit.id
+        await session.commit()
+    agent_id = await _seed_agent_with_toolkits(admin_db, toolkit_ids=[tk_id])
+
+    resolver = ToolkitBindingResolver(admin_db, control_db)
+    result = await resolver.derive_toolkits(
+        agent_id=agent_id, vendor="acme-com", name="pets-api", version="v1"
+    )
+
+    assert result.toolkits == ()
+    assert result.identity_mismatch is None

--- a/tests/integration/control/test_effects_resolve_toolkits.py
+++ b/tests/integration/control/test_effects_resolve_toolkits.py
@@ -1,0 +1,120 @@
+"""Integration tests for bind-time toolkit resolution (M2, ``EffectsRepository``).
+
+Exercises ``resolve_toolkits_for_api`` against a real control DB. Stored credential
+identities are canonical (slugified vendor/name), so a *raw* reference axis
+(``GitHub.com``) must be canonicalized at the SQL boundary or it would match
+nothing — the regression these tests guard (S2).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy import delete
+
+from jentic_one.control.core.schema.credentials import Credential
+from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
+from jentic_one.control.core.schema.toolkits import Toolkit
+from jentic_one.control.repos.effects_repo import EffectsRepository
+from jentic_one.shared.db.ids import generate_ksuid
+from jentic_one.shared.db.session import DatabaseSession
+
+pytestmark = pytest.mark.integration
+
+_VENDOR_SLUG = "github-com"
+
+
+@pytest.fixture()
+async def clean_tables(control_db: DatabaseSession) -> AsyncGenerator[None, None]:
+    async def _truncate() -> None:
+        async with control_db.session() as session:
+            await session.execute(delete(ToolkitCredentialBinding))
+            await session.execute(delete(Credential).where(Credential.api_vendor == _VENDOR_SLUG))
+            await session.execute(delete(Toolkit).where(Toolkit.name.like("tk-eff-%")))
+            await session.commit()
+
+    await _truncate()
+    yield
+    await _truncate()
+
+
+async def _seed_bound_credential(
+    control_db: DatabaseSession,
+    *,
+    toolkit_name: str,
+    api_name: str | None,
+    api_version: str | None,
+) -> str:
+    """Seed a toolkit + canonical credential + binding; return the toolkit id."""
+    toolkit = Toolkit(name=toolkit_name)
+    credential = Credential(
+        type="token_value",
+        name=f"cred-{toolkit_name}",
+        api_vendor=_VENDOR_SLUG,
+        api_name=api_name,
+        api_version=api_version,
+    )
+    async with control_db.session() as session:
+        session.add(toolkit)
+        session.add(credential)
+        await session.flush()
+        tk_id = toolkit.id
+        session.add(
+            ToolkitCredentialBinding(
+                id=generate_ksuid("tcb"), toolkit_id=tk_id, credential_id=credential.id
+            )
+        )
+        await session.commit()
+    return tk_id
+
+
+async def test_resolve_canonicalizes_raw_reference_vendor_and_name(
+    control_db: DatabaseSession, clean_tables: None
+) -> None:
+    """A raw ``GitHub.com``/``Repos-API`` reference resolves the canonical stored row."""
+    tk_id = await _seed_bound_credential(
+        control_db, toolkit_name="tk-eff-canon", api_name="repos-api", api_version="v3"
+    )
+
+    async with control_db.session() as session:
+        toolkits = await EffectsRepository.resolve_toolkits_for_api(
+            session, vendor="GitHub.com", name="Repos-API", version="v3", owner_ids=None
+        )
+
+    assert toolkits == [tk_id]
+
+
+async def test_resolve_wildcard_credential_matches_name_scoped_reference(
+    control_db: DatabaseSession, clean_tables: None
+) -> None:
+    """A vendor-wide (NULL name) credential is resolved for a name-scoped reference."""
+    tk_id = await _seed_bound_credential(
+        control_db, toolkit_name="tk-eff-wild", api_name=None, api_version=None
+    )
+
+    async with control_db.session() as session:
+        toolkits = await EffectsRepository.resolve_toolkits_for_api(
+            session, vendor="github.com", name="repos-api", version="v3", owner_ids=None
+        )
+
+    assert toolkits == [tk_id]
+
+
+async def test_resolve_prefers_exact_name_over_wildcard(
+    control_db: DatabaseSession, clean_tables: None
+) -> None:
+    """An exact-name credential is preferred over a vendor-wide wildcard for the name."""
+    exact_tk = await _seed_bound_credential(
+        control_db, toolkit_name="tk-eff-exact", api_name="repos-api", api_version="v3"
+    )
+    await _seed_bound_credential(
+        control_db, toolkit_name="tk-eff-any", api_name=None, api_version=None
+    )
+
+    async with control_db.session() as session:
+        toolkits = await EffectsRepository.resolve_toolkits_for_api(
+            session, vendor="github.com", name="repos-api", version="v3", owner_ids=None
+        )
+
+    assert toolkits == [exact_tk]

--- a/tests/unit/broker/test_caching_toolkit_deriver_observability.py
+++ b/tests/unit/broker/test_caching_toolkit_deriver_observability.py
@@ -10,6 +10,7 @@ from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 
 import jentic_one.broker.repos.caching_toolkit_deriver as _deriver_mod
 from jentic_one.broker.repos.caching_toolkit_deriver import CachingToolkitDeriver
+from jentic_one.shared.broker.protocols import ToolkitDerivation
 
 
 class _CountingDeriver:
@@ -21,12 +22,15 @@ class _CountingDeriver:
 
     async def derive_toolkits(
         self, *, agent_id: str, vendor: str, name: str, version: str
-    ) -> list[str]:
+    ) -> ToolkitDerivation:
         self.calls += 1
-        return list(self.result)
-
-    async def any_toolkit_serves_api(self, *, vendor: str, name: str, version: str) -> bool:
-        return bool(self.result)
+        tk = tuple(self.result)
+        return ToolkitDerivation(
+            toolkits=tk,
+            agent_bound_any=bool(tk),
+            api_served_toolkits=tk,
+            identity_mismatch=None,
+        )
 
 
 def _get_counter_value(reader: InMemoryMetricReader, name: str) -> int:

--- a/tests/unit/broker/test_nearest_miss_ranking.py
+++ b/tests/unit/broker/test_nearest_miss_ranking.py
@@ -1,0 +1,42 @@
+"""Unit tests for the nearest-miss ranking helper (``_axes_matched``).
+
+``_axes_matched`` ranks near-miss credential identities so the #748 diagnostic
+picks the *closest* miss deterministically. It is a pure scoring function — not
+an authorization signal — so it is unit-tested in isolation from the cross-DB
+query that feeds it.
+"""
+
+from __future__ import annotations
+
+from jentic_one.broker.repos.toolkit_binding_resolver import _axes_matched
+from jentic_one.shared.models.api_identity import CredentialScope
+
+
+def test_axes_matched_all_three() -> None:
+    scope = CredentialScope(vendor="acme", name="widgets", version="1.0.0")
+    assert _axes_matched(scope, vendor="acme", name="widgets", version="1.0.0") == 3
+
+
+def test_axes_matched_vendor_only() -> None:
+    scope = CredentialScope(vendor="acme", name="gadgets", version="2.0.0")
+    assert _axes_matched(scope, vendor="acme", name="widgets", version="1.0.0") == 1
+
+
+def test_axes_matched_slugifies_vendor_and_name() -> None:
+    # Stored scope is canonical; the operation identity is given raw here and must
+    # be slugified before comparison, or a canonical scope would never match.
+    scope = CredentialScope(vendor="acme-com", name="pets-api", version="v1")
+    assert _axes_matched(scope, vendor="Acme.com", name="Pets-API", version="v1") == 3
+
+
+def test_axes_matched_wildcard_axis_does_not_count() -> None:
+    # An unscoped (NULL) axis would have *covered* the operation, so it never
+    # reaches the near-miss path; for ranking it does not count as a match.
+    scope = CredentialScope(vendor="acme", name=None, version=None)
+    assert _axes_matched(scope, vendor="acme", name="widgets", version="1.0.0") == 1
+
+
+def test_axes_matched_version_not_slugified() -> None:
+    # Versions are trimmed, never slugified: '1.1.4' must compare intact.
+    scope = CredentialScope(vendor="acme", name="widgets", version="1.1.4")
+    assert _axes_matched(scope, vendor="acme", name="widgets", version=" 1.1.4 ") == 3

--- a/tests/unit/broker/test_problem_json.py
+++ b/tests/unit/broker/test_problem_json.py
@@ -19,11 +19,13 @@ from jentic_one.broker.core.exceptions import (
     UpstreamTimeoutError,
     action_denied_directive,
     ambiguous_toolkit_directive,
+    credential_identity_mismatch_directive,
     no_toolkit_binding_directive,
     switch_toolkit_directive,
 )
 from jentic_one.broker.core.headers import JenticHeader
 from jentic_one.broker.web.errors import STATUS_BY_ERROR, handle_broker_error, problem_response
+from jentic_one.shared.broker.protocols import IdentityMismatch
 
 
 def _body(resp: Any) -> dict[str, Any]:
@@ -46,6 +48,17 @@ def test_directive_factories_emit_known_strategies() -> None:
             vendor="acme", name="widgets", version="1.0.0", toolkit_serves_api=True
         ),
         ambiguous_toolkit_directive(["tk_a", "tk_b"]),
+        credential_identity_mismatch_directive(
+            mismatch=IdentityMismatch(
+                expected_vendor="acme",
+                expected_name="widgets",
+                expected_version="1.0.0",
+                found_vendor="acme",
+                found_name="gadgets",
+                found_version="1.0.0",
+                would_match_if_normalized=False,
+            )
+        ),
         action_denied_directive(),
     ]
     for d in directives:
@@ -59,6 +72,68 @@ def test_ambiguous_toolkit_suggested_command_is_runnable() -> None:
     cmd = d.parameters["suggested_command"]
     assert "…" not in cmd
     assert "Jentic-Toolkit-Id=tk_a" in cmd
+
+
+def test_credential_identity_mismatch_directive_has_no_fabricated_command() -> None:
+    """The mismatch directive names expected/found but emits no CLI command.
+
+    Fixing a credential is an operator action with no verbatim agent-runnable
+    command, so a ``suggested_command`` here would be fiction the CLI prints
+    verbatim (review B2)."""
+    d = credential_identity_mismatch_directive(
+        mismatch=IdentityMismatch(
+            expected_vendor="acme",
+            expected_name="widgets",
+            expected_version="1.0.0",
+            found_vendor="acme",
+            found_name="gadgets",
+            found_version="1.0.0",
+            would_match_if_normalized=False,
+        )
+    )
+    assert "suggested_command" not in d.parameters
+    assert d.parameters["expected"]["name"] == "widgets"
+    assert d.parameters["found"]["name"] == "gadgets"
+    assert d.parameters["would_match_if_normalized"] is False
+    # Expected/found identities must appear so the operator can act.
+    assert "acme/widgets/1.0.0" in d.human_readable_instruction
+    assert "acme/gadgets/1.0.0" in d.human_readable_instruction
+
+
+def test_credential_identity_mismatch_directive_renders_unset_axes() -> None:
+    """A vendor-wide (unset name) found identity renders ``vendor/*/version`` (review N6).
+
+    Without the ``*`` placeholder, ``(acme, None, "1.0.0")`` would render as the
+    ambiguous ``acme/1.0.0`` — indistinguishable from vendor/name."""
+    d = credential_identity_mismatch_directive(
+        mismatch=IdentityMismatch(
+            expected_vendor="acme",
+            expected_name="widgets",
+            expected_version="1.0.0",
+            found_vendor="acme",
+            found_name=None,
+            found_version="1.0.0",
+            would_match_if_normalized=False,
+        )
+    )
+    assert "acme/*/1.0.0" in d.human_readable_instruction
+
+
+def test_credential_identity_mismatch_directive_would_normalize_message() -> None:
+    """When only normalization differs, the instruction says so (#746 legacy row)."""
+    d = credential_identity_mismatch_directive(
+        mismatch=IdentityMismatch(
+            expected_vendor="acme",
+            expected_name="widgets",
+            expected_version="1.0.0",
+            found_vendor="Acme.com",
+            found_name="Widgets",
+            found_version="1.0.0",
+            would_match_if_normalized=True,
+        )
+    )
+    assert "normaliz" in d.human_readable_instruction.lower()
+    assert d.parameters["would_match_if_normalized"] is True
 
 
 def test_problem_response_defaults() -> None:

--- a/tests/unit/broker/test_resolver.py
+++ b/tests/unit/broker/test_resolver.py
@@ -295,3 +295,107 @@ async def test_resolve_matches_when_only_casing_differs() -> None:
         result = await resolver.resolve(api=api, caller="caller_1")
 
     assert result.credential_id == "cred_abc"
+
+
+@pytest.mark.asyncio
+async def test_resolve_vendor_scoped_wildcard_covers_concrete_op() -> None:
+    """A vendor-scoped credential (NULL name/version) resolves for a concrete op (#775)."""
+    cred = _make_credential(api_vendor="stripe", api_name=None, api_version=None)
+    tvc = MagicMock()
+    tvc.encrypted_token_value = "enc:wild"
+    cred.token_value_credential = tvc
+
+    ctx = _make_ctx_with_control_session(AsyncMock())
+    api = APIReference(vendor="stripe", name="payments", version="v1")
+
+    with patch(
+        "jentic_one.broker.services.credentials.resolver.CredentialRepository.list_by_vendor",
+        new_callable=AsyncMock,
+        return_value=[cred],
+    ):
+        result = await CredentialResolver(ctx).resolve(api=api, caller="caller_1")
+
+    assert result.credential_id == "cred_abc"
+    assert result.encrypted_secret == "enc:wild"  # pragma: allowlist secret
+
+
+@pytest.mark.asyncio
+async def test_resolve_empty_string_stored_axis_covers_concrete_op() -> None:
+    """A legacy '' name/version credential still resolves (canonicalized at read, #775)."""
+    cred = _make_credential(api_vendor="stripe", api_name="", api_version="")
+    tvc = MagicMock()
+    tvc.encrypted_token_value = "enc:legacy"
+    cred.token_value_credential = tvc
+
+    ctx = _make_ctx_with_control_session(AsyncMock())
+    api = APIReference(vendor="stripe", name="payments", version="v1")
+
+    with patch(
+        "jentic_one.broker.services.credentials.resolver.CredentialRepository.list_by_vendor",
+        new_callable=AsyncMock,
+        return_value=[cred],
+    ):
+        result = await CredentialResolver(ctx).resolve(api=api, caller="caller_1")
+
+    assert result.credential_id == "cred_abc"
+
+
+@pytest.mark.asyncio
+async def test_resolve_wrong_version_does_not_cover() -> None:
+    """A version-pinned credential does not cover a different version."""
+    cred = _make_credential(api_vendor="stripe", api_name="payments", api_version="v2")
+
+    ctx = _make_ctx_with_control_session(AsyncMock())
+    api = APIReference(vendor="stripe", name="payments", version="v1")
+
+    with (
+        patch(
+            "jentic_one.broker.services.credentials.resolver.CredentialRepository.list_by_vendor",
+            new_callable=AsyncMock,
+            return_value=[cred],
+        ),
+        pytest.raises(CredentialNotProvisionedError),
+    ):
+        await CredentialResolver(ctx).resolve(api=api, caller="caller_1")
+
+
+@pytest.mark.asyncio
+async def test_resolve_pin_wins_over_vendor_wildcard_no_ambiguity() -> None:
+    """A vendor wildcard coexisting with a pinned credential → pin wins, no 409 (#775)."""
+    wildcard = _make_credential(cred_id="cred_wild", api_name=None, api_version=None)
+    pinned = _make_credential(cred_id="cred_pin", api_name="payments", api_version="v1")
+    tvc = MagicMock()
+    tvc.encrypted_token_value = "enc:pin"
+    pinned.token_value_credential = tvc
+
+    ctx = _make_ctx_with_control_session(AsyncMock())
+    api = APIReference(vendor="stripe", name="payments", version="v1")
+
+    with patch(
+        "jentic_one.broker.services.credentials.resolver.CredentialRepository.list_by_vendor",
+        new_callable=AsyncMock,
+        return_value=[wildcard, pinned],
+    ):
+        result = await CredentialResolver(ctx).resolve(api=api, caller="caller_1")
+
+    assert result.credential_id == "cred_pin"
+
+
+@pytest.mark.asyncio
+async def test_resolve_same_specificity_tie_is_ambiguous() -> None:
+    """Two credentials at the same specificity remain a genuine 409."""
+    a = _make_credential(cred_id="cred_a", api_name="payments", api_version="v1")
+    b = _make_credential(cred_id="cred_b", api_name="payments", api_version="v1")
+
+    ctx = _make_ctx_with_control_session(AsyncMock())
+    api = APIReference(vendor="stripe", name="payments", version="v1")
+
+    with (
+        patch(
+            "jentic_one.broker.services.credentials.resolver.CredentialRepository.list_by_vendor",
+            new_callable=AsyncMock,
+            return_value=[a, b],
+        ),
+        pytest.raises(AmbiguousCredentialError),
+    ):
+        await CredentialResolver(ctx).resolve(api=api, caller="caller_1")

--- a/tests/unit/broker/test_resolver.py
+++ b/tests/unit/broker/test_resolver.py
@@ -399,3 +399,37 @@ async def test_resolve_same_specificity_tie_is_ambiguous() -> None:
         pytest.raises(AmbiguousCredentialError),
     ):
         await CredentialResolver(ctx).resolve(api=api, caller="caller_1")
+
+
+@pytest.mark.asyncio
+async def test_resolve_credential_name_selects_less_specific_covering() -> None:
+    """An explicit credential_name may pick a covering-but-less-specific credential (N1).
+
+    A vendor-wide wildcard and a name/version pin both cover the API. Naming the
+    wildcard must resolve *it* — the name search runs over all covering
+    credentials, before specificity narrowing — instead of raising
+    CredentialNameNotFoundError because the pin out-ranked it.
+    """
+    wildcard = _make_credential(
+        cred_id="cred_wild", name="shared-account", api_name=None, api_version=None
+    )
+    tvc = MagicMock()
+    tvc.encrypted_token_value = "enc:wild"  # pragma: allowlist secret
+    wildcard.token_value_credential = tvc
+    pinned = _make_credential(
+        cred_id="cred_pin", name="pinned-account", api_name="payments", api_version="v1"
+    )
+
+    ctx = _make_ctx_with_control_session(AsyncMock())
+    api = APIReference(vendor="stripe", name="payments", version="v1")
+
+    with patch(
+        "jentic_one.broker.services.credentials.resolver.CredentialRepository.list_by_vendor",
+        new_callable=AsyncMock,
+        return_value=[wildcard, pinned],
+    ):
+        result = await CredentialResolver(ctx).resolve(
+            api=api, caller="caller_1", credential_name="shared-account"
+        )
+
+    assert result.credential_id == "cred_wild"

--- a/tests/unit/broker/test_toolkit_cache.py
+++ b/tests/unit/broker/test_toolkit_cache.py
@@ -7,7 +7,17 @@ import asyncio
 import pytest
 
 from jentic_one.broker.repos.caching_toolkit_deriver import CachingToolkitDeriver
-from jentic_one.shared.broker.protocols import ToolkitDeriverProtocol
+from jentic_one.shared.broker.protocols import ToolkitDerivation, ToolkitDeriverProtocol
+
+
+def _derivation(toolkits: list[str]) -> ToolkitDerivation:
+    tk = tuple(toolkits)
+    return ToolkitDerivation(
+        toolkits=tk,
+        agent_bound_any=bool(tk),
+        api_served_toolkits=tk,
+        identity_mismatch=None,
+    )
 
 
 class _CountingDeriver:
@@ -20,14 +30,11 @@ class _CountingDeriver:
 
     async def derive_toolkits(
         self, *, agent_id: str, vendor: str, name: str, version: str
-    ) -> list[str]:
+    ) -> ToolkitDerivation:
         self.calls += 1
         if self.gate is not None:
             await self.gate.wait()
-        return list(self.result)
-
-    async def any_toolkit_serves_api(self, *, vendor: str, name: str, version: str) -> bool:
-        return bool(self.result)
+        return _derivation(self.result)
 
 
 def test_wrapper_satisfies_protocol() -> None:
@@ -44,8 +51,8 @@ async def test_second_request_hits_cache() -> None:
     first = await cache.derive_toolkits(agent_id="a1", vendor="acme", name="api", version="1")
     second = await cache.derive_toolkits(agent_id="a1", vendor="acme", name="api", version="1")
 
-    assert first == ["tk_1", "tk_2"]
-    assert second == ["tk_1", "tk_2"]
+    assert first.toolkits == ("tk_1", "tk_2")
+    assert second.toolkits == ("tk_1", "tk_2")
     assert inner.calls == 1
 
 
@@ -82,7 +89,7 @@ async def test_concurrent_misses_single_flight_to_one_lookup() -> None:
     inner.gate = asyncio.Event()
     cache = CachingToolkitDeriver(inner, cache_ttl_seconds=300.0)
 
-    async def call() -> list[str]:
+    async def call() -> ToolkitDerivation:
         return await cache.derive_toolkits(agent_id="a1", vendor="acme", name="api", version="1")
 
     tasks = [asyncio.create_task(call()) for _ in range(15)]
@@ -91,23 +98,24 @@ async def test_concurrent_misses_single_flight_to_one_lookup() -> None:
     results = await asyncio.gather(*tasks)
 
     assert inner.calls == 1
-    assert all(r == ["tk_1"] for r in results)
+    assert all(r.toolkits == ("tk_1",) for r in results)
     # And a subsequent call is now a pure cache hit.
     await cache.derive_toolkits(agent_id="a1", vendor="acme", name="api", version="1")
     assert inner.calls == 1
 
 
 @pytest.mark.asyncio
-async def test_returned_list_is_isolated_from_cache() -> None:
-    """Mutating a returned list does not corrupt the cached entry."""
+async def test_cached_result_is_immutable() -> None:
+    """The cached derivation is a frozen dataclass of tuples — callers can't corrupt it."""
     inner = _CountingDeriver(["tk_1"])
     cache = CachingToolkitDeriver(inner, cache_ttl_seconds=300.0)
 
     first = await cache.derive_toolkits(agent_id="a1", vendor="acme", name="api", version="1")
-    first.append("tk_injected")
+    with pytest.raises(AttributeError):
+        first.toolkits = ("tk_injected",)  # type: ignore[misc]
     second = await cache.derive_toolkits(agent_id="a1", vendor="acme", name="api", version="1")
 
-    assert second == ["tk_1"]
+    assert second.toolkits == ("tk_1",)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/broker/test_toolkit_select.py
+++ b/tests/unit/broker/test_toolkit_select.py
@@ -13,12 +13,14 @@ from jentic.problem_details import Forbidden, ProblemDetailException
 from jentic_one.broker.core.exceptions import (
     ActionDeniedError,
     AmbiguousMatchError,
+    CredentialIdentityMismatchError,
     no_toolkit_binding_directive,
 )
 from jentic_one.broker.web.errors import install_broker_error_handlers
 from jentic_one.broker.web.routers.execute import select_toolkit
 from jentic_one.shared.access_guidance import no_toolkit_serves_api_reason
 from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.broker.protocols import IdentityMismatch, ToolkitDerivation
 from jentic_one.shared.models import ActorType
 from jentic_one.shared.schemas import APIReference
 
@@ -27,23 +29,49 @@ _INSTANCE = "/acme.example.com/v1/widgets"
 
 
 class _StubDeriver:
-    def __init__(self, candidates: list[str], *, toolkit_serves_api: bool = True) -> None:
+    """Stub deriver returning a hand-built ToolkitDerivation.
+
+    ``toolkit_serves_api`` controls whether ``api_served_toolkits`` is non-empty;
+    ``agent_bound_any`` defaults to True when there are candidates, else follows
+    the explicit flag. ``mismatch`` injects a nearest-miss for the #747/#748 case.
+    """
+
+    def __init__(
+        self,
+        candidates: list[str],
+        *,
+        toolkit_serves_api: bool = True,
+        agent_bound_any: bool | None = None,
+        mismatch: IdentityMismatch | None = None,
+    ) -> None:
         self.candidates = candidates
         self._toolkit_serves_api = toolkit_serves_api
+        self._agent_bound_any = agent_bound_any
+        self._mismatch = mismatch
         self.calls: list[dict[str, str]] = []
-        self.serves_calls: list[dict[str, str]] = []
 
     async def derive_toolkits(
         self, *, agent_id: str, vendor: str, name: str, version: str
-    ) -> list[str]:
+    ) -> ToolkitDerivation:
         self.calls.append(
             {"agent_id": agent_id, "vendor": vendor, "name": name, "version": version}
         )
-        return self.candidates
-
-    async def any_toolkit_serves_api(self, *, vendor: str, name: str, version: str) -> bool:
-        self.serves_calls.append({"vendor": vendor, "name": name, "version": version})
-        return self._toolkit_serves_api
+        bound = (
+            self._agent_bound_any if self._agent_bound_any is not None else bool(self.candidates)
+        )
+        # A served set that is independent of the agent's candidates: when a
+        # toolkit serves the API, model at least one serving toolkit even if the
+        # agent is bound to none of them (the "bound elsewhere" case).
+        if self._toolkit_serves_api:
+            served = tuple(self.candidates) if self.candidates else ("tk_serving",)
+        else:
+            served = ()
+        return ToolkitDerivation(
+            toolkits=tuple(self.candidates),
+            agent_bound_any=bound or bool(self.candidates),
+            api_served_toolkits=served,
+            identity_mismatch=self._mismatch,
+        )
 
 
 def _identity(actor_type: str = "agent") -> Identity:
@@ -127,8 +155,43 @@ async def test_zero_candidates_no_toolkit_serves_recommends_credential_first() -
     instruction = exc.value.directive.human_readable_instruction
     assert "credential" in instruction.lower()
     assert "provision" in instruction.lower()
-    # The broker consulted the "any toolkit serves this API?" predicate.
-    assert deriver.serves_calls == [{"vendor": "acme", "name": "widgets", "version": "1.0.0"}]
+
+
+async def test_zero_candidates_bound_with_identity_mismatch_points_at_credential() -> None:
+    # #747/#748: the agent is bound, but no toolkit serves the API because the
+    # bound credential's identity does not cover it. The denial must be a
+    # credential_identity_mismatch pointing at the credential — never a bind request.
+    mismatch = IdentityMismatch(
+        expected_vendor="acme",
+        expected_name="widgets",
+        expected_version="1.0.0",
+        found_vendor="acme.com",
+        found_name="widgets",
+        found_version="1.0.0",
+        would_match_if_normalized=True,
+    )
+    deriver = _StubDeriver([], toolkit_serves_api=False, agent_bound_any=True, mismatch=mismatch)
+    with pytest.raises(CredentialIdentityMismatchError) as exc:
+        await _select(deriver, header_toolkit=None)
+    assert exc.value.type == "credential_identity_mismatch"
+    assert exc.value.instance == _INSTANCE
+    assert exc.value.directive is not None
+    assert exc.value.directive.strategy == "prompt_human"
+    assert exc.value.directive.parameters["expected"]["vendor"] == "acme"
+    assert exc.value.directive.parameters["found"]["vendor"] == "acme.com"
+    assert exc.value.directive.parameters["would_match_if_normalized"] is True
+    instruction = exc.value.directive.human_readable_instruction.lower()
+    assert "credential" in instruction
+    assert "access request" not in instruction or "do not file an access request" in instruction
+
+
+async def test_zero_candidates_bound_no_mismatch_stays_no_toolkit_binding() -> None:
+    # Bound elsewhere, nothing serves this API, but no near-miss credential:
+    # this is a genuine provisioning gap, not a mismatch → no_toolkit_binding.
+    deriver = _StubDeriver([], toolkit_serves_api=False, agent_bound_any=True, mismatch=None)
+    with pytest.raises(ActionDeniedError) as exc:
+        await _select(deriver, header_toolkit=None)
+    assert exc.value.type == "no_toolkit_binding"
 
 
 async def test_multiple_candidates_no_header_raises_409_with_candidates() -> None:

--- a/tests/unit/control/credentials/test_identity_canonicalization.py
+++ b/tests/unit/control/credentials/test_identity_canonicalization.py
@@ -1,0 +1,40 @@
+"""Unit tests for credential API-identity canonicalization on create (#746/#775)."""
+
+from __future__ import annotations
+
+import pytest
+
+from jentic_one.control.services.credentials.errors import InvalidCredentialInputError
+from jentic_one.control.services.credentials.schemas.provision import APIReference
+from jentic_one.control.services.credentials.service import CredentialService
+
+
+def test_canonical_scope_slugs_vendor_and_name_and_coerces_empty() -> None:
+    scope = CredentialService._canonical_api_scope(
+        APIReference(vendor="GitHub.com", name="", version="")
+    )
+    assert scope.vendor == "github-com"
+    assert scope.name is None
+    assert scope.version is None
+
+
+def test_canonical_scope_preserves_concrete_identity() -> None:
+    scope = CredentialService._canonical_api_scope(
+        APIReference(vendor="GitHub.com", name="API.Name", version="1.1.4")
+    )
+    assert scope.vendor == "github-com"
+    assert scope.name == "api-name"
+    # version is trimmed, never slugified
+    assert scope.version == "1.1.4"
+
+
+@pytest.mark.parametrize(
+    "api",
+    [
+        APIReference(vendor="github-com", name="openapi/main", version="1.1.4"),
+        APIReference(vendor="github-com", name="openapi", version="api.github.com/main/1.1.4"),
+    ],
+)
+def test_canonical_scope_rejects_path_shaped_identity(api: APIReference) -> None:
+    with pytest.raises(InvalidCredentialInputError):
+        CredentialService._canonical_api_scope(api)

--- a/tests/unit/shared/test_api_identity.py
+++ b/tests/unit/shared/test_api_identity.py
@@ -1,10 +1,18 @@
-"""Unit tests for the shared API-identity slug helper."""
+"""Unit tests for the shared API-identity slug helper and coverage seam."""
 
 from __future__ import annotations
 
 import pytest
 
-from jentic_one.shared.models.api_identity import API_FIELD_MAX_LENGTH, slugify_api_field
+from jentic_one.shared.models.api_identity import (
+    API_FIELD_MAX_LENGTH,
+    CredentialScope,
+    canonical_credential_scope,
+    credential_coverage_where,
+    credential_covers,
+    credential_specificity,
+    slugify_api_field,
+)
 
 
 @pytest.mark.parametrize(
@@ -34,3 +42,115 @@ def test_slugify_api_field_truncates_to_max_length() -> None:
 def test_slugify_api_field_is_idempotent() -> None:
     once = slugify_api_field("Vendor.Com")
     assert slugify_api_field(once) == once
+
+
+def test_canonical_scope_slugs_vendor_and_name() -> None:
+    scope = canonical_credential_scope(vendor="GitHub.com", name="API.Name", version="1.1.4")
+    assert scope == CredentialScope(vendor="github-com", name="api-name", version="1.1.4")
+
+
+def test_canonical_scope_empty_axes_coerced_to_none() -> None:
+    scope = canonical_credential_scope(vendor="stripe", name="", version="")
+    assert scope == CredentialScope(vendor="stripe", name=None, version=None)
+
+
+def test_canonical_scope_none_axes_stay_none() -> None:
+    scope = canonical_credential_scope(vendor="stripe", name=None, version=None)
+    assert scope == CredentialScope(vendor="stripe", name=None, version=None)
+
+
+def test_canonical_scope_version_is_trimmed_but_not_slugified() -> None:
+    # Slugifying a version would corrupt it (1.1.4 -> 1-1-4).
+    scope = canonical_credential_scope(vendor="v", name=None, version="  1.1.4  ")
+    assert scope.version == "1.1.4"
+
+
+def test_canonical_scope_whitespace_only_axis_becomes_none() -> None:
+    scope = canonical_credential_scope(vendor="v", name="   ", version="   ")
+    assert scope.name is None
+    assert scope.version is None
+
+
+@pytest.mark.parametrize(
+    ("scope", "covers"),
+    [
+        # vendor-only wildcard covers any concrete op for that vendor
+        (CredentialScope("google", None, None), True),
+        # name-scoped covers any version of that name
+        (CredentialScope("google", "main", None), True),
+        # fully pinned matches the exact op
+        (CredentialScope("google", "main", "1"), True),
+        # wrong name does not cover
+        (CredentialScope("google", "other", None), False),
+        # wrong version does not cover
+        (CredentialScope("google", "main", "2"), False),
+        # wrong vendor does not cover
+        (CredentialScope("azure", None, None), False),
+    ],
+)
+def test_credential_covers_truth_table(scope: CredentialScope, covers: bool) -> None:
+    assert credential_covers(scope, vendor="google", name="main", version="1") is covers
+
+
+def test_credential_covers_normalizes_operation_side() -> None:
+    # A concrete op given in non-canonical form still compares canonically.
+    scope = CredentialScope("github-com", "api-name", None)
+    assert credential_covers(scope, vendor="GitHub.com", name="API.Name", version="1")
+
+
+def test_credential_covers_version_compared_after_trim() -> None:
+    scope = CredentialScope("v", None, "1.1.4")
+    assert credential_covers(scope, vendor="v", name="n", version="  1.1.4  ")
+
+
+def test_credential_specificity_orders_most_specific_highest() -> None:
+    vendor_only = CredentialScope("v", None, None)
+    name_scoped = CredentialScope("v", "n", None)
+    fully_pinned = CredentialScope("v", "n", "1")
+    assert credential_specificity(vendor_only) == 0
+    assert credential_specificity(name_scoped) == 1
+    assert credential_specificity(fully_pinned) == 2
+    assert (
+        credential_specificity(fully_pinned)
+        > credential_specificity(name_scoped)
+        > credential_specificity(vendor_only)
+    )
+
+
+def test_credential_specificity_version_without_name_counts_one_axis() -> None:
+    assert credential_specificity(CredentialScope("v", None, "1")) == 1
+
+
+def test_coverage_where_default_scopes_all_axes() -> None:
+    frag = credential_coverage_where()
+    assert frag == (
+        "c.api_vendor = :vendor "
+        "AND (c.api_name IS NULL OR c.api_name = :name) "
+        "AND (c.api_version IS NULL OR c.api_version = :version)"
+    )
+
+
+def test_coverage_where_unscoped_reference_omits_axes() -> None:
+    frag = credential_coverage_where(name_scoped=False, version_scoped=False)
+    assert frag == "c.api_vendor = :vendor"
+    assert ":name" not in frag
+    assert ":version" not in frag
+
+
+def test_coverage_where_partial_scope_keeps_named_axis_only() -> None:
+    frag = credential_coverage_where(version_scoped=False)
+    assert "c.api_name" in frag
+    assert ":version" not in frag
+
+
+def test_coverage_where_custom_alias() -> None:
+    frag = credential_coverage_where(alias="cred")
+    assert "cred.api_vendor = :vendor" in frag
+    assert "c.api_vendor" not in frag
+
+
+def test_coverage_where_no_dialect_specific_syntax() -> None:
+    # Must stay portable across Postgres and SQLite: no casts / regex.
+    frag = credential_coverage_where()
+    assert "::" not in frag
+    assert "~" not in frag


### PR DESCRIPTION
## Summary

Theme 1 of the backend credential work: unify credential identity matching behind a **single shared seam** and fix the family of `no_toolkit_binding` / silent default-deny failures caused by inconsistent wildcard handling (`NULL` vs `''`), non-canonical stored identities, and discarded diagnostics.

Before this change, three separate matchers hand-rolled subtly different rules for "does this credential cover this operation?":
- **M1** — runtime toolkit derivation (`broker/repos/toolkit_binding_resolver.py`)
- **M2** — bind-time toolkit selection (`control/repos/effects_repo.py`)
- **M3** — injection-time credential resolution (`broker/services/credentials/resolver.py`)

They now all import one definition from `shared/models/api_identity.py`, so they can't drift apart.

## Issues fixed

- Fixes #775 — empty-string vs NULL identity wildcard: `NULL` is now the single "unscoped axis" sentinel; empty strings are coerced on write and backfilled. A vendor-scoped credential once again covers its concrete operations.
- Fixes #746 — credential identity not canonicalized on write: `CredentialService.create` slugifies vendor/name, coerces empty→`NULL`, trims (never slugifies) the version, and rejects a path-shaped identity as a 400. Legacy rows are re-slugged by migration.
- Fixes #747 — binding-resolution reason discarded: `derive_toolkits` now returns a structured `ToolkitDerivation` that carries *why* an empty toolkit set is empty.
- Fixes #748 — misleading `no_toolkit_binding` on a credential identity mismatch: a bound-but-mismatched credential now raises a distinct `CredentialIdentityMismatchError` (403) with a directive pointing at fixing the credential.
- Subsumes #683 — the `any_toolkit_serves_api` probe is deleted; its "does any toolkit serve this API?" signal is now `ToolkitDerivation.api_served_toolkits`, so the `no_toolkit_binding` recovery directive (bind request vs. provision-a-credential-first) is chosen without a second DB round-trip.

## Changes

**Shared seam** (`shared/models/api_identity.py`)
- `CredentialScope`, `canonical_credential_scope`, `credential_covers`, `credential_specificity`, and the dialect-portable `credential_coverage_where`.

**Write path + migrations** (#746)
- Canonicalization + path-shape guard in `CredentialService.create` (the sole `CredentialRepository.create` call site).
- `k2f3a4b5c6d7` — backfill `'' → NULL` for `api_name`/`api_version`.
- `l3a4b5c6d7e8` — re-slug legacy `api_vendor`/`api_name` (Python, portable, idempotent).

**Matchers** (#775)
- M1/M2 use `credential_coverage_where` (M2 omits an axis when the *reference* is a wildcard).
- M3 uses `credential_covers` + `credential_specificity` — most-specific-wins, so a vendor-wildcard credential coexisting with a pin resolves to the pin instead of a spurious 409; same-specificity ties remain a genuine 409.

**Honest denials** (#747/#748, subsumes #683)
- `ToolkitDeriverProtocol.derive_toolkits` → `ToolkitDerivation(toolkits, agent_bound_any, api_served_toolkits, identity_mismatch)`; `any_toolkit_serves_api` removed.
- `select_toolkit` branches four ways; new `CredentialIdentityMismatchError` (403, `credential_identity_mismatch`) + `credential_identity_mismatch_directive` registered in `broker/web/errors.py`.

### Design note
Most-specific-wins is applied to **M3 only**; M1 stays accept-any (intersected with the agent's bindings), preserving the existing bind-time/execute-time asymmetry and the `Jentic-Toolkit-Id` disambiguation behavior.

## Test plan

- [x] `ruff check` + `ruff format --check`: clean
- [x] `mypy`: no issues (1037 files)
- [x] `make test-unit`: 1942 passed, 78.89% coverage
- [x] `make test-arch`: 131 passed (module boundaries, no-test-classes, ORM conventions)
- [x] SQLite integration (resolver, credential service, effects, access-requests, execute): 128 passed
- [x] Both new control migrations apply cleanly to SQLite through head (idempotent on re-run)
- [ ] CI green on Postgres

Made with [Cursor](https://cursor.com)