### PR TITLE
feat(access-requests): advise operators when a filed bind targets an unserved API

### DIFF
--- a/src/jentic_one/control/services/access_requests/service.py
+++ b/src/jentic_one/control/services/access_requests/service.py
@@ -13,6 +13,7 @@ from jentic_one.control.core.schema.access_request_items import RULE_BEARING_COM
 from jentic_one.control.core.schema.access_requests import AccessRequest
 from jentic_one.control.repos.access_request_repo import AccessRequestRepository
 from jentic_one.control.repos.credential_repo import CredentialRepository
+from jentic_one.control.repos.effects_repo import EffectsRepository
 from jentic_one.control.repos.prerequisite_repo import PrerequisiteRepository
 from jentic_one.control.repos.toolkit_repo import ToolkitRepository
 from jentic_one.control.scoping.filters import build_access_filters
@@ -52,11 +53,12 @@ from jentic_one.control.services.access_requests.schemas.access_requests import 
 from jentic_one.shared.audit import AuditAction, AuditTargetType, record_audit_best_effort
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.context import Context
-from jentic_one.shared.events import emit_event
+from jentic_one.shared.events import emit_event, emit_event_best_effort
 from jentic_one.shared.models import (
     AccessRequestItemStatus,
     AccessRequestStatus,
 )
+from jentic_one.shared.models.api_identity import slugify_api_field
 from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.pagination import decode_cursor_str, encode_cursor
 from jentic_one.shared.scopes import AGENTS_WRITE, ORG_ADMIN
@@ -164,6 +166,104 @@ class AccessRequestService:
         except Exception:
             logger.warning("emit_event_failed", request_id=request_id, type=type, exc_info=True)
 
+    async def _advise_unserved_bind_references(
+        self,
+        *,
+        items: list[dict[str, Any]],
+        filer_owner_id: str,
+        identity: Identity,
+        request_id: str,
+    ) -> None:
+        """Emit a best-effort ``TOOLKIT_BINDING_UNSERVED`` for unfulfillable filings.
+
+        A plain (non-plan) ``toolkit:bind`` filed by ``vendor/name`` reference
+        will deny on approval with :class:`ToolkitReferenceUnresolvedError`
+        when no toolkit visible to the filer's owner currently serves that
+        API. Surfacing that at file time gives operators an early signal —
+        symmetric to the broker's own emit for the same event on execute-time
+        denials (see ``execute._emit_toolkit_binding_unserved``).
+
+        Deliberately silent when:
+
+        - the item names a specific ``resource_id``/``to_id`` (fulfilment is by
+          id, not by reference — no cheap file-time check applies);
+        - the request also carries fulfilment intents (a *provisioning plan*
+          creates the toolkit that will serve the API, so "nothing serves it
+          yet" is expected);
+        - a toolkit already serves the API for this owner (the plain-approve
+          path will resolve cleanly).
+
+        Never blocks the filing — the emit is best-effort and any lookup
+        failure logs and continues.
+        """
+        plan_types = {("toolkit", "create"), ("credential", "provision")}
+        if any((it.get("resource_type"), it.get("action")) in plan_types for it in items):
+            return
+
+        actor_type_value = identity.actor_type.value if identity.actor_type is not None else None
+        for item in items:
+            if (item.get("resource_type"), item.get("action")) != ("toolkit", "bind"):
+                continue
+            if item.get("resource_id") or item.get("to_id"):
+                continue
+            reference = item.get("resource_reference") or {}
+            vendor = reference.get("vendor")
+            if not vendor:
+                continue
+            raw_name = reference.get("name")
+            try:
+                async with self._ctx.control_db.session() as session:
+                    candidates = await EffectsRepository.resolve_toolkits_for_api(
+                        session,
+                        vendor=slugify_api_field(str(vendor)),
+                        name=(slugify_api_field(str(raw_name)) if raw_name else raw_name),
+                        version=reference.get("version"),
+                        owner_ids=[filer_owner_id],
+                    )
+            except Exception:
+                logger.warning(
+                    "unserved_binding_check_failed",
+                    request_id=request_id,
+                    vendor=vendor,
+                    exc_info=True,
+                )
+                continue
+
+            if candidates:
+                continue
+
+            api_id = "/".join(part for part in (str(vendor), raw_name) if part) or str(vendor)
+            summary = (
+                f"Access request {request_id} names API '{api_id}' but no owned "
+                "toolkit serves it yet — provision a credential to enable binding."
+            )
+            try:
+                async with self._ctx.admin_db.transaction() as session:
+                    await emit_event_best_effort(
+                        session,
+                        type=EventType.TOOLKIT_BINDING_UNSERVED,
+                        severity=EventSeverity.WARNING,
+                        summary=summary,
+                        created_by=identity.sub,
+                        actor_id=identity.sub,
+                        actor_type=actor_type_value,
+                        data={
+                            "request_id": request_id,
+                            "api": {
+                                "vendor": vendor,
+                                "name": raw_name,
+                                "version": reference.get("version"),
+                            },
+                        },
+                    )
+            except Exception:
+                logger.warning(
+                    "telemetry_emit_failed",
+                    event_type=EventType.TOOLKIT_BINDING_UNSERVED,
+                    request_id=request_id,
+                    exc_info=True,
+                )
+
     async def file(
         self,
         *,
@@ -253,6 +353,14 @@ class AccessRequestService:
             created_by=created_by,
             actor_id=created_by,
             actor_type=identity.actor_type,
+        )
+        # File-time fulfillability advisory: a plain (non-plan) toolkit:bind
+        # referenced by vendor/name that no owned toolkit currently serves will
+        # deny on approval with ToolkitReferenceUnresolvedError (§03). Emit an
+        # operator-visible signal *now* so the operator sees the gap before an
+        # approve/deny cycle. Best-effort — never blocks the file() commit.
+        await self._advise_unserved_bind_references(
+            items=items, filer_owner_id=filer_owner_id, identity=identity, request_id=view.id
         )
         await record_audit_best_effort(
             self._ctx,

--- a/tests/integration/control/test_access_request_service.py
+++ b/tests/integration/control/test_access_request_service.py
@@ -1281,3 +1281,177 @@ async def test_decide_conflict_raises_item_not_pending(
             identity=reviewer,
             item_decisions=[{"item_id": filed.items[0].id, "decision": "denied"}],
         )
+
+
+# --- file-time fulfillability advisory (theme 3 residual) ---
+
+
+async def _list_events_by_type(admin_db: DatabaseSession, event_type: str) -> list[Event]:
+    async with admin_db.session() as session:
+        return await EventRepository.list_all(session, event_type=[event_type])
+
+
+async def test_file_emits_unserved_advisory_for_plain_toolkit_bind_with_no_serving_toolkit(
+    svc: AccessRequestService,
+    clean_access_requests: None,
+    clean_events: None,
+    seed_binding: None,
+    admin_db: DatabaseSession,
+) -> None:
+    """A plain `toolkit:bind` by reference with no serving toolkit emits an advisory."""
+    filer = _filer_identity()
+    filed = await svc.file(
+        actor_id=FILER_SUB,
+        reason="bind me to a not-yet-served api",
+        items=[
+            {
+                "resource_type": "toolkit",
+                "action": "bind",
+                "resource_reference": {"vendor": "no-such-vendor", "name": "no-such-api"},
+            }
+        ],
+        identity=filer,
+    )
+    assert filed.status == "pending"  # advisory doesn't block the filing
+
+    events = await _list_events_by_type(admin_db, "broker.toolkit_binding_unserved")
+    matching = [e for e in events if e.data.get("request_id") == filed.id]
+    assert len(matching) == 1
+    event = matching[0]
+    assert event.severity == "warning"
+    assert event.data["api"] == {
+        "vendor": "no-such-vendor",
+        "name": "no-such-api",
+        "version": None,
+    }
+    assert "no-such-vendor/no-such-api" in event.summary
+
+
+async def test_file_skips_unserved_advisory_when_toolkit_serves_api(
+    svc: AccessRequestService,
+    clean_access_requests: None,
+    clean_events: None,
+    seed_binding: None,
+    control_db: DatabaseSession,
+    admin_db: DatabaseSession,
+) -> None:
+    """When a toolkit already serves the referenced API, no advisory fires."""
+    async with control_db.transaction() as session:
+        await session.execute(
+            text(
+                "INSERT INTO toolkits (id, name, created_by) "
+                "VALUES (:id, :name, :created_by) "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {
+                "id": "tk_served",
+                "name": "served-toolkit",
+                "created_by": OWNER_SUB,
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO credentials "
+                "(id, type, name, api_vendor, api_name, created_by) "
+                "VALUES (:id, 'token', :name, :vendor, :api_name, :created_by) "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {
+                "id": "cred_served_001",
+                "name": "served-cred",
+                "vendor": "servedvendor",
+                "api_name": "widgets",
+                "created_by": OWNER_SUB,
+            },
+        )
+        await EffectsRepository.bind_credential_to_toolkit(
+            session,
+            toolkit_id="tk_served",
+            credential_id="cred_served_001",
+            created_by=OWNER_SUB,
+        )
+
+    filer = _filer_identity()
+    filed = await svc.file(
+        actor_id=FILER_SUB,
+        reason="bind me to a served api",
+        items=[
+            {
+                "resource_type": "toolkit",
+                "action": "bind",
+                "resource_reference": {"vendor": "servedvendor", "name": "widgets"},
+            }
+        ],
+        identity=filer,
+    )
+    assert filed.status == "pending"
+
+    events = await _list_events_by_type(admin_db, "broker.toolkit_binding_unserved")
+    matching = [e for e in events if e.data.get("request_id") == filed.id]
+    assert matching == []
+
+
+async def test_file_skips_unserved_advisory_when_request_carries_fulfilment_intent(
+    svc: AccessRequestService,
+    clean_access_requests: None,
+    clean_events: None,
+    seed_binding: None,
+    admin_db: DatabaseSession,
+) -> None:
+    """Plans expect nothing to serve the API yet — the advisory must stay silent."""
+    filer = _filer_identity()
+    filed = await svc.file(
+        actor_id=FILER_SUB,
+        reason="provision then bind",
+        items=[
+            {
+                "resource_type": "toolkit",
+                "action": "create",
+                "resource_reference": {"vendor": "brandnew", "name": "widgets"},
+            },
+            {
+                "resource_type": "credential",
+                "action": "provision",
+                "resource_reference": {"vendor": "brandnew", "name": "widgets"},
+            },
+            {
+                "resource_type": "toolkit",
+                "action": "bind",
+                "resource_reference": {"vendor": "brandnew", "name": "widgets"},
+            },
+        ],
+        identity=filer,
+    )
+    assert filed.status == "pending"
+
+    events = await _list_events_by_type(admin_db, "broker.toolkit_binding_unserved")
+    matching = [e for e in events if e.data.get("request_id") == filed.id]
+    assert matching == []
+
+
+async def test_file_skips_unserved_advisory_when_bind_names_toolkit_by_id(
+    svc: AccessRequestService,
+    clean_access_requests: None,
+    clean_events: None,
+    seed_binding: None,
+    admin_db: DatabaseSession,
+) -> None:
+    """A `toolkit:bind` with an explicit id (not a reference) is not by-name — no advisory."""
+    filer = _filer_identity()
+    filed = await svc.file(
+        actor_id=FILER_SUB,
+        reason="bind by id",
+        items=[
+            {
+                "resource_type": "toolkit",
+                "action": "bind",
+                "resource_id": "tk_target",
+            }
+        ],
+        identity=filer,
+    )
+    assert filed.status == "pending"
+
+    events = await _list_events_by_type(admin_db, "broker.toolkit_binding_unserved")
+    matching = [e for e in events if e.data.get("request_id") == filed.id]
+    assert matching == []


### PR DESCRIPTION
> Stacked on top of #788 (adds \`TOOLKIT_BINDING_UNSERVED\`). Target once that lands, or merge with the stacked chain.

## Summary

A plain (non-plan) \`toolkit:bind\` filed by \`vendor/name\` reference denies on approval with \`ToolkitReferenceUnresolvedError\` when no toolkit owned by the filer's owner serves that API. Today that only surfaces after an approve/deny cycle — the operator can't see the gap while the request is pending.

- After \`file()\` commits, iterate \`toolkit:bind\` items and for each *reference-only* item (\`resource_reference\` present, no \`resource_id\`/\`to_id\`) check whether the filer's owner has any toolkit serving that canonical \`(vendor, name)\`. If not, emit \`TOOLKIT_BINDING_UNSERVED\` (WARNING) best-effort. Payload carries the \`request_id\` and the \`api\` triple.
- Symmetric to the broker's execute-time emit (#788) for the same event.

## Deliberately silent when

- the item names a specific \`resource_id\` — fulfilment is by id, no cheap file-time check applies;
- the request also carries fulfilment intents (\`toolkit:create\` / \`credential:provision\`) — a provisioning plan *creates* the toolkit that will serve the API, so \"nothing serves it yet\" is expected;
- a toolkit already serves the API for this owner.

Reference axes are slugified via the shared identity seam so raw-domain references (\`httpbin.org\`) match stored slug form (\`httpbin-org\`), matching \`resolve_toolkits_for_api\` and PR #787's plan-governance rule.

Best-effort: never blocks the filing. Any lookup or emit failure logs and continues.

## Test plan

- [x] 4 new sqlite integration tests (\`tests/integration/control/test_access_request_service.py\`) covering: positive advisory, served-toolkit skip, plan skip, by-id skip
- [x] \`make test-integration-sqlite\` — 507 passed / 9 skipped
- [x] \`make test-arch\` — 131 passed
- [x] \`make openapi\` — zero drift
- [x] \`uv run ruff check .\`, \`uv run ruff format --check .\`, \`uv run mypy\` — clean

Made with [Cursor](https://cursor.com)