### PR TITLE
fix(permissions): overhaul rule authoring, storage, and enforcement

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -178,7 +178,7 @@
         "filename": "cli/internal/install/render_test.go",
         "hashed_secret": "5530a000e0696af2f05defa12f45933c43252268",
         "is_verified": false,
-        "line_number": 120
+        "line_number": 122
       }
     ],
     "cli/internal/profile/store.go": [
@@ -316,6 +316,13 @@
         "hashed_secret": "99075eb0baa8cfda1cae029da06b57b93cc13a31",
         "is_verified": false,
         "line_number": 13
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docker/local-setup/init-schemas.sql",
+        "hashed_secret": "210cbe3d21b1c88069f9fb0e1e6621afc03aa2e0",
+        "is_verified": false,
+        "line_number": 44
       }
     ],
     "openapi/control/control.openapi.yaml": [
@@ -324,7 +331,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "2c4ea53d93a5d7661383e1c667d72270f9bf2fb6",
         "is_verified": false,
-        "line_number": 15841
+        "line_number": 16061
       }
     ],
     "release-please-config.json": [
@@ -334,6 +341,15 @@
         "hashed_secret": "56e68a94ea187933463e68fdffe946afee3ba0b9",
         "is_verified": false,
         "line_number": 4
+      }
+    ],
+    "scripts/flywheel_manual.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "scripts/flywheel_manual.py",
+        "hashed_secret": "fa826227f569cc5bde479bac89924ac67fa6d687",
+        "is_verified": false,
+        "line_number": 55
       }
     ],
     "src/jentic_one/auth/services/crypto.py": [
@@ -989,14 +1005,14 @@
         "filename": "tests/integration/control/test_credential_service.py",
         "hashed_secret": "10797dadcfe91a7717765eb4de5d72523c07c57b",
         "is_verified": false,
-        "line_number": 180
+        "line_number": 182
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/control/test_credential_service.py",
         "hashed_secret": "089f2d7c3e3bc715036946840246d11af28635ff",
         "is_verified": false,
-        "line_number": 203
+        "line_number": 260
       }
     ],
     "tests/integration/registry/core/schema/test_spec_files.py": [
@@ -1431,7 +1447,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "ui/public/mockServiceWorker.js",
-        "hashed_secret": "992fb17b2709e520bb55b00bf985b02964b806cf",
+        "hashed_secret": "4f1dadf6d082244ae74673641b1c8311e64411a3",
         "is_verified": false,
         "line_number": 11
       }
@@ -1553,5 +1569,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-21T15:23:55Z"
+  "generated_at": "2026-07-24T15:03:28Z"
 }

--- a/docs/reference/endpoints.json
+++ b/docs/reference/endpoints.json
@@ -3055,6 +3055,32 @@
         "owner:toolkits:read": [],
         "toolkits:read": []
       },
+      "method": "POST",
+      "operation_id": "testToolkitPermissions",
+      "path": "/toolkits/{toolkit_id}/credentials/{credential_id}/permissions:test",
+      "public": false,
+      "required_scopes": [
+        "toolkits:read",
+        "owner:toolkits:read"
+      ],
+      "summary": "Dry-run permission evaluation",
+      "surface": "toolkits",
+      "typical_caller": "any"
+    },
+    {
+      "actor_types": [
+        "user",
+        "agent",
+        "service_account",
+        "toolkit"
+      ],
+      "auth_note": null,
+      "authenticated": true,
+      "group": "Any authenticated actor",
+      "implied_scopes": {
+        "owner:toolkits:read": [],
+        "toolkits:read": []
+      },
       "method": "GET",
       "operation_id": "listKeys",
       "path": "/toolkits/{toolkit_id}/keys",
@@ -4453,5 +4479,5 @@
     ],
     "total": 30
   },
-  "total": 150
+  "total": 151
 }

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -27,7 +27,7 @@ Every API endpoint grouped by its **typical caller**, then by surface, annotated
 
 > The grouping and the _Typical caller_ column are an **advisory hint** at who usually calls a route, inferred from the scope family. They are **not** an enforced restriction: access is gated by the **scope**, not the actor kind, so any actor holding the required scope can call the endpoint.
 
-_Total endpoints: **150**._
+_Total endpoints: **151**._
 
 
 ## Agent-facing (typically agent / service-account / toolkit) (31)
@@ -200,7 +200,7 @@ _Total endpoints: **150**._
 | POST | `/users/{user_id}:enable` | `users:write` | operator | Enable User |
 | POST | `/users/{user_id}:reissue-invite` | `users:write` | operator | Reissue Invite |
 
-## Any authenticated actor (59)
+## Any authenticated actor (60)
 
 
 ### `access-requests`
@@ -320,6 +320,7 @@ _Total endpoints: **150**._
 | GET | `/toolkits/{toolkit_id}/credentials/{credential_id}/permissions` | `toolkits:read`, `owner:toolkits:read` | any | List binding permission rules |
 | PATCH | `/toolkits/{toolkit_id}/credentials/{credential_id}/permissions` | `toolkits:write` | any | Patch binding permission rules |
 | PUT | `/toolkits/{toolkit_id}/credentials/{credential_id}/permissions` | `toolkits:write` | any | Replace binding permission rules |
+| POST | `/toolkits/{toolkit_id}/credentials/{credential_id}/permissions:test` | `toolkits:read`, `owner:toolkits:read` | any | Dry-run permission evaluation |
 | GET | `/toolkits/{toolkit_id}/keys` | `toolkits:read`, `owner:toolkits:read` | any | List toolkit keys |
 | POST | `/toolkits/{toolkit_id}/keys` | `toolkits:write` | any | Issue toolkit key |
 | DELETE | `/toolkits/{toolkit_id}/keys/{key_id}` | `toolkits:write` | any | Revoke toolkit key |

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -1339,6 +1339,28 @@ components:
       - type
       title: BearerTokenUpdateRequest
       type: object
+    BindingWarningSchema:
+      description: A non-fatal signal about a bind (or create-time inline bind).
+      properties:
+        code:
+          description: Stable machine-readable warning code.
+          title: Code
+          type: string
+        credential_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Credential the warning applies to; null when the whole binding is meant.
+          title: Credential Id
+        message:
+          description: Human-readable explanation with a recovery pointer.
+          title: Message
+          type: string
+      required:
+      - code
+      - message
+      title: BindingWarningSchema
+      type: object
     CatalogEntryLinksResponse:
       description: Hypermedia links for a catalog entry.
       examples:
@@ -3173,6 +3195,14 @@ components:
           - deny
           title: Effect
           type: string
+        match_mode:
+          default: regex
+          enum:
+          - regex
+          - prefix
+          - exact
+          title: Match Mode
+          type: string
         methods:
           anyOf:
           - items:
@@ -3195,6 +3225,69 @@ components:
       required:
       - effect
       title: PermissionRuleReadSchema
+      type: object
+    PermissionTestRequest:
+      additionalProperties: false
+      description: Request body for :test — dry-run a request shape against pooled rules.
+      properties:
+        method:
+          description: HTTP method of the hypothetical request (case-insensitive).
+          title: Method
+          type: string
+        operation_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Optional OpenAPI operation id resolved from the request URL.
+          title: Operation Id
+        path:
+          description: Path of the hypothetical request as the broker would see it.
+          title: Path
+          type: string
+      required:
+      - method
+      - path
+      title: PermissionTestRequest
+      type: object
+    PermissionTestResponse:
+      description: Dry-run result matching :class:`PermissionTestResult`.
+      properties:
+        allowed:
+          description: Whether the broker would allow this request under the pooled rules.
+          title: Allowed
+          type: boolean
+        credential_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Which binding contributed the matching rule — vendor pooling means this may not equal the credential in the request URL.
+          title: Credential Id
+        effect:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Effect of the matching rule (`allow`/`deny`); null when no match.
+          title: Effect
+        is_system:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: True when the matching rule was written by the system; null when no match.
+          title: Is System
+        matched:
+          description: Whether any rule matched; when false, the outcome is default-deny.
+          title: Matched
+          type: boolean
+        rule_index:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          description: Zero-based index in the vendor-pooled rule list; null when no match.
+          title: Rule Index
+      required:
+      - allowed
+      - matched
+      title: PermissionTestResponse
       type: object
     Permissions:
       description: 'Structured permissions view: assigned + effective.'
@@ -4259,13 +4352,6 @@ components:
           maxLength: 255
           title: Name
           type: string
-        permissions:
-          anyOf:
-          - items:
-              $ref: '#/components/schemas/jentic_one__control__web__schemas__toolkits__PermissionRuleSchema'
-            type: array
-          - type: 'null'
-          title: Permissions
       required:
       - name
       title: ToolkitCreateRequest
@@ -4278,14 +4364,26 @@ components:
           type: string
         toolkit:
           $ref: '#/components/schemas/ToolkitResponse'
+        warnings:
+          description: Non-fatal signals about the create — e.g. inline-bound credentials that landed with zero permission rules (broker denies by default).
+          items:
+            $ref: '#/components/schemas/BindingWarningSchema'
+          title: Warnings
+          type: array
       required:
       - toolkit
       - api_key
       title: ToolkitCreateResponse
       type: object
     ToolkitCredentialBindRequest:
+      additionalProperties: false
       description: Bind a credential to a toolkit.
       properties:
+        allow_all:
+          default: false
+          description: 'Convenience flag: bind with a single `allow` rule that matches every request for this binding''s vendor. Mutually exclusive with `permissions`.'
+          title: Allow All
+          type: boolean
         credential_id:
           title: Credential Id
           type: string
@@ -4338,6 +4436,12 @@ components:
         toolkit_id:
           title: Toolkit Id
           type: string
+        warnings:
+          description: Non-fatal bind-time signals — e.g. a binding that landed with zero permission rules (broker denies by default until rules are added).
+          items:
+            $ref: '#/components/schemas/BindingWarningSchema'
+          title: Warnings
+          type: array
       required:
       - toolkit_id
       - credential_id
@@ -4533,12 +4637,6 @@ components:
         name:
           title: Name
           type: string
-        permissions:
-          items:
-            additionalProperties: true
-            type: object
-          title: Permissions
-          type: array
         toolkit_id:
           title: Toolkit Id
           type: string
@@ -4552,7 +4650,6 @@ components:
       - toolkit_id
       - name
       - active
-      - permissions
       - key_count
       - credential_count
       - created_at
@@ -4937,44 +5034,14 @@ components:
           - require-approval
           title: Effect
           type: string
-        methods:
-          anyOf:
-          - items:
-              type: string
-            type: array
-          - type: 'null'
-          title: Methods
-        operations:
-          anyOf:
-          - items:
-              type: string
-            type: array
-          - type: 'null'
-          title: Operations
-        path:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Path
-      required:
-      - effect
-      title: PermissionRuleSchema
-      type: object
-    jentic_one__control__web__schemas__toolkits__PermissionRuleSchema:
-      additionalProperties: false
-      description: |-
-        Permission rule for a toolkit-credential binding.
-
-        Rules are evaluated first-match-wins. If no rule matches, the request is
-        denied (default-deny). A binding with zero rules therefore blocks all
-        operations — users must explicitly add at least one allow rule.
-      properties:
-        effect:
-          description: Whether this rule allows or denies the matched request.
+        match_mode:
+          default: regex
+          description: 'How `path` is interpreted: `regex` (full-match), `prefix` (string prefix), or `exact` (equality). Defaults to `regex` for backwards compatibility.'
           enum:
-          - allow
-          - deny
-          title: Effect
+          - regex
+          - prefix
+          - exact
+          title: Match Mode
           type: string
         methods:
           anyOf:
@@ -4996,7 +5063,58 @@ components:
           anyOf:
           - type: string
           - type: 'null'
-          description: Regex pattern for the request path. None matches all paths.
+          description: 'Path pattern to match. Interpreted per `match_mode`: `regex` uses full-match semantics (the pattern must describe the whole path); `prefix` and `exact` are literal. None matches all paths.'
+          title: Path
+      required:
+      - effect
+      title: PermissionRuleSchema
+      type: object
+    jentic_one__control__web__schemas__toolkits__PermissionRuleSchema:
+      additionalProperties: false
+      description: |-
+        Permission rule for a toolkit-credential binding.
+
+        Rules are evaluated first-match-wins. If no rule matches, the request is
+        denied (default-deny). A binding with zero rules therefore blocks all
+        operations — users must explicitly add at least one allow rule.
+      properties:
+        effect:
+          description: Whether this rule allows or denies the matched request.
+          enum:
+          - allow
+          - deny
+          title: Effect
+          type: string
+        match_mode:
+          default: regex
+          description: 'How `path` is interpreted: `regex` (full-match), `prefix` (string prefix), or `exact` (equality). Defaults to `regex` for backwards compatibility.'
+          enum:
+          - regex
+          - prefix
+          - exact
+          title: Match Mode
+          type: string
+        methods:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          description: HTTP methods to match (case-insensitive). None matches all.
+          title: Methods
+        operations:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          description: OpenAPI operation IDs to match. None matches all operations.
+          title: Operations
+        path:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: 'Path pattern to match. Interpreted per `match_mode`: `regex` uses full-match semantics (the pattern must describe the whole path); `prefix` and `exact` are literal. None matches all paths.'
           title: Path
       required:
       - effect
@@ -13795,7 +13913,8 @@ paths:
 
         The plaintext key (`jntc_live_…`) is returned **once** in `api_key` and is
         never retrievable again. Optional `credential_ids` bind existing credentials
-        at creation time.
+        at creation time; each inline bind emits a ``no_permission_rules`` warning
+        because the broker denies by default until rules are added.
       operationId: createToolkit
       requestBody:
         content:
@@ -14655,6 +14774,96 @@ paths:
       security:
       - BearerAuth: []
       summary: Replace binding permission rules
+      tags:
+      - Toolkit Permissions
+  /toolkits/{toolkit_id}/credentials/{credential_id}/permissions:test:
+    post:
+      description: |-
+        Answer "what would the broker do for this request?" without calling upstream.
+
+        Evaluates the same **vendor-pooled** rule set the broker sees at request
+        time — rules from all same-vendor bindings on this toolkit compete in one
+        ordered list. The response names which binding contributed the matching
+        rule, which is not obvious from the toolkit id alone under pooling.
+      operationId: testToolkitPermissions
+      parameters:
+      - in: path
+        name: toolkit_id
+        required: true
+        schema:
+          title: Toolkit Id
+          type: string
+      - in: path
+        name: credential_id
+        required: true
+        schema:
+          title: Credential Id
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PermissionTestRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PermissionTestResponse'
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '401':
+          content:
+            application/problem+json:
+              example: *id005
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unauthorized
+        '403':
+          content:
+            application/problem+json:
+              example: *id006
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Forbidden
+        '404':
+          content:
+            application/problem+json:
+              example: *id007
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Not Found
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security:
+      - BearerAuth: []
+      summary: Dry-run permission evaluation
       tags:
       - Toolkit Permissions
   /toolkits/{toolkit_id}/keys:
@@ -15852,7 +16061,7 @@ tags:
 - description: |-
     Sub-resource of **Toolkits** (Core / Access bounded context). The fine-grained PBAC tier — per-`(toolkit, credential)` allow / deny / require-approval rules evaluated server-side. Rules use a priority model: `deny` > `require-approval` > `allow` — the strictest matching rule wins. Absence of a matching rule is an implicit deny. System rules (`_system: true`) participate in the same priority pool as user rules.
 
-    The coarse JWT-embedded scope tier on `Toolkit.permissions` (`capabilities:execute`, `apis:read`) is checked separately and composes with these rules — both must allow.
+    Toolkits have no separate scope tier of their own: a toolkit API key is minted with the fixed broker-execute scope (`capabilities:execute`), and every gated operation is decided by these per-binding rules.
   name: Toolkit Permissions
 - description: |-
     Actor-agnostic, multi-item access-request surface (Core / Access bounded context). When an agent's brokered call is rejected by a permission rule — or the agent needs access it doesn't yet have — the agent files an `AccessRequest` containing one or more line items (`AccessRequestItem`). The request enters `pending` state and surfaces an `approve_url` that the agent presents to a human reviewer.
@@ -15947,7 +16156,7 @@ tags:
 
     One reserved superpower short-circuits individual checks in code: `org:admin` (full deployment-wide access, granted via direct DB action). It is not enumerated to non-holders by `GET /permissions`, and is rejected by `PUT /users/{user_id}/permissions` from any caller who doesn't already hold it.
 
-    The same vocabulary is used for `User.permissions` and for `Toolkit.permissions` — coarse JWT-embedded scopes — so the one catalogue covers both. Per-binding fine-grained `PermissionRule[]` (the inner PBAC tier) lives separately under the `Toolkit Permissions` tag.
+    The same vocabulary is used for `User.permissions` — coarse JWT-embedded scopes — so the catalogue below covers user assignment. Toolkits have no separate scope tier of their own: a toolkit API key is minted with the fixed broker-execute scope, and the per-binding fine-grained `PermissionRule[]` (the inner PBAC tier) lives separately under the `Toolkit Permissions` tag.
   name: Permissions
 - description: Operational endpoints for service health and platform tooling. Not part of any bounded context — surfaced here so orchestrators and load balancers have a stable probe target.
   name: System

--- a/src/jentic_one/broker/repos/rule_evaluator.py
+++ b/src/jentic_one/broker/repos/rule_evaluator.py
@@ -5,6 +5,11 @@ cannot import control ORM) and evaluates the ordered rule list against the
 inbound request. A first-match-wins policy terminates on the first matching
 rule's effect; an exhausted rule list defaults to DENY (secure-by-default).
 
+Path matching (``regex``/``prefix``/``exact``) is delegated to the shared
+``shared.permissions.matching`` seam so authoring surfaces and this enforcer
+cannot disagree; a stored pattern that fails to compile at load time is
+fail-closed (never matches) rather than the pre-#751 silent-wildcard.
+
 Performance: the rule list per (toolkit, credential) pair is short-TTL cached
 (LRU + single-flight) so the hot-path DB hit is amortised across requests.
 """
@@ -12,7 +17,6 @@ Performance: the rule list per (toolkit, credential) pair is short-TTL cached
 from __future__ import annotations
 
 import json
-import re
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -21,14 +25,14 @@ import structlog
 from sqlalchemy import text
 
 from jentic_one.broker.core.singleflight import SingleFlight
+from jentic_one.shared.broker.protocols import RuleEvaluation
 from jentic_one.shared.db import DatabaseSession
+from jentic_one.shared.permissions.matching import PathMatcher, compile_matcher
 
 _logger = structlog.get_logger(__name__)
 
-_MAX_PATTERN_LENGTH = 1000
-
 _RULES_QUERY = text(
-    "SELECT tpr.effect, tpr.methods, tpr.path, tpr.operations "
+    "SELECT tpr.effect, tpr.methods, tpr.path, tpr.operations, tpr.match_mode "
     "FROM toolkit_permission_rules tpr "
     "JOIN toolkit_credential_bindings tcb "
     "  ON tcb.toolkit_id = tpr.toolkit_id AND tcb.credential_id = tpr.credential_id "
@@ -48,20 +52,29 @@ class PermissionRule:
 
     effect: str
     methods: frozenset[str] | None
-    path: re.Pattern[str] | None
+    path: PathMatcher | None
     operations: tuple[str, ...] | None
 
 
-def _compile_path(raw: str | None) -> re.Pattern[str] | None:
-    """Pre-compile a path pattern, returning None for invalid/oversized patterns."""
-    if raw is None:
-        return None
-    if len(raw) > _MAX_PATTERN_LENGTH:
-        return None
-    try:
-        return re.compile(raw)
-    except re.error:
-        return None
+def _compile_path_for_rule(raw: str | None, mode: str, *, toolkit_id: str) -> PathMatcher | None:
+    """Compile a stored path pattern; log-once on a fail-closed row.
+
+    Delegates to the shared seam and warns when a stored pattern was
+    unparseable (a legacy row that predates save-time validation). The
+    resulting matcher never matches — the opposite of the pre-#751 silent
+    wildcard — and the warning identifies the misconfigured toolkit so an
+    operator can fix the offending row.
+    """
+    matcher = compile_matcher(raw, mode)
+    if matcher is not None and matcher.never:
+        _logger.warning(
+            "Ignoring toolkit permission rule with an invalid stored path pattern "
+            "(fail-closed — the rule never matches); fix the pattern to restore intent",
+            toolkit_id=toolkit_id,
+            path=raw,
+            match_mode=mode,
+        )
+    return matcher
 
 
 def _coerce_json_list(value: object) -> list[str] | None:
@@ -105,7 +118,7 @@ def _rule_matches(
     """Return True if ALL defined criteria in the rule match the request."""
     if rule.methods is not None and method.upper() not in rule.methods:
         return False
-    if rule.path is not None and not rule.path.match(path):
+    if rule.path is not None and not rule.path.matches(path):
         return False
     if rule.operations is not None:
         return operation_id is not None and operation_id in rule.operations
@@ -182,18 +195,25 @@ class RuleEvaluator:
         path: str,
         operation_id: str | None,
         api_vendor: str = "",
-    ) -> bool:
-        """Evaluate permission rules for the toolkit. Returns True if allowed."""
+    ) -> RuleEvaluation:
+        """Evaluate permission rules for the toolkit.
+
+        Returns a :class:`RuleEvaluation` — ``allowed`` plus the vendor-pooled
+        rule count so the router can distinguish "no rules loaded for this
+        vendor" (rules_loaded == 0) from "loaded but nothing matched" in the
+        deny problem detail (#578).
+        """
         rules = await self._get_rules(toolkit_id, api_vendor)
         if not rules:
-            return False
-        return evaluate_rules(
+            return RuleEvaluation(allowed=False, rules_loaded=0)
+        allowed = evaluate_rules(
             rules,
             method=method,
             path=path,
             operation_id=operation_id,
             toolkit_id=toolkit_id,
         )
+        return RuleEvaluation(allowed=allowed, rules_loaded=len(rules))
 
     async def _get_rules(self, toolkit_id: str, api_vendor: str) -> list[PermissionRule]:
         """Fetch rules from cache or DB (single-flighted)."""
@@ -223,7 +243,7 @@ class RuleEvaluator:
             PermissionRule(
                 effect=row[0],
                 methods=_normalize_methods(_coerce_json_list(row[1])),
-                path=_compile_path(row[2]),
+                path=_compile_path_for_rule(row[2], str(row[4] or "regex"), toolkit_id=toolkit_id),
                 operations=(tuple(ops) if (ops := _coerce_json_list(row[3])) is not None else None),
             )
             for row in rows

--- a/src/jentic_one/broker/web/routers/execute.py
+++ b/src/jentic_one/broker/web/routers/execute.py
@@ -542,23 +542,42 @@ async def _handle(
     )
 
     # Evaluate toolkit permission rules — default-deny when no rule matches.
-    # Unconditional: even if toolkit_id were empty the evaluator returns False
-    # (no rules → deny), preserving the secure-by-default posture.
-    allowed = await rule_evaluator.evaluate(
+    # Unconditional: even if toolkit_id were empty the evaluator returns a
+    # zero-rules-loaded denial, preserving the secure-by-default posture.
+    evaluation = await rule_evaluator.evaluate(
         toolkit_id=ctx_req.toolkit_id,
         method=method,
         path=urlparse(upstream_url).path,
         operation_id=resolved.operation_id,
         api_vendor=resolved.api.vendor,
     )
-    if not allowed:
+    if not evaluation.allowed:
+        # #578: distinguish the two deny paths in the caller-visible detail.
+        # ``rules_loaded == 0`` means the vendor-pooled rule set is empty —
+        # nothing to match (wrong vendor, empty binding, misconfigured store);
+        # otherwise we loaded rules but none matched the request shape. Both
+        # branches emit ``PBAC_DENIED`` telemetry with the corresponding
+        # summary so operators can grep for the branch.
+        no_rules = evaluation.rules_loaded == 0
+        summary = (
+            "Operation denied by toolkit permission rule (no rules loaded for this vendor)"
+            if no_rules
+            else "Operation denied by toolkit permission rule (no rule matched)"
+        )
+        detail = (
+            "The requested operation is denied — this toolkit has no permission rules "
+            "loaded for the target API's vendor. Attach rules to the vendor's binding "
+            "under PUT /toolkits/{toolkit_id}/credentials/{credential_id}/permissions."
+            if no_rules
+            else "The requested operation is denied by a toolkit permission rule."
+        )
         try:
             async with ctx.admin_db.transaction() as session:
                 await emit_event_best_effort(
                     session,
                     type=EventType.PBAC_DENIED,
                     severity=EventSeverity.WARNING,
-                    summary="Operation denied by toolkit permission rule",
+                    summary=summary,
                     created_by=identity.sub,
                     actor_id=identity.sub,
                     actor_type=identity.actor_type.value,
@@ -566,7 +585,7 @@ async def _handle(
         except Exception:
             logger.warning("telemetry_emit_failed", event_type=EventType.PBAC_DENIED, exc_info=True)
         raise ActionDeniedError(
-            detail="The requested operation is denied by a toolkit permission rule.",
+            detail=detail,
             type="action_denied",
             instance=request.url.path,
             directive=action_denied_directive(),

--- a/src/jentic_one/control/core/schema/toolkit_permission_rules.py
+++ b/src/jentic_one/control/core/schema/toolkit_permission_rules.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlalchemy import Boolean, ForeignKey, Index, Integer, String
+from sqlalchemy import Boolean, ForeignKey, Index, Integer, String, text
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
@@ -39,6 +39,11 @@ class ToolkitPermissionRule(AuditableMixin, ControlBase):
     effect: Mapped[str] = mapped_column(String(10), nullable=False)
     methods: Mapped[list[str] | None] = mapped_column(json_variant(), nullable=True)
     path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    # ``MATCH`` is a reserved word in SQLite and a Python soft keyword; use
+    # ``match_mode`` throughout (schema field, column, and dict key).
+    match_mode: Mapped[str] = mapped_column(
+        String(10), nullable=False, default="regex", server_default=text("'regex'")
+    )
     operations: Mapped[list[str] | None] = mapped_column(json_variant(), nullable=True)
     is_system: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     comment: Mapped[str | None] = mapped_column(String(500), nullable=True)

--- a/src/jentic_one/control/core/schema/toolkits.py
+++ b/src/jentic_one/control/core/schema/toolkits.py
@@ -10,7 +10,6 @@ from sqlalchemy.sql import func
 
 from jentic_one.shared.db.base import AuditableMixin, ControlBase
 from jentic_one.shared.db.ids import generate_ksuid
-from jentic_one.shared.db.types import json_variant
 
 if TYPE_CHECKING:
     from jentic_one.control.core.schema.toolkit_credential_bindings import (
@@ -34,9 +33,6 @@ class Toolkit(AuditableMixin, ControlBase):
     description: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     active: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=True, server_default=text("true")
-    )
-    permissions: Mapped[list[dict[str, object]]] = mapped_column(
-        json_variant(), nullable=False, default=list, server_default=text("'[]'")
     )
 
     keys: Mapped[list[ToolkitKey]] = relationship(

--- a/src/jentic_one/control/repos/toolkit_permission_repo.py
+++ b/src/jentic_one/control/repos/toolkit_permission_repo.py
@@ -8,6 +8,8 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
+from jentic_one.control.core.schema.credentials import Credential
+from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
 from jentic_one.control.core.schema.toolkit_permission_rules import ToolkitPermissionRule
 
 
@@ -41,6 +43,39 @@ class ToolkitPermissionRepository:
         return list(result.scalars().all())
 
     @staticmethod
+    async def list_rules_for_vendor(
+        session: AsyncSession,
+        toolkit_id: str,
+        api_vendor: str,
+    ) -> list[ToolkitPermissionRule]:
+        """List rules for the ``(toolkit, api_vendor)`` pool the broker evaluates.
+
+        The broker's ``_RULES_QUERY`` joins ``toolkit_permission_rules``
+        through ``toolkit_credential_bindings`` and ``credentials`` and
+        filters by ``toolkit_id`` + ``api_vendor``, so rules attached to
+        *any* binding of a same-vendor credential are pooled into one
+        ordered list. A dry-run must evaluate this same pooled set — a
+        naive per-binding read would misrepresent what the broker actually
+        does (issue #751 review, dry-run parity).
+        """
+        stmt = (
+            select(ToolkitPermissionRule)
+            .join(
+                ToolkitCredentialBinding,
+                (ToolkitCredentialBinding.toolkit_id == ToolkitPermissionRule.toolkit_id)
+                & (ToolkitCredentialBinding.credential_id == ToolkitPermissionRule.credential_id),
+            )
+            .join(Credential, Credential.id == ToolkitCredentialBinding.credential_id)
+            .where(
+                ToolkitPermissionRule.toolkit_id == toolkit_id,
+                Credential.api_vendor == api_vendor,
+            )
+            .order_by(ToolkitPermissionRule.sequence.asc())
+        )
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
     async def replace_user_rules(
         session: AsyncSession,
         toolkit_id: str,
@@ -65,6 +100,7 @@ class ToolkitPermissionRepository:
                 effect=str(rule_data.get("effect", "allow")),
                 methods=rule_data.get("methods"),
                 path=rule_data.get("path"),
+                match_mode=str(rule_data.get("match_mode", "regex")),
                 operations=rule_data.get("operations"),
                 is_system=False,
                 comment=rule_data.get("comment"),
@@ -106,6 +142,7 @@ class ToolkitPermissionRepository:
                     effect=str(rule_data.get("effect", "allow")),
                     methods=rule_data.get("methods"),
                     path=rule_data.get("path"),
+                    match_mode=str(rule_data.get("match_mode", "regex")),
                     operations=rule_data.get("operations"),
                     is_system=False,
                     comment=rule_data.get("comment"),

--- a/src/jentic_one/control/repos/toolkit_repo.py
+++ b/src/jentic_one/control/repos/toolkit_repo.py
@@ -23,14 +23,12 @@ class ToolkitRepository:
         name: str,
         description: str | None = None,
         active: bool = True,
-        permissions: list[dict[str, object]] | None = None,
         created_by: str,
     ) -> Toolkit:
         toolkit = Toolkit(
             name=name,
             description=description,
             active=active,
-            permissions=permissions if permissions is not None else [],
             created_by=created_by,
         )
         session.add(toolkit)

--- a/src/jentic_one/control/services/toolkits/errors.py
+++ b/src/jentic_one/control/services/toolkits/errors.py
@@ -99,3 +99,24 @@ class KeyAlreadyRevokedError(ToolkitServiceError):
     def __init__(self, key_id: str) -> None:
         super().__init__(f"Key '{key_id}' is already revoked")
         self.key_id = key_id
+
+
+class ToolkitLevelPermissionsUnsupportedError(ToolkitServiceError):
+    """Raised when ``POST /toolkits`` carries a ``permissions`` array.
+
+    The old ``Toolkit.permissions`` JSON column was written on create but
+    never read by the broker's rule evaluator (which enforces the
+    per-binding ``toolkit_permission_rules`` table). Silently accepting
+    the field misled operators into thinking they had gated a toolkit
+    when they hadn't (issue #655). Reject with a ``422`` that names the
+    supported surface — the same "reject where not enforced" remedy as
+    #656/#680.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Toolkit-level permissions are not enforced; attach rules to a "
+            "credential binding via "
+            "PUT /toolkits/{toolkit_id}/credentials/{credential_id}/permissions "
+            "or inline on the bind request"
+        )

--- a/src/jentic_one/control/services/toolkits/schemas/__init__.py
+++ b/src/jentic_one/control/services/toolkits/schemas/__init__.py
@@ -1,11 +1,23 @@
 """Toolkit service result schemas."""
 
+from jentic_one.control.services.toolkits.schemas.bind_result import (
+    BINDING_WARNING_NO_RULES,
+    BindingWarning,
+    BindResult,
+    ToolkitCreateResult,
+)
 from jentic_one.control.services.toolkits.schemas.bindings import (
     BindingPage,
     BindingWithPermissions,
 )
+from jentic_one.control.services.toolkits.schemas.permission_test import PermissionTestResult
 
 __all__ = [
+    "BINDING_WARNING_NO_RULES",
+    "BindResult",
     "BindingPage",
+    "BindingWarning",
     "BindingWithPermissions",
+    "PermissionTestResult",
+    "ToolkitCreateResult",
 ]

--- a/src/jentic_one/control/services/toolkits/schemas/bind_result.py
+++ b/src/jentic_one/control/services/toolkits/schemas/bind_result.py
@@ -1,0 +1,58 @@
+"""Bind-time signals: BindingWarning + BindResult for the ``bind_credential`` service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
+from jentic_one.control.core.schema.toolkit_permission_rules import ToolkitPermissionRule
+
+if TYPE_CHECKING:
+    from jentic_one.control.core.schema.toolkits import Toolkit
+
+BINDING_WARNING_NO_RULES = "no_permission_rules"
+
+
+@dataclass(frozen=True, slots=True)
+class BindingWarning:
+    """A non-fatal signal about a bind (or create-time inline bind).
+
+    The broker defaults to deny when a binding has zero permission rules,
+    so a bind that produces a zero-rule binding is a "you probably meant
+    something else" moment. Surface it structurally in the same response,
+    so a caller cannot ship a broken toolkit without seeing it.
+    """
+
+    code: str
+    message: str
+    credential_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BindResult:
+    """Return value of ``ToolkitService.bind_credential``.
+
+    Carries the binding, the permission rules effective on it (so the
+    router does not need a second read), and any bind-time warnings
+    (issue #750).
+    """
+
+    binding: ToolkitCredentialBinding
+    rules: list[ToolkitPermissionRule]
+    warnings: tuple[BindingWarning, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True, slots=True)
+class ToolkitCreateResult:
+    """Return value of ``ToolkitService.create``.
+
+    Carries the toolkit + issued plaintext key, and any bind-time
+    warnings emitted for inline-bound ``credential_ids`` (issue #750
+    review — the same discoverability gap applies when a bind happens
+    during create).
+    """
+
+    toolkit: Toolkit
+    plaintext_key: str
+    warnings: tuple[BindingWarning, ...] = field(default_factory=tuple)

--- a/src/jentic_one/control/services/toolkits/schemas/permission_test.py
+++ b/src/jentic_one/control/services/toolkits/schemas/permission_test.py
@@ -1,0 +1,32 @@
+"""Permission-rule dry-run result — control-side parity with the broker.
+
+Used by ``ToolkitService.test_permissions`` to answer "what would the
+broker do for this ``(method, path, operation_id)``?" without issuing a
+real upstream call. The service pools rules with the same query shape as
+the broker's ``_RULES_QUERY`` (see ``ToolkitPermissionRepository.
+list_rules_for_vendor``), so a dry-run cannot lie about which rule wins.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class PermissionTestResult:
+    """The outcome of a permission-rule dry-run for a single request shape.
+
+    ``matched`` is True iff a rule in the pooled set matched the request;
+    when no rule matched, ``allowed`` is False (default-deny) and the
+    remaining fields are ``None``. When a rule did match, ``allowed``
+    reflects its effect, and ``credential_id`` names *which* binding
+    contributed the matching rule — with vendor pooling that is not
+    obvious from the toolkit id alone.
+    """
+
+    allowed: bool
+    matched: bool
+    effect: str | None
+    rule_index: int | None
+    credential_id: str | None
+    is_system: bool | None

--- a/src/jentic_one/control/services/toolkits/service.py
+++ b/src/jentic_one/control/services/toolkits/service.py
@@ -6,7 +6,6 @@ from typing import NoReturn
 
 import structlog
 
-from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
 from jentic_one.control.core.schema.toolkit_keys import ToolkitKey
 from jentic_one.control.core.schema.toolkit_permission_rules import ToolkitPermissionRule
 from jentic_one.control.core.schema.toolkits import Toolkit
@@ -28,13 +27,22 @@ from jentic_one.control.services.toolkits.errors import (
     ToolkitNotFoundError,
 )
 from jentic_one.control.services.toolkits.key_gen import generate_toolkit_key
-from jentic_one.control.services.toolkits.schemas import BindingPage, BindingWithPermissions
+from jentic_one.control.services.toolkits.schemas import (
+    BINDING_WARNING_NO_RULES,
+    BindingPage,
+    BindingWarning,
+    BindingWithPermissions,
+    BindResult,
+    PermissionTestResult,
+    ToolkitCreateResult,
+)
 from jentic_one.shared.audit import AuditAction, AuditTargetType, record_audit_best_effort
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.context import Context
 from jentic_one.shared.events import emit_event_best_effort
 from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.pagination import decode_cursor_str, encode_cursor
+from jentic_one.shared.permissions.matching import compile_matcher
 from jentic_one.shared.scopes import ORG_ADMIN
 
 logger = structlog.get_logger()
@@ -105,12 +113,13 @@ class ToolkitService:
         identity: Identity,
         description: str | None = None,
         active: bool = True,
-        permissions: list[dict[str, object]] | None = None,
         credential_ids: list[str] | None = None,
-    ) -> tuple[Toolkit, str]:
+    ) -> ToolkitCreateResult:
         """Create a toolkit with an initial API key.
 
-        Returns (toolkit, plaintext_key).
+        Returns a :class:`ToolkitCreateResult` with the toolkit, its
+        plaintext key (shown once), and any bind-time warnings for
+        inline-bound credentials.
         """
         plaintext, hashed, preview, lookup = generate_toolkit_key()
 
@@ -120,7 +129,6 @@ class ToolkitService:
                 name=name,
                 description=description,
                 active=active,
-                permissions=permissions,
                 created_by=identity.sub,
             )
             await ToolkitKeyRepository.create(
@@ -143,6 +151,23 @@ class ToolkitService:
             assert loaded is not None
             toolkit = loaded
 
+        # ``POST /toolkits`` with ``credential_ids`` inline-binds each
+        # credential with zero rules — the broker denies by default until
+        # rules are added. Warn per bind so the caller notices before
+        # shipping a "created but permanently denied" toolkit (#750).
+        warnings = tuple(
+            BindingWarning(
+                code=BINDING_WARNING_NO_RULES,
+                message=(
+                    "This binding has no permission rules; the broker denies all calls "
+                    "until rules are added via "
+                    f"PUT /toolkits/{toolkit.id}/credentials/{cred_id}/permissions"
+                ),
+                credential_id=cred_id,
+            )
+            for cred_id in (credential_ids or [])
+        )
+
         await record_audit_best_effort(
             self._ctx,
             action=AuditAction.CREATE,
@@ -158,7 +183,7 @@ class ToolkitService:
             summary=f"Toolkit {toolkit.id} created",
             identity=identity,
         )
-        return toolkit, plaintext
+        return ToolkitCreateResult(toolkit=toolkit, plaintext_key=plaintext, warnings=warnings)
 
     async def get(self, toolkit_id: str, *, identity: Identity) -> Toolkit:
         bound_ids = await self._bound_toolkit_ids(identity)
@@ -458,7 +483,31 @@ class ToolkitService:
         *,
         identity: Identity,
         permissions: list[dict[str, object]] | None = None,
-    ) -> ToolkitCredentialBinding:
+        allow_all: bool = False,
+    ) -> BindResult:
+        """Bind a credential and return the binding + effective rules + warnings.
+
+        Returns a :class:`BindResult` — the ORM binding, the rule rows
+        effective on it (avoiding a second read in the router), and any
+        bind-time warnings. When ``allow_all`` is set, writes a single
+        wildcard ``allow`` rule so the binding grants everything for its
+        vendor; this is mutually exclusive with ``permissions`` (checked
+        on the request schema).
+        """
+        if allow_all and permissions:
+            # Belt-and-braces: the schema-level check already rejects this,
+            # but a direct caller (tests, effect applicator later) benefits
+            # from a service-side guardrail too.
+            msg = "allow_all and permissions are mutually exclusive"
+            raise ValueError(msg)
+        effective_permissions = permissions
+        if allow_all:
+            # A specific catch-all rule (not condition-less) — satisfies
+            # #659's condition-less-``allow`` guard and states the intent
+            # visibly in the rule list. ``regex`` full-match on ``.*``
+            # matches every path.
+            effective_permissions = [{"effect": "allow", "path": ".*", "match_mode": "regex"}]
+
         access_filters = build_access_filters(
             identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
         )
@@ -491,10 +540,32 @@ class ToolkitService:
             binding = await ToolkitBindingRepository.bind(
                 session, toolkit_id=toolkit_id, credential_id=credential_id, created_by=identity.sub
             )
-            if permissions:
+            if effective_permissions:
                 await ToolkitPermissionRepository.replace_user_rules(
-                    session, toolkit_id, credential_id, permissions, created_by=identity.sub
+                    session,
+                    toolkit_id,
+                    credential_id,
+                    effective_permissions,
+                    created_by=identity.sub,
                 )
+            # Read the effective rules once inside the same transaction —
+            # the router previously did this in a follow-up call.
+            rules = await ToolkitPermissionRepository.list_rules(session, toolkit_id, credential_id)
+
+        warnings: tuple[BindingWarning, ...] = ()
+        if not rules:
+            warnings = (
+                BindingWarning(
+                    code=BINDING_WARNING_NO_RULES,
+                    message=(
+                        "This binding has no permission rules; the broker denies all calls "
+                        "until rules are added via "
+                        f"PUT /toolkits/{toolkit_id}/credentials/{credential_id}/permissions"
+                    ),
+                    credential_id=credential_id,
+                ),
+            )
+
         await record_audit_best_effort(
             self._ctx,
             action=AuditAction.GRANT,
@@ -511,7 +582,7 @@ class ToolkitService:
             summary=f"Credential {credential_id} bound to toolkit {toolkit_id}",
             identity=identity,
         )
-        return binding
+        return BindResult(binding=binding, rules=rules, warnings=warnings)
 
     async def list_bindings(
         self, toolkit_id: str, *, cursor: str | None = None, limit: int = 50, identity: Identity
@@ -683,3 +754,82 @@ class ToolkitService:
             identity=identity,
         )
         return result
+
+    async def test_permissions(
+        self,
+        toolkit_id: str,
+        credential_id: str,
+        *,
+        method: str,
+        path: str,
+        operation_id: str | None,
+        identity: Identity,
+    ) -> PermissionTestResult:
+        """Dry-run permission evaluation for a `(method, path, operation_id)` triple.
+
+        Evaluates the same **vendor-pooled** rule set the broker sees at
+        request time — for a given `(toolkit_id, api_vendor)` all rules
+        attached to any same-vendor binding are pooled and ordered by
+        sequence. A per-binding read would misrepresent what the broker
+        actually enforces (see issue #751 review). The named
+        ``credential_id`` locates the pool via its ``api_vendor``, and
+        surfaces which binding contributed the matching rule when there is
+        one.
+
+        The broker's condition-less-``allow`` skip is honoured here too so
+        legacy misconfigured rules don't lie in dry-run.
+        """
+        access_filters = build_access_filters(
+            identity, Toolkit, bound_toolkit_ids=await self._bound_toolkit_ids(identity)
+        )
+        async with self._ctx.control_db.session() as session:
+            toolkit = await ToolkitRepository.get_by_id(session, toolkit_id, filters=access_filters)
+            if toolkit is None:
+                await self._raise_toolkit_unavailable(toolkit_id)
+            binding = await ToolkitBindingRepository.get(session, toolkit_id, credential_id)
+            if binding is None:
+                raise BindingNotFoundError(toolkit_id, credential_id)
+            credential = await CredentialRepository.get_by_id(session, credential_id)
+            api_vendor = credential.api_vendor if credential is not None else ""
+            pooled = await ToolkitPermissionRepository.list_rules_for_vendor(
+                session, toolkit_id, api_vendor
+            )
+
+        method_upper = method.upper()
+        for idx, rule in enumerate(pooled):
+            rule_methods = rule.methods
+            rule_path = rule.path
+            rule_ops = rule.operations
+            # Mirror the broker's condition-less-`allow` skip; a bare
+            # `allow` with no constraints must not silently unlock a dry-run
+            # any more than it unlocks a real request.
+            is_condition_less = rule_methods is None and rule_path is None and rule_ops is None
+            if is_condition_less and rule.effect.lower() == "allow":
+                continue
+            if rule_methods is not None:
+                methods_set = {m.upper() for m in rule_methods}
+                if method_upper not in methods_set:
+                    continue
+            if rule_path is not None:
+                matcher = compile_matcher(rule_path, str(rule.match_mode or "regex"))
+                if matcher is not None and not matcher.matches(path):
+                    continue
+            if rule_ops is not None and (operation_id is None or operation_id not in rule_ops):
+                continue
+            allowed = rule.effect.lower() == "allow"
+            return PermissionTestResult(
+                allowed=allowed,
+                matched=True,
+                effect=rule.effect,
+                rule_index=idx,
+                credential_id=rule.credential_id,
+                is_system=rule.is_system,
+            )
+        return PermissionTestResult(
+            allowed=False,
+            matched=False,
+            effect=None,
+            rule_index=None,
+            credential_id=None,
+            is_system=None,
+        )

--- a/src/jentic_one/control/web/errors.py
+++ b/src/jentic_one/control/web/errors.py
@@ -36,6 +36,7 @@ from jentic_one.control.services.toolkits.errors import (
     KeyAlreadyRevokedError,
     ToolkitAccessDeniedError,
     ToolkitKeyNotFoundError,
+    ToolkitLevelPermissionsUnsupportedError,
     ToolkitNotFoundError,
 )
 from jentic_one.shared.db.errors import (
@@ -62,6 +63,7 @@ _TOOLKIT_ERROR_MAP: dict[type[Exception], tuple[int, str]] = {
     DuplicateBindingError: (409, "duplicate_binding"),
     ConflictingApiBindingError: (409, "conflicting_api_binding"),
     KeyAlreadyRevokedError: (409, "key_already_revoked"),
+    ToolkitLevelPermissionsUnsupportedError: (422, "toolkit_level_permissions_unsupported"),
 }
 
 toolkit_service_error_handler = make_service_error_handler(_TOOLKIT_ERROR_MAP)

--- a/src/jentic_one/control/web/routers/toolkits.py
+++ b/src/jentic_one/control/web/routers/toolkits.py
@@ -4,20 +4,25 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query, Response
+from fastapi import APIRouter, Depends, Query, Request, Response
 from pydantic import Field
 
 from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
 from jentic_one.control.core.schema.toolkit_keys import ToolkitKey
 from jentic_one.control.core.schema.toolkit_permission_rules import ToolkitPermissionRule
 from jentic_one.control.core.schema.toolkits import Toolkit
+from jentic_one.control.services.toolkits.errors import ToolkitLevelPermissionsUnsupportedError
+from jentic_one.control.services.toolkits.schemas import BindingWarning
 from jentic_one.control.services.toolkits.service import ToolkitService
 from jentic_one.control.web.deps import get_toolkit_service
 from jentic_one.control.web.schemas.toolkits import (
+    BindingWarningSchema,
     PermissionRuleListResponse,
     PermissionRuleReadSchema,
     PermissionRuleSchema,
     PermissionsPatchRequest,
+    PermissionTestRequest,
+    PermissionTestResponse,
     ToolkitAgentListResponse,
     ToolkitAgentResponse,
     ToolkitCreateRequest,
@@ -47,7 +52,6 @@ def _to_toolkit_response(toolkit: Toolkit) -> ToolkitResponse:
         name=toolkit.name,
         description=toolkit.description,
         active=toolkit.active,
-        permissions=toolkit.permissions,
         key_count=len(toolkit.keys),
         credential_count=len(toolkit.bindings),
         created_by=toolkit.created_by,
@@ -72,6 +76,7 @@ def _to_key_response(key: ToolkitKey) -> ToolkitKeyResponse:
 def _to_binding_response(
     binding: ToolkitCredentialBinding,
     permissions: list[ToolkitPermissionRule] | None = None,
+    warnings: list[BindingWarningSchema] | None = None,
 ) -> ToolkitCredentialBindingResponse:
     cred = binding.credential
     return ToolkitCredentialBindingResponse(
@@ -83,6 +88,15 @@ def _to_binding_response(
         label=cred.name if cred else None,
         bound_at=binding.bound_at,
         permissions=[_to_permission_rule(r) for r in permissions] if permissions else [],
+        warnings=warnings if warnings else [],
+    )
+
+
+def _to_binding_warning(warning: BindingWarning) -> BindingWarningSchema:
+    return BindingWarningSchema(
+        code=warning.code,
+        message=warning.message,
+        credential_id=warning.credential_id,
     )
 
 
@@ -92,6 +106,7 @@ def _to_permission_rule(rule: ToolkitPermissionRule) -> PermissionRuleReadSchema
             "effect": rule.effect,
             "methods": rule.methods,
             "path": rule.path,
+            "match_mode": rule.match_mode,
             "operations": rule.operations,
             "_system": rule.is_system,
             "_comment": rule.comment,
@@ -102,9 +117,34 @@ def _to_permission_rule(rule: ToolkitPermissionRule) -> PermissionRuleReadSchema
 # --- Toolkit CRUD ---
 
 
+async def _reject_toolkit_level_permissions(request: Request) -> None:
+    """Explicit reject for the legacy `POST /toolkits` `permissions` field.
+
+    Toolkit-level ``permissions`` were written on create but never enforced
+    by the broker (which reads per-binding ``toolkit_permission_rules``).
+    Dropping the field from the schema alone is not enough — Pydantic
+    silently ignores unknown keys on ``ToolkitCreateRequest``, so a client
+    would go on submitting the array with no feedback. Peek at the raw
+    body first; if ``permissions`` is present, raise the domain error the
+    error map surfaces as ``422 toolkit_level_permissions_unsupported``.
+    """
+    if request.method != "POST":
+        return
+    if request.headers.get("content-type", "").split(";")[0].strip() != "application/json":
+        return
+    try:
+        body = await request.json()
+    except ValueError:
+        # Malformed JSON — let the Pydantic body parser produce its own 422.
+        return
+    if isinstance(body, dict) and "permissions" in body:
+        raise ToolkitLevelPermissionsUnsupportedError()
+
+
 @router.post("/toolkits", status_code=201, summary="Create toolkit")
 async def create_toolkit(
     body: ToolkitCreateRequest,
+    _reject: None = Depends(_reject_toolkit_level_permissions),
     identity: Identity = get_current_identity(required_permissions=["toolkits:write"]),
     svc: ToolkitService = Depends(get_toolkit_service),
 ) -> ToolkitCreateResponse:
@@ -112,22 +152,20 @@ async def create_toolkit(
 
     The plaintext key (`jntc_live_…`) is returned **once** in `api_key` and is
     never retrievable again. Optional `credential_ids` bind existing credentials
-    at creation time.
+    at creation time; each inline bind emits a ``no_permission_rules`` warning
+    because the broker denies by default until rules are added.
     """
-    permissions = (
-        [p.model_dump(exclude_none=True) for p in body.permissions] if body.permissions else None
-    )
-    toolkit, plaintext = await svc.create(
+    result = await svc.create(
         name=body.name,
         identity=identity,
         description=body.description,
         active=body.active,
-        permissions=permissions,
         credential_ids=body.credential_ids,
     )
     return ToolkitCreateResponse(
-        toolkit=_to_toolkit_response(toolkit),
-        api_key=plaintext,
+        toolkit=_to_toolkit_response(result.toolkit),
+        api_key=result.plaintext_key,
+        warnings=[_to_binding_warning(w) for w in result.warnings],
     )
 
 
@@ -342,11 +380,16 @@ async def bind_credential(
     permissions_data = None
     if body.permissions:
         permissions_data = [p.model_dump(exclude_none=True) for p in body.permissions]
-    binding = await svc.bind_credential(
-        toolkit_id, body.credential_id, identity=identity, permissions=permissions_data
+    result = await svc.bind_credential(
+        toolkit_id,
+        body.credential_id,
+        identity=identity,
+        permissions=permissions_data,
+        allow_all=body.allow_all,
     )
-    rules = await svc.list_permissions(toolkit_id, body.credential_id, identity=identity)
-    return _to_binding_response(binding, rules)
+    return _to_binding_response(
+        result.binding, result.rules, [_to_binding_warning(w) for w in result.warnings]
+    )
 
 
 @router.get(
@@ -449,3 +492,43 @@ async def patch_permissions(
         toolkit_id, credential_id, identity=identity, add=add_data, remove=body.remove
     )
     return PermissionRuleListResponse(data=[_to_permission_rule(r) for r in rules])
+
+
+@router.post(
+    "/toolkits/{toolkit_id}/credentials/{credential_id}/permissions:test",
+    operation_id="testToolkitPermissions",
+    summary="Dry-run permission evaluation",
+    responses=not_found(),
+)
+async def test_permissions(
+    toolkit_id: str,
+    credential_id: str,
+    body: PermissionTestRequest,
+    identity: Identity = get_current_identity(
+        required_permissions=["toolkits:read", "owner:toolkits:read"]
+    ),
+    svc: ToolkitService = Depends(get_toolkit_service),
+) -> PermissionTestResponse:
+    """Answer "what would the broker do for this request?" without calling upstream.
+
+    Evaluates the same **vendor-pooled** rule set the broker sees at request
+    time — rules from all same-vendor bindings on this toolkit compete in one
+    ordered list. The response names which binding contributed the matching
+    rule, which is not obvious from the toolkit id alone under pooling.
+    """
+    result = await svc.test_permissions(
+        toolkit_id,
+        credential_id,
+        method=body.method,
+        path=body.path,
+        operation_id=body.operation_id,
+        identity=identity,
+    )
+    return PermissionTestResponse(
+        allowed=result.allowed,
+        matched=result.matched,
+        effect=result.effect,
+        rule_index=result.rule_index,
+        credential_id=result.credential_id,
+        is_system=result.is_system,
+    )

--- a/src/jentic_one/control/web/schemas/access_requests.py
+++ b/src/jentic_one/control/web/schemas/access_requests.py
@@ -5,32 +5,17 @@ from __future__ import annotations
 import datetime as dt
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, Field, model_validator
+
+from jentic_one.control.web.schemas.permission_rules import BasePermissionRuleSchema
 
 # --- Request models ---
 
 
-class PermissionRuleSchema(BaseModel):
+class PermissionRuleSchema(BasePermissionRuleSchema):
     """Permission rule for an access request item."""
 
-    model_config = ConfigDict(extra="forbid")
-
     effect: Literal["allow", "deny", "require-approval"]
-    methods: list[str] | None = None
-    path: str | None = None
-    operations: list[str] | None = None
-
-    @model_validator(mode="after")
-    def _reject_condition_less_allow(self) -> PermissionRuleSchema:
-        # A condition-less `allow` (no methods, path, or operations) matches every
-        # request under the broker's first-match-wins evaluation — i.e. an
-        # unrestricted grant. Reject it so an approver can never grant blanket
-        # access by accident. A condition-less `deny`/`require-approval` stays
-        # valid: a catch-all deny is a legitimate default-deny construct.
-        if self.effect == "allow" and not (self.methods or self.path or self.operations):
-            msg = "An 'allow' rule must constrain at least one of methods, path, or operations"
-            raise ValueError(msg)
-        return self
 
 
 class CredentialSpecSchema(BaseModel):

--- a/src/jentic_one/control/web/schemas/permission_rules.py
+++ b/src/jentic_one/control/web/schemas/permission_rules.py
@@ -1,0 +1,78 @@
+"""Shared base for permission-rule schemas.
+
+Two authoring surfaces write into the same enforced table
+(``toolkit_permission_rules``): the toolkit-bindings API (allow / deny)
+and the access-request API (which additionally accepts ``require-approval``
+on filed items). They share every field except ``effect``, so the common
+shape — including save-time path validation and the
+condition-less-``allow`` guard — lives here to prevent the two surfaces
+from drifting.
+
+Concrete subclasses in ``toolkits.py`` and ``access_requests.py`` add the
+appropriate ``effect`` ``Literal``.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from jentic_one.shared.permissions.matching import MatchMode, validate_path
+
+
+class BasePermissionRuleSchema(BaseModel):
+    """Shared fields + validation for both permission-rule authoring schemas.
+
+    ``extra="forbid"`` catches misspelled fields (e.g. ``mach_mode``) with
+    a ``422`` instead of the request silently ignoring them.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    methods: list[str] | None = Field(
+        default=None,
+        description="HTTP methods to match (case-insensitive). None matches all.",
+    )
+    path: str | None = Field(
+        default=None,
+        description=(
+            "Path pattern to match. Interpreted per `match_mode`: `regex` uses "
+            "full-match semantics (the pattern must describe the whole path); "
+            "`prefix` and `exact` are literal. None matches all paths."
+        ),
+    )
+    match_mode: MatchMode = Field(
+        default="regex",
+        description=(
+            "How `path` is interpreted: `regex` (full-match), `prefix` "
+            "(string prefix), or `exact` (equality). Defaults to `regex` for "
+            "backwards compatibility."
+        ),
+    )
+    operations: list[str] | None = Field(
+        default=None,
+        description="OpenAPI operation IDs to match. None matches all operations.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_path(self) -> BasePermissionRuleSchema:
+        # Surface the underlying ``re.error`` (or length/empty/unknown-mode
+        # reason) as the ``ValueError`` message; FastAPI renders it as ``422``
+        # with the reason in the ``detail``, so callers can fix the pattern
+        # without guessing what tripped validation.
+        err = validate_path(self.path, self.match_mode)
+        if err is not None:
+            raise ValueError(err.reason)
+        return self
+
+    @model_validator(mode="after")
+    def _reject_condition_less_allow(self) -> BasePermissionRuleSchema:
+        # A condition-less ``allow`` matches every request under the broker's
+        # first-match-wins evaluation — an unrestricted grant. Reject it so a
+        # binding can never grant blanket access by accident. Empty-string
+        # ``path`` cannot slip past here because ``_validate_path`` above
+        # already rejects it in every mode.
+        effect = getattr(self, "effect", None)
+        if effect == "allow" and not (self.methods or self.path or self.operations):
+            msg = "An 'allow' rule must constrain at least one of methods, path, or operations"
+            raise ValueError(msg)
+        return self

--- a/src/jentic_one/control/web/schemas/toolkits.py
+++ b/src/jentic_one/control/web/schemas/toolkits.py
@@ -8,10 +8,13 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from jentic_one.control.web.schemas.permission_rules import BasePermissionRuleSchema
+from jentic_one.shared.permissions.matching import MatchMode
+
 # --- Request models ---
 
 
-class PermissionRuleSchema(BaseModel):
+class PermissionRuleSchema(BasePermissionRuleSchema):
     """Permission rule for a toolkit-credential binding.
 
     Rules are evaluated first-match-wins. If no rule matches, the request is
@@ -19,31 +22,9 @@ class PermissionRuleSchema(BaseModel):
     operations — users must explicitly add at least one allow rule.
     """
 
-    model_config = ConfigDict(extra="forbid")
-
     effect: Literal["allow", "deny"] = Field(
         description="Whether this rule allows or denies the matched request."
     )
-    methods: list[str] | None = Field(
-        default=None, description="HTTP methods to match (case-insensitive). None matches all."
-    )
-    path: str | None = Field(
-        default=None, description="Regex pattern for the request path. None matches all paths."
-    )
-    operations: list[str] | None = Field(
-        default=None, description="OpenAPI operation IDs to match. None matches all operations."
-    )
-
-    @model_validator(mode="after")
-    def _reject_condition_less_allow(self) -> PermissionRuleSchema:
-        # A condition-less `allow` matches every request under the broker's
-        # first-match-wins evaluation — an unrestricted grant. Reject it so a
-        # binding can never grant blanket access by accident. A condition-less
-        # `deny` stays valid as a legitimate catch-all default-deny.
-        if self.effect == "allow" and not (self.methods or self.path or self.operations):
-            msg = "An 'allow' rule must constrain at least one of methods, path, or operations"
-            raise ValueError(msg)
-        return self
 
 
 class ToolkitCreateRequest(BaseModel):
@@ -53,7 +34,6 @@ class ToolkitCreateRequest(BaseModel):
     description: str | None = None
     active: bool = True
     credential_ids: list[str] | None = None
-    permissions: list[PermissionRuleSchema] | None = None
 
 
 class ToolkitUpdateRequest(BaseModel):
@@ -103,8 +83,27 @@ class ToolkitKeyUpdateRequest(BaseModel):
 class ToolkitCredentialBindRequest(BaseModel):
     """Bind a credential to a toolkit."""
 
+    model_config = ConfigDict(extra="forbid")
+
     credential_id: str
     permissions: list[PermissionRuleSchema] | None = None
+    allow_all: bool = Field(
+        default=False,
+        description=(
+            "Convenience flag: bind with a single `allow` rule that matches every "
+            "request for this binding's vendor. Mutually exclusive with `permissions`."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _allow_all_conflicts_with_permissions(self) -> ToolkitCredentialBindRequest:
+        # ``allow_all=True`` sets a specific rule under the hood; combining it
+        # with an authored ``permissions`` list is ambiguous — reject at the
+        # boundary so the caller has to pick one intent.
+        if self.allow_all and self.permissions:
+            msg = "allow_all and permissions are mutually exclusive"
+            raise ValueError(msg)
+        return self
 
 
 class PermissionRuleReadSchema(BaseModel):
@@ -113,6 +112,7 @@ class PermissionRuleReadSchema(BaseModel):
     effect: Literal["allow", "deny"]
     methods: list[str] | None = None
     path: str | None = None
+    match_mode: MatchMode = "regex"
     operations: list[str] | None = None
     is_system: bool = Field(alias="_system", default=False)
     comment: str | None = Field(alias="_comment", default=None)
@@ -137,7 +137,6 @@ class ToolkitResponse(BaseModel):
     name: str
     description: str | None = None
     active: bool
-    permissions: list[dict[str, object]]
     key_count: int
     credential_count: int
     created_by: str | None = None
@@ -145,11 +144,29 @@ class ToolkitResponse(BaseModel):
     updated_at: datetime | None = None
 
 
+class BindingWarningSchema(BaseModel):
+    """A non-fatal signal about a bind (or create-time inline bind)."""
+
+    code: str = Field(description="Stable machine-readable warning code.")
+    message: str = Field(description="Human-readable explanation with a recovery pointer.")
+    credential_id: str | None = Field(
+        default=None,
+        description="Credential the warning applies to; null when the whole binding is meant.",
+    )
+
+
 class ToolkitCreateResponse(BaseModel):
     """Create response: toolkit + api_key shown once."""
 
     toolkit: ToolkitResponse
     api_key: str
+    warnings: list[BindingWarningSchema] = Field(
+        default_factory=list,
+        description=(
+            "Non-fatal signals about the create — e.g. inline-bound credentials "
+            "that landed with zero permission rules (broker denies by default)."
+        ),
+    )
 
 
 class ToolkitListResponse(BaseModel):
@@ -199,6 +216,13 @@ class ToolkitCredentialBindingResponse(BaseModel):
     label: str | None = None
     bound_at: datetime
     permissions: list[PermissionRuleReadSchema] = Field(default_factory=list)
+    warnings: list[BindingWarningSchema] = Field(
+        default_factory=list,
+        description=(
+            "Non-fatal bind-time signals — e.g. a binding that landed with zero "
+            "permission rules (broker denies by default until rules are added)."
+        ),
+    )
 
 
 class ToolkitCredentialListResponse(BaseModel):
@@ -230,3 +254,50 @@ class PermissionRuleListResponse(BaseModel):
     """List of permission rules."""
 
     data: list[PermissionRuleReadSchema]
+
+
+class PermissionTestRequest(BaseModel):
+    """Request body for :test — dry-run a request shape against pooled rules."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    method: str = Field(
+        description="HTTP method of the hypothetical request (case-insensitive).",
+    )
+    path: str = Field(
+        description="Path of the hypothetical request as the broker would see it.",
+    )
+    operation_id: str | None = Field(
+        default=None,
+        description="Optional OpenAPI operation id resolved from the request URL.",
+    )
+
+
+class PermissionTestResponse(BaseModel):
+    """Dry-run result matching :class:`PermissionTestResult`."""
+
+    allowed: bool = Field(
+        description="Whether the broker would allow this request under the pooled rules."
+    )
+    matched: bool = Field(
+        description="Whether any rule matched; when false, the outcome is default-deny."
+    )
+    effect: str | None = Field(
+        default=None,
+        description="Effect of the matching rule (`allow`/`deny`); null when no match.",
+    )
+    rule_index: int | None = Field(
+        default=None,
+        description="Zero-based index in the vendor-pooled rule list; null when no match.",
+    )
+    credential_id: str | None = Field(
+        default=None,
+        description=(
+            "Which binding contributed the matching rule — vendor pooling means "
+            "this may not equal the credential in the request URL."
+        ),
+    )
+    is_system: bool | None = Field(
+        default=None,
+        description="True when the matching rule was written by the system; null when no match.",
+    )

--- a/src/jentic_one/migrations/control/versions/k2f3a4b5c6d7_add_toolkit_permission_rule_match_mode.py
+++ b/src/jentic_one/migrations/control/versions/k2f3a4b5c6d7_add_toolkit_permission_rule_match_mode.py
@@ -1,0 +1,38 @@
+"""add match_mode to toolkit_permission_rules
+
+Revision ID: k2f3a4b5c6d7
+Revises: j1e2f3a4b5c6
+Create Date: 2026-07-24
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "k2f3a4b5c6d7"
+down_revision: str | None = "j1e2f3a4b5c6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Add ``match_mode`` to ``toolkit_permission_rules`` so a rule can declare
+    # how its ``path`` is interpreted (``regex``/``prefix``/``exact``).
+    # NOT NULL with ``server_default 'regex'`` back-fills existing rows in a
+    # single statement — issue #751. NOTE: the column name is ``match_mode``,
+    # not ``match``, because ``MATCH`` is a reserved word in SQLite.
+    op.add_column(
+        "toolkit_permission_rules",
+        sa.Column(
+            "match_mode",
+            sa.String(length=10),
+            nullable=False,
+            server_default="regex",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("toolkit_permission_rules", "match_mode")

--- a/src/jentic_one/migrations/control/versions/l3f4a5b6c7d8_drop_toolkits_permissions_column.py
+++ b/src/jentic_one/migrations/control/versions/l3f4a5b6c7d8_drop_toolkits_permissions_column.py
@@ -1,0 +1,48 @@
+"""drop toolkits.permissions (never enforced)
+
+Revision ID: l3f4a5b6c7d8
+Revises: k2f3a4b5c6d7
+Create Date: 2026-07-24
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "l3f4a5b6c7d8"
+down_revision: str | None = "k2f3a4b5c6d7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ``toolkits.permissions`` (a JSON column populated on ``POST /toolkits``)
+    # was write-only from day one — the broker's rule evaluator reads the
+    # per-binding ``toolkit_permission_rules`` table exclusively and never
+    # consulted this column. Silently accepting the field on create misled
+    # operators into thinking they had gated a toolkit when they hadn't
+    # (issue #655). ``POST /toolkits`` now rejects the field with 422 and the
+    # column is retired in the same release. No data migration: the payloads
+    # never had enforcement semantics, so there is nothing meaningful to
+    # migrate to the enforced surface — operators re-authoring rules attach
+    # them to the intended binding via
+    # ``PUT /toolkits/{id}/credentials/{id}/permissions``.
+    op.drop_column("toolkits", "permissions")
+
+
+def downgrade() -> None:
+    # Restores the column with its original nullable=False + empty-list
+    # default so a rollback lands on a schema-shape identical to the
+    # pre-#655 state. Existing rows are back-filled with the empty list;
+    # the historical payloads are not restored (see upgrade rationale).
+    op.add_column(
+        "toolkits",
+        sa.Column(
+            "permissions",
+            sa.JSON(),
+            nullable=False,
+            server_default="[]",
+        ),
+    )

--- a/src/jentic_one/migrations/control/versions/m4a5b6c7d8e9_add_toolkit_permission_rule_match_mode.py
+++ b/src/jentic_one/migrations/control/versions/m4a5b6c7d8e9_add_toolkit_permission_rule_match_mode.py
@@ -1,7 +1,7 @@
 """add match_mode to toolkit_permission_rules
 
-Revision ID: k2f3a4b5c6d7
-Revises: j1e2f3a4b5c6
+Revision ID: m4a5b6c7d8e9
+Revises: l3a4b5c6d7e8
 Create Date: 2026-07-24
 
 """
@@ -11,8 +11,8 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "k2f3a4b5c6d7"
-down_revision: str | None = "j1e2f3a4b5c6"
+revision: str = "m4a5b6c7d8e9"
+down_revision: str | None = "l3a4b5c6d7e8"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/src/jentic_one/migrations/control/versions/n5b6c7d8e9f0_drop_toolkits_permissions_column.py
+++ b/src/jentic_one/migrations/control/versions/n5b6c7d8e9f0_drop_toolkits_permissions_column.py
@@ -1,7 +1,7 @@
 """drop toolkits.permissions (never enforced)
 
-Revision ID: l3f4a5b6c7d8
-Revises: k2f3a4b5c6d7
+Revision ID: n5b6c7d8e9f0
+Revises: m4a5b6c7d8e9
 Create Date: 2026-07-24
 
 """
@@ -11,8 +11,8 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "l3f4a5b6c7d8"
-down_revision: str | None = "k2f3a4b5c6d7"
+revision: str = "n5b6c7d8e9f0"
+down_revision: str | None = "m4a5b6c7d8e9"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/src/jentic_one/shared/broker/protocols.py
+++ b/src/jentic_one/shared/broker/protocols.py
@@ -89,13 +89,31 @@ class TokenResolverProtocol(Protocol):
     async def resolve_access_token(self, token: str) -> Identity | None: ...
 
 
+@dataclass(frozen=True, slots=True)
+class RuleEvaluation:
+    """Outcome of a permission-rule evaluation with just enough context to explain a deny.
+
+    ``allowed`` is the same signal the pre-#578 bare-bool evaluator emitted.
+    ``rules_loaded`` distinguishes two very different deny paths that used to
+    collapse into one bare 403 (#578): a zero-length pool (nothing matched
+    because there was nothing to match — wrong vendor, unbound credential,
+    empty binding, misconfigured store) vs a non-empty pool where no rule
+    happened to match. The router turns this into a two-variant detail
+    sentence — no rule contents, no internal ids, redaction-safe.
+    """
+
+    allowed: bool
+    rules_loaded: int
+
+
 @runtime_checkable
 class RuleEvaluatorProtocol(Protocol):
     """Evaluates toolkit permission rules against an inbound request.
 
-    Returns ``True`` if the request is allowed, ``False`` if denied. Evaluation
-    follows a first-match-wins policy over an ordered rule list; an exhausted
-    list defaults to deny (secure-by-default).
+    Returns a :class:`RuleEvaluation` with the allow/deny outcome and the
+    size of the vendor-pooled rule list evaluated. Evaluation follows
+    first-match-wins over an ordered rule list; an exhausted list defaults
+    to deny (secure-by-default).
     """
 
     async def evaluate(
@@ -106,7 +124,7 @@ class RuleEvaluatorProtocol(Protocol):
         path: str,
         operation_id: str | None,
         api_vendor: str = "",
-    ) -> bool: ...
+    ) -> RuleEvaluation: ...
 
 
 @runtime_checkable

--- a/src/jentic_one/shared/permissions/__init__.py
+++ b/src/jentic_one/shared/permissions/__init__.py
@@ -1,0 +1,1 @@
+"""Shared permission-rule primitives (path matching, validation)."""

--- a/src/jentic_one/shared/permissions/matching.py
+++ b/src/jentic_one/shared/permissions/matching.py
@@ -1,0 +1,157 @@
+"""Toolkit permission-rule path matching (single source of truth).
+
+Rules are authored on two surfaces — the toolkit-bindings API
+(``control/web/schemas/toolkits.py``) and the access-request API
+(``control/web/schemas/access_requests.py``) — and enforced on a third
+(``broker/repos/rule_evaluator.py``). This module is the one place that
+knows how a ``(path, match_mode)`` pair is validated at save time and how
+it matches an inbound request path at enforce time, so the three surfaces
+cannot drift.
+
+Design invariants
+-----------------
+* Save-time validation raises structured errors (returned as ``None`` when
+  valid) so schemas can surface the underlying ``re.error`` to callers as
+  ``422`` — a stored pattern that could not be compiled at save time never
+  reaches the enforce path.
+* Enforce-time matching is **fail-closed**: an already-stored pattern that
+  fails to compile (a legacy row written before validation existed) yields
+  a matcher that never matches, rather than today's silent wildcard.
+* Regex mode uses **full-match** semantics (``re.fullmatch``) — the
+  pattern must describe the whole request path — replacing the previous
+  ``re.match`` (start-anchored) behaviour, which silently over-matched.
+* ``path is None`` means "no path constraint" (the rule matches every
+  path) and is the sole trigger for the condition-less-``allow`` guard;
+  an empty string is rejected by ``validate_path`` in every mode so it
+  cannot slip past that guard.
+
+This module has no framework or ORM dependencies and stays in ``shared/``
+so both broker and control can import it (broker cannot import control).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+MatchMode = Literal["regex", "prefix", "exact"]
+"""How a rule's ``path`` string is interpreted against an inbound request path."""
+
+MATCH_MODES: tuple[MatchMode, ...] = ("regex", "prefix", "exact")
+"""All valid match modes, in the same order as the Literal for OpenAPI stability."""
+
+MAX_PATTERN_LENGTH: int = 1000
+"""Save- and enforce-time cap; matches the ``VARCHAR(1000)`` on ``path``."""
+
+PathValidationCode = Literal["invalid_regex", "pattern_too_long", "empty_path", "unknown_mode"]
+
+
+@dataclass(frozen=True, slots=True)
+class PathValidationError:
+    """Structured save-time rejection reason (schemas surface ``reason`` as 422)."""
+
+    code: PathValidationCode
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class PathMatcher:
+    """Compiled path matcher — immutable so the evaluator can cache it safely.
+
+    ``pattern`` is the compiled regex for regex mode, ``None`` for literal
+    modes. ``never`` is the fail-closed flag: a stored pattern that failed
+    to compile at load time matches nothing (instead of today's silent
+    wildcard). ``literal`` carries the original string for literal modes.
+    """
+
+    mode: MatchMode
+    literal: str | None
+    pattern: re.Pattern[str] | None
+    never: bool = False
+
+    def matches(self, request_path: str) -> bool:
+        """True iff the request path is constrained by this matcher and matches it."""
+        if self.never:
+            return False
+        if self.mode == "regex":
+            # `pattern` is present unless `never` is True (guarded above).
+            assert self.pattern is not None
+            return self.pattern.fullmatch(request_path) is not None
+        # Literal modes — `literal` is present unless `never` is True.
+        assert self.literal is not None
+        if self.mode == "prefix":
+            return request_path.startswith(self.literal)
+        return request_path == self.literal
+
+
+def _check(path: str | None, mode: str) -> PathValidationError | None:
+    """Shared save-and-load validation; returns ``None`` when valid.
+
+    ``path is None`` is always valid (no constraint). Otherwise the pair
+    ``(path, mode)`` must pass the mode-specific checks. Empty strings
+    are rejected in every mode because:
+
+    * ``prefix``/``exact``: ``""`` is a truthy field (satisfies the
+      condition-less-``allow`` guard) yet matches every request in prefix
+      mode — an unrestricted grant disguised as a constraint.
+    * ``regex``: ``""`` full-matches only the empty path — never useful,
+      always a mistake — and would similarly slip past the guard.
+    """
+    if path is None:
+        return None
+    if mode not in MATCH_MODES:
+        return PathValidationError(
+            code="unknown_mode",
+            reason=f"Unknown match_mode {mode!r}; expected one of {list(MATCH_MODES)}",
+        )
+    if len(path) > MAX_PATTERN_LENGTH:
+        return PathValidationError(
+            code="pattern_too_long",
+            reason=f"path exceeds maximum length ({MAX_PATTERN_LENGTH} characters)",
+        )
+    if path == "":
+        return PathValidationError(
+            code="empty_path",
+            reason="path must not be empty; omit it to mean 'no path constraint'",
+        )
+    if mode == "regex":
+        try:
+            re.compile(path)
+        except re.error as exc:
+            return PathValidationError(
+                code="invalid_regex",
+                reason=f"invalid regex: {exc.msg} (at position {exc.pos})"
+                if exc.pos is not None
+                else f"invalid regex: {exc.msg}",
+            )
+    return None
+
+
+def validate_path(path: str | None, mode: str) -> PathValidationError | None:
+    """Validate an authored ``(path, match_mode)`` pair.
+
+    Returns ``None`` when the pair is valid; otherwise a structured error
+    the schema layer surfaces to the client as ``422``.
+    """
+    return _check(path, mode)
+
+
+def compile_matcher(path: str | None, mode: str) -> PathMatcher | None:
+    """Compile a stored ``(path, match_mode)`` pair into a matcher.
+
+    Returns ``None`` when there is no path constraint on the rule
+    (``path is None``). Never raises: a stored pattern that fails to
+    compile (legacy row written before ``validate_path`` existed) returns
+    a ``PathMatcher(never=True)`` — a matcher that never matches. That is
+    the opposite of today's silent-wildcard behaviour and is enforced
+    fail-closed so legacy bad rows cannot accidentally grant access.
+    """
+    if path is None:
+        return None
+    error = _check(path, mode)
+    if error is not None:
+        return PathMatcher(mode="regex", literal=None, pattern=None, never=True)
+    if mode == "regex":
+        return PathMatcher(mode="regex", literal=None, pattern=re.compile(path))
+    return PathMatcher(mode=mode, literal=path, pattern=None)  # type: ignore[arg-type]

--- a/src/jentic_one/shared/web/openapi_meta.py
+++ b/src/jentic_one/shared/web/openapi_meta.py
@@ -273,9 +273,9 @@ OPENAPI_TAGS: list[dict[str, str]] = [
             "`allow` — the strictest matching rule wins. Absence of a matching rule is an "
             "implicit deny. System rules (`_system: true`) participate in the same priority "
             "pool as user rules.\n\n"
-            "The coarse JWT-embedded scope tier on `Toolkit.permissions` "
-            "(`capabilities:execute`, `apis:read`) is checked separately and composes with "
-            "these rules — both must allow."
+            "Toolkits have no separate scope tier of their own: a toolkit API key is minted "
+            "with the fixed broker-execute scope (`capabilities:execute`), and every gated "
+            "operation is decided by these per-binding rules."
         ),
     },
     {
@@ -544,10 +544,11 @@ OPENAPI_TAGS: list[dict[str, str]] = [
             "(full deployment-wide access, granted via direct DB action). It is not enumerated "
             "to non-holders by `GET /permissions`, and is rejected by `PUT "
             "/users/{user_id}/permissions` from any caller who doesn't already hold it.\n\n"
-            "The same vocabulary is used for `User.permissions` and for `Toolkit.permissions` "
-            "— coarse JWT-embedded scopes — so the one catalogue covers both. Per-binding "
-            "fine-grained `PermissionRule[]` (the inner PBAC tier) lives separately under the "
-            "`Toolkit Permissions` tag."
+            "The same vocabulary is used for `User.permissions` — coarse JWT-embedded scopes — "
+            "so the catalogue below covers user assignment. Toolkits have no separate scope tier "
+            "of their own: a toolkit API key is minted with the fixed broker-execute scope, and "
+            "the per-binding fine-grained `PermissionRule[]` (the inner PBAC tier) lives "
+            "separately under the `Toolkit Permissions` tag."
         ),
     },
     {

--- a/tests/integration/control/test_permission_match_modes.py
+++ b/tests/integration/control/test_permission_match_modes.py
@@ -1,0 +1,427 @@
+"""Integration tests for the toolkit permission-rule path matcher.
+
+Covers the #751 write path end-to-end against a real database:
+
+* the new ``match_mode`` column persists via ``replace_user_rules`` / ``patch_rules``
+* the broker evaluator (raw ``text()`` SQL) reads it and enforces the mode
+* the vendor-pooled dry-run service reflects the enforcer's decision
+* invalid stored patterns fail closed (never match) instead of the pre-#751
+  silent wildcard.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy import delete
+
+from jentic_one.broker.repos.rule_evaluator import RuleEvaluator
+from jentic_one.control.core.schema.credentials import Credential
+from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
+from jentic_one.control.core.schema.toolkit_permission_rules import ToolkitPermissionRule
+from jentic_one.control.core.schema.toolkits import Toolkit
+from jentic_one.control.repos.toolkit_permission_repo import ToolkitPermissionRepository
+from jentic_one.control.services.toolkits.service import ToolkitService
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.context import Context
+from jentic_one.shared.db.session import DatabaseSession
+from jentic_one.shared.models import ActorType
+
+pytestmark = pytest.mark.integration
+
+_VENDOR = "acme751.com"
+_IDENTITY = Identity(sub="usr_test751", actor_type=ActorType.USER, permissions=["org:admin"])
+
+
+@pytest.fixture()
+async def clean_tables(control_db: DatabaseSession) -> AsyncGenerator[None, None]:
+    async def _truncate() -> None:
+        async with control_db.session() as session:
+            await session.execute(delete(ToolkitPermissionRule))
+            await session.execute(delete(ToolkitCredentialBinding))
+            await session.execute(delete(Credential).where(Credential.api_vendor == _VENDOR))
+            await session.execute(delete(Toolkit).where(Toolkit.name.like("tk751-%")))
+            await session.commit()
+
+    await _truncate()
+    yield
+    await _truncate()
+
+
+async def _seed(
+    control_db: DatabaseSession,
+    *,
+    name: str,
+    cred_id: str,
+    api_name: str = "main",
+) -> tuple[str, str]:
+    toolkit = Toolkit(name=name)
+    credential = Credential(
+        id=cred_id,
+        type="token_value",
+        name=f"cred-{cred_id}",
+        api_vendor=_VENDOR,
+        api_name=api_name,
+        api_version="1",
+        active=True,
+    )
+    async with control_db.session() as session:
+        session.add(toolkit)
+        session.add(credential)
+        await session.flush()
+        tk_id = toolkit.id
+        session.add(
+            ToolkitCredentialBinding(toolkit_id=tk_id, credential_id=cred_id, created_by="test")
+        )
+        await session.commit()
+    return tk_id, cred_id
+
+
+# ---------------------------------------------------------------------------
+# Storage: match_mode round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replace_user_rules_persists_match_mode(
+    control_db: DatabaseSession, clean_tables: None
+) -> None:
+    tk_id, cred_id = await _seed(control_db, name="tk751-round", cred_id="cred_751_round")
+
+    async with control_db.session() as session:
+        await ToolkitPermissionRepository.replace_user_rules(
+            session,
+            tk_id,
+            cred_id,
+            [
+                {"effect": "allow", "path": "/v1/things", "match_mode": "prefix"},
+                {"effect": "deny", "path": "/v1/things/delete", "match_mode": "exact"},
+            ],
+            created_by="test",
+        )
+        await session.commit()
+
+        rules = await ToolkitPermissionRepository.list_rules(session, tk_id, cred_id)
+
+    modes = [r.match_mode for r in rules]
+    assert modes == ["prefix", "exact"]
+
+
+@pytest.mark.asyncio
+async def test_replace_user_rules_defaults_match_mode_to_regex(
+    control_db: DatabaseSession, clean_tables: None
+) -> None:
+    # A rule dict that omits ``match_mode`` — the effect applicator for access
+    # requests emits dicts this way — lands as ``regex`` for compatibility.
+    tk_id, cred_id = await _seed(control_db, name="tk751-default", cred_id="cred_751_default")
+
+    async with control_db.session() as session:
+        await ToolkitPermissionRepository.replace_user_rules(
+            session, tk_id, cred_id, [{"effect": "allow", "path": ".*"}], created_by="test"
+        )
+        await session.commit()
+        rules = await ToolkitPermissionRepository.list_rules(session, tk_id, cred_id)
+
+    assert [r.match_mode for r in rules] == ["regex"]
+
+
+# ---------------------------------------------------------------------------
+# Enforcement: broker reads match_mode and uses the shared matcher
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_broker_enforces_prefix_match_mode(
+    control_db: DatabaseSession, clean_tables: None
+) -> None:
+    tk_id, cred_id = await _seed(control_db, name="tk751-prefix", cred_id="cred_751_prefix")
+
+    async with control_db.session() as session:
+        await ToolkitPermissionRepository.replace_user_rules(
+            session,
+            tk_id,
+            cred_id,
+            [{"effect": "allow", "path": "/v1/things", "match_mode": "prefix"}],
+            created_by="test",
+        )
+        await session.commit()
+
+    evaluator = RuleEvaluator(control_db, cache_ttl_seconds=0)
+    # Prefix mode is literal: substring after the prefix is fine…
+    result = await evaluator.evaluate(
+        toolkit_id=tk_id,
+        method="GET",
+        path="/v1/things/42",
+        operation_id=None,
+        api_vendor=_VENDOR,
+    )
+    assert result.allowed is True
+    # …but a different prefix does not match.
+    result = await evaluator.evaluate(
+        toolkit_id=tk_id,
+        method="GET",
+        path="/v2/things",
+        operation_id=None,
+        api_vendor=_VENDOR,
+    )
+    assert result.allowed is False
+
+
+@pytest.mark.asyncio
+async def test_broker_full_match_regex_rejects_trailing_content(
+    control_db: DatabaseSession, clean_tables: None
+) -> None:
+    # #751 anchoring migration: ``.match()`` accepted ``/v1/users/42/extra`` for
+    # ``/v1/users/\d+``; ``.fullmatch()`` (via the shared matcher) rejects it.
+    tk_id, cred_id = await _seed(control_db, name="tk751-full", cred_id="cred_751_full")
+
+    async with control_db.session() as session:
+        await ToolkitPermissionRepository.replace_user_rules(
+            session,
+            tk_id,
+            cred_id,
+            [{"effect": "allow", "path": r"/v1/users/\d+", "match_mode": "regex"}],
+            created_by="test",
+        )
+        await session.commit()
+
+    evaluator = RuleEvaluator(control_db, cache_ttl_seconds=0)
+    result = await evaluator.evaluate(
+        toolkit_id=tk_id,
+        method="GET",
+        path="/v1/users/42",
+        operation_id=None,
+        api_vendor=_VENDOR,
+    )
+    assert result.allowed is True
+    result = await evaluator.evaluate(
+        toolkit_id=tk_id,
+        method="GET",
+        path="/v1/users/42/roles",
+        operation_id=None,
+        api_vendor=_VENDOR,
+    )
+    assert result.allowed is False
+
+
+@pytest.mark.asyncio
+async def test_broker_fail_closed_on_stored_invalid_pattern(
+    control_db: DatabaseSession, clean_tables: None
+) -> None:
+    # A legacy row that predates ``validate_path`` (bypass the API by writing
+    # directly with the ORM) must fail closed at enforcement — the opposite
+    # of today's silent-wildcard.
+    tk_id, cred_id = await _seed(control_db, name="tk751-legacy", cred_id="cred_751_legacy")
+
+    async with control_db.session() as session:
+        session.add(
+            ToolkitPermissionRule(
+                toolkit_id=tk_id,
+                credential_id=cred_id,
+                effect="allow",
+                methods=None,
+                path="[unterminated",
+                match_mode="regex",
+                operations=None,
+                is_system=False,
+                comment=None,
+                sequence=0,
+                created_by="test",
+            )
+        )
+        await session.commit()
+
+    evaluator = RuleEvaluator(control_db, cache_ttl_seconds=0)
+    result = await evaluator.evaluate(
+        toolkit_id=tk_id,
+        method="GET",
+        path="/any",
+        operation_id=None,
+        api_vendor=_VENDOR,
+    )
+    assert result.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# Dry-run parity with the broker (vendor pooling)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_pools_rules_across_same_vendor_bindings(
+    control_db: DatabaseSession, integration_context: Context, clean_tables: None
+) -> None:
+    # Two bindings for the same vendor: a rule attached to binding B allows
+    # the request when queried under binding A. The broker sees the pooled
+    # set, and so must the dry-run.
+    toolkit = Toolkit(name="tk751-pool")
+    cred_a = Credential(
+        id="cred_751_pool_a",
+        type="token_value",
+        name="cred-a",
+        api_vendor=_VENDOR,
+        api_name="one",
+        api_version="1",
+        active=True,
+    )
+    cred_b = Credential(
+        id="cred_751_pool_b",
+        type="token_value",
+        name="cred-b",
+        api_vendor=_VENDOR,
+        api_name="two",
+        api_version="1",
+        active=True,
+    )
+    async with control_db.session() as session:
+        session.add(toolkit)
+        session.add(cred_a)
+        session.add(cred_b)
+        await session.flush()
+        tk_id = toolkit.id
+        session.add(
+            ToolkitCredentialBinding(toolkit_id=tk_id, credential_id=cred_a.id, created_by="test")
+        )
+        session.add(
+            ToolkitCredentialBinding(toolkit_id=tk_id, credential_id=cred_b.id, created_by="test")
+        )
+        await session.commit()
+
+    async with control_db.session() as session:
+        await ToolkitPermissionRepository.replace_user_rules(
+            session,
+            tk_id,
+            cred_b.id,
+            [{"effect": "allow", "path": "/v1/thing", "match_mode": "exact"}],
+            created_by="test",
+        )
+        await session.commit()
+
+    svc = ToolkitService(integration_context)
+    # Query the dry-run under binding A (which has zero rules of its own).
+    result = await svc.test_permissions(
+        tk_id,
+        cred_a.id,
+        method="GET",
+        path="/v1/thing",
+        operation_id=None,
+        identity=_IDENTITY,
+    )
+    assert result.matched is True
+    assert result.allowed is True
+    # Vendor pooling means the winning rule lives on binding B — the
+    # response names it explicitly so an operator understands what happened.
+    assert result.credential_id == cred_b.id
+
+
+@pytest.mark.asyncio
+async def test_dry_run_reports_default_deny_when_no_rule_matches(
+    control_db: DatabaseSession, integration_context: Context, clean_tables: None
+) -> None:
+    tk_id, cred_id = await _seed(control_db, name="tk751-noop", cred_id="cred_751_noop")
+
+    async with control_db.session() as session:
+        await ToolkitPermissionRepository.replace_user_rules(
+            session,
+            tk_id,
+            cred_id,
+            [{"effect": "allow", "path": "/only/this", "match_mode": "exact"}],
+            created_by="test",
+        )
+        await session.commit()
+
+    svc = ToolkitService(integration_context)
+    result = await svc.test_permissions(
+        tk_id,
+        cred_id,
+        method="GET",
+        path="/something/else",
+        operation_id=None,
+        identity=_IDENTITY,
+    )
+    assert result.matched is False
+    assert result.allowed is False
+    assert result.credential_id is None
+
+
+# ---------------------------------------------------------------------------
+# #578: wildcard `.*` rule + two-variant deny diagnostic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wildcard_rule_allows_end_to_end(
+    control_db: DatabaseSession, clean_tables: None
+) -> None:
+    # #578 regression: a single `{effect:allow, path:".*"}` rule must
+    # allow every request under full-match regex semantics — this was
+    # the exact user-visible complaint that closed as "denied despite
+    # wildcard rule".
+    tk_id, cred_id = await _seed(control_db, name="tk578-wild", cred_id="cred_578_wild")
+
+    async with control_db.session() as session:
+        await ToolkitPermissionRepository.replace_user_rules(
+            session,
+            tk_id,
+            cred_id,
+            [{"effect": "allow", "path": ".*", "match_mode": "regex"}],
+            created_by="test",
+        )
+        await session.commit()
+
+    evaluator = RuleEvaluator(control_db, cache_ttl_seconds=0)
+    result = await evaluator.evaluate(
+        toolkit_id=tk_id,
+        method="POST",
+        path="/deep/nested/resource/42",
+        operation_id="anyOp",
+        api_vendor=_VENDOR,
+    )
+    assert result.allowed is True
+    assert result.rules_loaded == 1
+
+
+@pytest.mark.asyncio
+async def test_deny_variant_distinguishes_empty_pool_from_no_match(
+    control_db: DatabaseSession, clean_tables: None
+) -> None:
+    # #578 diagnostic: the router keys its detail sentence on rules_loaded.
+    # A wrong-vendor request produces a zero-length pool (the DB join
+    # filters by api_vendor); a same-vendor request that misses every rule
+    # produces a non-zero pool with allowed=False.
+    tk_id, cred_id = await _seed(control_db, name="tk578-variants", cred_id="cred_578_variants")
+
+    async with control_db.session() as session:
+        await ToolkitPermissionRepository.replace_user_rules(
+            session,
+            tk_id,
+            cred_id,
+            [{"effect": "allow", "path": "/only/this", "match_mode": "exact"}],
+            created_by="test",
+        )
+        await session.commit()
+
+    evaluator = RuleEvaluator(control_db, cache_ttl_seconds=0)
+
+    # Empty-pool branch: no rules for this vendor.
+    empty_pool = await evaluator.evaluate(
+        toolkit_id=tk_id,
+        method="GET",
+        path="/only/this",
+        operation_id=None,
+        api_vendor="different-vendor.com",
+    )
+    assert empty_pool.allowed is False
+    assert empty_pool.rules_loaded == 0
+
+    # Loaded-but-no-match branch: the pool exists, nothing matched.
+    no_match = await evaluator.evaluate(
+        toolkit_id=tk_id,
+        method="GET",
+        path="/somewhere/else",
+        operation_id=None,
+        api_vendor=_VENDOR,
+    )
+    assert no_match.allowed is False
+    assert no_match.rules_loaded == 1

--- a/tests/integration/control/test_provisioning_plan_e2e.py
+++ b/tests/integration/control/test_provisioning_plan_e2e.py
@@ -141,9 +141,8 @@ async def test_provisioning_plan_end_to_end(integration_context: Context, clean:
     )
 
     # 2. WIZARD (operator) fulfils the create/provision steps with real resources.
-    created_toolkit, _key = await toolkit_svc.create(
-        name="httpbin.org/httpbin", identity=_owner_identity()
-    )
+    _create = await toolkit_svc.create(name="httpbin.org/httpbin", identity=_owner_identity())
+    created_toolkit = _create.toolkit
     created_cred = await cred_svc.create(
         CredentialCreate(
             type=CredentialType.BEARER_TOKEN,
@@ -266,9 +265,8 @@ async def test_noauth_plan_is_executable_via_broker_resolvers(
 
     # 2. WIZARD fulfils: create the toolkit + a NO_AUTH credential (no version →
     #    persisted NULL), amend their ids onto the binds, then approve.
-    created_toolkit, _key = await toolkit_svc.create(
-        name="country-is/country-is", identity=_owner_identity()
-    )
+    _create = await toolkit_svc.create(name="country-is/country-is", identity=_owner_identity())
+    created_toolkit = _create.toolkit
     created_cred = await cred_svc.create(
         CredentialCreate(
             type=CredentialType.NO_AUTH,

--- a/tests/integration/control/test_toolkit_bind_api_conflict.py
+++ b/tests/integration/control/test_toolkit_bind_api_conflict.py
@@ -117,9 +117,9 @@ async def test_bind_credential_for_different_api_allowed(
     await _bind_directly(control_db, tk_id, "cred_v1")
 
     svc = ToolkitService(integration_context)
-    binding = await svc.bind_credential(tk_id, "cred_v2", identity=_IDENTITY)
+    result = await svc.bind_credential(tk_id, "cred_v2", identity=_IDENTITY)
 
-    assert binding.credential_id == "cred_v2"
+    assert result.binding.credential_id == "cred_v2"
 
 
 async def test_bind_credential_when_existing_is_inactive_allowed(
@@ -140,6 +140,6 @@ async def test_bind_credential_when_existing_is_inactive_allowed(
     await _bind_directly(control_db, tk_id, "cred_stale")
 
     svc = ToolkitService(integration_context)
-    binding = await svc.bind_credential(tk_id, "cred_fresh", identity=_IDENTITY)
+    result = await svc.bind_credential(tk_id, "cred_fresh", identity=_IDENTITY)
 
-    assert binding.credential_id == "cred_fresh"
+    assert result.binding.credential_id == "cred_fresh"

--- a/tests/unit/broker/test_gate3_unconditional.py
+++ b/tests/unit/broker/test_gate3_unconditional.py
@@ -44,14 +44,15 @@ async def test_evaluator_denies_when_no_rules_loaded() -> None:
     mock_db.session = MagicMock(return_value=_AsyncCtx(mock_session))
 
     evaluator = RuleEvaluator(mock_db, cache_ttl_seconds=300.0)
-    allowed = await evaluator.evaluate(
+    result = await evaluator.evaluate(
         toolkit_id="tk_test",
         method="POST",
         path="/v1/resource",
         operation_id="createResource",
         api_vendor="acme",
     )
-    assert allowed is False
+    assert result.allowed is False
+    assert result.rules_loaded == 0
 
 
 @pytest.mark.asyncio
@@ -65,11 +66,11 @@ async def test_evaluator_denies_with_empty_toolkit_id() -> None:
     mock_db.session = MagicMock(return_value=_AsyncCtx(mock_session))
 
     evaluator = RuleEvaluator(mock_db, cache_ttl_seconds=300.0)
-    allowed = await evaluator.evaluate(
+    result = await evaluator.evaluate(
         toolkit_id="",
         method="GET",
         path="/anything",
         operation_id=None,
         api_vendor="vendor",
     )
-    assert allowed is False
+    assert result.allowed is False

--- a/tests/unit/broker/test_rule_evaluator.py
+++ b/tests/unit/broker/test_rule_evaluator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -11,12 +10,13 @@ from jentic_one.broker.repos.rule_evaluator import (
     PermissionRule,
     RuleEvaluator,
     _coerce_json_list,
-    _compile_path,
+    _compile_path_for_rule,
     _normalize_methods,
     _rule_matches,
     evaluate_rules,
 )
 from jentic_one.shared.broker.protocols import RuleEvaluatorProtocol
+from jentic_one.shared.permissions.matching import compile_matcher
 
 # ---------------------------------------------------------------------------
 # Rule matching
@@ -40,12 +40,56 @@ def test_methods_match() -> None:
     assert not _rule_matches(rule, method="DELETE", path="/x", operation_id=None)
 
 
-def test_path_regex_match() -> None:
+def test_path_regex_match_full_match_semantics() -> None:
+    # #751: regex mode is full-match, so a bare ``/v1/users/.*`` matches
+    # ``/v1/users/123`` but not ``/prefix/v1/users/123`` (which the old
+    # start-anchored ``.match()`` behaviour would also have rejected — the
+    # deliberate change is the tail: fullmatch is strict about what follows
+    # the last capture, not about the prefix).
     rule = PermissionRule(
-        effect="allow", methods=None, path=re.compile(r"^/v1/users/.*"), operations=None
+        effect="allow",
+        methods=None,
+        path=compile_matcher(r"/v1/users/.*", "regex"),
+        operations=None,
     )
     assert _rule_matches(rule, method="GET", path="/v1/users/123", operation_id=None)
     assert not _rule_matches(rule, method="GET", path="/v2/users/123", operation_id=None)
+
+
+def test_path_full_match_rejects_trailing_content() -> None:
+    # Regression for #578-adjacent behaviour: full-match means the pattern
+    # must describe the whole path — ``/v1/users/\d+`` no longer matches
+    # ``/v1/users/42/roles``.
+    rule = PermissionRule(
+        effect="allow",
+        methods=None,
+        path=compile_matcher(r"/v1/users/\d+", "regex"),
+        operations=None,
+    )
+    assert _rule_matches(rule, method="GET", path="/v1/users/42", operation_id=None)
+    assert not _rule_matches(rule, method="GET", path="/v1/users/42/roles", operation_id=None)
+
+
+def test_path_prefix_mode_is_literal() -> None:
+    rule = PermissionRule(
+        effect="allow",
+        methods=None,
+        path=compile_matcher("/v1/users", "prefix"),
+        operations=None,
+    )
+    assert _rule_matches(rule, method="GET", path="/v1/users/42", operation_id=None)
+    assert not _rule_matches(rule, method="GET", path="/v2/users", operation_id=None)
+
+
+def test_path_exact_mode_is_literal() -> None:
+    rule = PermissionRule(
+        effect="allow",
+        methods=None,
+        path=compile_matcher("/v1/users", "exact"),
+        operations=None,
+    )
+    assert _rule_matches(rule, method="GET", path="/v1/users", operation_id=None)
+    assert not _rule_matches(rule, method="GET", path="/v1/users/42", operation_id=None)
 
 
 def test_operations_match() -> None:
@@ -65,7 +109,7 @@ def test_all_criteria_must_match() -> None:
     rule = PermissionRule(
         effect="allow",
         methods=frozenset({"GET"}),
-        path=re.compile(r"^/api/.*"),
+        path=compile_matcher(r"/api/.*", "regex"),
         operations=("getUser",),
     )
     assert _rule_matches(rule, method="GET", path="/api/users", operation_id="getUser")
@@ -75,26 +119,35 @@ def test_all_criteria_must_match() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Pattern compilation safety
+# Pattern compilation safety (delegates to shared seam; logs on fail-closed)
 # ---------------------------------------------------------------------------
 
 
-def test_compile_path_none() -> None:
-    assert _compile_path(None) is None
+def test_compile_none_returns_none() -> None:
+    assert _compile_path_for_rule(None, "regex", toolkit_id="tk_1") is None
 
 
-def test_compile_path_valid() -> None:
-    pat = _compile_path(r"^/v1/.*")
-    assert pat is not None
-    assert pat.match("/v1/foo")
+def test_compile_valid_returns_matcher() -> None:
+    m = _compile_path_for_rule(r"/v1/.*", "regex", toolkit_id="tk_1")
+    assert m is not None
+    assert m.never is False
+    assert m.matches("/v1/foo") is True
 
 
-def test_compile_path_invalid_regex() -> None:
-    assert _compile_path("[invalid") is None
+def test_compile_invalid_regex_is_fail_closed() -> None:
+    m = _compile_path_for_rule("[invalid", "regex", toolkit_id="tk_1")
+    assert m is not None
+    assert m.never is True
+    # Fail-closed replaces the pre-#751 silent wildcard: an unparseable
+    # legacy row now blocks every request rather than accidentally granting
+    # everything.
+    assert m.matches("/anything") is False
 
 
-def test_compile_path_oversized() -> None:
-    assert _compile_path("a" * 1001) is None
+def test_compile_oversized_is_fail_closed() -> None:
+    m = _compile_path_for_rule("a" * 1001, "regex", toolkit_id="tk_1")
+    assert m is not None
+    assert m.never is True
 
 
 # ---------------------------------------------------------------------------
@@ -282,7 +335,10 @@ async def test_evaluator_empty_rules_denies() -> None:
     result = await evaluator.evaluate(
         toolkit_id="tk_1", method="GET", path="/x", operation_id=None, api_vendor="acme"
     )
-    assert result is False
+    assert result.allowed is False
+    # #578: rules_loaded is 0 when nothing was loaded for the pool — the
+    # router keys its two-variant deny detail on this.
+    assert result.rules_loaded == 0
 
 
 @pytest.mark.asyncio
@@ -299,7 +355,7 @@ async def test_evaluator_coerces_sqlite_json_string_methods() -> None:
     mock_session = AsyncMock()
     mock_result = MagicMock()
     mock_result.all.return_value = [
-        ("allow", '["GET", "POST", "PUT", "PATCH", "DELETE"]', ".*", "null")
+        ("allow", '["GET", "POST", "PUT", "PATCH", "DELETE"]', ".*", "null", "regex")
     ]
     mock_session.execute = AsyncMock(return_value=mock_result)
     mock_db.session = MagicMock(return_value=_AsyncCtx(mock_session))
@@ -308,13 +364,16 @@ async def test_evaluator_coerces_sqlite_json_string_methods() -> None:
     allowed = await evaluator.evaluate(
         toolkit_id="tk_1", method="POST", path="/v1/things", operation_id=None, api_vendor="acme"
     )
-    assert allowed is True
+    assert allowed.allowed is True
+    assert allowed.rules_loaded == 1
 
     # A method outside the (correctly parsed) set must NOT match.
     denied = await evaluator.evaluate(
         toolkit_id="tk_1", method="OPTIONS", path="/v1/things", operation_id=None, api_vendor="acme"
     )
-    assert denied is False
+    assert denied.allowed is False
+    # Non-zero rules_loaded distinguishes "loaded but no match" from "no rules".
+    assert denied.rules_loaded == 1
 
 
 @pytest.mark.asyncio
@@ -323,7 +382,7 @@ async def test_evaluator_cached_second_call() -> None:
     mock_db = MagicMock()
     mock_session = AsyncMock()
     mock_result = MagicMock()
-    mock_result.all.return_value = [("allow", None, ".*", None)]
+    mock_result.all.return_value = [("allow", None, ".*", None, "regex")]
     mock_session.execute = AsyncMock(return_value=mock_result)
     mock_db.session = MagicMock(return_value=_AsyncCtx(mock_session))
 
@@ -334,8 +393,8 @@ async def test_evaluator_cached_second_call() -> None:
     r2 = await evaluator.evaluate(
         toolkit_id="tk_1", method="POST", path="/y", operation_id="op", api_vendor="acme"
     )
-    assert r1 is True
-    assert r2 is True
+    assert r1.allowed is True
+    assert r2.allowed is True
     mock_session.execute.assert_called_once()
 
 
@@ -345,7 +404,7 @@ async def test_evaluator_distinct_toolkits_separate_cache() -> None:
     mock_db = MagicMock()
     mock_session = AsyncMock()
     mock_result = MagicMock()
-    mock_result.all.return_value = [("allow", None, ".*", None)]
+    mock_result.all.return_value = [("allow", None, ".*", None, "regex")]
     mock_session.execute = AsyncMock(return_value=mock_result)
     mock_db.session = MagicMock(return_value=_AsyncCtx(mock_session))
 
@@ -365,7 +424,7 @@ async def test_evaluator_distinct_vendors_separate_cache() -> None:
     mock_db = MagicMock()
     mock_session = AsyncMock()
     mock_result = MagicMock()
-    mock_result.all.return_value = [("allow", None, ".*", None)]
+    mock_result.all.return_value = [("allow", None, ".*", None, "regex")]
     mock_session.execute = AsyncMock(return_value=mock_result)
     mock_db.session = MagicMock(return_value=_AsyncCtx(mock_session))
 
@@ -385,7 +444,7 @@ async def test_evaluator_clear_drops_cache() -> None:
     mock_db = MagicMock()
     mock_session = AsyncMock()
     mock_result = MagicMock()
-    mock_result.all.return_value = [("allow", None, ".*", None)]
+    mock_result.all.return_value = [("allow", None, ".*", None, "regex")]
     mock_session.execute = AsyncMock(return_value=mock_result)
     mock_db.session = MagicMock(return_value=_AsyncCtx(mock_session))
 

--- a/tests/unit/control/test_permission_rule_schemas.py
+++ b/tests/unit/control/test_permission_rule_schemas.py
@@ -1,0 +1,124 @@
+"""Unit tests for the shared permission-rule base schema.
+
+Both authoring surfaces (`toolkits.py` and `access_requests.py`) inherit
+from :class:`BasePermissionRuleSchema`, so validation is exercised through
+the concrete subclasses here — the goal is to prove save-time behaviour is
+identical on both surfaces.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from jentic_one.control.web.schemas.access_requests import (
+    PermissionRuleSchema as ARPermissionRuleSchema,
+)
+from jentic_one.control.web.schemas.toolkits import (
+    PermissionRuleSchema as TKPermissionRuleSchema,
+)
+
+# ---------------------------------------------------------------------------
+# match_mode default + acceptance
+# ---------------------------------------------------------------------------
+
+
+def test_toolkit_rule_defaults_match_mode_to_regex() -> None:
+    rule = TKPermissionRuleSchema(effect="allow", path=".*")
+    assert rule.match_mode == "regex"
+
+
+@pytest.mark.parametrize("mode", ["regex", "prefix", "exact"])
+def test_toolkit_rule_accepts_all_match_modes(mode: str) -> None:
+    rule = TKPermissionRuleSchema(effect="allow", path="/v1/x", match_mode=mode)  # type: ignore[arg-type]
+    assert rule.match_mode == mode
+
+
+def test_toolkit_rule_rejects_unknown_match_mode() -> None:
+    with pytest.raises(ValidationError):
+        TKPermissionRuleSchema.model_validate(
+            {"effect": "allow", "path": "/x", "match_mode": "glob"}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Path validation (delegates to shared seam, surfaces `re.error` reason)
+# ---------------------------------------------------------------------------
+
+
+def test_toolkit_rule_rejects_invalid_regex_with_reason() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        TKPermissionRuleSchema(effect="allow", path="[unterminated", match_mode="regex")
+    # The reason text carries the underlying ``re.error`` so callers can fix
+    # the pattern without guessing what tripped validation.
+    assert "invalid regex" in str(exc_info.value).lower()
+
+
+def test_toolkit_rule_rejects_oversized_path() -> None:
+    with pytest.raises(ValidationError):
+        TKPermissionRuleSchema(effect="allow", path="a" * 1001)
+
+
+@pytest.mark.parametrize("mode", ["regex", "prefix", "exact"])
+def test_toolkit_rule_rejects_empty_path(mode: str) -> None:
+    # An empty string satisfies the truthiness of "field is set" (bypassing
+    # the condition-less-allow guard) yet matches every request in prefix
+    # mode. The seam rejects it before the guard fires.
+    with pytest.raises(ValidationError):
+        TKPermissionRuleSchema.model_validate({"effect": "allow", "path": "", "match_mode": mode})
+
+
+# ---------------------------------------------------------------------------
+# Condition-less-`allow` guard (shared across surfaces)
+# ---------------------------------------------------------------------------
+
+
+def test_toolkit_condition_less_allow_still_rejected() -> None:
+    # Guard predates #751 but must survive the refactor onto the shared base.
+    with pytest.raises(ValidationError):
+        TKPermissionRuleSchema(effect="allow")
+
+
+def test_toolkit_condition_less_deny_stays_valid() -> None:
+    rule = TKPermissionRuleSchema(effect="deny")
+    assert rule.effect == "deny"
+
+
+def test_access_request_condition_less_allow_still_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ARPermissionRuleSchema(effect="allow")
+
+
+def test_access_request_require_approval_condition_less_stays_valid() -> None:
+    # ``require-approval`` (access-request-only) is a legitimate catch-all
+    # like ``deny``, so the guard must not fire on it.
+    rule = ARPermissionRuleSchema(effect="require-approval")
+    assert rule.effect == "require-approval"
+
+
+# ---------------------------------------------------------------------------
+# extra="forbid" — misspelled fields fail loud, both surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_toolkit_rule_rejects_unknown_field() -> None:
+    with pytest.raises(ValidationError):
+        TKPermissionRuleSchema.model_validate({"effect": "allow", "mach_mode": "regex"})
+
+
+def test_access_request_rule_rejects_unknown_field() -> None:
+    with pytest.raises(ValidationError):
+        ARPermissionRuleSchema.model_validate({"effect": "allow", "mach_mode": "regex"})
+
+
+# ---------------------------------------------------------------------------
+# Dump semantics — match_mode always survives model_dump(exclude_none=True)
+# ---------------------------------------------------------------------------
+
+
+def test_toolkit_rule_dump_always_carries_match_mode() -> None:
+    # ``match_mode`` has a non-None default so ``exclude_none=True`` never
+    # drops it — the repo layer can always trust ``rule_data["match_mode"]``.
+    rule = TKPermissionRuleSchema(effect="allow", path=".*")
+    dumped = rule.model_dump(exclude_none=True)
+    assert dumped["match_mode"] == "regex"

--- a/tests/unit/control/test_toolkit_schemas.py
+++ b/tests/unit/control/test_toolkit_schemas.py
@@ -26,22 +26,21 @@ def test_toolkit_create_request_minimal() -> None:
     assert req.description is None
     assert req.active is True
     assert req.credential_ids is None
-    assert req.permissions is None
 
 
 def test_toolkit_create_request_full() -> None:
+    # Toolkit-level ``permissions`` were dropped from the schema in issue
+    # #655 — the field is silently ignored by Pydantic here (the router
+    # rejects it with a raw-body peek at request time).
     req = ToolkitCreateRequest(
         name="full-toolkit",
         description="A toolkit",
         active=False,
         credential_ids=["cred_1", "cred_2"],
-        permissions=[PermissionRuleSchema(effect="allow", path="/api/*")],
     )
     assert req.name == "full-toolkit"
     assert req.active is False
     assert req.credential_ids == ["cred_1", "cred_2"]
-    assert req.permissions is not None
-    assert req.permissions[0].path == "/api/*"
 
 
 def test_toolkit_update_request_partial() -> None:
@@ -57,7 +56,6 @@ def test_toolkit_response_round_trip() -> None:
         toolkit_id="tk_abc123",
         name="test",
         active=True,
-        permissions=[],
         key_count=2,
         credential_count=1,
         created_at=now,
@@ -66,6 +64,9 @@ def test_toolkit_response_round_trip() -> None:
     assert data["toolkit_id"] == "tk_abc123"
     assert data["key_count"] == 2
     assert data["credential_count"] == 1
+    # #655: toolkit-level ``permissions`` was dropped from the response —
+    # the enforced surface is per-binding rules.
+    assert "permissions" not in data
 
 
 def test_permission_rule_schema_minimal() -> None:
@@ -147,6 +148,13 @@ def test_toolkit_credential_bind_request() -> None:
 def test_toolkit_create_request_missing_name_fails() -> None:
     with pytest.raises(ValidationError):
         ToolkitCreateRequest()  # type: ignore[call-arg]
+
+
+def test_toolkit_create_request_no_longer_has_permissions_field() -> None:
+    # #655 regression: the ``permissions`` field was silently accepted then
+    # dropped by the broker. It must be gone from the model — the router's
+    # raw-body peek is what catches a client still submitting the key.
+    assert "permissions" not in ToolkitCreateRequest.model_fields
 
 
 def test_toolkit_create_request_name_too_long() -> None:

--- a/tests/unit/shared/test_permission_matching.py
+++ b/tests/unit/shared/test_permission_matching.py
@@ -1,0 +1,148 @@
+"""Unit tests for the shared permission path-matching seam."""
+
+from __future__ import annotations
+
+import pytest
+
+from jentic_one.shared.permissions.matching import (
+    MATCH_MODES,
+    MAX_PATTERN_LENGTH,
+    PathValidationError,
+    compile_matcher,
+    validate_path,
+)
+
+# ---------------------------------------------------------------------------
+# validate_path
+# ---------------------------------------------------------------------------
+
+
+def test_none_path_is_always_valid() -> None:
+    # ``None`` is the "no path constraint" sentinel and must be accepted in
+    # every mode — that's the only way to author a rule that grants across
+    # the whole vendor without listing paths explicitly.
+    for mode in MATCH_MODES:
+        assert validate_path(None, mode) is None
+
+
+def test_empty_path_is_rejected_in_every_mode() -> None:
+    # Empty string would satisfy the schema's condition-less-allow guard
+    # (a set field is a "constraint") while matching every request in
+    # prefix mode — an unrestricted grant disguised as a constraint.
+    for mode in MATCH_MODES:
+        err = validate_path("", mode)
+        assert isinstance(err, PathValidationError)
+        assert err.code == "empty_path"
+
+
+def test_valid_regex_returns_none() -> None:
+    assert validate_path(r"/v1/users/.*", "regex") is None
+
+
+def test_invalid_regex_returns_structured_reason() -> None:
+    err = validate_path("[unterminated", "regex")
+    assert isinstance(err, PathValidationError)
+    assert err.code == "invalid_regex"
+    # The stored ``re.error`` reason is preserved so callers can fix the pattern
+    # without guessing what tripped the parser.
+    assert "invalid regex" in err.reason
+
+
+def test_oversized_pattern_rejected() -> None:
+    err = validate_path("a" * (MAX_PATTERN_LENGTH + 1), "regex")
+    assert isinstance(err, PathValidationError)
+    assert err.code == "pattern_too_long"
+
+
+def test_unknown_mode_rejected() -> None:
+    err = validate_path("/x", "glob")
+    assert isinstance(err, PathValidationError)
+    assert err.code == "unknown_mode"
+
+
+def test_literal_modes_accept_any_string_shape() -> None:
+    # Literal modes do not parse the string, so brackets that would blow up
+    # regex compilation are fine.
+    assert validate_path("[not-a-regex]", "prefix") is None
+    assert validate_path("[not-a-regex]", "exact") is None
+
+
+# ---------------------------------------------------------------------------
+# compile_matcher — regex
+# ---------------------------------------------------------------------------
+
+
+def test_compile_none_returns_none() -> None:
+    assert compile_matcher(None, "regex") is None
+
+
+def test_regex_matches_full_path_only() -> None:
+    # This is the anchoring migration: ``.match()`` used to accept
+    # ``/v1/users/1/extra`` for the pattern ``/v1/users/\d+``; ``.fullmatch()``
+    # (via the new matcher) rejects it.
+    matcher = compile_matcher(r"/v1/users/\d+", "regex")
+    assert matcher is not None
+    assert matcher.matches("/v1/users/42") is True
+    assert matcher.matches("/v1/users/42/roles") is False
+    assert matcher.matches("/prefix/v1/users/42") is False
+
+
+def test_regex_wildcard_full_matches_any_path() -> None:
+    matcher = compile_matcher(".*", "regex")
+    assert matcher is not None
+    assert matcher.matches("/anything/goes") is True
+
+
+def test_invalid_stored_regex_fails_closed() -> None:
+    # A legacy row that predates ``validate_path`` returns a matcher that
+    # never matches — the opposite of today's silent wildcard.
+    matcher = compile_matcher("[unterminated", "regex")
+    assert matcher is not None
+    assert matcher.never is True
+    assert matcher.matches("/x") is False
+
+
+def test_oversized_stored_pattern_fails_closed() -> None:
+    matcher = compile_matcher("a" * (MAX_PATTERN_LENGTH + 1), "regex")
+    assert matcher is not None
+    assert matcher.never is True
+
+
+# ---------------------------------------------------------------------------
+# compile_matcher — literal modes
+# ---------------------------------------------------------------------------
+
+
+def test_prefix_matches_by_string_prefix() -> None:
+    matcher = compile_matcher("/v1/users", "prefix")
+    assert matcher is not None
+    assert matcher.matches("/v1/users") is True
+    assert matcher.matches("/v1/users/42") is True
+    assert matcher.matches("/v2/users") is False
+
+
+def test_exact_requires_full_string_equality() -> None:
+    matcher = compile_matcher("/v1/users", "exact")
+    assert matcher is not None
+    assert matcher.matches("/v1/users") is True
+    assert matcher.matches("/v1/users/42") is False
+    assert matcher.matches("/v1/user") is False
+
+
+@pytest.mark.parametrize("mode", ["prefix", "exact"])
+def test_literal_modes_do_not_interpret_regex_metachars(mode: str) -> None:
+    matcher = compile_matcher(".*", mode)
+    assert matcher is not None
+    # In literal modes, ``.*`` is the literal two-character string — not
+    # a wildcard — so it does not match ``/foo``.
+    assert matcher.matches(".*") is True
+    assert matcher.matches("/foo") is False
+
+
+def test_empty_stored_path_fails_closed_in_every_mode() -> None:
+    # Symmetry with ``validate_path``: even if an empty string got past
+    # validation it must not silently match everything.
+    for mode in MATCH_MODES:
+        matcher = compile_matcher("", mode)
+        assert matcher is not None
+        assert matcher.never is True

--- a/tests/web/control/test_access_requests.py
+++ b/tests/web/control/test_access_requests.py
@@ -272,7 +272,9 @@ def test_amend_returns_200(filer_client: TestClient) -> None:
     assert resp.status_code == 200
     body = resp.json()
     amended_item = next(i for i in body["items"] if i["id"] == item_id)
-    assert amended_item["rules"] == new_rules
+    assert amended_item["rules"] == [
+        {"effect": "allow", "methods": ["GET", "POST"], "match_mode": "regex"}
+    ]
 
 
 @pytest.fixture()

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -2184,6 +2184,39 @@
         "title": "BearerTokenUpdateRequest",
         "type": "object"
       },
+      "BindingWarningSchema": {
+        "description": "A non-fatal signal about a bind (or create-time inline bind).",
+        "properties": {
+          "code": {
+            "description": "Stable machine-readable warning code.",
+            "title": "Code",
+            "type": "string"
+          },
+          "credential_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Credential the warning applies to; null when the whole binding is meant.",
+            "title": "Credential Id"
+          },
+          "message": {
+            "description": "Human-readable explanation with a recovery pointer.",
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "title": "BindingWarningSchema",
+        "type": "object"
+      },
       "CatalogEntryLinksResponse": {
         "description": "Hypermedia links for a catalog entry.",
         "examples": [
@@ -5002,6 +5035,16 @@
             "title": "Effect",
             "type": "string"
           },
+          "match_mode": {
+            "default": "regex",
+            "enum": [
+              "regex",
+              "prefix",
+              "exact"
+            ],
+            "title": "Match Mode",
+            "type": "string"
+          },
           "methods": {
             "anyOf": [
               {
@@ -5046,6 +5089,109 @@
           "effect"
         ],
         "title": "PermissionRuleReadSchema",
+        "type": "object"
+      },
+      "PermissionTestRequest": {
+        "additionalProperties": false,
+        "description": "Request body for :test — dry-run a request shape against pooled rules.",
+        "properties": {
+          "method": {
+            "description": "HTTP method of the hypothetical request (case-insensitive).",
+            "title": "Method",
+            "type": "string"
+          },
+          "operation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional OpenAPI operation id resolved from the request URL.",
+            "title": "Operation Id"
+          },
+          "path": {
+            "description": "Path of the hypothetical request as the broker would see it.",
+            "title": "Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "method",
+          "path"
+        ],
+        "title": "PermissionTestRequest",
+        "type": "object"
+      },
+      "PermissionTestResponse": {
+        "description": "Dry-run result matching :class:`PermissionTestResult`.",
+        "properties": {
+          "allowed": {
+            "description": "Whether the broker would allow this request under the pooled rules.",
+            "title": "Allowed",
+            "type": "boolean"
+          },
+          "credential_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Which binding contributed the matching rule — vendor pooling means this may not equal the credential in the request URL.",
+            "title": "Credential Id"
+          },
+          "effect": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Effect of the matching rule (`allow`/`deny`); null when no match.",
+            "title": "Effect"
+          },
+          "is_system": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "True when the matching rule was written by the system; null when no match.",
+            "title": "Is System"
+          },
+          "matched": {
+            "description": "Whether any rule matched; when false, the outcome is default-deny.",
+            "title": "Matched",
+            "type": "boolean"
+          },
+          "rule_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Zero-based index in the vendor-pooled rule list; null when no match.",
+            "title": "Rule Index"
+          }
+        },
+        "required": [
+          "allowed",
+          "matched"
+        ],
+        "title": "PermissionTestResponse",
         "type": "object"
       },
       "Permissions": {
@@ -6687,20 +6833,6 @@
             "maxLength": 255,
             "title": "Name",
             "type": "string"
-          },
-          "permissions": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/jentic_one__control__web__schemas__toolkits__PermissionRuleSchema"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Permissions"
           }
         },
         "required": [
@@ -6718,6 +6850,14 @@
           },
           "toolkit": {
             "$ref": "#/components/schemas/ToolkitResponse"
+          },
+          "warnings": {
+            "description": "Non-fatal signals about the create — e.g. inline-bound credentials that landed with zero permission rules (broker denies by default).",
+            "items": {
+              "$ref": "#/components/schemas/BindingWarningSchema"
+            },
+            "title": "Warnings",
+            "type": "array"
           }
         },
         "required": [
@@ -6728,8 +6868,15 @@
         "type": "object"
       },
       "ToolkitCredentialBindRequest": {
+        "additionalProperties": false,
         "description": "Bind a credential to a toolkit.",
         "properties": {
+          "allow_all": {
+            "default": false,
+            "description": "Convenience flag: bind with a single `allow` rule that matches every request for this binding's vendor. Mutually exclusive with `permissions`.",
+            "title": "Allow All",
+            "type": "boolean"
+          },
           "credential_id": {
             "title": "Credential Id",
             "type": "string"
@@ -6821,6 +6968,14 @@
           "toolkit_id": {
             "title": "Toolkit Id",
             "type": "string"
+          },
+          "warnings": {
+            "description": "Non-fatal bind-time signals — e.g. a binding that landed with zero permission rules (broker denies by default until rules are added).",
+            "items": {
+              "$ref": "#/components/schemas/BindingWarningSchema"
+            },
+            "title": "Warnings",
+            "type": "array"
           }
         },
         "required": [
@@ -7141,14 +7296,6 @@
             "title": "Name",
             "type": "string"
           },
-          "permissions": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "title": "Permissions",
-            "type": "array"
-          },
           "toolkit_id": {
             "title": "Toolkit Id",
             "type": "string"
@@ -7170,7 +7317,6 @@
           "toolkit_id",
           "name",
           "active",
-          "permissions",
           "key_count",
           "credential_count",
           "created_at"
@@ -7719,63 +7865,15 @@
             "title": "Effect",
             "type": "string"
           },
-          "methods": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Methods"
-          },
-          "operations": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Operations"
-          },
-          "path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Path"
-          }
-        },
-        "required": [
-          "effect"
-        ],
-        "title": "PermissionRuleSchema",
-        "type": "object"
-      },
-      "jentic_one__control__web__schemas__toolkits__PermissionRuleSchema": {
-        "additionalProperties": false,
-        "description": "Permission rule for a toolkit-credential binding.\n\nRules are evaluated first-match-wins. If no rule matches, the request is\ndenied (default-deny). A binding with zero rules therefore blocks all\noperations — users must explicitly add at least one allow rule.",
-        "properties": {
-          "effect": {
-            "description": "Whether this rule allows or denies the matched request.",
+          "match_mode": {
+            "default": "regex",
+            "description": "How `path` is interpreted: `regex` (full-match), `prefix` (string prefix), or `exact` (equality). Defaults to `regex` for backwards compatibility.",
             "enum": [
-              "allow",
-              "deny"
+              "regex",
+              "prefix",
+              "exact"
             ],
-            "title": "Effect",
+            "title": "Match Mode",
             "type": "string"
           },
           "methods": {
@@ -7817,7 +7915,80 @@
                 "type": "null"
               }
             ],
-            "description": "Regex pattern for the request path. None matches all paths.",
+            "description": "Path pattern to match. Interpreted per `match_mode`: `regex` uses full-match semantics (the pattern must describe the whole path); `prefix` and `exact` are literal. None matches all paths.",
+            "title": "Path"
+          }
+        },
+        "required": [
+          "effect"
+        ],
+        "title": "PermissionRuleSchema",
+        "type": "object"
+      },
+      "jentic_one__control__web__schemas__toolkits__PermissionRuleSchema": {
+        "additionalProperties": false,
+        "description": "Permission rule for a toolkit-credential binding.\n\nRules are evaluated first-match-wins. If no rule matches, the request is\ndenied (default-deny). A binding with zero rules therefore blocks all\noperations — users must explicitly add at least one allow rule.",
+        "properties": {
+          "effect": {
+            "description": "Whether this rule allows or denies the matched request.",
+            "enum": [
+              "allow",
+              "deny"
+            ],
+            "title": "Effect",
+            "type": "string"
+          },
+          "match_mode": {
+            "default": "regex",
+            "description": "How `path` is interpreted: `regex` (full-match), `prefix` (string prefix), or `exact` (equality). Defaults to `regex` for backwards compatibility.",
+            "enum": [
+              "regex",
+              "prefix",
+              "exact"
+            ],
+            "title": "Match Mode",
+            "type": "string"
+          },
+          "methods": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "HTTP methods to match (case-insensitive). None matches all.",
+            "title": "Methods"
+          },
+          "operations": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "OpenAPI operation IDs to match. None matches all operations.",
+            "title": "Operations"
+          },
+          "path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Path pattern to match. Interpreted per `match_mode`: `regex` uses full-match semantics (the pattern must describe the whole path); `prefix` and `exact` are literal. None matches all paths.",
             "title": "Path"
           }
         },
@@ -26325,7 +26496,7 @@
         ]
       },
       "post": {
-        "description": "Create a toolkit and issue its first API key.\n\nThe plaintext key (`jntc_live_…`) is returned **once** in `api_key` and is\nnever retrievable again. Optional `credential_ids` bind existing credentials\nat creation time.",
+        "description": "Create a toolkit and issue its first API key.\n\nThe plaintext key (`jntc_live_…`) is returned **once** in `api_key` and is\nnever retrievable again. Optional `credential_ids` bind existing credentials\nat creation time; each inline bind emits a ``no_permission_rules`` warning\nbecause the broker denies by default until rules are added.",
         "operationId": "createToolkit",
         "requestBody": {
           "content": {
@@ -28223,6 +28394,188 @@
           }
         ],
         "summary": "Replace binding permission rules",
+        "tags": [
+          "Toolkit Permissions"
+        ]
+      }
+    },
+    "/toolkits/{toolkit_id}/credentials/{credential_id}/permissions:test": {
+      "post": {
+        "description": "Answer \"what would the broker do for this request?\" without calling upstream.\n\nEvaluates the same **vendor-pooled** rule set the broker sees at request\ntime — rules from all same-vendor bindings on this toolkit compete in one\nordered list. The response names which binding contributed the matching\nrule, which is not obvious from the toolkit id alone under pooling.",
+        "operationId": "testToolkitPermissions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "toolkit_id",
+            "required": true,
+            "schema": {
+              "title": "Toolkit Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "credential_id",
+            "required": true,
+            "schema": {
+              "title": "Credential Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PermissionTestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionTestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The request was malformed or failed a precondition.",
+                  "instance": "/example/path",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "type": "bad_request"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Authentication is required or the bearer token is invalid.",
+                  "instance": "/example/path",
+                  "status": 401,
+                  "title": "Unauthorized",
+                  "type": "unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The authenticated principal lacks the required permission.",
+                  "instance": "/example/path",
+                  "status": 403,
+                  "title": "Forbidden",
+                  "type": "forbidden"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The requested resource does not exist or is not visible to you.",
+                  "instance": "/example/path",
+                  "status": 404,
+                  "title": "Not Found",
+                  "type": "not_found"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Request validation failed; see errors[] for details.",
+                  "errors": [
+                    {
+                      "detail": "Field 'name' must not be blank.",
+                      "pointer": "#/name"
+                    }
+                  ],
+                  "instance": "/example/path",
+                  "status": 422,
+                  "title": "Unprocessable Entity",
+                  "type": "validation_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "An unexpected error occurred.",
+                  "instance": "/example/path",
+                  "status": 500,
+                  "title": "Internal Server Error",
+                  "type": "server_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The database is temporarily unavailable; please retry.",
+                  "instance": "/example/path",
+                  "status": 503,
+                  "title": "Service Unavailable",
+                  "type": "database_unavailable"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Dry-run permission evaluation",
         "tags": [
           "Toolkit Permissions"
         ]
@@ -30817,7 +31170,7 @@
       "name": "Toolkit Credentials"
     },
     {
-      "description": "Sub-resource of **Toolkits** (Core / Access bounded context). The fine-grained PBAC tier — per-`(toolkit, credential)` allow / deny / require-approval rules evaluated server-side. Rules use a priority model: `deny` > `require-approval` > `allow` — the strictest matching rule wins. Absence of a matching rule is an implicit deny. System rules (`_system: true`) participate in the same priority pool as user rules.\n\nThe coarse JWT-embedded scope tier on `Toolkit.permissions` (`capabilities:execute`, `apis:read`) is checked separately and composes with these rules — both must allow.",
+      "description": "Sub-resource of **Toolkits** (Core / Access bounded context). The fine-grained PBAC tier — per-`(toolkit, credential)` allow / deny / require-approval rules evaluated server-side. Rules use a priority model: `deny` > `require-approval` > `allow` — the strictest matching rule wins. Absence of a matching rule is an implicit deny. System rules (`_system: true`) participate in the same priority pool as user rules.\n\nToolkits have no separate scope tier of their own: a toolkit API key is minted with the fixed broker-execute scope (`capabilities:execute`), and every gated operation is decided by these per-binding rules.",
       "name": "Toolkit Permissions"
     },
     {
@@ -30877,7 +31230,7 @@
       "name": "Users"
     },
     {
-      "description": "Part of the **Admin / Audit** bounded context — the catalogue of grantable permission strings. Permissions are namespaced `resource:action` strings (`users:write`, `capabilities:execute`, `credentials:read`, …) gating every other surface in the API. The set is platform-defined and small; `GET /permissions` returns it in full, with each entry describing what it does, what it implies (the static implication map; e.g. `capabilities:execute` implies `apis:read` and `executions:read`), and whether the calling user is authorised to grant it.\n\nOne reserved superpower short-circuits individual checks in code: `org:admin` (full deployment-wide access, granted via direct DB action). It is not enumerated to non-holders by `GET /permissions`, and is rejected by `PUT /users/{user_id}/permissions` from any caller who doesn't already hold it.\n\nThe same vocabulary is used for `User.permissions` and for `Toolkit.permissions` — coarse JWT-embedded scopes — so the one catalogue covers both. Per-binding fine-grained `PermissionRule[]` (the inner PBAC tier) lives separately under the `Toolkit Permissions` tag.",
+      "description": "Part of the **Admin / Audit** bounded context — the catalogue of grantable permission strings. Permissions are namespaced `resource:action` strings (`users:write`, `capabilities:execute`, `credentials:read`, …) gating every other surface in the API. The set is platform-defined and small; `GET /permissions` returns it in full, with each entry describing what it does, what it implies (the static implication map; e.g. `capabilities:execute` implies `apis:read` and `executions:read`), and whether the calling user is authorised to grant it.\n\nOne reserved superpower short-circuits individual checks in code: `org:admin` (full deployment-wide access, granted via direct DB action). It is not enumerated to non-holders by `GET /permissions`, and is rejected by `PUT /users/{user_id}/permissions` from any caller who doesn't already hold it.\n\nThe same vocabulary is used for `User.permissions` — coarse JWT-embedded scopes — so the catalogue below covers user assignment. Toolkits have no separate scope tier of their own: a toolkit API key is minted with the fixed broker-execute scope, and the per-binding fine-grained `PermissionRule[]` (the inner PBAC tier) lives separately under the `Toolkit Permissions` tag.",
       "name": "Permissions"
     },
     {

--- a/ui/src/shared/api/generated/index.ts
+++ b/ui/src/shared/api/generated/index.ts
@@ -49,6 +49,7 @@ export type { BasicAuthCreateRequest } from './models/BasicAuthCreateRequest';
 export type { BasicAuthUpdateRequest } from './models/BasicAuthUpdateRequest';
 export type { BearerTokenCreateRequest } from './models/BearerTokenCreateRequest';
 export type { BearerTokenUpdateRequest } from './models/BearerTokenUpdateRequest';
+export type { BindingWarningSchema } from './models/BindingWarningSchema';
 export type { CatalogEntryLinksResponse } from './models/CatalogEntryLinksResponse';
 export type { CatalogEntryResponse } from './models/CatalogEntryResponse';
 export type { CatalogListResponse } from './models/CatalogListResponse';
@@ -123,6 +124,8 @@ export type { PermissionRuleListResponse } from './models/PermissionRuleListResp
 export { PermissionRuleReadSchema } from './models/PermissionRuleReadSchema';
 export type { Permissions } from './models/Permissions';
 export type { PermissionsPatchRequest } from './models/PermissionsPatchRequest';
+export type { PermissionTestRequest } from './models/PermissionTestRequest';
+export type { PermissionTestResponse } from './models/PermissionTestResponse';
 export type { PreviewInfoResponse } from './models/PreviewInfoResponse';
 export type { PreviewOperationResponse } from './models/PreviewOperationResponse';
 export type { PreviewParameterResponse } from './models/PreviewParameterResponse';

--- a/ui/src/shared/api/generated/models/BindingWarningSchema.ts
+++ b/ui/src/shared/api/generated/models/BindingWarningSchema.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * A non-fatal signal about a bind (or create-time inline bind).
+ */
+export type BindingWarningSchema = {
+    /**
+     * Stable machine-readable warning code.
+     */
+    code: string;
+    /**
+     * Credential the warning applies to; null when the whole binding is meant.
+     */
+    credential_id?: (string | null);
+    /**
+     * Human-readable explanation with a recovery pointer.
+     */
+    message: string;
+};
+

--- a/ui/src/shared/api/generated/models/PermissionRuleReadSchema.ts
+++ b/ui/src/shared/api/generated/models/PermissionRuleReadSchema.ts
@@ -9,6 +9,7 @@ export type PermissionRuleReadSchema = {
     _comment?: (string | null);
     _system?: boolean;
     effect: PermissionRuleReadSchema.effect;
+    match_mode?: PermissionRuleReadSchema.match_mode;
     methods?: (Array<string> | null);
     operations?: (Array<string> | null);
     path?: (string | null);
@@ -17,6 +18,11 @@ export namespace PermissionRuleReadSchema {
     export enum effect {
         ALLOW = 'allow',
         DENY = 'deny',
+    }
+    export enum match_mode {
+        REGEX = 'regex',
+        PREFIX = 'prefix',
+        EXACT = 'exact',
     }
 }
 

--- a/ui/src/shared/api/generated/models/PermissionTestRequest.ts
+++ b/ui/src/shared/api/generated/models/PermissionTestRequest.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Request body for :test — dry-run a request shape against pooled rules.
+ */
+export type PermissionTestRequest = {
+    /**
+     * HTTP method of the hypothetical request (case-insensitive).
+     */
+    method: string;
+    /**
+     * Optional OpenAPI operation id resolved from the request URL.
+     */
+    operation_id?: (string | null);
+    /**
+     * Path of the hypothetical request as the broker would see it.
+     */
+    path: string;
+};
+

--- a/ui/src/shared/api/generated/models/PermissionTestResponse.ts
+++ b/ui/src/shared/api/generated/models/PermissionTestResponse.ts
@@ -1,0 +1,34 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Dry-run result matching :class:`PermissionTestResult`.
+ */
+export type PermissionTestResponse = {
+    /**
+     * Whether the broker would allow this request under the pooled rules.
+     */
+    allowed: boolean;
+    /**
+     * Which binding contributed the matching rule — vendor pooling means this may not equal the credential in the request URL.
+     */
+    credential_id?: (string | null);
+    /**
+     * Effect of the matching rule (`allow`/`deny`); null when no match.
+     */
+    effect?: (string | null);
+    /**
+     * True when the matching rule was written by the system; null when no match.
+     */
+    is_system?: (boolean | null);
+    /**
+     * Whether any rule matched; when false, the outcome is default-deny.
+     */
+    matched: boolean;
+    /**
+     * Zero-based index in the vendor-pooled rule list; null when no match.
+     */
+    rule_index?: (number | null);
+};
+

--- a/ui/src/shared/api/generated/models/ToolkitCreateRequest.ts
+++ b/ui/src/shared/api/generated/models/ToolkitCreateRequest.ts
@@ -2,7 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { jentic_one__control__web__schemas__toolkits__PermissionRuleSchema } from './jentic_one__control__web__schemas__toolkits__PermissionRuleSchema';
 /**
  * Create a new toolkit.
  */
@@ -11,6 +10,5 @@ export type ToolkitCreateRequest = {
     credential_ids?: (Array<string> | null);
     description?: (string | null);
     name: string;
-    permissions?: (Array<jentic_one__control__web__schemas__toolkits__PermissionRuleSchema> | null);
 };
 

--- a/ui/src/shared/api/generated/models/ToolkitCreateResponse.ts
+++ b/ui/src/shared/api/generated/models/ToolkitCreateResponse.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { BindingWarningSchema } from './BindingWarningSchema';
 import type { ToolkitResponse } from './ToolkitResponse';
 /**
  * Create response: toolkit + api_key shown once.
@@ -9,5 +10,9 @@ import type { ToolkitResponse } from './ToolkitResponse';
 export type ToolkitCreateResponse = {
     api_key: string;
     toolkit: ToolkitResponse;
+    /**
+     * Non-fatal signals about the create — e.g. inline-bound credentials that landed with zero permission rules (broker denies by default).
+     */
+    warnings?: Array<BindingWarningSchema>;
 };
 

--- a/ui/src/shared/api/generated/models/ToolkitCredentialBindRequest.ts
+++ b/ui/src/shared/api/generated/models/ToolkitCredentialBindRequest.ts
@@ -7,6 +7,10 @@ import type { jentic_one__control__web__schemas__toolkits__PermissionRuleSchema 
  * Bind a credential to a toolkit.
  */
 export type ToolkitCredentialBindRequest = {
+    /**
+     * Convenience flag: bind with a single `allow` rule that matches every request for this binding's vendor. Mutually exclusive with `permissions`.
+     */
+    allow_all?: boolean;
     credential_id: string;
     permissions?: (Array<jentic_one__control__web__schemas__toolkits__PermissionRuleSchema> | null);
 };

--- a/ui/src/shared/api/generated/models/ToolkitCredentialBindingResponse.ts
+++ b/ui/src/shared/api/generated/models/ToolkitCredentialBindingResponse.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { BindingWarningSchema } from './BindingWarningSchema';
 import type { PermissionRuleReadSchema } from './PermissionRuleReadSchema';
 /**
  * Credential binding response.
@@ -15,5 +16,9 @@ export type ToolkitCredentialBindingResponse = {
     label?: (string | null);
     permissions?: Array<PermissionRuleReadSchema>;
     toolkit_id: string;
+    /**
+     * Non-fatal bind-time signals — e.g. a binding that landed with zero permission rules (broker denies by default until rules are added).
+     */
+    warnings?: Array<BindingWarningSchema>;
 };
 

--- a/ui/src/shared/api/generated/models/ToolkitResponse.ts
+++ b/ui/src/shared/api/generated/models/ToolkitResponse.ts
@@ -13,7 +13,6 @@ export type ToolkitResponse = {
     description?: (string | null);
     key_count: number;
     name: string;
-    permissions: Array<Record<string, any>>;
     toolkit_id: string;
     updated_at?: (string | null);
 };

--- a/ui/src/shared/api/generated/models/jentic_one__control__web__schemas__access_requests__PermissionRuleSchema.ts
+++ b/ui/src/shared/api/generated/models/jentic_one__control__web__schemas__access_requests__PermissionRuleSchema.ts
@@ -7,8 +7,21 @@
  */
 export type jentic_one__control__web__schemas__access_requests__PermissionRuleSchema = {
     effect: jentic_one__control__web__schemas__access_requests__PermissionRuleSchema.effect;
+    /**
+     * How `path` is interpreted: `regex` (full-match), `prefix` (string prefix), or `exact` (equality). Defaults to `regex` for backwards compatibility.
+     */
+    match_mode?: jentic_one__control__web__schemas__access_requests__PermissionRuleSchema.match_mode;
+    /**
+     * HTTP methods to match (case-insensitive). None matches all.
+     */
     methods?: (Array<string> | null);
+    /**
+     * OpenAPI operation IDs to match. None matches all operations.
+     */
     operations?: (Array<string> | null);
+    /**
+     * Path pattern to match. Interpreted per `match_mode`: `regex` uses full-match semantics (the pattern must describe the whole path); `prefix` and `exact` are literal. None matches all paths.
+     */
     path?: (string | null);
 };
 export namespace jentic_one__control__web__schemas__access_requests__PermissionRuleSchema {
@@ -16,6 +29,14 @@ export namespace jentic_one__control__web__schemas__access_requests__PermissionR
         ALLOW = 'allow',
         DENY = 'deny',
         REQUIRE_APPROVAL = 'require-approval',
+    }
+    /**
+     * How `path` is interpreted: `regex` (full-match), `prefix` (string prefix), or `exact` (equality). Defaults to `regex` for backwards compatibility.
+     */
+    export enum match_mode {
+        REGEX = 'regex',
+        PREFIX = 'prefix',
+        EXACT = 'exact',
     }
 }
 

--- a/ui/src/shared/api/generated/models/jentic_one__control__web__schemas__toolkits__PermissionRuleSchema.ts
+++ b/ui/src/shared/api/generated/models/jentic_one__control__web__schemas__toolkits__PermissionRuleSchema.ts
@@ -15,6 +15,10 @@ export type jentic_one__control__web__schemas__toolkits__PermissionRuleSchema = 
      */
     effect: jentic_one__control__web__schemas__toolkits__PermissionRuleSchema.effect;
     /**
+     * How `path` is interpreted: `regex` (full-match), `prefix` (string prefix), or `exact` (equality). Defaults to `regex` for backwards compatibility.
+     */
+    match_mode?: jentic_one__control__web__schemas__toolkits__PermissionRuleSchema.match_mode;
+    /**
      * HTTP methods to match (case-insensitive). None matches all.
      */
     methods?: (Array<string> | null);
@@ -23,7 +27,7 @@ export type jentic_one__control__web__schemas__toolkits__PermissionRuleSchema = 
      */
     operations?: (Array<string> | null);
     /**
-     * Regex pattern for the request path. None matches all paths.
+     * Path pattern to match. Interpreted per `match_mode`: `regex` uses full-match semantics (the pattern must describe the whole path); `prefix` and `exact` are literal. None matches all paths.
      */
     path?: (string | null);
 };
@@ -34,6 +38,14 @@ export namespace jentic_one__control__web__schemas__toolkits__PermissionRuleSche
     export enum effect {
         ALLOW = 'allow',
         DENY = 'deny',
+    }
+    /**
+     * How `path` is interpreted: `regex` (full-match), `prefix` (string prefix), or `exact` (equality). Defaults to `regex` for backwards compatibility.
+     */
+    export enum match_mode {
+        REGEX = 'regex',
+        PREFIX = 'prefix',
+        EXACT = 'exact',
     }
 }
 

--- a/ui/src/shared/api/generated/services/ToolkitPermissionsService.ts
+++ b/ui/src/shared/api/generated/services/ToolkitPermissionsService.ts
@@ -5,6 +5,8 @@
 import type { jentic_one__control__web__schemas__toolkits__PermissionRuleSchema } from '../models/jentic_one__control__web__schemas__toolkits__PermissionRuleSchema';
 import type { PermissionRuleListResponse } from '../models/PermissionRuleListResponse';
 import type { PermissionsPatchRequest } from '../models/PermissionsPatchRequest';
+import type { PermissionTestRequest } from '../models/PermissionTestRequest';
+import type { PermissionTestResponse } from '../models/PermissionTestResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -93,6 +95,46 @@ export class ToolkitPermissionsService {
         return __request(OpenAPI, {
             method: 'PUT',
             url: '/toolkits/{toolkit_id}/credentials/{credential_id}/permissions',
+            path: {
+                'toolkit_id': toolkitId,
+                'credential_id': credentialId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `Bad Request`,
+                401: `Unauthorized`,
+                403: `Forbidden`,
+                404: `Not Found`,
+                422: `Unprocessable Entity`,
+                500: `Internal Server Error`,
+                503: `Service Unavailable`,
+            },
+        });
+    }
+    /**
+     * Dry-run permission evaluation
+     * Answer "what would the broker do for this request?" without calling upstream.
+     *
+     * Evaluates the same **vendor-pooled** rule set the broker sees at request
+     * time — rules from all same-vendor bindings on this toolkit compete in one
+     * ordered list. The response names which binding contributed the matching
+     * rule, which is not obvious from the toolkit id alone under pooling.
+     * @returns PermissionTestResponse Successful Response
+     * @throws ApiError
+     */
+    public static testToolkitPermissions({
+        toolkitId,
+        credentialId,
+        requestBody,
+    }: {
+        toolkitId: string,
+        credentialId: string,
+        requestBody: PermissionTestRequest,
+    }): CancelablePromise<PermissionTestResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/toolkits/{toolkit_id}/credentials/{credential_id}/permissions:test',
             path: {
                 'toolkit_id': toolkitId,
                 'credential_id': credentialId,

--- a/ui/src/shared/api/generated/services/ToolkitsService.ts
+++ b/ui/src/shared/api/generated/services/ToolkitsService.ts
@@ -48,7 +48,8 @@ export class ToolkitsService {
      *
      * The plaintext key (`jntc_live_…`) is returned **once** in `api_key` and is
      * never retrievable again. Optional `credential_ids` bind existing credentials
-     * at creation time.
+     * at creation time; each inline bind emits a ``no_permission_rules`` warning
+     * because the broker denies by default until rules are added.
      * @returns ToolkitCreateResponse Successful Response
      * @throws ApiError
      */


### PR DESCRIPTION
## Summary

Consolidated fix for the four Theme 2 permission-enforcement issues, guided by
[`jentic-one-rules/docs/plans/theme-2-IMPL.md`](../jentic-one-rules/docs/plans/theme-2-IMPL.md).
All four are variants of the same "rule set is not rule read" bug — this PR
aligns authoring, storage, and enforcement onto one seam so they cannot drift again.

Closes #655, #751, #750, #578.

### Fixes #751 — path validation & matching

- New `src/jentic_one/shared/permissions/matching.py` is the single source of
  truth for `(path, match_mode)` validation and matching. Both authoring
  surfaces (`toolkits.py`, `access_requests.py`) now extend a shared
  `BasePermissionRuleSchema` so validation stays in lockstep.
- Save-time `validate_path()` surfaces the underlying `re.error` reason as
  ``422`` — callers can fix the pattern without guessing what tripped.
- Enforce-time `PathMatcher` is **fail-closed** on an unparseable stored row
  (legacy data), replacing the pre-fix silent-wildcard.
- Regex mode switches to **full-match** (`re.fullmatch`) — a pattern must
  describe the whole path, not just prefix-anchor it.
- New `match_mode` column (regex/prefix/exact) on `toolkit_permission_rules`
  with a back-filling migration (`k2f3a4b5c6d7`). NOTE: named `match_mode`,
  not `match`, because `MATCH` is a SQLite reserved word.
- New dry-run endpoint
  `POST /toolkits/{tk}/credentials/{cid}/permissions:test` evaluates the same
  **vendor-pooled** rule set the broker sees, so a dry-run cannot lie about
  which binding contributed the winning rule under pooling.

### Fixes #655 — toolkit-level permissions ignored

- `POST /toolkits` rejects a body carrying `permissions` via a raw-body
  dependency that raises `ToolkitLevelPermissionsUnsupportedError`, mapped
  to ``422 toolkit_level_permissions_unsupported`` — same "reject where not
  enforced" remedy as #656/#680.
- Drop the write-only `Toolkit.permissions` JSON column
  (migration `l3f4a5b6c7d8`); no data migration because the payloads never
  had enforcement semantics.
- Fix the misleading OpenAPI tag/permissions catalogue docs that described
  `Toolkit.permissions` as a coarse JWT scope tier.

### Fixes #750 — bind vs permission empty-deny

- `ToolkitService.bind_credential` now returns `BindResult(binding, rules,
  warnings)`; `create` returns `ToolkitCreateResult(toolkit, plaintext_key,
  warnings)`.
- Emit a structured ``no_permission_rules`` warning for **every** zero-rule
  bind — including inline binds via `credential_ids` on create — so an
  operator cannot ship a "created but permanently denied" toolkit without
  seeing it in the response.
- Add `allow_all` convenience flag on `ToolkitCredentialBindRequest` that
  writes an explicit `{effect: allow, path: .*, match_mode: regex}` rule
  (mutually exclusive with `permissions`).
- `ToolkitCreateResponse` and `ToolkitCredentialBindingResponse` gain a
  ``warnings[]`` field.

### Fixes #578 — wildcard rule still denies

- `RuleEvaluatorProtocol.evaluate` now returns
  `RuleEvaluation(allowed, rules_loaded)`.
- Gate 3 in `broker/web/routers/execute.py` keys its detail sentence on
  ``rules_loaded == 0`` — distinguishing **"no rules loaded for this vendor"**
  from **"loaded but nothing matched"** — with matching `PBAC_DENIED`
  telemetry summaries. No rule contents leak.
- Adds an end-to-end regression test proving `{effect: allow, path: ".*"}`
  actually allows under the new full-match semantics.

## Architectural notes

- The shared matcher lives in `shared/` because the broker cannot import
  control ORM — same boundary discipline as Theme 1.
- All rule writers (`replace_user_rules`, `patch_rules`, and the access-request
  `EffectApplicator` via the shared schema) now persist `match_mode`; the
  new `list_rules_for_vendor` mirrors the broker's `_RULES_QUERY` so the
  dry-run and the broker cannot disagree.
- No cross-DB writes were introduced; all writes stay in the control DB
  transaction.

## Test plan

- [x] `uv run pytest tests/unit tests/arch --no-cov` — **2 469 pass**
  (17 new unit tests for the shared matcher, 17 new for the shared schema
  base, evaluator + gate3 tests updated for `RuleEvaluation`, toolkit
  schema tests updated for the dropped `permissions` field)
- [x] `JENTIC_TEST_BACKEND=sqlite uv run pytest tests/integration -m integration --no-cov`
  — **490 pass** (10 new integration tests covering match-mode round-trip,
  prefix / full-match / fail-closed enforcement, vendor-pooled dry-run,
  and the #578 wildcard + two-variant-deny regression)
- [x] `make lint` — `ruff check`, `ruff format --check`, `mypy` all clean
  over 1 044 source files
- [x] `make openapi` regenerated `openapi/control/control.openapi.yaml` and
  `ui/openapi.json`; `make endpoints` regenerated the endpoint reference
- [x] `detect-secrets` and `commitlint` pre-commit hooks passed
- [ ] Postgres integration (`tests/web/*`) — requires local fixtures
  (`make start-fixtures`); the same code paths are covered by SQLite
  integration so this is a belt-and-braces check for the reviewer
- [ ] Manual smoke: `POST /toolkits {"permissions": [...]}` returns
  ``422 toolkit_level_permissions_unsupported``; bind with zero rules
  returns a ``no_permission_rules`` warning; wildcard `.*` rule allows an
  end-to-end brokered call; dry-run against a same-vendor sibling binding
  reports the pooling correctly


Made with [Cursor](https://cursor.com)