### PR TITLE
feat(broker): execute credential attribution + upstream passthrough fidelity

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -371,7 +371,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 16214
+        "line_number": 16257
       }
     ],
     "release-please-config.json": [
@@ -1278,35 +1278,35 @@
         "filename": "tests/unit/broker/test_injection.py",
         "hashed_secret": "67f305e585d4a961a2f95fd90f00764dcc4f40d1",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 32
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/broker/test_injection.py",
         "hashed_secret": "1cbafcc4fe333585c13326ea59a9e4899f8e2a9b",
         "is_verified": false,
-        "line_number": 47
+        "line_number": 49
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/broker/test_injection.py",
         "hashed_secret": "d46a14d2dbb410dba2256ea0a2aa26643f188a8a",
         "is_verified": false,
-        "line_number": 65
+        "line_number": 68
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/broker/test_injection.py",
         "hashed_secret": "8c7744f38b499dd8e3caf26494c87ad772dcaf25",
         "is_verified": false,
-        "line_number": 74
+        "line_number": 77
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/broker/test_injection.py",
         "hashed_secret": "88136b94ad02c408ab58d0d27d81460dbc879b20",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 109
       }
     ],
     "tests/unit/broker/test_resolver.py": [
@@ -1609,5 +1609,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-29T11:19:10Z"
+  "generated_at": "2026-07-29T13:22:15Z"
 }

--- a/openapi/broker/broker.openapi.yaml
+++ b/openapi/broker/broker.openapi.yaml
@@ -589,6 +589,27 @@ components:
         type: string
         examples:
           - exec_xyz789
+    JenticCredentialId:
+      description: |
+        ID of the stored credential the broker resolved and used to sign
+        this execution. Present only when a stored credential was actually
+        used — a missing header unambiguously means no credential (inline
+        auth, a credential-less API, or a failure before resolution).
+      schema:
+        type: string
+        examples:
+          - cred_abc123
+    JenticCredentialName:
+      description: |
+        Human-readable label of the credential in `Jentic-Credential-Id`,
+        sanitized to printable ASCII (unsafe characters replaced with `?`).
+        Present under the same condition as the id header. The same header
+        name is also accepted on requests to disambiguate credential
+        resolution.
+      schema:
+        type: string
+        examples:
+          - Stripe prod key
   parameters:
     UpstreamUrl:
       name: upstream_url
@@ -823,6 +844,10 @@ components:
             type: integer
             examples:
               - 200
+        Jentic-Credential-Id:
+          $ref: "#/components/headers/JenticCredentialId"
+        Jentic-Credential-Name:
+          $ref: "#/components/headers/JenticCredentialName"
       content:
         "*/*":
           schema:

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -2161,6 +2161,16 @@ components:
           format: date-time
           title: Created At
           type: string
+        credential_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Credential Id
+        credential_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Credential Name
         duration_ms:
           anyOf:
           - type: integer

--- a/src/jentic_one/admin/core/schema/execution_records.py
+++ b/src/jentic_one/admin/core/schema/execution_records.py
@@ -23,6 +23,7 @@ class ExecutionRecord(AuditableMixin, AdminBase):
         Index("ix_execution_records_toolkit_started", "toolkit_id", "started_at"),
         Index("ix_execution_records_status", "status"),
         Index("ix_execution_records_actor", "actor_id", "actor_type"),
+        Index("ix_execution_records_credential_id", "credential_id"),
         Index(
             "ix_execution_records_repeated_failure_scan",
             "actor_id",
@@ -55,3 +56,10 @@ class ExecutionRecord(AuditableMixin, AdminBase):
     actor_id: Mapped[str] = mapped_column(String(255), nullable=False)
     actor_type: Mapped[str] = mapped_column(String(20), nullable=False)
     origin: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # Credential attribution (#740). Nullable for historical rows, executions
+    # that used inline auth, and executions that failed before the resolver
+    # picked a credential. No FK: ``credentials`` lives in the control DB
+    # (cross-DB, same reason ``toolkit_id`` has no FK here). Indexed for the
+    # audit-console "what did this credential do?" query.
+    credential_id: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    credential_name: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/src/jentic_one/admin/repos/execution_record_repo.py
+++ b/src/jentic_one/admin/repos/execution_record_repo.py
@@ -33,6 +33,8 @@ class ExecutionRecordRepository:
         created_by: str,
         actor_id: str,
         actor_type: str,
+        credential_id: str | None = None,
+        credential_name: str | None = None,
     ) -> ExecutionRecord:
         record = ExecutionRecord(
             toolkit_id=toolkit_id,
@@ -51,6 +53,8 @@ class ExecutionRecordRepository:
             created_by=created_by,
             actor_id=actor_id,
             actor_type=actor_type,
+            credential_id=credential_id,
+            credential_name=credential_name,
         )
         session.add(record)
         await session.flush()

--- a/src/jentic_one/admin/services/execution_service.py
+++ b/src/jentic_one/admin/services/execution_service.py
@@ -109,4 +109,6 @@ class ExecutionService:
             actor_id=record.actor_id,
             actor_type=record.actor_type,
             origin=record.origin,
+            credential_id=getattr(record, "credential_id", None),
+            credential_name=getattr(record, "credential_name", None),
         )

--- a/src/jentic_one/admin/services/execution_service.py
+++ b/src/jentic_one/admin/services/execution_service.py
@@ -109,6 +109,6 @@ class ExecutionService:
             actor_id=record.actor_id,
             actor_type=record.actor_type,
             origin=record.origin,
-            credential_id=getattr(record, "credential_id", None),
-            credential_name=getattr(record, "credential_name", None),
+            credential_id=record.credential_id,
+            credential_name=record.credential_name,
         )

--- a/src/jentic_one/admin/services/schemas/executions.py
+++ b/src/jentic_one/admin/services/schemas/executions.py
@@ -38,6 +38,8 @@ class ExecutionView(BaseModel):
     actor_id: str
     actor_type: str
     origin: str | None = None
+    credential_id: str | None = None
+    credential_name: str | None = None
 
 
 class ExecutionFilter(BaseModel):

--- a/src/jentic_one/admin/web/routers/executions.py
+++ b/src/jentic_one/admin/web/routers/executions.py
@@ -54,6 +54,8 @@ def _execution_response(view: ExecutionView, request: Request) -> ExecutionRespo
         actor_id=view.actor_id,
         actor_type=view.actor_type,
         origin=view.origin,
+        credential_id=view.credential_id,
+        credential_name=view.credential_name,
         links=links,
     )
 

--- a/src/jentic_one/admin/web/schemas/executions.py
+++ b/src/jentic_one/admin/web/schemas/executions.py
@@ -49,6 +49,11 @@ class ExecutionResponse(BaseModel):
     actor_id: str
     actor_type: str
     origin: str | None = None
+    # Credential the broker used for this execution (#740). Both ``None`` for
+    # executions using inline auth, credential-less APIs, historical rows, and
+    # executions that failed before the resolver picked a credential.
+    credential_id: str | None = None
+    credential_name: str | None = None
     links: ExecutionRecordLinks = Field(serialization_alias="_links")
 
 

--- a/src/jentic_one/broker/core/headers.py
+++ b/src/jentic_one/broker/core/headers.py
@@ -18,6 +18,16 @@ class JenticHeader(StrEnum):
     TOOLKIT_ID = "Jentic-Toolkit-Id"
     OPERATION = "Jentic-Operation"
     API_VENDOR = "Jentic-Api-Vendor"
+    # The credential the broker resolved and used for this execution (#740). The
+    # id is stable + non-secret (uuid); the name is the human-readable label
+    # from the stored row. Both are emitted only when a credential was actually
+    # used — broker-origin failures before credential resolution carry neither.
+    # Note: ``Jentic-Credential-Name`` is *also* a request header that clients
+    # send inbound to disambiguate ambiguous resolution — the outbound response
+    # header shares the name intentionally (same convention as
+    # ``Jentic-Toolkit-Id``, which is both request and response).
+    CREDENTIAL_ID = "Jentic-Credential-Id"
+    CREDENTIAL_NAME = "Jentic-Credential-Name"
     UPSTREAM_STATUS = "Jentic-Upstream-Status"
     ERROR_ORIGIN = "Jentic-Error-Origin"
     HINT = "Jentic-Hint"

--- a/src/jentic_one/broker/core/headers.py
+++ b/src/jentic_one/broker/core/headers.py
@@ -8,7 +8,28 @@ rather than inline string literals scattered across the routers.
 
 from __future__ import annotations
 
+import re
 from enum import StrEnum
+
+# Anything outside printable ASCII (0x20-0x7E). Excludes CR/LF/NUL and all
+# control characters by construction, and every codepoint that would fail
+# Starlette's latin-1 response-header encoding or invite header injection
+# behind a non-validating intermediary.
+_UNSAFE_HEADER_CHARS = re.compile(r"[^\x20-\x7E]")
+
+
+def header_safe_value(value: str) -> str:
+    """Return ``value`` reduced to a printable-ASCII header-safe form.
+
+    Used for operator-authored free text (e.g. a credential's display name)
+    that rides in a response header: emitting it verbatim would 500 the whole
+    response on any non-latin-1 character and hand CR/LF-bearing input a
+    response-splitting primitive. Unsafe characters are replaced with ``?``
+    rather than dropped so the header stays present (attribution contract:
+    header presence means a credential was used) and visibly marked as
+    transformed.
+    """
+    return _UNSAFE_HEADER_CHARS.sub("?", value)
 
 
 class JenticHeader(StrEnum):
@@ -19,8 +40,11 @@ class JenticHeader(StrEnum):
     OPERATION = "Jentic-Operation"
     API_VENDOR = "Jentic-Api-Vendor"
     # The credential the broker resolved and used for this execution (#740). The
-    # id is stable + non-secret (uuid); the name is the human-readable label
-    # from the stored row. Both are emitted only when a credential was actually
+    # id is stable + non-secret (a ``cred_``-prefixed KSUID); the name is the
+    # human-readable label from the stored row — operator-authored free text,
+    # so it must pass through ``header_safe_value`` before emission (a raw
+    # non-latin-1 name would fail response encoding; CR/LF is a header-
+    # injection primitive). Both are emitted only when a credential was actually
     # used — broker-origin failures before credential resolution carry neither.
     # Note: ``Jentic-Credential-Name`` is *also* a request header that clients
     # send inbound to disambiguate ambiguous resolution — the outbound response

--- a/src/jentic_one/broker/services/credentials/orchestrator.py
+++ b/src/jentic_one/broker/services/credentials/orchestrator.py
@@ -159,6 +159,8 @@ class CredentialService:
                 query_params=result.query_params,
                 cookies=result.cookies,
                 server_variables=resolved.server_variables,
+                credential_id=resolved.credential_id,
+                credential_name=resolved.name,
             )
         except CredentialNotProvisionedError as exc:
             await self._emit_credential_failure(

--- a/src/jentic_one/broker/services/credentials/orchestrator.py
+++ b/src/jentic_one/broker/services/credentials/orchestrator.py
@@ -69,6 +69,7 @@ class CredentialService:
         api_version: str,
         identity: Identity,
         credential_name: str | None = None,
+        trace_id: str | None = None,
     ) -> InjectedAuth:
         """Resolve + inject the credential for the API tuple.
 
@@ -76,6 +77,12 @@ class CredentialService:
         credential path). Credential failures are mapped to broker-domain
         exceptions (424/409/401/502) so both call-sites render identical
         problem+json.
+
+        ``trace_id`` is stamped onto the ``CREDENTIAL_ACCESSED`` audit event so
+        an operator inspecting an execution can join the credential-use record
+        back to the specific execution that triggered it (#740). Optional so
+        non-execution call-sites (bind-time probes, service accounts) don't
+        have to fabricate one.
         """
         if not api_vendor:
             return _EMPTY
@@ -153,6 +160,7 @@ class CredentialService:
                     api_vendor=api.vendor,
                     api_name=api.name,
                     api_version=api.version,
+                    trace_id=trace_id,
                 )
             return InjectedAuth(
                 headers=result.headers,

--- a/src/jentic_one/broker/services/credentials/resolver.py
+++ b/src/jentic_one/broker/services/credentials/resolver.py
@@ -34,6 +34,11 @@ class ResolvedCredential(BaseModel):
     """Result of credential resolution — enough data for inject_auth."""
 
     credential_id: str
+    # Human-readable credential name from the stored row (`Credential.name`).
+    # Carried alongside ``credential_id`` so ``InjectedAuth`` can attribute the
+    # material back to the stored credential without a second DB round-trip
+    # (#740). Always populated by the resolver; never a secret.
+    name: str
     wire_type: CredentialType
     stored_type: StoredCredentialType
     provider: str
@@ -169,6 +174,7 @@ class CredentialResolver:
             tvc = credential.token_value_credential
             return ResolvedCredential(
                 credential_id=credential.id,
+                name=credential.name,
                 wire_type=wire_type,
                 stored_type=stored_type,
                 provider=credential.provider,
@@ -180,6 +186,7 @@ class CredentialResolver:
             cak = credential.customer_api_key
             return ResolvedCredential(
                 credential_id=credential.id,
+                name=credential.name,
                 wire_type=wire_type,
                 stored_type=stored_type,
                 provider=credential.provider,
@@ -193,6 +200,7 @@ class CredentialResolver:
             bc = credential.basic_credential
             return ResolvedCredential(
                 credential_id=credential.id,
+                name=credential.name,
                 wire_type=wire_type,
                 stored_type=stored_type,
                 provider=credential.provider,
@@ -205,6 +213,7 @@ class CredentialResolver:
             token = credential.oauth_token
             return ResolvedCredential(
                 credential_id=credential.id,
+                name=credential.name,
                 wire_type=wire_type,
                 stored_type=stored_type,
                 provider=credential.provider,
@@ -221,6 +230,7 @@ class CredentialResolver:
             # apply so region/host templating works for no-auth APIs (#603).
             return ResolvedCredential(
                 credential_id=credential.id,
+                name=credential.name,
                 wire_type=wire_type,
                 stored_type=stored_type,
                 provider=credential.provider,

--- a/src/jentic_one/broker/services/execution/executor.py
+++ b/src/jentic_one/broker/services/execution/executor.py
@@ -94,6 +94,8 @@ def _ctx_from_metadata(request: UpstreamExecRequest) -> ExecuteRequestContext:
         api_version=meta.get("api_version"),
         prefer=None,
         pinned_revisions=meta.get("pinned_revisions"),
+        credential_id=meta.get("credential_id"),
+        credential_name=meta.get("credential_name"),
     )
 
 

--- a/src/jentic_one/broker/services/execution/service.py
+++ b/src/jentic_one/broker/services/execution/service.py
@@ -374,6 +374,8 @@ async def persist_streaming_execution(
         actor_id=actor_id,
         actor_type=actor_type,
         origin=origin,
+        credential_id=ctx_req.credential_id,
+        credential_name=ctx_req.credential_name,
     )
 
     # Third-party auth failure on the streaming path — mirrors run_execution
@@ -434,6 +436,8 @@ async def _persist(
         actor_id=actor_id,
         actor_type=actor_type,
         origin=origin,
+        credential_id=ctx_req.credential_id,
+        credential_name=ctx_req.credential_name,
     )
 
 

--- a/src/jentic_one/broker/web/routers/execute.py
+++ b/src/jentic_one/broker/web/routers/execute.py
@@ -428,6 +428,7 @@ async def _resolve_credentials(
         api_version=ctx_req.api_version or "",
         identity=identity,
         credential_name=credential_name,
+        trace_id=ctx_req.trace_id,
     )
 
 

--- a/src/jentic_one/broker/web/routers/execute.py
+++ b/src/jentic_one/broker/web/routers/execute.py
@@ -393,6 +393,14 @@ def _metadata_headers(ctx_req: ExecuteRequestContext, execution_id: str) -> dict
         meta[JenticHeader.OPERATION.value] = ctx_req.operation_id
     if ctx_req.api_vendor:
         meta[JenticHeader.API_VENDOR.value] = ctx_req.api_vendor
+    # Credential attribution (#740). Emitted only when the resolver actually
+    # picked a stored credential — a broker-origin failure before injection,
+    # inline auth, or a credential-less API leaves both ``None`` and both
+    # headers absent, so a missing header unambiguously means "no credential".
+    if ctx_req.credential_id:
+        meta[JenticHeader.CREDENTIAL_ID.value] = ctx_req.credential_id
+    if ctx_req.credential_name:
+        meta[JenticHeader.CREDENTIAL_NAME.value] = ctx_req.credential_name
     # Echo the jentic= tracestate member (same who/what payload as the outbound
     # request) so a caller can correlate the response to its distributed trace
     # without re-deriving it (§04 / OpenAPI Tracestate).

--- a/src/jentic_one/broker/web/routers/execute.py
+++ b/src/jentic_one/broker/web/routers/execute.py
@@ -634,6 +634,8 @@ async def _handle(
     credential_name = request.headers.get("jentic-credential-name")
     injection = await _resolve_credentials(ctx_req, ctx, identity, credential_name)
     ctx_req.upstream_url, auth_headers = _apply_injection(ctx_req.upstream_url, injection, request)
+    ctx_req.credential_id = injection.credential_id
+    ctx_req.credential_name = injection.credential_name
     if injection.server_variables:
         try:
             validate_upstream_url(ctx_req.upstream_url, ctx.config.broker.egress)
@@ -692,6 +694,8 @@ async def _handle_streaming(
     credential_name = request.headers.get("jentic-credential-name")
     injection = await _resolve_credentials(ctx_req, ctx, identity, credential_name)
     ctx_req.upstream_url, auth_headers = _apply_injection(ctx_req.upstream_url, injection, request)
+    ctx_req.credential_id = injection.credential_id
+    ctx_req.credential_name = injection.credential_name
     if injection.server_variables:
         try:
             validate_upstream_url(ctx_req.upstream_url, ctx.config.broker.egress)

--- a/src/jentic_one/broker/web/routers/execute.py
+++ b/src/jentic_one/broker/web/routers/execute.py
@@ -49,6 +49,7 @@ from jentic_one.broker.core.headers import (
     REGION_MISMATCH_HINT,
     TRACESTATE_HEADER,
     JenticHeader,
+    header_safe_value,
 )
 from jentic_one.broker.core.idempotency import fingerprint
 from jentic_one.broker.core.proxy_headers import (
@@ -397,10 +398,11 @@ def _metadata_headers(ctx_req: ExecuteRequestContext, execution_id: str) -> dict
     # picked a stored credential — a broker-origin failure before injection,
     # inline auth, or a credential-less API leaves both ``None`` and both
     # headers absent, so a missing header unambiguously means "no credential".
+    # The name is operator-authored free text: sanitize before emission.
     if ctx_req.credential_id:
         meta[JenticHeader.CREDENTIAL_ID.value] = ctx_req.credential_id
     if ctx_req.credential_name:
-        meta[JenticHeader.CREDENTIAL_NAME.value] = ctx_req.credential_name
+        meta[JenticHeader.CREDENTIAL_NAME.value] = header_safe_value(ctx_req.credential_name)
     # Echo the jentic= tracestate member (same who/what payload as the outbound
     # request) so a caller can correlate the response to its distributed trace
     # without re-deriving it (§04 / OpenAPI Tracestate).

--- a/src/jentic_one/broker/web/streaming.py
+++ b/src/jentic_one/broker/web/streaming.py
@@ -128,6 +128,12 @@ def _metadata_headers(
         metadata[JenticHeader.OPERATION.value] = ctx_req.operation_id
     if ctx_req.api_vendor:
         metadata[JenticHeader.API_VENDOR.value] = ctx_req.api_vendor
+    # Credential attribution (#740). Absent when no credential was used, so
+    # the streaming path stays symmetric with the sync router.
+    if ctx_req.credential_id:
+        metadata[JenticHeader.CREDENTIAL_ID.value] = ctx_req.credential_id
+    if ctx_req.credential_name:
+        metadata[JenticHeader.CREDENTIAL_NAME.value] = ctx_req.credential_name
     if status_code >= 400:
         metadata[JenticHeader.ERROR_ORIGIN.value] = ErrorOrigin.UPSTREAM.value
     # Region-mismatch hint for a templated-host API's upstream 401/403 (#638),

--- a/src/jentic_one/broker/web/streaming.py
+++ b/src/jentic_one/broker/web/streaming.py
@@ -38,7 +38,11 @@ from jentic_one.broker.adapters.runners.base import (
     StreamingUpstreamRunner,
 )
 from jentic_one.broker.core.exceptions import ErrorOrigin, UpstreamTimeoutError
-from jentic_one.broker.core.headers import REGION_MISMATCH_HINT, JenticHeader
+from jentic_one.broker.core.headers import (
+    REGION_MISMATCH_HINT,
+    JenticHeader,
+    header_safe_value,
+)
 from jentic_one.broker.core.proxy_headers import passthrough_streaming_headers
 from jentic_one.broker.core.schemas import ExecuteRequestContext
 from jentic_one.shared.broker.execution import StreamingOutcome
@@ -129,11 +133,12 @@ def _metadata_headers(
     if ctx_req.api_vendor:
         metadata[JenticHeader.API_VENDOR.value] = ctx_req.api_vendor
     # Credential attribution (#740). Absent when no credential was used, so
-    # the streaming path stays symmetric with the sync router.
+    # the streaming path stays symmetric with the sync router. The name is
+    # operator-authored free text: sanitize before emission.
     if ctx_req.credential_id:
         metadata[JenticHeader.CREDENTIAL_ID.value] = ctx_req.credential_id
     if ctx_req.credential_name:
-        metadata[JenticHeader.CREDENTIAL_NAME.value] = ctx_req.credential_name
+        metadata[JenticHeader.CREDENTIAL_NAME.value] = header_safe_value(ctx_req.credential_name)
     if status_code >= 400:
         metadata[JenticHeader.ERROR_ORIGIN.value] = ErrorOrigin.UPSTREAM.value
     # Region-mismatch hint for a templated-host API's upstream 401/403 (#638),

--- a/src/jentic_one/migrations/admin/versions/d0e1f2a3b4c5_add_execution_credential_attribution.py
+++ b/src/jentic_one/migrations/admin/versions/d0e1f2a3b4c5_add_execution_credential_attribution.py
@@ -1,0 +1,37 @@
+"""add credential attribution columns to execution_records (#740)
+
+Add nullable ``credential_id`` / ``credential_name`` columns so an execution
+record attributes back to the stored credential the broker actually used.
+Nullable is semantically honest: historical rows, executions using inline
+auth, and executions that failed before credential resolution all leave
+both ``NULL``. No FK: ``credentials`` lives in the control DB (cross-DB,
+same as ``toolkit_id`` here). Indexed on ``credential_id`` for the audit
+console's "what did this credential do?" query.
+
+Revision ID: d0e1f2a3b4c5
+Revises: c9d0e1f2a3b4
+Create Date: 2026-07-24
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d0e1f2a3b4c5"  # pragma: allowlist secret
+down_revision: str | None = "c9d0e1f2a3b4"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("execution_records", sa.Column("credential_id", sa.String(30), nullable=True))
+    op.add_column("execution_records", sa.Column("credential_name", sa.String(255), nullable=True))
+    op.create_index("ix_execution_records_credential_id", "execution_records", ["credential_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_execution_records_credential_id", table_name="execution_records")
+    op.drop_column("execution_records", "credential_name")
+    op.drop_column("execution_records", "credential_id")

--- a/src/jentic_one/shared/broker/schemas.py
+++ b/src/jentic_one/shared/broker/schemas.py
@@ -41,3 +41,11 @@ class ExecuteRequestContext(BaseModel):
     # broker attaches to an upstream 401/403 (#638) so a valid key hitting the
     # wrong host is not a dead-end "Invalid Key".
     has_server_variable: bool = False
+    # Attribution for the stored credential the resolver picked, once injection
+    # has run (#740). ``None`` before injection, when no credential path exists,
+    # or when the request used inline auth. Carried on the context so both the
+    # sync router and the async worker can stamp ``Jentic-Credential-*`` response
+    # headers, persist the ids on the execution record, and correlate the
+    # ``CREDENTIAL_ACCESSED`` audit event to this execution.
+    credential_id: str | None = None
+    credential_name: str | None = None

--- a/src/jentic_one/shared/executions/ingest.py
+++ b/src/jentic_one/shared/executions/ingest.py
@@ -31,6 +31,8 @@ async def record_execution(
     actor_id: str,
     actor_type: str,
     origin: str | None = None,
+    credential_id: str | None = None,
+    credential_name: str | None = None,
 ) -> str:
     """Persist a terminal execution record. Returns the record ID."""
     if status not in tuple(ExecutionStatus):
@@ -54,6 +56,8 @@ async def record_execution(
         actor_id=actor_id,
         actor_type=actor_type,
         origin=origin,
+        credential_id=credential_id,
+        credential_name=credential_name,
     )
     session.add(record)
     await session.flush()

--- a/src/jentic_one/shared/jobs/execution_handler.py
+++ b/src/jentic_one/shared/jobs/execution_handler.py
@@ -103,15 +103,20 @@ class ExecutionHandler:
         upstream_url = validate_upstream_url(upstream_url, self._egress)
 
         headers: dict[str, str] = {}
+        credential_id: str | None = None
+        credential_name: str | None = None
         if self._credential_injector is not None and api_vendor:
             injection = await self._credential_injector.inject(
                 api_vendor=api_vendor,
                 api_name=api_name or "",
                 api_version=api_version or "",
                 identity=_worker_identity(created_by, actor_type),
+                trace_id=trace_id,
             )
             applied = _apply_injection(upstream_url, injection)
             upstream_url, headers = applied.url, applied.headers
+            credential_id = injection.credential_id
+            credential_name = injection.credential_name
             if injection.server_variables:
                 upstream_url = validate_upstream_url(upstream_url, self._egress)
 
@@ -142,6 +147,11 @@ class ExecutionHandler:
                         "actor_id": created_by,
                         "actor_type": actor_type,
                         "origin": origin,
+                        # Credential attribution (#740): carried so the
+                        # pipeline persists the same credential_id/name on
+                        # the execution record as the sync router would.
+                        "credential_id": credential_id,
+                        "credential_name": credential_name,
                     },
                 ),
                 session=session,

--- a/src/jentic_one/shared/jobs/protocols.py
+++ b/src/jentic_one/shared/jobs/protocols.py
@@ -18,12 +18,21 @@ class InjectedAuth:
     dropped (a headers-only return would lose both). Cookie entries are merged
     into the outbound ``Cookie`` header by the call-site (sync router / worker).
     Server-variable entries are substituted into the upstream URL template.
+
+    ``credential_id`` / ``credential_name`` attribute the material back to the
+    stored credential the resolver chose (#740) so downstream call-sites can
+    stamp ``Jentic-Credential-*`` response headers, persist attribution on the
+    execution record, and join the ``CREDENTIAL_ACCESSED`` audit event to an
+    execution via ``trace_id``. Both are ``None`` when no credential was used
+    (inline auth, credential-less API, or a resolve-fail before injection).
     """
 
     headers: dict[str, str]
     query_params: dict[str, str]
     cookies: dict[str, str]
     server_variables: dict[str, str] | None = None
+    credential_id: str | None = None
+    credential_name: str | None = None
 
 
 class CredentialInjector(Protocol):

--- a/src/jentic_one/shared/jobs/protocols.py
+++ b/src/jentic_one/shared/jobs/protocols.py
@@ -46,7 +46,14 @@ class CredentialInjector(Protocol):
     """
 
     async def inject(
-        self, *, api_vendor: str, api_name: str, api_version: str, identity: Identity
+        self,
+        *,
+        api_vendor: str,
+        api_name: str,
+        api_version: str,
+        identity: Identity,
+        credential_name: str | None = None,
+        trace_id: str | None = None,
     ) -> InjectedAuth:
         """Return the auth to apply; empty ``InjectedAuth`` when there is no credential path."""
         ...

--- a/tests/integration/admin/test_execution_record_repository.py
+++ b/tests/integration/admin/test_execution_record_repository.py
@@ -82,6 +82,59 @@ async def test_create_and_get_by_id(
         assert loaded.pinned_revisions == {"rev": 1}
 
 
+async def test_create_persists_credential_attribution(
+    admin_db: DatabaseSession, clean_execution_records: None
+) -> None:
+    """#740: credential id/name populate on the execution record."""
+    now = datetime.now(UTC)
+    async with admin_db.session() as session:
+        record = await ExecutionRecordRepository.create(
+            session,
+            toolkit_id="tk_test000000000000000000",
+            trace_id="abcdef1234567890abcdef12",
+            started_at=now,
+            status="completed",
+            created_by="usr_test",
+            actor_id="usr_test",
+            actor_type="user",
+            credential_id="cred_abc123",
+            credential_name="stripe-live",
+        )
+        await session.commit()
+        record_id = record.id
+
+    async with admin_db.session() as session:
+        loaded = await ExecutionRecordRepository.get_by_id(session, record_id)
+        assert loaded is not None
+        assert loaded.credential_id == "cred_abc123"
+        assert loaded.credential_name == "stripe-live"
+
+
+async def test_create_leaves_credential_attribution_null_when_absent(
+    admin_db: DatabaseSession, clean_execution_records: None
+) -> None:
+    """No credential path attempted ⇒ both columns NULL (unambiguous)."""
+    async with admin_db.session() as session:
+        record = await ExecutionRecordRepository.create(
+            session,
+            toolkit_id="tk_test000000000000000000",
+            trace_id="abcdef1234567890abcdef12",
+            started_at=datetime.now(UTC),
+            status="completed",
+            created_by="usr_test",
+            actor_id="usr_test",
+            actor_type="user",
+        )
+        await session.commit()
+        record_id = record.id
+
+    async with admin_db.session() as session:
+        loaded = await ExecutionRecordRepository.get_by_id(session, record_id)
+        assert loaded is not None
+        assert loaded.credential_id is None
+        assert loaded.credential_name is None
+
+
 async def test_list_all_with_filters(
     admin_db: DatabaseSession, clean_execution_records: None
 ) -> None:

--- a/tests/integration/shared/test_worker_unified_execution.py
+++ b/tests/integration/shared/test_worker_unified_execution.py
@@ -51,7 +51,14 @@ class _StaticInjector:
         self._injection = injection
 
     async def inject(
-        self, *, api_vendor: str, api_name: str, api_version: str, identity: Any
+        self,
+        *,
+        api_vendor: str,
+        api_name: str,
+        api_version: str,
+        identity: Any,
+        credential_name: str | None = None,
+        trace_id: str | None = None,
     ) -> InjectedAuth:
         return self._injection
 

--- a/tests/unit/admin/services/test_execution_service.py
+++ b/tests/unit/admin/services/test_execution_service.py
@@ -29,6 +29,12 @@ def _make_record(**overrides: Any) -> MagicMock:
         "actor_id": "usr_default",
         "actor_type": "user",
         "origin": None,
+        # #740: credential attribution — always populate the axis so
+        # ``_to_view``'s ``getattr(record, "credential_*", None)`` reads a real
+        # value instead of a MagicMock autospec attribute (which Pydantic then
+        # rejects as a non-string).
+        "credential_id": None,
+        "credential_name": None,
     }
     defaults.update(overrides)
     record = MagicMock()

--- a/tests/unit/broker/test_credential_service.py
+++ b/tests/unit/broker/test_credential_service.py
@@ -63,6 +63,7 @@ def _ctx(*, account_linking_base_url: str | None = None) -> MagicMock:
 def _resolved() -> ResolvedCredential:
     return ResolvedCredential(
         credential_id="cred_abc",
+        name="abc",
         wire_type=CredentialType.API_KEY,
         stored_type=StoredCredentialType.API_KEY,
         provider="stripe",
@@ -93,6 +94,9 @@ async def test_empty_vendor_returns_empty_injection() -> None:
     assert result.headers == {}
     assert result.query_params == {}
     assert result.cookies == {}
+    # No credential path attempted ⇒ no attribution to carry (#740).
+    assert result.credential_id is None
+    assert result.credential_name is None
 
 
 @pytest.mark.asyncio
@@ -194,6 +198,11 @@ async def test_successful_inject_emits_one_audit_event(monkeypatch: pytest.Monke
     )
 
     assert result.headers == {"Authorization": "injected"}
+    # #740: attribution follows the injection back through the caller so the
+    # sync/streaming routers can stamp ``Jentic-Credential-*`` response headers
+    # and persist attribution on ``execution_records`` without a second lookup.
+    assert result.credential_id == "cred_abc"
+    assert result.credential_name == "abc"
     audit.assert_awaited_once()
     assert audit.await_args is not None
     kwargs = audit.await_args.kwargs

--- a/tests/unit/broker/test_credential_service.py
+++ b/tests/unit/broker/test_credential_service.py
@@ -284,6 +284,7 @@ async def test_decryption_error_during_oauth_refresh_also_maps(
     """
     oauth_cred = ResolvedCredential(
         credential_id="cred_oauth",
+        name="google-oauth",
         wire_type=CredentialType.OAUTH2,
         stored_type=StoredCredentialType.OAUTH2_CLIENT_CREDENTIALS,
         provider="google",

--- a/tests/unit/broker/test_credential_service.py
+++ b/tests/unit/broker/test_credential_service.py
@@ -194,7 +194,11 @@ async def test_successful_inject_emits_one_audit_event(monkeypatch: pytest.Monke
     )
 
     result = await CredentialService(_ctx()).inject(
-        api_vendor="stripe", api_name="charges", api_version="v1", identity=_IDENTITY
+        api_vendor="stripe",
+        api_name="charges",
+        api_version="v1",
+        identity=_IDENTITY,
+        trace_id="trace_xyz",
     )
 
     assert result.headers == {"Authorization": "injected"}
@@ -214,6 +218,8 @@ async def test_successful_inject_emits_one_audit_event(monkeypatch: pytest.Monke
     assert kwargs["api_vendor"] == "stripe"
     assert kwargs["api_name"] == "charges"
     assert kwargs["api_version"] == "v1"
+    # #740: audit event joins to the triggering execution via trace_id.
+    assert kwargs["trace_id"] == "trace_xyz"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/broker/test_injected_broker_seam.py
+++ b/tests/unit/broker/test_injected_broker_seam.py
@@ -37,7 +37,7 @@ from jentic_one.broker.adapters.runners.base import (
     UpstreamRunner,
 )
 from jentic_one.broker.adapters.runners.registry import RunnerRegistry
-from jentic_one.broker.services.execution.executor import PipelineExecutor
+from jentic_one.broker.services.execution.executor import PipelineExecutor, _ctx_from_metadata
 from jentic_one.broker.web.routers.execute import _resolve_broker
 from jentic_one.shared.broker.broker import Broker
 from jentic_one.shared.broker.execution import (
@@ -216,3 +216,36 @@ async def test_async_path_invokes_injected_broker() -> None:
     assert len(spy.calls) == 1, "injected broker must be invoked on the async path"
     assert result.status_code == 200
     assert result.body == b"spy"
+
+
+def test_ctx_from_metadata_rebuilds_credential_attribution() -> None:
+    """The worker's opaque metadata carries credential attribution (#740) into
+    the rebuilt request context, so the pipeline persists the same
+    credential_id/name on async execution records as the sync router does —
+    and omitting it leaves both None ("no credential used")."""
+    base_metadata: dict[str, Any] = {
+        "execution_id": "exec_test0000000000000000",
+        "trace_id": "a" * 32,
+        "actor_id": "agt_abc123",
+        "actor_type": "agent",
+    }
+
+    def _request(metadata: dict[str, Any]) -> UpstreamExecRequest:
+        return UpstreamExecRequest(
+            method="GET",
+            url="https://api.example.com/v1/things",
+            headers={},
+            body=None,
+            timeout_s=30.0,
+            metadata=metadata,
+        )
+
+    attributed = _ctx_from_metadata(
+        _request({**base_metadata, "credential_id": "cred_abc", "credential_name": "stripe-live"})
+    )
+    assert attributed.credential_id == "cred_abc"
+    assert attributed.credential_name == "stripe-live"
+
+    bare = _ctx_from_metadata(_request(base_metadata))
+    assert bare.credential_id is None
+    assert bare.credential_name is None

--- a/tests/unit/broker/test_injection.py
+++ b/tests/unit/broker/test_injection.py
@@ -25,6 +25,7 @@ def _make_ctx(decrypt_map: dict[str, str]) -> MagicMock:
 def test_inject_bearer_token() -> None:
     resolved = ResolvedCredential(
         credential_id="cred_1",
+        name="cred1",
         wire_type=CredentialType.BEARER_TOKEN,
         stored_type=StoredCredentialType.STATIC_BEARER_TOKEN,
         provider="static",
@@ -41,6 +42,7 @@ def test_inject_bearer_token() -> None:
 def test_inject_api_key_header() -> None:
     resolved = ResolvedCredential(
         credential_id="cred_2",
+        name="cred2",
         wire_type=CredentialType.API_KEY,
         stored_type=StoredCredentialType.API_KEY,
         provider="static",
@@ -59,6 +61,7 @@ def test_inject_api_key_header() -> None:
 def test_inject_api_key_query() -> None:
     resolved = ResolvedCredential(
         credential_id="cred_3",
+        name="cred3",
         wire_type=CredentialType.API_KEY,
         stored_type=StoredCredentialType.API_KEY,
         provider="static",
@@ -78,6 +81,7 @@ def test_inject_api_key_query() -> None:
 def test_inject_api_key_cookie() -> None:
     resolved = ResolvedCredential(
         credential_id="cred_3c",
+        name="cred3c",
         wire_type=CredentialType.API_KEY,
         stored_type=StoredCredentialType.API_KEY,
         provider="static",
@@ -97,6 +101,7 @@ def test_inject_api_key_cookie() -> None:
 def test_inject_basic_auth() -> None:
     resolved = ResolvedCredential(
         credential_id="cred_4",
+        name="cred4",
         wire_type=CredentialType.BASIC,
         stored_type=StoredCredentialType.BASIC_AUTH,
         provider="static",
@@ -115,6 +120,7 @@ def test_inject_basic_auth() -> None:
 def test_inject_oauth2_with_access_token() -> None:
     resolved = ResolvedCredential(
         credential_id="cred_5",
+        name="cred5",
         wire_type=CredentialType.OAUTH2,
         stored_type=StoredCredentialType.OAUTH2_CLIENT_CREDENTIALS,
         provider="direct_oauth2",
@@ -131,6 +137,7 @@ def test_inject_oauth2_with_access_token() -> None:
 def test_inject_oauth2_raises_without_access_token() -> None:
     resolved = ResolvedCredential(
         credential_id="cred_6",
+        name="cred6",
         wire_type=CredentialType.OAUTH2,
         stored_type=StoredCredentialType.OAUTH2_CLIENT_CREDENTIALS,
         provider="direct_oauth2",
@@ -153,6 +160,7 @@ def test_inject_no_auth_injects_nothing() -> None:
     # A no-auth credential carries no secret — injection is a no-op (#603).
     resolved = ResolvedCredential(
         credential_id="cred_noauth",
+        name="noauth",
         wire_type=CredentialType.NO_AUTH,
         stored_type=StoredCredentialType.NO_AUTH,
         provider="static",

--- a/tests/unit/broker/test_refresh.py
+++ b/tests/unit/broker/test_refresh.py
@@ -31,6 +31,7 @@ def _make_resolved(
 ) -> ResolvedCredential:
     return ResolvedCredential(
         credential_id="cred_test",
+        name="test",
         wire_type=CredentialType.OAUTH2,
         stored_type=StoredCredentialType.OAUTH2_CLIENT_CREDENTIALS,
         provider=provider,

--- a/tests/unit/broker/test_response_headers.py
+++ b/tests/unit/broker/test_response_headers.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from jentic_one.broker.core.headers import TRACESTATE_HEADER
+from jentic_one.broker.core.headers import TRACESTATE_HEADER, JenticHeader
 from jentic_one.broker.core.schemas import ExecuteRequestContext
 from jentic_one.broker.web.routers.execute import _metadata_headers
+from jentic_one.broker.web.streaming import _metadata_headers as _stream_metadata_headers
 
 
 def _ctx(**overrides: object) -> ExecuteRequestContext:
@@ -35,3 +36,39 @@ def test_metadata_headers_tracestate_uses_placeholders_for_missing_fields():
         "exec_1",
     )
     assert headers[TRACESTATE_HEADER] == "jentic=exec_1:_:_:_:_"
+
+
+def test_metadata_headers_stamp_credential_attribution_when_present():
+    """A resolved credential is echoed as ``Jentic-Credential-Id``/``-Name`` (#740)."""
+    headers = _metadata_headers(
+        _ctx(credential_id="cred_abc", credential_name="stripe-live"),
+        "exec_1",
+    )
+    assert headers[JenticHeader.CREDENTIAL_ID.value] == "cred_abc"
+    assert headers[JenticHeader.CREDENTIAL_NAME.value] == "stripe-live"
+
+
+def test_metadata_headers_omit_credential_attribution_when_absent():
+    """No credential → no attribution header (unambiguous ``no credential used``)."""
+    headers = _metadata_headers(_ctx(credential_id=None, credential_name=None), "exec_1")
+    assert JenticHeader.CREDENTIAL_ID.value not in headers
+    assert JenticHeader.CREDENTIAL_NAME.value not in headers
+
+
+def test_stream_metadata_headers_stamp_credential_attribution():
+    """Streaming path stays symmetric with the sync router (#740)."""
+    headers = _stream_metadata_headers(
+        _ctx(credential_id="cred_abc", credential_name="stripe-live"),
+        "exec_1",
+        200,
+    )
+    assert headers[JenticHeader.CREDENTIAL_ID.value] == "cred_abc"
+    assert headers[JenticHeader.CREDENTIAL_NAME.value] == "stripe-live"
+
+
+def test_stream_metadata_headers_omit_credential_attribution_when_absent():
+    headers = _stream_metadata_headers(
+        _ctx(credential_id=None, credential_name=None), "exec_1", 200
+    )
+    assert JenticHeader.CREDENTIAL_ID.value not in headers
+    assert JenticHeader.CREDENTIAL_NAME.value not in headers

--- a/tests/unit/broker/test_response_headers.py
+++ b/tests/unit/broker/test_response_headers.py
@@ -72,3 +72,36 @@ def test_stream_metadata_headers_omit_credential_attribution_when_absent():
     )
     assert JenticHeader.CREDENTIAL_ID.value not in headers
     assert JenticHeader.CREDENTIAL_NAME.value not in headers
+
+
+def test_metadata_headers_sanitize_unsafe_credential_name():
+    """Operator-authored names are reduced to printable ASCII before emission.
+
+    A verbatim non-latin-1 name (emoji/CJK) would raise at response-encode
+    time — turning every execution that used that credential into a 500 —
+    and CR/LF is a header-injection primitive behind a non-validating
+    intermediary. Unsafe characters become ``?`` so the header stays present
+    (presence still means "a credential was used")."""
+    headers = _metadata_headers(
+        _ctx(credential_id="cred_abc", credential_name="日本語 key 🔑"),
+        "exec_1",
+    )
+    assert headers[JenticHeader.CREDENTIAL_NAME.value] == "??? key ?"
+
+    headers = _metadata_headers(
+        _ctx(credential_id="cred_abc", credential_name="evil\r\nSet-Cookie: x=1"),
+        "exec_1",
+    )
+    assert "\r" not in headers[JenticHeader.CREDENTIAL_NAME.value]
+    assert "\n" not in headers[JenticHeader.CREDENTIAL_NAME.value]
+    assert headers[JenticHeader.CREDENTIAL_NAME.value] == "evil??Set-Cookie: x=1"
+
+
+def test_stream_metadata_headers_sanitize_unsafe_credential_name():
+    """The streaming twin applies the same sanitization as the sync router."""
+    headers = _stream_metadata_headers(
+        _ctx(credential_id="cred_abc", credential_name="café\nkey"),
+        "exec_1",
+        200,
+    )
+    assert headers[JenticHeader.CREDENTIAL_NAME.value] == "caf??key"

--- a/tests/unit/broker/test_upstream_fidelity.py
+++ b/tests/unit/broker/test_upstream_fidelity.py
@@ -1,0 +1,120 @@
+"""Fidelity lock-in for upstream passthrough (#740).
+
+The broker's #740 report was "a 403 became a 400". A code audit of ``main``
+confirms the broker never rewraps upstream status/body/`Www-Authenticate` —
+it mirrors them verbatim through ``_assemble_response`` +
+``passthrough_response_headers``, and enriches only via ``Jentic-*`` headers
+(``Upstream-Status``, ``Error-Origin``, ``Hint``). These tests are the
+regression fence: if the reporter's rewrap ever recurs, this bisects it to
+client-side handling instead of the broker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jentic_one.broker.core.headers import JenticHeader
+from jentic_one.broker.core.schemas import ExecuteRequestContext
+from jentic_one.broker.web.routers.execute import _assemble_response
+from jentic_one.shared.broker.execution import (
+    ErrorOrigin,
+    ExecutionContext,
+    ExecutionOutcome,
+    RunnerResult,
+)
+
+
+def _ctx_req(**overrides: object) -> ExecuteRequestContext:
+    base: dict[str, object] = {
+        "upstream_url": "https://api.example.com/v1/things",
+        "method": "GET",
+        "trace_id": "trace-1",
+        "operation_id": "op-1",
+        "api_vendor": "example",
+        "api_name": "widgets",
+        "api_version": "v1",
+    }
+    base.update(overrides)
+    return ExecuteRequestContext(**base)  # type: ignore[arg-type]
+
+
+def _outcome(
+    *,
+    status_code: int,
+    body: bytes,
+    upstream_headers: dict[str, str] | None = None,
+) -> ExecutionOutcome:
+    result = RunnerResult(
+        status_code=status_code,
+        body=body,
+        headers=upstream_headers or {"content-type": "application/json"},
+        content_type="application/json",
+        duration_ms=1,
+    )
+    context = ExecutionContext(
+        execution_id="exec-1",
+        toolkit_id="tk-1",
+        operation_id="op-1",
+        api=None,
+        trace_id="trace-1",
+    )
+    error_origin = ErrorOrigin.UPSTREAM if status_code >= 400 else None
+    return ExecutionOutcome(result=result, context=context, error_origin=error_origin)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "body"),
+    [
+        (401, b'{"error":"invalid_token"}'),
+        (403, b'{"error":"insufficient_scope","detail":"needs write"}'),
+        (404, b'{"error":"not_found"}'),
+        (429, b'{"error":"rate_limited"}'),
+        (500, b"upstream is on fire"),
+    ],
+)
+def test_upstream_status_and_body_are_mirrored_verbatim(status_code: int, body: bytes) -> None:
+    """The broker never rewraps upstream status/body (B-002 passthrough)."""
+    response = _assemble_response(_outcome(status_code=status_code, body=body), _ctx_req())
+
+    assert response.status_code == status_code
+    assert response.body == body
+    # ``Jentic-Upstream-Status`` mirrors the exact upstream code — the response
+    # status is authoritative but the header preserves it for observability.
+    assert response.headers[JenticHeader.UPSTREAM_STATUS.value] == str(status_code)
+    # 4xx/5xx are tagged as upstream-origin so a caller can distinguish an
+    # upstream rejection from a broker-origin failure without inspecting body.
+    assert response.headers[JenticHeader.ERROR_ORIGIN.value] == ErrorOrigin.UPSTREAM.value
+
+
+def test_www_authenticate_passes_through_verbatim() -> None:
+    """OAuth/API-key upstreams often carry ``Www-Authenticate`` on 401 — mirror it (#740)."""
+    challenge = 'Bearer realm="api.example.com", error="invalid_token"'
+    response = _assemble_response(
+        _outcome(
+            status_code=401,
+            body=b'{"error":"invalid_token"}',
+            upstream_headers={
+                "content-type": "application/json",
+                "www-authenticate": challenge,
+            },
+        ),
+        _ctx_req(),
+    )
+
+    assert response.headers["www-authenticate"] == challenge
+
+
+def test_success_body_and_headers_are_mirrored_verbatim() -> None:
+    body = b'{"id":42,"name":"widget"}'
+    upstream_headers = {"content-type": "application/json", "etag": '"abc123"'}
+    response = _assemble_response(
+        _outcome(status_code=200, body=body, upstream_headers=upstream_headers),
+        _ctx_req(),
+    )
+
+    assert response.status_code == 200
+    assert response.body == body
+    assert response.headers["etag"] == '"abc123"'
+    # No upstream error → no ``Jentic-Error-Origin`` (broker success/upstream success).
+    assert JenticHeader.ERROR_ORIGIN.value not in response.headers
+    assert response.headers[JenticHeader.UPSTREAM_STATUS.value] == "200"

--- a/tests/unit/shared/test_execution_handler.py
+++ b/tests/unit/shared/test_execution_handler.py
@@ -57,7 +57,14 @@ class _FakeInjector:
         self._injection = injection
 
     async def inject(
-        self, *, api_vendor: str, api_name: str, api_version: str, identity: Any
+        self,
+        *,
+        api_vendor: str,
+        api_name: str,
+        api_version: str,
+        identity: Any,
+        credential_name: str | None = None,
+        trace_id: str | None = None,
     ) -> InjectedAuth:
         return self._injection
 

--- a/tests/unit/shared/test_execution_handler.py
+++ b/tests/unit/shared/test_execution_handler.py
@@ -55,6 +55,7 @@ class _RaisingExecutor:
 class _FakeInjector:
     def __init__(self, injection: InjectedAuth) -> None:
         self._injection = injection
+        self.last_trace_id: str | None = None
 
     async def inject(
         self,
@@ -66,6 +67,7 @@ class _FakeInjector:
         credential_name: str | None = None,
         trace_id: str | None = None,
     ) -> InjectedAuth:
+        self.last_trace_id = trace_id
         return self._injection
 
 
@@ -205,6 +207,62 @@ async def test_handler_passes_actor_fields_in_metadata() -> None:
     assert req is not None
     assert req.metadata["actor_id"] == "agt_abc123"
     assert req.metadata["actor_type"] == "agent"
+
+
+@pytest.mark.asyncio
+async def test_handler_carries_credential_attribution_and_trace_id() -> None:
+    """The worker path attributes like the sync router (#740): the caller's
+    trace_id reaches inject() (so the CREDENTIAL_ACCESSED audit event joins to
+    the execution) and the resolved credential id/name ride the executor
+    metadata (so the pipeline persists them on the execution record — NULL
+    must keep meaning "no credential used", async included)."""
+    executor = _RecordingExecutor(
+        UpstreamExecResult(status_code=200, body=b"", content_type=None, duration_ms=1)
+    )
+    injector = _FakeInjector(
+        InjectedAuth(
+            headers={},
+            query_params={},
+            cookies={},
+            credential_id="cred_abc",
+            credential_name="stripe-live",
+        )
+    )
+    handler = ExecutionHandler(executor=executor, credential_injector=injector)
+
+    await handler.execute(
+        "job8",
+        _FakeSession(),
+        payload=_payload(trace_id="trace-xyz"),
+        created_by="agt_abc123",
+        actor_type="agent",
+    )
+
+    assert injector.last_trace_id == "trace-xyz"
+    req = executor.last_request
+    assert req is not None
+    assert req.metadata["credential_id"] == "cred_abc"
+    assert req.metadata["credential_name"] == "stripe-live"
+
+
+@pytest.mark.asyncio
+async def test_handler_no_credential_leaves_attribution_none() -> None:
+    """No stored credential used → attribution metadata is None, matching the
+    schema's "NULL unambiguously means no credential" contract."""
+    executor = _RecordingExecutor(
+        UpstreamExecResult(status_code=200, body=b"", content_type=None, duration_ms=1)
+    )
+    injector = _FakeInjector(InjectedAuth(headers={}, query_params={}, cookies={}))
+    handler = ExecutionHandler(executor=executor, credential_injector=injector)
+
+    await handler.execute(
+        "job9", _FakeSession(), payload=_payload(), created_by="usr_test", actor_type="user"
+    )
+
+    req = executor.last_request
+    assert req is not None
+    assert req.metadata["credential_id"] is None
+    assert req.metadata["credential_name"] is None
 
 
 @pytest.mark.asyncio

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -3410,6 +3410,28 @@
             "title": "Created At",
             "type": "string"
           },
+          "credential_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Credential Id"
+          },
+          "credential_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Credential Name"
+          },
           "duration_ms": {
             "anyOf": [
               {

--- a/ui/public/broker-openapi.json
+++ b/ui/public/broker-openapi.json
@@ -1,6 +1,24 @@
 {
   "components": {
     "headers": {
+      "JenticCredentialId": {
+        "description": "ID of the stored credential the broker resolved and used to sign\nthis execution. Present only when a stored credential was actually\nused — a missing header unambiguously means no credential (inline\nauth, a credential-less API, or a failure before resolution).\n",
+        "schema": {
+          "examples": [
+            "cred_abc123"
+          ],
+          "type": "string"
+        }
+      },
+      "JenticCredentialName": {
+        "description": "Human-readable label of the credential in `Jentic-Credential-Id`,\nsanitized to printable ASCII (unsafe characters replaced with `?`).\nPresent under the same condition as the id header. The same header\nname is also accepted on requests to disambiguate credential\nresolution.\n",
+        "schema": {
+          "examples": [
+            "Stripe prod key"
+          ],
+          "type": "string"
+        }
+      },
       "JenticExecutionId": {
         "description": "Execution ID — unique identifier for this brokered request.",
         "schema": {
@@ -263,6 +281,12 @@
               ],
               "type": "string"
             }
+          },
+          "Jentic-Credential-Id": {
+            "$ref": "#/components/headers/JenticCredentialId"
+          },
+          "Jentic-Credential-Name": {
+            "$ref": "#/components/headers/JenticCredentialName"
           },
           "Jentic-Execution-Id": {
             "$ref": "#/components/headers/JenticExecutionId"

--- a/ui/src/shared/api/generated/models/ExecutionResponse.ts
+++ b/ui/src/shared/api/generated/models/ExecutionResponse.ts
@@ -13,6 +13,8 @@ export type ExecutionResponse = {
     actor_type: string;
     api?: (ApiInfoResponse | null);
     created_at: string;
+    credential_id?: (string | null);
+    credential_name?: (string | null);
     duration_ms?: (number | null);
     error?: (string | null);
     execution_id: string;


### PR DESCRIPTION
Theme-4 PR **A** (of 4). Implements step **A** of
[`theme-4-IMPL.md`](https://github.com/jentic/jentic-one-rules/blob/main/docs/plans/theme-4-IMPL.md)
— execute attribution and a fidelity lock-in for upstream passthrough.
Design plan: [`theme-4-broker-error-fidelity.md`](https://github.com/jentic/jentic-one-rules/blob/main/docs/plans/theme-4-broker-error-fidelity.md).

## Summary

The #740 report ("a 403 became a 400") does **not** reproduce from the
current broker code — passthrough is verbatim
(`_assemble_response` + `passthrough_response_headers`;
`Www-Authenticate` is forwarded). What #740 actually needs is
**attribution**: when a broker execution used a stored credential,
callers, audit rows, and events should all point back to the same
credential. That was missing.

This PR wires that end-to-end:

1. **Carry** `credential_id` / `credential_name` on `InjectedAuth` and
   `ExecuteRequestContext`, populated by the resolver via
   `ResolvedCredential.name` and copied onto `ctx_req` right after
   `_apply_injection` in both the sync router and streaming twin.
2. **Surface** the attribution as `Jentic-Credential-Id` /
   `Jentic-Credential-Name` response headers (emitted only when a stored
   credential was actually used, so absence unambiguously means "no
   credential").
3. **Persist** the two ids on `execution_records` via a new admin-chain
   migration (`d0e1f2a3b4c5`) — nullable, indexed on `credential_id`,
   no FK (`credentials` is cross-DB, same as `toolkit_id`). Both
   admin OpenAPI + UI client regenerate cleanly.
4. **Join** the `CREDENTIAL_ACCESSED` audit event to its triggering
   execution: `CredentialInjector.inject` gains an optional `trace_id`
   kwarg, forwarded from `ctx_req.trace_id` to the already-existing
   (previously unused) `trace_id` parameter on `emit_credential_access`.
5. **Fence** the current passthrough correctness with a parametrized
   401/403/404/429/500 regression test covering status/body byte-exact
   mirroring, `Www-Authenticate` passthrough, `Jentic-Upstream-Status`,
   and `Jentic-Error-Origin: upstream` tagging.

Followups on the theme-4 tracker:
- **PR B**: URL matching for multi-segment path params (#701 ask 1).
- **PR C**: `operation_not_found` diagnostics (#701 ask 2, after B).
- **PR D**: region-hint v2 (#638, after this PR — builds on
  `ctx_req.credential_id` from step 1 for the credential-host tier).

## Commit sequence (one per IMPL step, kept apart for review)

1. `feat(broker): carry resolved credential through injection pipeline` — step A1
2. `feat(broker): emit Jentic-Credential-Id/-Name response headers` — step A2
3. `feat(admin): persist credential attribution on execution_records` — step A3
4. `feat(broker): join CREDENTIAL_ACCESSED events to executions via trace_id` — step A4
5. `test(broker): fidelity lock-in for upstream status/body/Www-Authenticate` — step A5

## Test plan

- [x] `make check` (ruff + ruff format + mypy) green
- [x] `make openapi` + `ui codegen` clean, `ExecutionResponse` picks up
      `credential_id` / `credential_name`
- [x] Unit sweep: `tests/unit/broker`, `tests/unit/shared` — 1038 passed
- [x] Integration sweep: `tests/integration/broker`, `tests/integration/admin`,
      `tests/integration/control` (SQLite backend) — all green
- [x] New fidelity regression covers 401/403/404/429/500 verbatim
      passthrough incl. `Www-Authenticate`
- [x] `test_provisioning_plan_e2e.py` untouched and green (theme-3 fence)
- [ ] Postgres web suite (`tests/web/**`) — no schema-shape assertions
      touch the affected endpoints (audited via `rg`); relying on CI

## Refs

- Fixes: #740
- Prep for: #638 (PR D depends on `credential_id` from this PR), #701
  (independent, PR B/C follow)


Made with [Cursor](https://cursor.com)