### PR TITLE
feat(broker): emit operator event on unserved-API execute denial

### DIFF
--- a/src/jentic_one/broker/web/routers/execute.py
+++ b/src/jentic_one/broker/web/routers/execute.py
@@ -292,6 +292,59 @@ def _empty_derivation_denial(
     )
 
 
+def _is_unserved_no_toolkit_binding(exc: ActionDeniedError) -> bool:
+    """True when ``exc`` denies with the pre-binding "no toolkit serves this API" case.
+
+    Splits the two ``no_toolkit_binding`` flavours ``_empty_derivation_denial``
+    emits: ``serves=True`` (a toolkit exists, the caller just isn't bound) is
+    agent-recoverable via an access request and does not warrant an operator
+    event; ``serves=False`` (nothing serves this API yet — a credential must be
+    provisioned first) is the operator-attention case, mirroring the 424
+    ``CREDENTIAL_NOT_PROVISIONED`` event on the post-binding side.
+    """
+    if exc.type != "no_toolkit_binding" or exc.directive is None:
+        return False
+    return exc.directive.parameters.get("toolkit_serves_api") is False
+
+
+async def _emit_toolkit_binding_unserved(
+    ctx: Context, *, api: APIReference, identity: Identity
+) -> None:
+    """Emit ``TOOLKIT_BINDING_UNSERVED`` best-effort (mirrors the PBAC_DENIED emit).
+
+    Fires once per denied execute request (the caller wraps `select_toolkit`);
+    the caller's own retry loop will re-emit — acceptable at WARNING severity,
+    and consistent with how ``CREDENTIAL_NOT_PROVISIONED`` (424) already emits
+    per attempt without in-process debouncing.
+    """
+    api_id = "/".join(part for part in (api.vendor, api.name) if part) or api.vendor
+    summary = f"No toolkit serves API '{api_id}' — provision a credential to enable binding."
+    try:
+        async with ctx.admin_db.transaction() as session:
+            await emit_event_best_effort(
+                session,
+                type=EventType.TOOLKIT_BINDING_UNSERVED,
+                severity=EventSeverity.WARNING,
+                summary=summary,
+                created_by=identity.sub,
+                actor_id=identity.sub,
+                actor_type=identity.actor_type.value,
+                data={
+                    "api": {
+                        "vendor": api.vendor,
+                        "name": api.name,
+                        "version": api.version,
+                    },
+                },
+            )
+    except Exception:
+        logger.warning(
+            "telemetry_emit_failed",
+            event_type=EventType.TOOLKIT_BINDING_UNSERVED,
+            exc_info=True,
+        )
+
+
 async def select_toolkit(
     *,
     deriver: ToolkitDeriverProtocol,
@@ -533,13 +586,23 @@ async def _handle(
     ctx_req.has_server_variable = has_host_server_variable(upstream_url)
     # Toolkit is derived from the discovered API identity (never the inbound header
     # verbatim); drives credential injection and execution attribution (§03).
-    ctx_req.toolkit_id = await select_toolkit(
-        deriver=deriver,
-        identity=identity,
-        api=resolved.api,
-        header_toolkit=request.headers.get("jentic-toolkit-id"),
-        instance=request.url.path,
-    )
+    try:
+        ctx_req.toolkit_id = await select_toolkit(
+            deriver=deriver,
+            identity=identity,
+            api=resolved.api,
+            header_toolkit=request.headers.get("jentic-toolkit-id"),
+            instance=request.url.path,
+        )
+    except ActionDeniedError as exc:
+        # Emit the operator-visible signal for the pre-binding no-toolkit case
+        # (nothing serves this API yet) before re-raising. The 424
+        # ``credential_not_provisioned`` path already emits
+        # ``CREDENTIAL_NOT_PROVISIONED`` (post-binding); this is the missing
+        # pre-binding twin. See ``TOOLKIT_BINDING_UNSERVED``.
+        if _is_unserved_no_toolkit_binding(exc):
+            await _emit_toolkit_binding_unserved(ctx, api=resolved.api, identity=identity)
+        raise
 
     # Evaluate toolkit permission rules — default-deny when no rule matches.
     # Unconditional: even if toolkit_id were empty the evaluator returns a

--- a/src/jentic_one/control/services/access_requests/effects.py
+++ b/src/jentic_one/control/services/access_requests/effects.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import enum
-from typing import Any
+from collections.abc import Sequence
+from typing import Any, Protocol
 
 import structlog
 
@@ -32,12 +33,134 @@ from jentic_one.control.services.access_requests.schemas.effects import (
 from jentic_one.shared.audit import AuditAction, AuditTargetType, record_audit_best_effort
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.context import Context
+from jentic_one.shared.models.access_requests import AccessRequestItemStatus
 from jentic_one.shared.models.actors import actor_type_from_id
 from jentic_one.shared.models.api_identity import slugify_api_field
 
 logger = structlog.get_logger(__name__)
 
 EffectResult = CredentialBindEffect | ToolkitBindEffect | ScopeGrantEffect | SkippedEffect
+
+
+# The fulfilment-only intent item types that mark a request as a provisioning
+# plan. Exposed here (rather than only on the service) so ``plan_governed_bind_items``
+# — the pure function that computes which binds a plan governs — stays close
+# to the phase table it consults.
+PLAN_INTENT_COMBINATIONS: frozenset[tuple[str, str]] = frozenset(
+    {("toolkit", "create"), ("credential", "provision")}
+)
+
+# Bind item combinations whose fulfilment contract flips inside a plan.
+_PLAN_GOVERNABLE_BINDS: frozenset[tuple[str, str]] = frozenset(
+    {("credential", "bind"), ("toolkit", "bind")}
+)
+
+# Item statuses that keep an intent (or bind) "live" for the purposes of
+# governance. A withdrawn/denied intent no longer defines a plan on a later
+# decide() call.
+_LIVE_ITEM_STATUSES: frozenset[str] = frozenset(
+    {AccessRequestItemStatus.PENDING.value, AccessRequestItemStatus.APPROVED.value}
+)
+
+
+class _PlanGovernanceItem(Protocol):
+    """Minimal read-only view of an access-request item for governance.
+
+    ``plan_governed_bind_items`` only inspects a handful of attributes; declaring
+    that surface explicitly lets the tests pass ordinary duck-typed mocks
+    without an ``AccessRequestItem`` construction.
+    """
+
+    id: str
+    resource_type: str
+    action: str
+    resource_reference: dict[str, Any] | None
+    status: str
+
+
+def _canonical_api_key(reference: dict[str, Any] | None) -> tuple[str, str | None] | None:
+    """Return the ``(vendor, name)`` slug key an item's reference targets.
+
+    Version is deliberately excluded from the key: an intent filed against
+    ``vendor/name`` wildcards every version of that API for governance purposes
+    — a plan for ``sendgrid`` covers a bind for ``sendgrid@1``. Both axes are
+    slugified via the shared identity seam so raw-domain references from the
+    CLI (``httpbin.org``) match stored slug form (``httpbin-org``); see the
+    same normalization in ``_resolve_toolkit_reference``.
+    """
+    if not reference:
+        return None
+    vendor = reference.get("vendor")
+    if not vendor:
+        return None
+    raw_name = reference.get("name")
+    return (
+        slugify_api_field(str(vendor)),
+        slugify_api_field(str(raw_name)) if raw_name else None,
+    )
+
+
+def plan_governed_bind_items(items: Sequence[_PlanGovernanceItem]) -> frozenset[str]:
+    """Compute the ids of bind items governed by a provisioning plan.
+
+    A request is a *plan* iff it carries at least one live fulfilment-only
+    intent (``toolkit:create`` / ``credential:provision``). This function
+    returns the bind items *inside that request* whose fulfilment contract
+    the plan flips: they can only be satisfied by ids stamped by the wizard
+    (see ``EffectApplicator.validate``). A plain approval of such a bind
+    denies with :class:`ProvisioningPlanNotFulfilledError`.
+
+    Governance is per-item, not request-wide (issue #778):
+
+    - A ``toolkit:bind`` is governed iff a live intent's canonical
+      ``(vendor, name)`` matches the bind's ``resource_reference``. Version is
+      not part of the key — an intent for ``vendor/name`` covers all versions.
+      A bind for a different API is *not* governed and resolves normally by
+      its reference.
+    - A ``credential:bind`` is governed whenever any live intent exists in
+      the request: agents never carry credential ids at file time, so a
+      credential-bind sharing a request with an intent is always the wizard's
+      to satisfy.
+
+    Non-live intents (``denied`` / ``withdrawn``) do not govern — abandoning a
+    plan reverts remaining binds to the plain contract on the next decide.
+    """
+    live_intents = [
+        it
+        for it in items
+        if (it.resource_type, it.action) in PLAN_INTENT_COMBINATIONS
+        and (it.status in _LIVE_ITEM_STATUSES)
+    ]
+    if not live_intents:
+        return frozenset()
+
+    intent_api_keys = {
+        key for it in live_intents if (key := _canonical_api_key(it.resource_reference)) is not None
+    }
+    has_untargeted_intent = any(
+        _canonical_api_key(it.resource_reference) is None for it in live_intents
+    )
+
+    governed: set[str] = set()
+    for item in items:
+        key = (item.resource_type, item.action)
+        if key not in _PLAN_GOVERNABLE_BINDS:
+            continue
+        if item.status not in _LIVE_ITEM_STATUSES:
+            # An already-decided bind isn't going to be re-validated; excluding
+            # it keeps the set to items decide() actually processes.
+            continue
+        if key == ("credential", "bind"):
+            governed.add(item.id)
+            continue
+        # ("toolkit", "bind"): governed only when a live intent targets the
+        # same API. An untargeted intent (unusual — the CLI always fills a
+        # reference) is treated as covering all bind targets to preserve the
+        # pre-#778 conservative behaviour for that edge case.
+        bind_key = _canonical_api_key(item.resource_reference)
+        if has_untargeted_intent or (bind_key is not None and bind_key in intent_api_keys):
+            governed.add(item.id)
+    return frozenset(governed)
 
 
 class EffectPhase(enum.Enum):

--- a/src/jentic_one/control/services/access_requests/service.py
+++ b/src/jentic_one/control/services/access_requests/service.py
@@ -21,6 +21,7 @@ from jentic_one.control.services.access_requests.effects import (
     EffectPhase,
     admin_effect_keys,
     classify_effect,
+    plan_governed_bind_items,
 )
 from jentic_one.control.services.access_requests.errors import (
     AccessRequestNotFoundError,
@@ -84,7 +85,9 @@ _UNFULFILLABLE_BIND_TARGET: tuple[type[Exception], ...] = (
 # plan. Their presence means the bind items are fulfilled out-of-band by the
 # setup wizard (create toolkit + credential, then amend their ids), so a plain
 # approval of an unfulfilled bind must be denied with a plan-aware reason rather
-# than half-approving into a guaranteed-broken state.
+# than half-approving into a guaranteed-broken state. Governance is computed
+# per-item by :func:`plan_governed_bind_items` (issue #778); this constant is
+# retained only for tests/documentation that name the combinations.
 _PLAN_INTENT_COMBINATIONS: frozenset[tuple[str, str]] = frozenset(
     {("toolkit", "create"), ("credential", "provision")}
 )
@@ -363,12 +366,14 @@ class AccessRequestService:
                 raise NotAReviewerError(request_id)
 
             items_by_id = {item.id: item for item in request.items}
-            # A request is a provisioning plan when it carries fulfilment intents;
-            # its bind items are only satisfiable after the wizard fulfils them, so
-            # validate() denies an unfulfilled bind with a plan-aware reason.
-            is_plan = any(
-                (it.resource_type, it.action) in _PLAN_INTENT_COMBINATIONS for it in request.items
-            )
+            # Provisioning-plan governance is per-item (issue #778): a bind is
+            # only held to the "must resolve by id (wizard-stamped)" contract
+            # when a live intent in the same request actually targets it. An
+            # independent reference-only toolkit:bind for a different API in
+            # the same request stays on the plain contract and resolves by its
+            # reference; a withdrawn/denied intent no longer governs. See
+            # ``plan_governed_bind_items`` for the full rule.
+            plan_governed = plan_governed_bind_items(request.items)
             control_effect_items: list[tuple[str, Any]] = []
 
             for decision in item_decisions:
@@ -403,7 +408,7 @@ class AccessRequestService:
                                 existing,
                                 identity=identity,
                                 control_session=session,
-                                is_provisioning_plan=is_plan,
+                                is_provisioning_plan=existing.id in plan_governed,
                             )
                         except _UNFULFILLABLE_BIND_TARGET as exc:
                             verdict = AccessRequestItemStatus.DENIED
@@ -440,7 +445,7 @@ class AccessRequestService:
                         target,
                         identity=identity,
                         control_session=session,
-                        is_provisioning_plan=is_plan,
+                        is_provisioning_plan=target.id in plan_governed,
                     )
 
                 phase = classify_effect(target.resource_type, target.action)

--- a/src/jentic_one/shared/models/events.py
+++ b/src/jentic_one/shared/models/events.py
@@ -54,6 +54,14 @@ class EventType:
     AGENT_REGISTRATION_APPROVED = "agent.registration_approved"
     AGENT_REGISTRATION_DENIED = "agent.registration_denied"
     PBAC_DENIED = "broker.pbac_denied"
+    # Emitted when the broker denies an execute with 403 ``no_toolkit_binding``
+    # AND no toolkit yet serves the requested API — the caller's next step is
+    # for an operator to provision a credential (which is what makes a toolkit
+    # serve the API). Distinct from ``CREDENTIAL_NOT_PROVISIONED`` (424, fires
+    # when a bound toolkit's credential is unresolvable at inject time): this
+    # event is the *pre-binding* signal, giving operators visibility into
+    # agent-needed APIs before a doomed access request appears.
+    TOOLKIT_BINDING_UNSERVED = "broker.toolkit_binding_unserved"
 
     ALL: frozenset[str] = frozenset(
         {
@@ -91,6 +99,7 @@ class EventType:
             AGENT_REGISTRATION_APPROVED,
             AGENT_REGISTRATION_DENIED,
             PBAC_DENIED,
+            TOOLKIT_BINDING_UNSERVED,
         }
     )
 

--- a/tests/unit/broker/test_toolkit_select.py
+++ b/tests/unit/broker/test_toolkit_select.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -17,11 +18,16 @@ from jentic_one.broker.core.exceptions import (
     no_toolkit_binding_directive,
 )
 from jentic_one.broker.web.errors import install_broker_error_handlers
-from jentic_one.broker.web.routers.execute import select_toolkit
+from jentic_one.broker.web.routers.execute import (
+    _emit_toolkit_binding_unserved,
+    _is_unserved_no_toolkit_binding,
+    select_toolkit,
+)
 from jentic_one.shared.access_guidance import no_toolkit_serves_api_reason
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.broker.protocols import IdentityMismatch, ToolkitDerivation
 from jentic_one.shared.models import ActorType
+from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.schemas import APIReference
 
 _API = APIReference(vendor="acme", name="widgets", version="1.0.0")
@@ -344,3 +350,81 @@ def test_no_toolkit_binding_credential_first_directive_and_denial_reason_agree()
     assert "credential" in denial_reason
     assert "provision" in denial_reason
     assert "no toolkit serves" in denial_reason
+
+
+# --- unserved-API operator event (theme 3 residual) --------------------------
+
+
+def _no_toolkit_binding_error(*, serves: bool) -> ActionDeniedError:
+    return ActionDeniedError(
+        "No toolkit binding for this API",
+        type="no_toolkit_binding",
+        instance=_INSTANCE,
+        directive=no_toolkit_binding_directive(
+            vendor=_API.vendor, name=_API.name, version=_API.version, toolkit_serves_api=serves
+        ),
+    )
+
+
+def test_is_unserved_no_toolkit_binding_true_when_serves_false() -> None:
+    assert _is_unserved_no_toolkit_binding(_no_toolkit_binding_error(serves=False)) is True
+
+
+def test_is_unserved_no_toolkit_binding_false_when_serves_true() -> None:
+    # A toolkit exists, the caller just isn't bound → agent-recoverable via a
+    # bind access request; we deliberately do NOT emit the operator event here.
+    assert _is_unserved_no_toolkit_binding(_no_toolkit_binding_error(serves=True)) is False
+
+
+def test_is_unserved_no_toolkit_binding_false_for_other_error_types() -> None:
+    other = ActionDeniedError("denied", type="action_denied", instance=_INSTANCE, directive=None)
+    assert _is_unserved_no_toolkit_binding(other) is False
+
+
+def test_is_unserved_no_toolkit_binding_false_without_directive() -> None:
+    exc = ActionDeniedError(
+        "No toolkit binding for this API",
+        type="no_toolkit_binding",
+        instance=_INSTANCE,
+        directive=None,
+    )
+    assert _is_unserved_no_toolkit_binding(exc) is False
+
+
+async def test_emit_toolkit_binding_unserved_writes_event() -> None:
+    ctx = MagicMock()
+    session = AsyncMock()
+    ctx.admin_db.transaction.return_value.__aenter__ = AsyncMock(return_value=session)
+    ctx.admin_db.transaction.return_value.__aexit__ = AsyncMock(return_value=False)
+    identity = Identity(sub="agnt_001", actor_type=ActorType.AGENT, permissions=[])
+
+    with patch(
+        "jentic_one.broker.web.routers.execute.emit_event_best_effort",
+        new_callable=AsyncMock,
+    ) as mock_emit:
+        await _emit_toolkit_binding_unserved(ctx, api=_API, identity=identity)
+
+    mock_emit.assert_awaited_once()
+    call = mock_emit.await_args
+    assert call is not None
+    kwargs = call.kwargs
+    assert kwargs["type"] == EventType.TOOLKIT_BINDING_UNSERVED
+    assert kwargs["severity"] is EventSeverity.WARNING
+    assert kwargs["actor_id"] == "agnt_001"
+    assert kwargs["actor_type"] == ActorType.AGENT.value
+    assert kwargs["data"]["api"] == {
+        "vendor": _API.vendor,
+        "name": _API.name,
+        "version": _API.version,
+    }
+    assert "acme/widgets" in kwargs["summary"]
+
+
+async def test_emit_toolkit_binding_unserved_swallows_errors() -> None:
+    # Telemetry is best-effort: an admin-DB failure must not surface to the
+    # execute request (which is already returning 403 anyway).
+    ctx = MagicMock()
+    ctx.admin_db.transaction.side_effect = RuntimeError("db down")
+    identity = Identity(sub="agnt_001", actor_type=ActorType.AGENT, permissions=[])
+
+    await _emit_toolkit_binding_unserved(ctx, api=_API, identity=identity)  # must not raise

--- a/tests/unit/control/access_requests/test_effects.py
+++ b/tests/unit/control/access_requests/test_effects.py
@@ -14,6 +14,7 @@ from jentic_one.control.services.access_requests.effects import (
     admin_effect_keys,
     classify_effect,
     is_admin_effect,
+    plan_governed_bind_items,
 )
 from jentic_one.control.services.access_requests.errors import (
     CredentialNotFoundForBindError,
@@ -70,6 +71,7 @@ def _make_item(
     actor_id: str = "agnt_001",
     rules: list[dict[str, Any]] | None = None,
     item_id: str = "arqi_001",
+    status: str = "pending",
 ) -> MagicMock:
     item = MagicMock()
     item.id = item_id
@@ -80,6 +82,7 @@ def _make_item(
     item.to_id = to_id
     item.actor_id = actor_id
     item.rules = rules
+    item.status = status
     return item
 
 
@@ -934,3 +937,191 @@ async def test_validate_toolkit_bind_in_plan_denies_when_unfulfilled() -> None:
             control_session=session,
             is_provisioning_plan=True,
         )
+
+
+# --- plan governance (issue #778) --------------------------------------------
+#
+# ``plan_governed_bind_items`` is the pure function that replaced the
+# request-wide ``is_plan`` flag. These tests exercise the four things the flag
+# used to get wrong:
+#
+#   1. an intent for API X should not govern an independent bind for API Y;
+#   2. non-live (withdrawn/denied) intents should not govern anything;
+#   3. the CLI's 4-item plan bundle (all items target the same API) still has
+#      every bind governed — the CLI behaviour is preserved;
+#   4. slug normalization ("httpbin.org" vs "httpbin-org") does not defeat
+#      governance.
+
+
+def _intent(
+    *,
+    kind: str = "toolkit_create",
+    vendor: str = "acme",
+    name: str | None = "widgets",
+    item_id: str = "arqi_intent",
+    status: str = "pending",
+) -> MagicMock:
+    combos = {
+        "toolkit_create": ("toolkit", "create"),
+        "credential_provision": ("credential", "provision"),
+    }
+    resource_type, action = combos[kind]
+    ref: dict[str, Any] = {"vendor": vendor}
+    if name is not None:
+        ref["name"] = name
+    return _make_item(
+        resource_type=resource_type,
+        action=action,
+        resource_id=None,
+        resource_reference=ref,
+        to_id=None,
+        item_id=item_id,
+        status=status,
+    )
+
+
+def test_plan_governed_empty_when_no_intents() -> None:
+    bind = _make_item(item_id="arqi_bind_1")
+    assert plan_governed_bind_items([bind]) == frozenset()
+
+
+def test_plan_governed_governs_matching_toolkit_bind() -> None:
+    # The CLI's typical 4-item plan bundle: intents + binds all for the same API.
+    items = [
+        _intent(kind="toolkit_create", vendor="acme", name="widgets", item_id="arqi_i1"),
+        _intent(kind="credential_provision", vendor="acme", name="widgets", item_id="arqi_i2"),
+        _make_item(
+            resource_type="credential",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            item_id="arqi_cbind",
+        ),
+        _make_item(
+            resource_type="toolkit",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            resource_reference={"vendor": "acme", "name": "widgets"},
+            item_id="arqi_tbind",
+        ),
+    ]
+    governed = plan_governed_bind_items(items)
+    assert governed == frozenset({"arqi_cbind", "arqi_tbind"})
+
+
+def test_plan_governed_leaves_independent_toolkit_bind_ungoverned() -> None:
+    # #778 core case: one intent for API X + an independent reference-only
+    # toolkit:bind for API Y must not flip the Y bind onto the plan contract.
+    items = [
+        _intent(vendor="acme", name="widgets", item_id="arqi_intent"),
+        _make_item(
+            resource_type="toolkit",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            resource_reference={"vendor": "other", "name": "thing"},
+            item_id="arqi_independent_bind",
+        ),
+    ]
+    assert plan_governed_bind_items(items) == frozenset()
+
+
+def test_plan_governed_governs_all_credential_binds_when_any_intent_lives() -> None:
+    # A credential:bind sharing a request with a live intent is always
+    # wizard-fulfilled: agents never carry credential ids at file time.
+    items = [
+        _intent(vendor="acme", name="widgets", item_id="arqi_i1"),
+        _make_item(
+            resource_type="credential",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            item_id="arqi_cbind_any",
+        ),
+    ]
+    assert plan_governed_bind_items(items) == frozenset({"arqi_cbind_any"})
+
+
+def test_plan_governed_ignores_withdrawn_intents() -> None:
+    # An abandoned plan must not carry over: subsequent binds revert to the
+    # plain contract on the next decide().
+    items = [
+        _intent(vendor="acme", name="widgets", item_id="arqi_dead", status="withdrawn"),
+        _make_item(
+            resource_type="toolkit",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            resource_reference={"vendor": "acme", "name": "widgets"},
+            item_id="arqi_tbind",
+        ),
+    ]
+    assert plan_governed_bind_items(items) == frozenset()
+
+
+def test_plan_governed_ignores_denied_intents() -> None:
+    items = [
+        _intent(vendor="acme", name="widgets", item_id="arqi_dead", status="denied"),
+        _make_item(
+            resource_type="credential",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            item_id="arqi_cbind",
+        ),
+    ]
+    assert plan_governed_bind_items(items) == frozenset()
+
+
+def test_plan_governed_normalizes_slug_vs_raw_domain() -> None:
+    # An agent files a reference with a raw domain (``httpbin.org``); the
+    # intent may have been stored slugified. Governance must match either way.
+    items = [
+        _intent(vendor="httpbin-org", name=None, item_id="arqi_i1"),
+        _make_item(
+            resource_type="toolkit",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            resource_reference={"vendor": "httpbin.org"},
+            item_id="arqi_tbind",
+        ),
+    ]
+    assert plan_governed_bind_items(items) == frozenset({"arqi_tbind"})
+
+
+def test_plan_governed_intent_name_wildcards_all_versions() -> None:
+    # An intent's (vendor, name) matches a bind for the same API regardless
+    # of version — the intent covers all versions of that API.
+    items = [
+        _intent(vendor="acme", name="widgets", item_id="arqi_i1"),
+        _make_item(
+            resource_type="toolkit",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            resource_reference={"vendor": "acme", "name": "widgets", "version": "1.0.0"},
+            item_id="arqi_tbind",
+        ),
+    ]
+    assert plan_governed_bind_items(items) == frozenset({"arqi_tbind"})
+
+
+def test_plan_governed_excludes_already_decided_binds() -> None:
+    # decide() only re-validates PENDING or APPROVED items; a DENIED/WITHDRAWN
+    # bind is never re-validated so its governance doesn't matter and we omit
+    # it to keep the set tight against actual decide() behaviour.
+    items = [
+        _intent(vendor="acme", name="widgets", item_id="arqi_i1"),
+        _make_item(
+            resource_type="toolkit",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            resource_reference={"vendor": "acme", "name": "widgets"},
+            item_id="arqi_dead_bind",
+            status="denied",
+        ),
+    ]
+    assert plan_governed_bind_items(items) == frozenset()


### PR DESCRIPTION
## Summary

The broker already denies an execute with 403 \`no_toolkit_binding\` when the caller has no binding to any toolkit serving the requested API, and the directive tells the agent to have an operator provision a credential first (\`toolkit_serves_api=False\`, #683). But nothing on the operator side sees that signal — no dashboard entry, no SSE event — so an operator only learns after the agent files a doomed access request.

- New \`EventType.TOOLKIT_BINDING_UNSERVED\` — \"broker.toolkit_binding_unserved\".
- Emit best-effort from \`_handle\` when \`select_toolkit\` raises the unserved flavour of \`no_toolkit_binding\`. Same admin-DB best-effort pattern as \`CREDENTIAL_NOT_PROVISIONED\` (the 424 twin on the post-binding side).
- Classification is a small pure helper (\`_is_unserved_no_toolkit_binding\`) that reads off the existing denial directive rather than growing a new signal through \`select_toolkit\`.
- Deliberately internal-only (not added to \`TELEMETRY_EVENTS\`) — this is an operator-visibility signal, not a product-telemetry funnel event.

## Why not debounce

Same shape as \`CREDENTIAL_NOT_PROVISIONED\`: emits per denied execute request. WARNING severity + a per-request cadence matches the existing operator-signal contract; adding cross-request debouncing is a bigger operational change and can layer later if the event proves noisy.

## Test plan

- [x] \`uv run pytest tests/unit/broker/ tests/unit/shared/test_event_types.py tests/unit/shared/telemetry/ --no-cov -q\` — 519 broker unit tests + declared-events + telemetry-registry tests green
- [x] \`make test-integration-sqlite\` — 503 passed / 9 skipped
- [x] \`make test-arch\` — 131 passed (no-inline-imports enforced)
- [x] \`make openapi\` — zero drift
- [x] \`uv run ruff check .\`, \`uv run mypy\` — clean

Made with [Cursor](https://cursor.com)