### PR TITLE
feat: theme-3 access-request residuals + broker visibility (#778, +2)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1516,7 +1516,7 @@
         "filename": "ui/src/modules/toolkits/api/types.ts",
         "hashed_secret": "cf678cab87dc1f7d1b95b964f15375e088461679",
         "is_verified": false,
-        "line_number": 72
+        "line_number": 76
       }
     ],
     "ui/src/modules/toolkits/mocks/handlers.ts": [
@@ -1525,14 +1525,14 @@
         "filename": "ui/src/modules/toolkits/mocks/handlers.ts",
         "hashed_secret": "c549d02cfde9464385223ed238d6f38947430d75",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 290
       },
       {
         "type": "Secret Keyword",
         "filename": "ui/src/modules/toolkits/mocks/handlers.ts",
         "hashed_secret": "c34820c37dd8dfb1b6e3ef065c44a1bbf9949e4f",
         "is_verified": false,
-        "line_number": 203
+        "line_number": 347
       }
     ],
     "ui/src/shared/api/generated/models/CredentialType.ts": [
@@ -1618,5 +1618,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-29T18:12:02Z"
+  "generated_at": "2026-07-29T19:01:35Z"
 }

--- a/src/jentic_one/broker/web/routers/execute.py
+++ b/src/jentic_one/broker/web/routers/execute.py
@@ -293,6 +293,59 @@ def _empty_derivation_denial(
     )
 
 
+def _is_unserved_no_toolkit_binding(exc: ActionDeniedError) -> bool:
+    """True when ``exc`` denies with the pre-binding "no toolkit serves this API" case.
+
+    Splits the two ``no_toolkit_binding`` flavours ``_empty_derivation_denial``
+    emits: ``serves=True`` (a toolkit exists, the caller just isn't bound) is
+    agent-recoverable via an access request and does not warrant an operator
+    event; ``serves=False`` (nothing serves this API yet — a credential must be
+    provisioned first) is the operator-attention case, mirroring the 424
+    ``CREDENTIAL_NOT_PROVISIONED`` event on the post-binding side.
+    """
+    if exc.type != "no_toolkit_binding" or exc.directive is None:
+        return False
+    return exc.directive.parameters.get("toolkit_serves_api") is False
+
+
+async def _emit_toolkit_binding_unserved(
+    ctx: Context, *, api: APIReference, identity: Identity
+) -> None:
+    """Emit ``TOOLKIT_BINDING_UNSERVED`` best-effort (mirrors the PBAC_DENIED emit).
+
+    Fires once per denied execute request (the caller wraps `select_toolkit`);
+    the caller's own retry loop will re-emit — acceptable at WARNING severity,
+    and consistent with how ``CREDENTIAL_NOT_PROVISIONED`` (424) already emits
+    per attempt without in-process debouncing.
+    """
+    api_id = "/".join(part for part in (api.vendor, api.name) if part) or api.vendor
+    summary = f"No toolkit serves API '{api_id}' — provision a credential to enable binding."
+    try:
+        async with ctx.admin_db.transaction() as session:
+            await emit_event_best_effort(
+                session,
+                type=EventType.TOOLKIT_BINDING_UNSERVED,
+                severity=EventSeverity.WARNING,
+                summary=summary,
+                created_by=identity.sub,
+                actor_id=identity.sub,
+                actor_type=identity.actor_type.value,
+                data={
+                    "api": {
+                        "vendor": api.vendor,
+                        "name": api.name,
+                        "version": api.version,
+                    },
+                },
+            )
+    except Exception:
+        logger.warning(
+            "telemetry_emit_failed",
+            event_type=EventType.TOOLKIT_BINDING_UNSERVED,
+            exc_info=True,
+        )
+
+
 async def select_toolkit(
     *,
     deriver: ToolkitDeriverProtocol,
@@ -544,13 +597,23 @@ async def _handle(
     ctx_req.has_server_variable = has_host_server_variable(upstream_url)
     # Toolkit is derived from the discovered API identity (never the inbound header
     # verbatim); drives credential injection and execution attribution (§03).
-    ctx_req.toolkit_id = await select_toolkit(
-        deriver=deriver,
-        identity=identity,
-        api=resolved.api,
-        header_toolkit=request.headers.get("jentic-toolkit-id"),
-        instance=request.url.path,
-    )
+    try:
+        ctx_req.toolkit_id = await select_toolkit(
+            deriver=deriver,
+            identity=identity,
+            api=resolved.api,
+            header_toolkit=request.headers.get("jentic-toolkit-id"),
+            instance=request.url.path,
+        )
+    except ActionDeniedError as exc:
+        # Emit the operator-visible signal for the pre-binding no-toolkit case
+        # (nothing serves this API yet) before re-raising. The 424
+        # ``credential_not_provisioned`` path already emits
+        # ``CREDENTIAL_NOT_PROVISIONED`` (post-binding); this is the missing
+        # pre-binding twin. See ``TOOLKIT_BINDING_UNSERVED``.
+        if _is_unserved_no_toolkit_binding(exc):
+            await _emit_toolkit_binding_unserved(ctx, api=resolved.api, identity=identity)
+        raise
 
     # Evaluate toolkit permission rules — default-deny when no rule matches.
     # Unconditional: even if toolkit_id were empty the evaluator returns a

--- a/src/jentic_one/control/services/access_requests/effects.py
+++ b/src/jentic_one/control/services/access_requests/effects.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import enum
-from typing import Any
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol
 
 import structlog
 
@@ -32,12 +34,189 @@ from jentic_one.control.services.access_requests.schemas.effects import (
 from jentic_one.shared.audit import AuditAction, AuditTargetType, record_audit_best_effort
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.context import Context
+from jentic_one.shared.models.access_requests import AccessRequestItemStatus
 from jentic_one.shared.models.actors import actor_type_from_id
 from jentic_one.shared.models.api_identity import slugify_api_field
 
 logger = structlog.get_logger(__name__)
 
 EffectResult = CredentialBindEffect | ToolkitBindEffect | ScopeGrantEffect | SkippedEffect
+
+
+# The fulfilment-only intent item types that mark a request as a provisioning
+# plan. Exposed here (rather than only on the service) so ``plan_governance_for_items``
+# — the pure function that computes which binds a plan governs — stays close
+# to the phase table it consults.
+PLAN_INTENT_COMBINATIONS: frozenset[tuple[str, str]] = frozenset(
+    {("toolkit", "create"), ("credential", "provision")}
+)
+
+# Bind item combinations whose fulfilment contract flips inside a plan.
+_PLAN_GOVERNABLE_BINDS: frozenset[tuple[str, str]] = frozenset(
+    {("credential", "bind"), ("toolkit", "bind")}
+)
+
+# Item statuses that keep an intent (or bind) "live" for the purposes of
+# governance. A withdrawn/denied intent no longer defines a plan on a later
+# decide() call.
+_LIVE_ITEM_STATUSES: frozenset[str] = frozenset(
+    {AccessRequestItemStatus.PENDING.value, AccessRequestItemStatus.APPROVED.value}
+)
+
+
+class _PlanGovernanceItem(Protocol):
+    """Minimal read-only view of an access-request item for governance.
+
+    ``plan_governance_for_items`` only inspects a handful of attributes; declaring
+    that surface explicitly lets the tests pass ordinary duck-typed mocks
+    without an ``AccessRequestItem`` construction.
+    """
+
+    id: str
+    resource_type: str
+    action: str
+    resource_reference: dict[str, Any] | None
+    status: str
+
+
+def _canonical_api_key(reference: dict[str, Any] | None) -> tuple[str, str | None] | None:
+    """Return the ``(vendor, name)`` slug key an item's reference targets.
+
+    Version is deliberately excluded from the key: an intent filed against
+    ``vendor/name`` wildcards every version of that API for governance purposes
+    — a plan for ``sendgrid`` covers a bind for ``sendgrid@1``. Both axes are
+    slugified via the shared identity seam so raw-domain references from the
+    CLI (``httpbin.org``) match stored slug form (``httpbin-org``); see the
+    same normalization in ``_resolve_toolkit_reference``.
+    """
+    if not reference:
+        return None
+    vendor = reference.get("vendor")
+    if not vendor:
+        return None
+    raw_name = reference.get("name")
+    return (
+        slugify_api_field(str(vendor)),
+        slugify_api_field(str(raw_name)) if raw_name else None,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PlanGovernance:
+    """Why a bind item is governed by a provisioning plan.
+
+    Carries the specific live intent item ids whose fulfilment the wizard
+    must stamp before this bind can approve, and — for ``toolkit:bind`` — the
+    canonical ``(vendor, name)`` slug key that made those intents relevant.
+    ``credential:bind`` items intentionally leave ``governing_api`` at
+    ``None``: the credential-bind governance rule is "any live intent" (§778
+    review), not tied to a specific API.
+
+    Default construction (``PlanGovernance()``) means "not governed by any
+    plan" — the plain fulfilment contract applies. ``is_governed`` is the
+    single decision point call-sites branch on; the id / API fields are for
+    the diagnostic path (which intent must be fulfilled? which API tuple?),
+    replacing the coarser ``is_provisioning_plan: bool`` that used to be
+    threaded through :meth:`EffectApplicator.validate`.
+    """
+
+    governing_intent_ids: frozenset[str] = field(default_factory=frozenset)
+    governing_api: tuple[str, str | None] | None = None
+
+    @property
+    def is_governed(self) -> bool:
+        return bool(self.governing_intent_ids)
+
+
+# Shared no-plan sentinel — cheap to reuse across every call-site and every
+# non-governed bind item without re-allocating an empty dataclass instance.
+# Exported (no leading underscore) so ``AccessRequestService.decide`` can pass
+# it as the default when looking a bind up in a governance mapping.
+UNGOVERNED_PLAN: PlanGovernance = PlanGovernance()
+
+
+def plan_governance_for_items(
+    items: Sequence[_PlanGovernanceItem],
+) -> Mapping[str, PlanGovernance]:
+    """Compute per-item plan governance for a request's bind items.
+
+    A request is a *plan* iff it carries at least one live fulfilment-only
+    intent (``toolkit:create`` / ``credential:provision``). This function
+    returns a mapping from bind ``item_id`` to :class:`PlanGovernance` for
+    every bind whose fulfilment contract the plan flips — the bind can only
+    be satisfied by ids stamped by the wizard (see
+    ``EffectApplicator.validate``); a plain approval of such a bind denies
+    with :class:`ProvisioningPlanNotFulfilledError`. Bind items not in the
+    mapping are governed by the plain contract.
+
+    Governance is per-item, not request-wide (issue #778):
+
+    - A ``toolkit:bind`` is governed iff a live intent's canonical
+      ``(vendor, name)`` matches the bind's ``resource_reference``. Version is
+      not part of the key — an intent for ``vendor/name`` covers all versions.
+      A bind for a different API is *not* governed and resolves normally by
+      its reference.
+    - A ``credential:bind`` is governed whenever any live intent exists in
+      the request: agents never carry credential ids at file time, so a
+      credential-bind sharing a request with an intent is always the wizard's
+      to satisfy.
+
+    Non-live intents (``denied`` / ``withdrawn``) do not govern — abandoning a
+    plan reverts remaining binds to the plain contract on the next decide.
+
+    The mapping value carries *which* live intent(s) govern this bind and, for
+    ``toolkit:bind``, *which* API tuple made them relevant — richer than a
+    boolean so a diagnostic (an ``UNFULFILLABLE`` DENY reason, an operator
+    dashboard row) can name the intent the wizard needs to fulfil rather than
+    just "some plan somewhere".
+    """
+    live_intents = [
+        it
+        for it in items
+        if (it.resource_type, it.action) in PLAN_INTENT_COMBINATIONS
+        and (it.status in _LIVE_ITEM_STATUSES)
+    ]
+    if not live_intents:
+        return {}
+
+    intents_by_api: dict[tuple[str, str | None], list[str]] = {}
+    untargeted_intent_ids: list[str] = []
+    for it in live_intents:
+        key = _canonical_api_key(it.resource_reference)
+        if key is None:
+            untargeted_intent_ids.append(it.id)
+        else:
+            intents_by_api.setdefault(key, []).append(it.id)
+
+    governance: dict[str, PlanGovernance] = {}
+    all_live_intent_ids = frozenset(it.id for it in live_intents)
+    for item in items:
+        key = (item.resource_type, item.action)
+        if key not in _PLAN_GOVERNABLE_BINDS:
+            continue
+        if item.status not in _LIVE_ITEM_STATUSES:
+            # An already-decided bind isn't going to be re-validated; excluding
+            # it keeps the mapping to items decide() actually processes.
+            continue
+        if key == ("credential", "bind"):
+            # Every live intent could plausibly be the reason this credential
+            # bind exists — record them all so a diagnostic can name them.
+            governance[item.id] = PlanGovernance(governing_intent_ids=all_live_intent_ids)
+            continue
+        # ("toolkit", "bind"): governed only when a live intent targets the
+        # same API. An untargeted intent (unusual — the CLI always fills a
+        # reference) is treated as covering all bind targets to preserve the
+        # pre-#778 conservative behaviour for that edge case.
+        bind_key = _canonical_api_key(item.resource_reference)
+        matching_intent_ids: list[str] = list(untargeted_intent_ids)
+        if bind_key is not None and bind_key in intents_by_api:
+            matching_intent_ids.extend(intents_by_api[bind_key])
+        if matching_intent_ids:
+            governance[item.id] = PlanGovernance(
+                governing_intent_ids=frozenset(matching_intent_ids),
+                governing_api=bind_key,
+            )
+    return governance
 
 
 class EffectPhase(enum.Enum):
@@ -156,7 +335,7 @@ class EffectApplicator:
         *,
         identity: Identity,
         control_session: Any,
-        is_provisioning_plan: bool = False,
+        plan_governance: PlanGovernance = UNGOVERNED_PLAN,
     ) -> None:
         """Validate an approved item's effect can be applied — without writing.
 
@@ -167,17 +346,24 @@ class EffectApplicator:
         transactions and cannot be rolled back by the control-DB transaction, so
         the only safe place to fail is up front.
 
-        ``is_provisioning_plan`` is set by ``decide()`` when the item's request
-        also carries fulfilment intents (``toolkit:create`` / ``credential:provision``).
-        A bind item in such a plan that hasn't been fulfilled (no ``to_id`` /
-        ``resource_id`` stamped by the wizard) is denied with a plan-aware,
-        actionable reason rather than the cryptic "to_id missing" / "no toolkit
-        serves API" a plain approval would otherwise surface.
+        ``plan_governance`` is computed by ``decide()`` from the request's live
+        fulfilment intents (see :func:`plan_governance_for_items`). Governed
+        bind items can only be satisfied by the ids the wizard stamps
+        (``to_id`` / ``resource_id``); a plain approval of one is denied with
+        an actionable, plan-aware reason that names the intent id(s) still
+        awaiting fulfilment rather than the cryptic "to_id missing" / "no
+        toolkit serves API" a plain approval would otherwise surface.
+        Default (``_UNGOVERNED``) means "plain contract" — non-plan items and
+        non-plan requests never construct a governance value at all.
         """
         key = (item.resource_type, item.action)
         if key == ("credential", "bind"):
-            if is_provisioning_plan and not (item.to_id and item.resource_id):
-                raise ProvisioningPlanNotFulfilledError(item.resource_type, item.action)
+            if plan_governance.is_governed and not (item.to_id and item.resource_id):
+                raise ProvisioningPlanNotFulfilledError(
+                    item.resource_type,
+                    item.action,
+                    governing_intent_ids=plan_governance.governing_intent_ids,
+                )
             # credential:bind writes only to the shared control-session and so
             # rolls back cleanly with the decision. We still pre-validate that the
             # named credential exists and is visible to the decider, so a bad
@@ -193,13 +379,18 @@ class EffectApplicator:
             # _apply_toolkit_bind for the full rationale.
             if item.rules:
                 raise RulesNotSupportedForBindError(item.resource_type, item.action)
-            if is_provisioning_plan and not (item.resource_id or item.to_id):
+            if plan_governance.is_governed and not (item.resource_id or item.to_id):
                 # In a plan the agent binding must resolve by the concrete toolkit
                 # id the wizard creates (the credential→toolkit binding it depends
                 # on isn't visible to the reference join until the credential:bind
                 # applies later in the same decision). An unfulfilled reference-only
                 # toolkit:bind can't be satisfied by a plain approval.
-                raise ProvisioningPlanNotFulfilledError(item.resource_type, item.action)
+                raise ProvisioningPlanNotFulfilledError(
+                    item.resource_type,
+                    item.action,
+                    governing_intent_ids=plan_governance.governing_intent_ids,
+                    governing_api=plan_governance.governing_api,
+                )
             await self._resolve_toolkit_bind_target(
                 item, identity=identity, session=control_session
             )

--- a/src/jentic_one/control/services/access_requests/effects.py
+++ b/src/jentic_one/control/services/access_requests/effects.py
@@ -353,7 +353,7 @@ class EffectApplicator:
         an actionable, plan-aware reason that names the intent id(s) still
         awaiting fulfilment rather than the cryptic "to_id missing" / "no
         toolkit serves API" a plain approval would otherwise surface.
-        Default (``_UNGOVERNED``) means "plain contract" — non-plan items and
+        Default (``UNGOVERNED_PLAN``) means "plain contract" — non-plan items and
         non-plan requests never construct a governance value at all.
         """
         key = (item.resource_type, item.action)

--- a/src/jentic_one/control/services/access_requests/errors.py
+++ b/src/jentic_one/control/services/access_requests/errors.py
@@ -225,15 +225,42 @@ class ProvisioningPlanNotFulfilledError(AccessRequestServiceError):
     the cryptic "to_id missing" / "no toolkit serves API" a plain approval would
     otherwise produce. This error is in ``_UNFULFILLABLE_BIND_TARGET`` so the
     ``--wait`` loop closes with a legible message.
+
+    ``governing_intent_ids`` — populated by the caller from the ``PlanGovernance``
+    value ``decide()`` computed — names the specific fulfilment intents whose
+    approval the wizard is still waiting on. For a ``toolkit:bind``,
+    ``governing_api`` additionally names the canonical ``(vendor, name)`` slug
+    key that tied the plan to this bind. Both are ``None``/empty when the caller
+    doesn't have the richer context (older call-sites, tests that construct the
+    error directly), keeping the constructor backwards-compatible.
     """
 
-    def __init__(self, resource_type: str, action: str) -> None:
-        super().__init__(
+    def __init__(
+        self,
+        resource_type: str,
+        action: str,
+        *,
+        governing_intent_ids: frozenset[str] | None = None,
+        governing_api: tuple[str, str | None] | None = None,
+    ) -> None:
+        base = (
             f"{resource_type}:{action} is part of a provisioning plan that has not been "
             "fulfilled yet. Approve this request from the setup wizard, which creates the "
             "toolkit and credential and wires them before granting — a plain approval cannot "
             "complete a plan."
         )
+        details: list[str] = []
+        if governing_api is not None:
+            vendor, name = governing_api
+            api_label = f"{vendor}/{name}" if name else vendor
+            details.append(f"governing api: {api_label}")
+        if governing_intent_ids:
+            details.append("awaiting intent(s): " + ", ".join(sorted(governing_intent_ids)))
+        if details:
+            base = f"{base} ({'; '.join(details)})"
+        super().__init__(base)
+        self.governing_intent_ids: frozenset[str] = frozenset(governing_intent_ids or ())
+        self.governing_api: tuple[str, str | None] | None = governing_api
         self.resource_type = resource_type
         self.action = action
 

--- a/src/jentic_one/control/services/access_requests/service.py
+++ b/src/jentic_one/control/services/access_requests/service.py
@@ -17,10 +17,12 @@ from jentic_one.control.repos.prerequisite_repo import PrerequisiteRepository
 from jentic_one.control.repos.toolkit_repo import ToolkitRepository
 from jentic_one.control.scoping.filters import build_access_filters
 from jentic_one.control.services.access_requests.effects import (
+    UNGOVERNED_PLAN,
     EffectApplicator,
     EffectPhase,
     admin_effect_keys,
     classify_effect,
+    plan_governance_for_items,
 )
 from jentic_one.control.services.access_requests.errors import (
     AccessRequestNotFoundError,
@@ -85,7 +87,9 @@ _UNFULFILLABLE_BIND_TARGET: tuple[type[Exception], ...] = (
 # plan. Their presence means the bind items are fulfilled out-of-band by the
 # setup wizard (create toolkit + credential, then amend their ids), so a plain
 # approval of an unfulfilled bind must be denied with a plan-aware reason rather
-# than half-approving into a guaranteed-broken state.
+# than half-approving into a guaranteed-broken state. Governance is computed
+# per-item by :func:`plan_governance_for_items` (issue #778); this constant is
+# retained only for tests/documentation that name the combinations.
 _PLAN_INTENT_COMBINATIONS: frozenset[tuple[str, str]] = frozenset(
     {("toolkit", "create"), ("credential", "provision")}
 )
@@ -440,12 +444,17 @@ class AccessRequestService:
                 raise NotAReviewerError(request_id)
 
             items_by_id = {item.id: item for item in request.items}
-            # A request is a provisioning plan when it carries fulfilment intents;
-            # its bind items are only satisfiable after the wizard fulfils them, so
-            # validate() denies an unfulfilled bind with a plan-aware reason.
-            is_plan = any(
-                (it.resource_type, it.action) in _PLAN_INTENT_COMBINATIONS for it in request.items
-            )
+            # Provisioning-plan governance is per-item (issue #778): a bind is
+            # only held to the "must resolve by id (wizard-stamped)" contract
+            # when a live intent in the same request actually targets it. An
+            # independent reference-only toolkit:bind for a different API in
+            # the same request stays on the plain contract and resolves by its
+            # reference; a withdrawn/denied intent no longer governs. See
+            # ``plan_governance_for_items`` for the full rule. The mapping
+            # carries a per-item ``PlanGovernance`` value (intent ids + api
+            # tuple, or the empty default for non-plan items) so ``validate()``
+            # gets the *reason* an item is governed rather than a coarse bool.
+            plan_governance = plan_governance_for_items(request.items)
             control_effect_items: list[tuple[str, Any]] = []
 
             for decision in item_decisions:
@@ -480,7 +489,7 @@ class AccessRequestService:
                                 existing,
                                 identity=identity,
                                 control_session=session,
-                                is_provisioning_plan=is_plan,
+                                plan_governance=plan_governance.get(existing.id, UNGOVERNED_PLAN),
                             )
                         except _UNFULFILLABLE_BIND_TARGET as exc:
                             verdict = AccessRequestItemStatus.DENIED
@@ -517,7 +526,7 @@ class AccessRequestService:
                         target,
                         identity=identity,
                         control_session=session,
-                        is_provisioning_plan=is_plan,
+                        plan_governance=plan_governance.get(target.id, UNGOVERNED_PLAN),
                     )
 
                 phase = classify_effect(target.resource_type, target.action)

--- a/src/jentic_one/control/services/access_requests/service.py
+++ b/src/jentic_one/control/services/access_requests/service.py
@@ -18,6 +18,7 @@ from jentic_one.control.repos.prerequisite_repo import PrerequisiteRepository
 from jentic_one.control.repos.toolkit_repo import ToolkitRepository
 from jentic_one.control.scoping.filters import build_access_filters
 from jentic_one.control.services.access_requests.effects import (
+    PLAN_INTENT_COMBINATIONS,
     UNGOVERNED_PLAN,
     EffectApplicator,
     EffectPhase,
@@ -83,17 +84,6 @@ _UNFULFILLABLE_BIND_TARGET: tuple[type[Exception], ...] = (
     CredentialNotFoundForBindError,
     RequiredFieldMissingError,
     ProvisioningPlanNotFulfilledError,
-)
-
-# The fulfilment-only intent item types that mark a request as a provisioning
-# plan. Their presence means the bind items are fulfilled out-of-band by the
-# setup wizard (create toolkit + credential, then amend their ids), so a plain
-# approval of an unfulfilled bind must be denied with a plan-aware reason rather
-# than half-approving into a guaranteed-broken state. Governance is computed
-# per-item by :func:`plan_governance_for_items` (issue #778); this constant is
-# retained only for tests/documentation that name the combinations.
-_PLAN_INTENT_COMBINATIONS: frozenset[tuple[str, str]] = frozenset(
-    {("toolkit", "create"), ("credential", "provision")}
 )
 
 # Statuses in which a request has been decided and its actionable
@@ -217,11 +207,15 @@ class AccessRequestService:
         """Emit a best-effort ``TOOLKIT_BINDING_UNSERVED`` for unfulfillable filings.
 
         A plain (non-plan) ``toolkit:bind`` filed by ``vendor/name`` reference
-        will deny on approval with :class:`ToolkitReferenceUnresolvedError`
-        when no toolkit visible to the filer's owner currently serves that
-        API. Surfacing that at file time gives operators an early signal —
-        symmetric to the broker's own emit for the same event on execute-time
-        denials (see ``execute._emit_toolkit_binding_unserved``).
+        will typically deny on approval with
+        :class:`ToolkitReferenceUnresolvedError` when no toolkit owned by the
+        filer's owner currently serves that API. (Approval-time resolution
+        runs under the *decider's* scope — an org-admin can resolve toolkits
+        the filer's owner doesn't hold, so this owner-scoped check is a
+        heuristic, not a promise of denial.) Surfacing it at file time gives
+        operators an early signal — symmetric to the broker's own emit for
+        the same event on execute-time denials (see
+        ``execute._emit_toolkit_binding_unserved``).
 
         Deliberately silent when:
 
@@ -235,9 +229,17 @@ class AccessRequestService:
 
         Never blocks the filing — the emit is best-effort and any lookup
         failure logs and continues.
+
+        The plan check here is deliberately request-wide (any intent item
+        silences all binds), unlike :func:`plan_governance_for_items`'s
+        per-item scoping used at approval time: at file() everything is
+        pending and a request carrying any fulfilment intent is wizard-bound,
+        where the operator will see unfulfillable binds up close anyway —
+        a coarser, quieter heuristic is the right trade-off for an advisory.
         """
-        plan_types = {("toolkit", "create"), ("credential", "provision")}
-        if any((it.get("resource_type"), it.get("action")) in plan_types for it in items):
+        if any(
+            (it.get("resource_type"), it.get("action")) in PLAN_INTENT_COMBINATIONS for it in items
+        ):
             return
 
         actor_type_value = identity.actor_type.value if identity.actor_type is not None else None
@@ -247,17 +249,29 @@ class AccessRequestService:
             if item.get("resource_id") or item.get("to_id"):
                 continue
             reference = item.get("resource_reference") or {}
-            vendor = reference.get("vendor")
-            if not vendor:
+            raw_vendor = reference.get("vendor")
+            if not raw_vendor:
                 continue
+            # ``resource_reference`` is schema-typed ``dict[str, Any]`` — coerce
+            # the fields once so a non-string value can't raise past the
+            # best-effort guards below (the filing is already committed here;
+            # an escape would 500 the request and skip its audit record).
+            # Emit the canonical slug forms (matching the broker's emit, which
+            # uses the resolved APIReference) so the same API correlates across
+            # the two emit sites — a raw `httpbin.org` filing and the broker's
+            # `httpbin-org` denial are the same problem.
+            vendor = slugify_api_field(str(raw_vendor))
             raw_name = reference.get("name")
+            name = slugify_api_field(str(raw_name)) if raw_name is not None else None
+            raw_version = reference.get("version")
+            version = str(raw_version) if raw_version is not None else None
             try:
                 async with self._ctx.control_db.session() as session:
                     candidates = await EffectsRepository.resolve_toolkits_for_api(
                         session,
-                        vendor=slugify_api_field(str(vendor)),
-                        name=(slugify_api_field(str(raw_name)) if raw_name else raw_name),
-                        version=reference.get("version"),
+                        vendor=vendor,
+                        name=name,
+                        version=version,
                         owner_ids=[filer_owner_id],
                     )
             except Exception:
@@ -272,7 +286,7 @@ class AccessRequestService:
             if candidates:
                 continue
 
-            api_id = "/".join(part for part in (str(vendor), raw_name) if part) or str(vendor)
+            api_id = "/".join(part for part in (vendor, name) if part) or vendor
             summary = (
                 f"Access request {request_id} names API '{api_id}' but no owned "
                 "toolkit serves it yet — provision a credential to enable binding."
@@ -291,8 +305,8 @@ class AccessRequestService:
                             "request_id": request_id,
                             "api": {
                                 "vendor": vendor,
-                                "name": raw_name,
-                                "version": reference.get("version"),
+                                "name": name,
+                                "version": version,
                             },
                         },
                     )
@@ -396,7 +410,7 @@ class AccessRequestService:
         )
         # File-time fulfillability advisory: a plain (non-plan) toolkit:bind
         # referenced by vendor/name that no owned toolkit currently serves will
-        # deny on approval with ToolkitReferenceUnresolvedError (§03). Emit an
+        # deny on approval with ToolkitReferenceUnresolvedError. Emit an
         # operator-visible signal *now* so the operator sees the gap before an
         # approve/deny cycle. Best-effort — never blocks the file() commit.
         await self._advise_unserved_bind_references(

--- a/src/jentic_one/control/services/access_requests/service.py
+++ b/src/jentic_one/control/services/access_requests/service.py
@@ -13,6 +13,7 @@ from jentic_one.control.core.schema.access_request_items import RULE_BEARING_COM
 from jentic_one.control.core.schema.access_requests import AccessRequest
 from jentic_one.control.repos.access_request_repo import AccessRequestRepository
 from jentic_one.control.repos.credential_repo import CredentialRepository
+from jentic_one.control.repos.effects_repo import EffectsRepository
 from jentic_one.control.repos.prerequisite_repo import PrerequisiteRepository
 from jentic_one.control.repos.toolkit_repo import ToolkitRepository
 from jentic_one.control.scoping.filters import build_access_filters
@@ -54,11 +55,12 @@ from jentic_one.control.services.access_requests.schemas.access_requests import 
 from jentic_one.shared.audit import AuditAction, AuditTargetType, record_audit_best_effort
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.context import Context
-from jentic_one.shared.events import emit_event, settle_actionable_events
+from jentic_one.shared.events import emit_event, emit_event_best_effort, settle_actionable_events
 from jentic_one.shared.models import (
     AccessRequestItemStatus,
     AccessRequestStatus,
 )
+from jentic_one.shared.models.api_identity import slugify_api_field
 from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.pagination import decode_cursor_str, encode_cursor
 from jentic_one.shared.scopes import AGENTS_WRITE, ORG_ADMIN
@@ -204,6 +206,104 @@ class AccessRequestService:
             logger.warning("settle_filed_alerts_failed", request_id=request_id, exc_info=True)
             return 0
 
+    async def _advise_unserved_bind_references(
+        self,
+        *,
+        items: list[dict[str, Any]],
+        filer_owner_id: str,
+        identity: Identity,
+        request_id: str,
+    ) -> None:
+        """Emit a best-effort ``TOOLKIT_BINDING_UNSERVED`` for unfulfillable filings.
+
+        A plain (non-plan) ``toolkit:bind`` filed by ``vendor/name`` reference
+        will deny on approval with :class:`ToolkitReferenceUnresolvedError`
+        when no toolkit visible to the filer's owner currently serves that
+        API. Surfacing that at file time gives operators an early signal —
+        symmetric to the broker's own emit for the same event on execute-time
+        denials (see ``execute._emit_toolkit_binding_unserved``).
+
+        Deliberately silent when:
+
+        - the item names a specific ``resource_id``/``to_id`` (fulfilment is by
+          id, not by reference — no cheap file-time check applies);
+        - the request also carries fulfilment intents (a *provisioning plan*
+          creates the toolkit that will serve the API, so "nothing serves it
+          yet" is expected);
+        - a toolkit already serves the API for this owner (the plain-approve
+          path will resolve cleanly).
+
+        Never blocks the filing — the emit is best-effort and any lookup
+        failure logs and continues.
+        """
+        plan_types = {("toolkit", "create"), ("credential", "provision")}
+        if any((it.get("resource_type"), it.get("action")) in plan_types for it in items):
+            return
+
+        actor_type_value = identity.actor_type.value if identity.actor_type is not None else None
+        for item in items:
+            if (item.get("resource_type"), item.get("action")) != ("toolkit", "bind"):
+                continue
+            if item.get("resource_id") or item.get("to_id"):
+                continue
+            reference = item.get("resource_reference") or {}
+            vendor = reference.get("vendor")
+            if not vendor:
+                continue
+            raw_name = reference.get("name")
+            try:
+                async with self._ctx.control_db.session() as session:
+                    candidates = await EffectsRepository.resolve_toolkits_for_api(
+                        session,
+                        vendor=slugify_api_field(str(vendor)),
+                        name=(slugify_api_field(str(raw_name)) if raw_name else raw_name),
+                        version=reference.get("version"),
+                        owner_ids=[filer_owner_id],
+                    )
+            except Exception:
+                logger.warning(
+                    "unserved_binding_check_failed",
+                    request_id=request_id,
+                    vendor=vendor,
+                    exc_info=True,
+                )
+                continue
+
+            if candidates:
+                continue
+
+            api_id = "/".join(part for part in (str(vendor), raw_name) if part) or str(vendor)
+            summary = (
+                f"Access request {request_id} names API '{api_id}' but no owned "
+                "toolkit serves it yet — provision a credential to enable binding."
+            )
+            try:
+                async with self._ctx.admin_db.transaction() as session:
+                    await emit_event_best_effort(
+                        session,
+                        type=EventType.TOOLKIT_BINDING_UNSERVED,
+                        severity=EventSeverity.WARNING,
+                        summary=summary,
+                        created_by=identity.sub,
+                        actor_id=identity.sub,
+                        actor_type=actor_type_value,
+                        data={
+                            "request_id": request_id,
+                            "api": {
+                                "vendor": vendor,
+                                "name": raw_name,
+                                "version": reference.get("version"),
+                            },
+                        },
+                    )
+            except Exception:
+                logger.warning(
+                    "telemetry_emit_failed",
+                    event_type=EventType.TOOLKIT_BINDING_UNSERVED,
+                    request_id=request_id,
+                    exc_info=True,
+                )
+
     async def file(
         self,
         *,
@@ -293,6 +393,14 @@ class AccessRequestService:
             created_by=created_by,
             actor_id=created_by,
             actor_type=identity.actor_type,
+        )
+        # File-time fulfillability advisory: a plain (non-plan) toolkit:bind
+        # referenced by vendor/name that no owned toolkit currently serves will
+        # deny on approval with ToolkitReferenceUnresolvedError (§03). Emit an
+        # operator-visible signal *now* so the operator sees the gap before an
+        # approve/deny cycle. Best-effort — never blocks the file() commit.
+        await self._advise_unserved_bind_references(
+            items=items, filer_owner_id=filer_owner_id, identity=identity, request_id=view.id
         )
         await record_audit_best_effort(
             self._ctx,

--- a/src/jentic_one/shared/models/events.py
+++ b/src/jentic_one/shared/models/events.py
@@ -61,7 +61,10 @@ class EventType:
     # serve the API). Distinct from ``CREDENTIAL_NOT_PROVISIONED`` (424, fires
     # when a bound toolkit's credential is unresolvable at inject time): this
     # event is the *pre-binding* signal, giving operators visibility into
-    # agent-needed APIs before a doomed access request appears.
+    # agent-needed APIs before a doomed access request appears. Despite the
+    # ``broker.`` namespace, the control plane also emits it as a file-time
+    # advisory for the same condition (see
+    # ``AccessRequestService._advise_unserved_bind_references``).
     TOOLKIT_BINDING_UNSERVED = "broker.toolkit_binding_unserved"
 
     ALL: frozenset[str] = frozenset(

--- a/src/jentic_one/shared/models/events.py
+++ b/src/jentic_one/shared/models/events.py
@@ -55,6 +55,14 @@ class EventType:
     AGENT_REGISTRATION_APPROVED = "agent.registration_approved"
     AGENT_REGISTRATION_DENIED = "agent.registration_denied"
     PBAC_DENIED = "broker.pbac_denied"
+    # Emitted when the broker denies an execute with 403 ``no_toolkit_binding``
+    # AND no toolkit yet serves the requested API — the caller's next step is
+    # for an operator to provision a credential (which is what makes a toolkit
+    # serve the API). Distinct from ``CREDENTIAL_NOT_PROVISIONED`` (424, fires
+    # when a bound toolkit's credential is unresolvable at inject time): this
+    # event is the *pre-binding* signal, giving operators visibility into
+    # agent-needed APIs before a doomed access request appears.
+    TOOLKIT_BINDING_UNSERVED = "broker.toolkit_binding_unserved"
 
     ALL: frozenset[str] = frozenset(
         {
@@ -93,6 +101,7 @@ class EventType:
             AGENT_REGISTRATION_APPROVED,
             AGENT_REGISTRATION_DENIED,
             PBAC_DENIED,
+            TOOLKIT_BINDING_UNSERVED,
         }
     )
 

--- a/tests/integration/control/test_access_request_service.py
+++ b/tests/integration/control/test_access_request_service.py
@@ -1414,3 +1414,177 @@ async def test_decide_conflict_raises_item_not_pending(
             identity=reviewer,
             item_decisions=[{"item_id": filed.items[0].id, "decision": "denied"}],
         )
+
+
+# --- file-time fulfillability advisory (theme 3 residual) ---
+
+
+async def _list_events_by_type(admin_db: DatabaseSession, event_type: str) -> list[Event]:
+    async with admin_db.session() as session:
+        return await EventRepository.list_all(session, event_type=[event_type])
+
+
+async def test_file_emits_unserved_advisory_for_plain_toolkit_bind_with_no_serving_toolkit(
+    svc: AccessRequestService,
+    clean_access_requests: None,
+    clean_events: None,
+    seed_binding: None,
+    admin_db: DatabaseSession,
+) -> None:
+    """A plain `toolkit:bind` by reference with no serving toolkit emits an advisory."""
+    filer = _filer_identity()
+    filed = await svc.file(
+        actor_id=FILER_SUB,
+        reason="bind me to a not-yet-served api",
+        items=[
+            {
+                "resource_type": "toolkit",
+                "action": "bind",
+                "resource_reference": {"vendor": "no-such-vendor", "name": "no-such-api"},
+            }
+        ],
+        identity=filer,
+    )
+    assert filed.status == "pending"  # advisory doesn't block the filing
+
+    events = await _list_events_by_type(admin_db, "broker.toolkit_binding_unserved")
+    matching = [e for e in events if e.data.get("request_id") == filed.id]
+    assert len(matching) == 1
+    event = matching[0]
+    assert event.severity == "warning"
+    assert event.data["api"] == {
+        "vendor": "no-such-vendor",
+        "name": "no-such-api",
+        "version": None,
+    }
+    assert "no-such-vendor/no-such-api" in event.summary
+
+
+async def test_file_skips_unserved_advisory_when_toolkit_serves_api(
+    svc: AccessRequestService,
+    clean_access_requests: None,
+    clean_events: None,
+    seed_binding: None,
+    control_db: DatabaseSession,
+    admin_db: DatabaseSession,
+) -> None:
+    """When a toolkit already serves the referenced API, no advisory fires."""
+    async with control_db.transaction() as session:
+        await session.execute(
+            text(
+                "INSERT INTO toolkits (id, name, created_by) "
+                "VALUES (:id, :name, :created_by) "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {
+                "id": "tk_served",
+                "name": "served-toolkit",
+                "created_by": OWNER_SUB,
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO credentials "
+                "(id, type, name, api_vendor, api_name, created_by) "
+                "VALUES (:id, 'token', :name, :vendor, :api_name, :created_by) "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {
+                "id": "cred_served_001",
+                "name": "served-cred",
+                "vendor": "servedvendor",
+                "api_name": "widgets",
+                "created_by": OWNER_SUB,
+            },
+        )
+        await EffectsRepository.bind_credential_to_toolkit(
+            session,
+            toolkit_id="tk_served",
+            credential_id="cred_served_001",
+            created_by=OWNER_SUB,
+        )
+
+    filer = _filer_identity()
+    filed = await svc.file(
+        actor_id=FILER_SUB,
+        reason="bind me to a served api",
+        items=[
+            {
+                "resource_type": "toolkit",
+                "action": "bind",
+                "resource_reference": {"vendor": "servedvendor", "name": "widgets"},
+            }
+        ],
+        identity=filer,
+    )
+    assert filed.status == "pending"
+
+    events = await _list_events_by_type(admin_db, "broker.toolkit_binding_unserved")
+    matching = [e for e in events if e.data.get("request_id") == filed.id]
+    assert matching == []
+
+
+async def test_file_skips_unserved_advisory_when_request_carries_fulfilment_intent(
+    svc: AccessRequestService,
+    clean_access_requests: None,
+    clean_events: None,
+    seed_binding: None,
+    admin_db: DatabaseSession,
+) -> None:
+    """Plans expect nothing to serve the API yet — the advisory must stay silent."""
+    filer = _filer_identity()
+    filed = await svc.file(
+        actor_id=FILER_SUB,
+        reason="provision then bind",
+        items=[
+            {
+                "resource_type": "toolkit",
+                "action": "create",
+                "resource_reference": {"vendor": "brandnew", "name": "widgets"},
+            },
+            {
+                "resource_type": "credential",
+                "action": "provision",
+                "resource_reference": {"vendor": "brandnew", "name": "widgets"},
+            },
+            {
+                "resource_type": "toolkit",
+                "action": "bind",
+                "resource_reference": {"vendor": "brandnew", "name": "widgets"},
+            },
+        ],
+        identity=filer,
+    )
+    assert filed.status == "pending"
+
+    events = await _list_events_by_type(admin_db, "broker.toolkit_binding_unserved")
+    matching = [e for e in events if e.data.get("request_id") == filed.id]
+    assert matching == []
+
+
+async def test_file_skips_unserved_advisory_when_bind_names_toolkit_by_id(
+    svc: AccessRequestService,
+    clean_access_requests: None,
+    clean_events: None,
+    seed_binding: None,
+    admin_db: DatabaseSession,
+) -> None:
+    """A `toolkit:bind` with an explicit id (not a reference) is not by-name — no advisory."""
+    filer = _filer_identity()
+    filed = await svc.file(
+        actor_id=FILER_SUB,
+        reason="bind by id",
+        items=[
+            {
+                "resource_type": "toolkit",
+                "action": "bind",
+                "resource_id": "tk_target",
+            }
+        ],
+        identity=filer,
+    )
+    assert filed.status == "pending"
+
+    events = await _list_events_by_type(admin_db, "broker.toolkit_binding_unserved")
+    matching = [e for e in events if e.data.get("request_id") == filed.id]
+    assert matching == []

--- a/tests/integration/control/test_access_request_service.py
+++ b/tests/integration/control/test_access_request_service.py
@@ -1460,6 +1460,46 @@ async def test_file_emits_unserved_advisory_for_plain_toolkit_bind_with_no_servi
     assert "no-such-vendor/no-such-api" in event.summary
 
 
+async def test_file_survives_non_string_reference_fields(
+    svc: AccessRequestService,
+    clean_access_requests: None,
+    clean_events: None,
+    seed_binding: None,
+    admin_db: DatabaseSession,
+) -> None:
+    """Non-string reference values must never escape the advisory (post-commit 500).
+
+    ``resource_reference`` is schema-typed ``dict[str, Any]``, so a caller can
+    put an int/list where ``name``/``version`` are expected. The advisory runs
+    after the filing has committed; an uncaught TypeError here would fail the
+    request *and* skip its CREATE audit record. Values are coerced to strings
+    instead.
+    """
+    filer = _filer_identity()
+    filed = await svc.file(
+        actor_id=FILER_SUB,
+        reason="crafted non-string reference fields",
+        items=[
+            {
+                "resource_type": "toolkit",
+                "action": "bind",
+                "resource_reference": {"vendor": "no-such-vendor", "name": 123, "version": 4},
+            }
+        ],
+        identity=filer,
+    )
+    assert filed.status == "pending"
+
+    events = await _list_events_by_type(admin_db, "broker.toolkit_binding_unserved")
+    matching = [e for e in events if e.data.get("request_id") == filed.id]
+    assert len(matching) == 1
+    assert matching[0].data["api"] == {
+        "vendor": "no-such-vendor",
+        "name": "123",
+        "version": "4",
+    }
+
+
 async def test_file_skips_unserved_advisory_when_toolkit_serves_api(
     svc: AccessRequestService,
     clean_access_requests: None,

--- a/tests/unit/broker/test_toolkit_select.py
+++ b/tests/unit/broker/test_toolkit_select.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -17,11 +18,16 @@ from jentic_one.broker.core.exceptions import (
     no_toolkit_binding_directive,
 )
 from jentic_one.broker.web.errors import install_broker_error_handlers
-from jentic_one.broker.web.routers.execute import select_toolkit
+from jentic_one.broker.web.routers.execute import (
+    _emit_toolkit_binding_unserved,
+    _is_unserved_no_toolkit_binding,
+    select_toolkit,
+)
 from jentic_one.shared.access_guidance import no_toolkit_serves_api_reason
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.broker.protocols import IdentityMismatch, ToolkitDerivation
 from jentic_one.shared.models import ActorType
+from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.schemas import APIReference
 
 _API = APIReference(vendor="acme", name="widgets", version="1.0.0")
@@ -344,3 +350,81 @@ def test_no_toolkit_binding_credential_first_directive_and_denial_reason_agree()
     assert "credential" in denial_reason
     assert "provision" in denial_reason
     assert "no toolkit serves" in denial_reason
+
+
+# --- unserved-API operator event (theme 3 residual) --------------------------
+
+
+def _no_toolkit_binding_error(*, serves: bool) -> ActionDeniedError:
+    return ActionDeniedError(
+        "No toolkit binding for this API",
+        type="no_toolkit_binding",
+        instance=_INSTANCE,
+        directive=no_toolkit_binding_directive(
+            vendor=_API.vendor, name=_API.name, version=_API.version, toolkit_serves_api=serves
+        ),
+    )
+
+
+def test_is_unserved_no_toolkit_binding_true_when_serves_false() -> None:
+    assert _is_unserved_no_toolkit_binding(_no_toolkit_binding_error(serves=False)) is True
+
+
+def test_is_unserved_no_toolkit_binding_false_when_serves_true() -> None:
+    # A toolkit exists, the caller just isn't bound → agent-recoverable via a
+    # bind access request; we deliberately do NOT emit the operator event here.
+    assert _is_unserved_no_toolkit_binding(_no_toolkit_binding_error(serves=True)) is False
+
+
+def test_is_unserved_no_toolkit_binding_false_for_other_error_types() -> None:
+    other = ActionDeniedError("denied", type="action_denied", instance=_INSTANCE, directive=None)
+    assert _is_unserved_no_toolkit_binding(other) is False
+
+
+def test_is_unserved_no_toolkit_binding_false_without_directive() -> None:
+    exc = ActionDeniedError(
+        "No toolkit binding for this API",
+        type="no_toolkit_binding",
+        instance=_INSTANCE,
+        directive=None,
+    )
+    assert _is_unserved_no_toolkit_binding(exc) is False
+
+
+async def test_emit_toolkit_binding_unserved_writes_event() -> None:
+    ctx = MagicMock()
+    session = AsyncMock()
+    ctx.admin_db.transaction.return_value.__aenter__ = AsyncMock(return_value=session)
+    ctx.admin_db.transaction.return_value.__aexit__ = AsyncMock(return_value=False)
+    identity = Identity(sub="agnt_001", actor_type=ActorType.AGENT, permissions=[])
+
+    with patch(
+        "jentic_one.broker.web.routers.execute.emit_event_best_effort",
+        new_callable=AsyncMock,
+    ) as mock_emit:
+        await _emit_toolkit_binding_unserved(ctx, api=_API, identity=identity)
+
+    mock_emit.assert_awaited_once()
+    call = mock_emit.await_args
+    assert call is not None
+    kwargs = call.kwargs
+    assert kwargs["type"] == EventType.TOOLKIT_BINDING_UNSERVED
+    assert kwargs["severity"] is EventSeverity.WARNING
+    assert kwargs["actor_id"] == "agnt_001"
+    assert kwargs["actor_type"] == ActorType.AGENT.value
+    assert kwargs["data"]["api"] == {
+        "vendor": _API.vendor,
+        "name": _API.name,
+        "version": _API.version,
+    }
+    assert "acme/widgets" in kwargs["summary"]
+
+
+async def test_emit_toolkit_binding_unserved_swallows_errors() -> None:
+    # Telemetry is best-effort: an admin-DB failure must not surface to the
+    # execute request (which is already returning 403 anyway).
+    ctx = MagicMock()
+    ctx.admin_db.transaction.side_effect = RuntimeError("db down")
+    identity = Identity(sub="agnt_001", actor_type=ActorType.AGENT, permissions=[])
+
+    await _emit_toolkit_binding_unserved(ctx, api=_API, identity=identity)  # must not raise

--- a/tests/unit/control/access_requests/test_effects.py
+++ b/tests/unit/control/access_requests/test_effects.py
@@ -9,11 +9,14 @@ import pytest
 
 from jentic_one.control.repos.effects_repo import BindTargetMissingError
 from jentic_one.control.services.access_requests.effects import (
+    UNGOVERNED_PLAN,
     EffectApplicator,
     EffectPhase,
+    PlanGovernance,
     admin_effect_keys,
     classify_effect,
     is_admin_effect,
+    plan_governance_for_items,
 )
 from jentic_one.control.services.access_requests.errors import (
     CredentialNotFoundForBindError,
@@ -70,6 +73,7 @@ def _make_item(
     actor_id: str = "agnt_001",
     rules: list[dict[str, Any]] | None = None,
     item_id: str = "arqi_001",
+    status: str = "pending",
 ) -> MagicMock:
     item = MagicMock()
     item.id = item_id
@@ -80,6 +84,7 @@ def _make_item(
     item.to_id = to_id
     item.actor_id = actor_id
     item.rules = rules
+    item.status = status
     return item
 
 
@@ -875,19 +880,26 @@ async def test_validate_fulfilment_only_intent_with_rules_is_rejected() -> None:
 
 async def test_validate_credential_bind_in_plan_denies_when_unfulfilled() -> None:
     # In a provisioning plan a credential:bind that the wizard hasn't fulfilled
-    # (missing to_id AND/OR resource_id) must be denied with the plan-aware error.
+    # (missing to_id AND/OR resource_id) must be denied with the plan-aware error,
+    # and the error must name the intent the wizard is still awaiting so the
+    # DENY-reason surfaces enough context to close the loop.
     ctx = _make_ctx()
     session = _make_session()
     applicator = EffectApplicator(ctx)
+    plan_governance = PlanGovernance(governing_intent_ids=frozenset({"arqi_intent_1"}))
     for to_id, resource_id in ((None, None), ("tk_001", None), (None, "cred_001")):
         item = _make_item(action="bind", to_id=to_id, resource_id=resource_id)
-        with pytest.raises(ProvisioningPlanNotFulfilledError):
+        with pytest.raises(ProvisioningPlanNotFulfilledError) as exc_info:
             await applicator.validate(
                 item,
                 identity=_make_identity(),
                 control_session=session,
-                is_provisioning_plan=True,
+                plan_governance=plan_governance,
             )
+        assert exc_info.value.governing_intent_ids == frozenset({"arqi_intent_1"})
+        # credential:bind carries no governing_api — it's the "any-intent-lives" rule.
+        assert exc_info.value.governing_api is None
+        assert "arqi_intent_1" in str(exc_info.value)
 
 
 @patch(f"{_MODULE}.CredentialRepository")
@@ -902,13 +914,14 @@ async def test_validate_credential_bind_in_plan_passes_when_fulfilled(
     session = _make_session()
     applicator = EffectApplicator(ctx)
     item = _make_item(action="bind", to_id="tk_001", resource_id="cred_001")
+    plan_governance = PlanGovernance(governing_intent_ids=frozenset({"arqi_intent_1"}))
     # Should not raise the plan error (a DB-validator raise would be a different type).
     try:
         await applicator.validate(
             item,
             identity=_make_identity(),
             control_session=session,
-            is_provisioning_plan=True,
+            plan_governance=plan_governance,
         )
     except ProvisioningPlanNotFulfilledError:  # pragma: no cover - failure path
         pytest.fail("a fulfilled credential:bind must not raise ProvisioningPlanNotFulfilledError")
@@ -916,7 +929,10 @@ async def test_validate_credential_bind_in_plan_passes_when_fulfilled(
 
 async def test_validate_toolkit_bind_in_plan_denies_when_unfulfilled() -> None:
     # A reference-only toolkit:bind in a plan (no resolved id) must be denied —
-    # it can't resolve by the not-yet-visible credential->toolkit join.
+    # it can't resolve by the not-yet-visible credential->toolkit join. The
+    # error carries both the intent id(s) and the (vendor, name) tuple that
+    # tied the plan to this bind, so the DENY reason names the API the wizard
+    # is still expected to fulfil.
     ctx = _make_ctx()
     session = _make_session()
     applicator = EffectApplicator(ctx)
@@ -927,10 +943,243 @@ async def test_validate_toolkit_bind_in_plan_denies_when_unfulfilled() -> None:
         to_id=None,
         resource_reference={"vendor": "acme", "name": "widgets"},
     )
-    with pytest.raises(ProvisioningPlanNotFulfilledError):
+    plan_governance = PlanGovernance(
+        governing_intent_ids=frozenset({"arqi_intent_1"}),
+        governing_api=("acme", "widgets"),
+    )
+    with pytest.raises(ProvisioningPlanNotFulfilledError) as exc_info:
         await applicator.validate(
             item,
             identity=_make_identity(),
             control_session=session,
-            is_provisioning_plan=True,
+            plan_governance=plan_governance,
         )
+    assert exc_info.value.governing_intent_ids == frozenset({"arqi_intent_1"})
+    assert exc_info.value.governing_api == ("acme", "widgets")
+    assert "acme/widgets" in str(exc_info.value)
+    assert "arqi_intent_1" in str(exc_info.value)
+
+
+# --- plan governance (issue #778) --------------------------------------------
+#
+# ``plan_governance_for_items`` is the pure function that replaced the
+# request-wide ``is_plan`` flag. It returns a per-item mapping to
+# :class:`PlanGovernance` values (which live intent ids govern this bind, and
+# for ``toolkit:bind`` the ``(vendor, name)`` slug key that made those intents
+# relevant). Bind items not in the mapping are ungoverned.
+#
+# These tests exercise the four things the flag used to get wrong:
+#
+#   1. an intent for API X should not govern an independent bind for API Y;
+#   2. non-live (withdrawn/denied) intents should not govern anything;
+#   3. the CLI's 4-item plan bundle (all items target the same API) still has
+#      every bind governed — the CLI behaviour is preserved;
+#   4. slug normalization ("httpbin.org" vs "httpbin-org") does not defeat
+#      governance.
+#
+# They also cover the extra facts the value object now carries: the
+# ``governing_intent_ids`` set, the ``governing_api`` tuple for toolkit binds,
+# and the ``is_governed`` boolean the ``validate()`` call-site branches on.
+
+
+def _intent(
+    *,
+    kind: str = "toolkit_create",
+    vendor: str = "acme",
+    name: str | None = "widgets",
+    item_id: str = "arqi_intent",
+    status: str = "pending",
+) -> MagicMock:
+    combos = {
+        "toolkit_create": ("toolkit", "create"),
+        "credential_provision": ("credential", "provision"),
+    }
+    resource_type, action = combos[kind]
+    ref: dict[str, Any] = {"vendor": vendor}
+    if name is not None:
+        ref["name"] = name
+    return _make_item(
+        resource_type=resource_type,
+        action=action,
+        resource_id=None,
+        resource_reference=ref,
+        to_id=None,
+        item_id=item_id,
+        status=status,
+    )
+
+
+def test_plan_governance_empty_when_no_intents() -> None:
+    bind = _make_item(item_id="arqi_bind_1")
+    assert plan_governance_for_items([bind]) == {}
+
+
+def test_plan_governance_matches_cli_four_item_bundle() -> None:
+    # The CLI's typical 4-item plan bundle: intents + binds all for the same API.
+    # Every bind should be governed and cite the intent(s) that put it under
+    # the plan.
+    items = [
+        _intent(kind="toolkit_create", vendor="acme", name="widgets", item_id="arqi_i1"),
+        _intent(kind="credential_provision", vendor="acme", name="widgets", item_id="arqi_i2"),
+        _make_item(
+            resource_type="credential",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            item_id="arqi_cbind",
+        ),
+        _make_item(
+            resource_type="toolkit",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            resource_reference={"vendor": "acme", "name": "widgets"},
+            item_id="arqi_tbind",
+        ),
+    ]
+    governance = plan_governance_for_items(items)
+    assert set(governance.keys()) == {"arqi_cbind", "arqi_tbind"}
+    assert governance["arqi_cbind"].is_governed
+    # credential:bind is a "any-intent-lives" rule, so it names every live intent.
+    assert governance["arqi_cbind"].governing_intent_ids == frozenset({"arqi_i1", "arqi_i2"})
+    # governing_api is intentionally None on credential:bind (§778 review comment):
+    # the rule isn't tied to a specific API tuple.
+    assert governance["arqi_cbind"].governing_api is None
+    # toolkit:bind is api-scoped, so both facts are populated.
+    assert governance["arqi_tbind"].governing_intent_ids == frozenset({"arqi_i1", "arqi_i2"})
+    assert governance["arqi_tbind"].governing_api == ("acme", "widgets")
+
+
+def test_plan_governance_leaves_independent_toolkit_bind_ungoverned() -> None:
+    # #778 core case: one intent for API X + an independent reference-only
+    # toolkit:bind for API Y must not flip the Y bind onto the plan contract.
+    items = [
+        _intent(vendor="acme", name="widgets", item_id="arqi_intent"),
+        _make_item(
+            resource_type="toolkit",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            resource_reference={"vendor": "other", "name": "thing"},
+            item_id="arqi_independent_bind",
+        ),
+    ]
+    governance = plan_governance_for_items(items)
+    # The Y bind isn't in the mapping — it stays on the plain contract. The
+    # credential-bind absence is expected (there is no credential-bind here).
+    assert "arqi_independent_bind" not in governance
+
+
+def test_plan_governance_governs_all_credential_binds_when_any_intent_lives() -> None:
+    # A credential:bind sharing a request with a live intent is always
+    # wizard-fulfilled: agents never carry credential ids at file time.
+    items = [
+        _intent(vendor="acme", name="widgets", item_id="arqi_i1"),
+        _make_item(
+            resource_type="credential",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            item_id="arqi_cbind_any",
+        ),
+    ]
+    governance = plan_governance_for_items(items)
+    assert set(governance.keys()) == {"arqi_cbind_any"}
+    assert governance["arqi_cbind_any"].governing_intent_ids == frozenset({"arqi_i1"})
+
+
+def test_plan_governance_ignores_withdrawn_intents() -> None:
+    # An abandoned plan must not carry over: subsequent binds revert to the
+    # plain contract on the next decide().
+    items = [
+        _intent(vendor="acme", name="widgets", item_id="arqi_dead", status="withdrawn"),
+        _make_item(
+            resource_type="toolkit",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            resource_reference={"vendor": "acme", "name": "widgets"},
+            item_id="arqi_tbind",
+        ),
+    ]
+    assert plan_governance_for_items(items) == {}
+
+
+def test_plan_governance_ignores_denied_intents() -> None:
+    items = [
+        _intent(vendor="acme", name="widgets", item_id="arqi_dead", status="denied"),
+        _make_item(
+            resource_type="credential",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            item_id="arqi_cbind",
+        ),
+    ]
+    assert plan_governance_for_items(items) == {}
+
+
+def test_plan_governance_normalizes_slug_vs_raw_domain() -> None:
+    # An agent files a reference with a raw domain (``httpbin.org``); the
+    # intent may have been stored slugified. Governance must match either way,
+    # and the ``governing_api`` field records the *slug* form so a diagnostic
+    # renders the canonical tuple rather than whichever spelling first arrived.
+    items = [
+        _intent(vendor="httpbin-org", name=None, item_id="arqi_i1"),
+        _make_item(
+            resource_type="toolkit",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            resource_reference={"vendor": "httpbin.org"},
+            item_id="arqi_tbind",
+        ),
+    ]
+    governance = plan_governance_for_items(items)
+    assert set(governance.keys()) == {"arqi_tbind"}
+    assert governance["arqi_tbind"].governing_api == ("httpbin-org", None)
+
+
+def test_plan_governance_intent_name_wildcards_all_versions() -> None:
+    # An intent's (vendor, name) matches a bind for the same API regardless
+    # of version — the intent covers all versions of that API.
+    items = [
+        _intent(vendor="acme", name="widgets", item_id="arqi_i1"),
+        _make_item(
+            resource_type="toolkit",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            resource_reference={"vendor": "acme", "name": "widgets", "version": "1.0.0"},
+            item_id="arqi_tbind",
+        ),
+    ]
+    governance = plan_governance_for_items(items)
+    assert set(governance.keys()) == {"arqi_tbind"}
+    assert governance["arqi_tbind"].governing_intent_ids == frozenset({"arqi_i1"})
+
+
+def test_plan_governance_excludes_already_decided_binds() -> None:
+    # decide() only re-validates PENDING or APPROVED items; a DENIED/WITHDRAWN
+    # bind is never re-validated so its governance doesn't matter and we omit
+    # it to keep the mapping tight against actual decide() behaviour.
+    items = [
+        _intent(vendor="acme", name="widgets", item_id="arqi_i1"),
+        _make_item(
+            resource_type="toolkit",
+            action="bind",
+            resource_id=None,
+            to_id=None,
+            resource_reference={"vendor": "acme", "name": "widgets"},
+            item_id="arqi_dead_bind",
+            status="denied",
+        ),
+    ]
+    assert plan_governance_for_items(items) == {}
+
+
+def test_plan_governance_default_is_not_governed() -> None:
+    """Sanity: the empty-default value is what ``validate()`` branches on for the plain path."""
+    assert not UNGOVERNED_PLAN.is_governed
+    assert not PlanGovernance().is_governed
+    assert PlanGovernance(governing_intent_ids=frozenset({"arqi_1"})).is_governed


### PR DESCRIPTION
Bundles the Theme-3 residuals into a single PR. Each commit is self-contained and can be reviewed independently; the stack order is the same as the original standalone PRs it supersedes.

Supersedes and closes:

- #787 — fix(access-requests): scope provisioning-plan governance per-item (#778)
- #788 — feat(broker): emit operator event on unserved-API execute denial
- #789 — feat(access-requests): advise operators when a filed bind targets an unserved API
- #790 — fix(ui): discard orphan wizard toolkits on programmatic unmount — **dropped from this PR, superseded on main**: #807's session-scoped wizard drafts made any unmount "keep & finish later" (reopening resumes the same toolkit/credential), so discard-on-unmount would now delete objects a draft still references. #781 stays open for the remaining gaps (OAuth same-tab redirect unloads the SPA; drafts clear on sign-out but the created objects survive as orphans).

## Summary

### 1. `fix(access-requests): scope provisioning-plan governance per-item (#778)`

Replaces the request-wide `is_provisioning_plan: bool` flag with a per-item `PlanGovernance` value object computed by a pure `plan_governance_for_items()` — same core fix as the standalone PR #787 (mixed-request case, withdrawn/denied intents, slug normalization, version-wildcard) but with the review note from #787 addressed:

> \"feels like we are losing granularity by doing this, store governed-plan instead\"

The prior draft flattened the intent context back down to a bool at the `validate()` boundary. It now carries a frozen `PlanGovernance(governing_intent_ids, governing_api)` — the specific live intent ids the wizard still owes fulfilment on, and (for `toolkit:bind`) the canonical `(vendor, name)` slug key that tied the plan to the bind. `ProvisioningPlanNotFulfilledError` accepts both and folds them into its message + exposes them as attributes so the `_UNFULFILLABLE_BIND_TARGET` → DENY reason names the actual intent an operator has to fulfil instead of \"some plan somewhere\". Default-constructed `PlanGovernance()` == the plain contract, and `UNGOVERNED_PLAN` is exported as the shared sentinel — no boolean anywhere. `decide()` passes `plan_governance=plan_governance.get(item.id, UNGOVERNED_PLAN)` to `EffectApplicator.validate` at both call sites (fresh-approve + reconcile).

### 2. `feat(broker): emit operator event on unserved-API execute denial`

New `EventType.TOOLKIT_BINDING_UNSERVED` emitted best-effort from `execute._handle` when `select_toolkit` raises the unserved flavour of `no_toolkit_binding`. Same admin-DB best-effort pattern as `CREDENTIAL_NOT_PROVISIONED`. Classification is a pure helper that reads off the existing denial directive rather than growing a new signal through `select_toolkit`. Surfaces in Monitor → Events (WARNING); deliberately not an Action-Inbox item, matching its `CREDENTIAL_NOT_PROVISIONED` twin.

### 3. `feat(access-requests): advise operators when a filed bind targets an unserved API`

Symmetric file-time advisory: after `file()` commits, iterate `toolkit:bind` items and emit `TOOLKIT_BINDING_UNSERVED` for reference-only binds whose canonical `(vendor, name)` is not served by any toolkit owned by the filer's owner. Silent when the bind names a concrete `resource_id`, when the request also carries fulfilment intents (plan → the toolkit will be created), or when an owned toolkit already serves the API. Best-effort — never blocks the filing.

### Review-board hardening (pre-merge)

A four-lens review board (security, architecture, product fit, cold-eyes fact check) ran on the rebased branch; all findings addressed:

- **security**: `resource_reference` fields are coerced to strings before use — a crafted non-string `name` previously hit the `api_id` join between the advisory's two best-effort guards, raising after the filing committed (500 + skipped CREATE audit record); regression test added
- the advisory payload now emits the canonical slug forms so the same API correlates across the control file-time emit and the broker execute-time emit
- the advisory's plan check reuses `effects.PLAN_INTENT_COMBINATIONS` (dead service-local copy removed); the deliberate request-wide (vs per-item) suppression trade-off is documented
- docstring/comment accuracy fixes (decider-scope caveat on the approval-denial claim, `UNGOVERNED_PLAN` name, control-plane emit noted on the `broker.*` event type)

## Test plan

- [x] `uv run pytest tests/unit -q` — 2086 passed
- [x] `make test-integration-sqlite` — 528 passed / 9 skipped (incl. 5 advisory tests)
- [x] `make test-arch` — 133 passed
- [x] `make openapi` / `make endpoints` — zero drift (no schema change)
- [x] `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` — all clean

## Follow-ups (tracked, not this PR)

- #781 stays open: OAuth same-tab redirect and sign-out still strand created objects (needs durable draft / recovery affordance on top of #807's session drafts)
- Consider a shared `emit_toolkit_binding_unserved` helper in `shared/events` if a third emit site appears
- Flat event visibility (any agent can read the events feed) is platform-wide, not specific to this event type

Closes #778.

Made with [Cursor](https://cursor.com)
