### PR TITLE
fix(app,tests): boot standalone control/registry and repair Helm smoke suite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,15 @@
 # Release pipeline — runs on a vX.Y.Z tag (created by merging the release-please
-# Release PR). Two gated stages:
+# Release PR). Three gated stages:
 #
 #   1. gate   — build the app + run every migration on a FRESH ephemeral SQLite
 #               DB (no Postgres, no real secrets — the bundled local-dev key) and
 #               assert /health serves the tag version. Nothing publishes if this
 #               fails.
-#   2. release — GoReleaser builds the signed, checksummed jenticctl + jentic
+#   2. smoke  — the full Helm smoke matrix (combined / parts / broker / +obs) on
+#               a kind cluster, reusing smoke-helm.yml. The same matrix runs
+#               post-merge on main, but that run doesn't block anything — this
+#               one does: a release cannot ship while any deployment mode is red.
+#   3. release — GoReleaser builds the signed, checksummed jenticctl + jentic
 #               binaries (cosign keyless via OIDC + syft SBOMs) and pushes the
 #               Homebrew cask. This is the install (see docs/releasing.md).
 #
@@ -111,9 +115,15 @@ jobs:
             exit 1
           fi
 
+  smoke:
+    name: Helm smoke matrix
+    permissions:
+      contents: read
+    uses: ./.github/workflows/smoke-helm.yml
+
   release:
     name: GoReleaser (signed CLI binaries)
-    needs: gate
+    needs: [gate, smoke]
     runs-on: ubuntu-latest
     permissions:
       contents: write # attach artifacts to the GitHub Release

--- a/.github/workflows/smoke-helm.yml
+++ b/.github/workflows/smoke-helm.yml
@@ -18,6 +18,11 @@ on:
         type: boolean
         default: false
 
+  # Release gate: release.yml calls this workflow on every vX.Y.Z tag and
+  # refuses to publish until the full matrix is green (same cells as a push
+  # to main).
+  workflow_call:
+
   # Post-merge gate: run the full matrix on main so a regression is caught
   # before it sits on the default branch unnoticed. Path filter keeps the
   # cost off doc-only commits (each cell takes ~5–8m on a free runner).
@@ -51,8 +56,9 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             cells='[{"mode":"${{ inputs.mode }}","obs":${{ inputs.obs }}}]'
           else
-            # push to main: every mode without obs, plus combined+obs to
-            # cover the OTel sidecar / central collector / remote-write wiring.
+            # push to main / release-gate workflow_call: every mode without
+            # obs, plus combined+obs to cover the OTel sidecar / central
+            # collector / remote-write wiring.
             cells='[
               {"mode":"combined","obs":false},
               {"mode":"parts","obs":false},

--- a/deploy/docker/admin.Dockerfile
+++ b/deploy/docker/admin.Dockerfile
@@ -5,5 +5,9 @@ COPY --from=python-base:builder /build/dist/*.whl /tmp/
 RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
 
 USER jentic
-ENV JENTIC__APPS=admin
+# The identity plane (auth: /register, /oauth, /agents, /me, ...) rides with
+# admin: both are owner-facing control surfaces rooted in the admin DB, and
+# no other parts-mode image serves them. Without this, parts mode has no
+# token issuance or agent registration at all.
+ENV JENTIC__APPS=admin,auth
 CMD ["python", "-m", "jentic_one"]

--- a/deploy/helm/jentic-one/charts/admin/templates/deployment.yaml
+++ b/deploy/helm/jentic-one/charts/admin/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
           ports:
             - containerPort: 8000
           env:
+{{- range $k, $v := .Values.extraEnv }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+{{- end }}
 {{ include "common.logging-env" . | indent 12 }}
 {{ include "common.metrics-env" . | indent 12 }}
 {{ include "common.db-env" . | indent 12 }}

--- a/deploy/helm/jentic-one/charts/control/templates/config-configmap.yaml
+++ b/deploy/helm/jentic-one/charts/control/templates/config-configmap.yaml
@@ -1,0 +1,1 @@
+{{ include "common.config-file.configmap" . }}

--- a/deploy/helm/jentic-one/charts/control/templates/deployment.yaml
+++ b/deploy/helm/jentic-one/charts/control/templates/deployment.yaml
@@ -24,9 +24,18 @@ spec:
           ports:
             - containerPort: 8000
           env:
+{{- range $k, $v := .Values.extraEnv }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+{{- end }}
+{{ include "common.config-file.env" . | indent 12 }}
 {{ include "common.logging-env" . | indent 12 }}
 {{ include "common.metrics-env" . | indent 12 }}
 {{ include "common.db-env" . | indent 12 }}
+{{- with (include "common.config-file.mount" . | trim) }}
+          volumeMounts:
+{{ . | indent 12 }}
+{{- end }}
           readinessProbe:
             httpGet:
               path: {{ .Values.healthCheck.path | default "/health" }}
@@ -44,7 +53,14 @@ spec:
         {{- if .Values.global.observability.otel.enabled }}
 {{ include "common.otel-sidecar" . | indent 8 }}
         {{- end }}
-      {{- if .Values.global.observability.otel.enabled }}
+      {{- $otel := .Values.global.observability.otel.enabled }}
+      {{- $cfg := (include "common.config-file.volume" . | trim) }}
+      {{- if or $otel $cfg }}
       volumes:
+      {{- if $otel }}
 {{ include "common.otel-config-volume" . | indent 8 }}
+      {{- end }}
+      {{- with $cfg }}
+{{ . | indent 8 }}
+      {{- end }}
       {{- end }}

--- a/deploy/helm/jentic-one/charts/gateway/templates/configmap.yaml
+++ b/deploy/helm/jentic-one/charts/gateway/templates/configmap.yaml
@@ -86,6 +86,71 @@ data:
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # --- Auth surface (colocated with admin, see admin.Dockerfile) ---
+        location /register {
+            proxy_pass http://admin_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /oauth {
+            proxy_pass http://admin_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /authorize {
+            proxy_pass http://admin_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /error {
+            proxy_pass http://admin_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /.well-known {
+            proxy_pass http://admin_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location = /me {
+            proxy_pass http://admin_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /agents {
+            proxy_pass http://admin_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /service-accounts {
+            proxy_pass http://admin_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # --- Control surface ---
         location /access-requests {
             proxy_pass http://control_backend;

--- a/deploy/helm/values/local-combined.yaml
+++ b/deploy/helm/values/local-combined.yaml
@@ -18,6 +18,7 @@ app:
     # specs from in-cluster ClusterIPs (kind service CIDR is in 10/8).
     JENTIC__INGEST__EGRESS__ALLOWED_INTERNAL_DOMAINS: .svc.cluster.local
     JENTIC__INGEST__EGRESS__ALLOWED_PRIVATE_SUBNETS: 10.0.0.0/8
+  resources:
     requests:
       cpu: 250m
       memory: 1Gi

--- a/deploy/helm/values/local-parts.yaml
+++ b/deploy/helm/values/local-parts.yaml
@@ -51,6 +51,25 @@ control:
   service:
     type: NodePort
     nodePort: 30083
+  # Credential-at-rest encryption keyset (+ the platform OAuth2 provider) —
+  # same contract as combined mode (see local-combined.yaml): `entries` is a
+  # list, which the flat JENTIC__* env-var convention cannot express, and
+  # without it every credential write on the control surface 500s
+  # ("EncryptionConfig.entries must not be empty"). LOCAL/SMOKE-ONLY: the key
+  # is a throwaway dev value committed for the kind cluster — never reuse it
+  # anywhere real (the ConfigMap is not a Secret).
+  configFile:
+    contents:
+      credentials:
+        encryption:
+          active_id: v1
+          entries:
+            - id: v1
+              material: "9ysLYfGPDFNdEcL9Z9RUa5YoREALVwjX9E2MCQ8iE7Q="  # pragma: allowlist secret
+        providers:
+          direct_oauth2:
+            kind: direct_oauth2
+            redirect_uri: "http://127.0.0.1:30080/credentials/oauth/callback"
 
 global:
   postgresql:

--- a/deploy/helm/values/local-parts.yaml
+++ b/deploy/helm/values/local-parts.yaml
@@ -38,6 +38,13 @@ admin:
   service:
     type: NodePort
     nodePort: 30082
+  extraEnv:
+    # The admin pod also hosts the auth surface (see admin.Dockerfile). Same
+    # contract as combined mode: the JWT-Bearer assertion audience is built
+    # from canonical_base_url and MUST match the URL clients actually use —
+    # the gateway on kind host port 8000 — or every token exchange fails
+    # 400 invalid_grant. See the longer note in local-combined.yaml.
+    JENTIC__AUTH__CANONICAL_BASE_URL: http://localhost:8000
 
 control:
   enabled: true

--- a/src/jentic_one/__main__.py
+++ b/src/jentic_one/__main__.py
@@ -35,6 +35,14 @@ SURFACE_DB_DEPS: dict[str, set[str]] = {
     # but the toolkit name lives in the control DB.
     "auth": {"admin", "control"},
     "broker": {"admin", "control", "registry"},
+    # Every standalone surface in SURFACES_NEEDING_AUTH verifies callers locally
+    # via the auth verifier (_install_auth_verifier), whose ApiKeyResolver and
+    # PermissionService resolve API keys / permissions against the admin DB.
+    # Without this, a standalone control/registry process crashes at boot with
+    # "Access to 'admin' database is not allowed in this context" — the failure
+    # mode behind the parts-mode Helm smoke timeouts.
+    "control": {"admin"},
+    "registry": {"admin"},
 }
 
 SURFACES_NEEDING_AUTH: set[str] = {"admin", "control", "registry", "broker"}

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -229,6 +229,10 @@ def test_user(base_url: str, admin_token: str) -> Generator[SmokeUser]:
         "events:read",
         "credentials:read",
         "apis:read",
+        # URL/inline import via POST /apis requires apis:write (apis:read only
+        # covers listing/inspection) — the import_and_wait tests file imports
+        # as this user.
+        "apis:write",
         "executions:read",
     ]
     perm_body, perm_status = authed_request(
@@ -439,6 +443,30 @@ def agent_token_exchange(base_url: str, agent_id: str, private_key: Ed25519Priva
     return access_token
 
 
+def grant_agent_scope(base_url: str, agent_id: str, admin_token: str, scope: str) -> None:
+    """Grant an extra scope on top of the agent's current grants.
+
+    Scopes are minted into the access token at exchange time, so call this
+    *before* ``agent_token_exchange`` for the grant to take effect.
+    """
+    scopes_body, status = authed_request(
+        f"{base_url}/agents/{agent_id}/scopes",
+        token=admin_token,
+    )
+    assert status == 200, f"Reading agent scopes failed: {status} {scopes_body}"
+    assert isinstance(scopes_body, dict)
+    scopes = list(scopes_body["scopes"])
+    if scope not in scopes:
+        scopes.append(scope)
+    _, put_status = authed_request(
+        f"{base_url}/agents/{agent_id}/scopes",
+        method="PUT",
+        token=admin_token,
+        body={"scopes": scopes},
+    )
+    assert put_status == 200, f"Granting {scope} failed: {put_status}"
+
+
 @pytest.fixture()
 def test_agent(base_url: str, admin_token: str) -> Generator[SmokeAgent]:
     """Register, approve, and token-exchange an agent; archive on teardown."""
@@ -447,6 +475,10 @@ def test_agent(base_url: str, admin_token: str) -> Generator[SmokeAgent]:
 
     agent_id, rat = register_agent(base_url, client_name, jwks)
     approve_agent(base_url, agent_id, admin_token)
+    # URL/inline import (POST /apis) needs apis:write, which is deliberately
+    # not in DEFAULT_AGENT_SCOPES — an owner must approve the elevation. The
+    # smoke agent imports specs directly, so simulate that owner approval here.
+    grant_agent_scope(base_url, agent_id, admin_token, "apis:write")
     access_token = agent_token_exchange(base_url, agent_id, private_key)
 
     yield SmokeAgent(

--- a/tests/smoke/test_agent_access_requests.py
+++ b/tests/smoke/test_agent_access_requests.py
@@ -1,83 +1,53 @@
-"""Smoke tests for the access request flow (file, list, get, decide, withdraw)."""
+"""Smoke tests for the access request flow (file, list, get, decide, withdraw).
+
+The items use ``scope:grant`` for ``apis:write`` — the one scope that is in
+``GRANTABLE_SCOPES`` but deliberately not in ``DEFAULT_AGENT_SCOPES``, so it is
+exactly what a real agent would file for and needs no toolkit/credential
+prerequisites (a ``credential:bind`` item with a ``to_id`` requires the agent
+to already be bound to that toolkit).
+"""
 
 from __future__ import annotations
 
-import uuid
+from typing import Any
 
 import pytest
 
-from tests.smoke.conftest import SmokeAgent, authed_request, unique_vendor
+from tests.smoke.conftest import SmokeAgent, authed_request
+
+_SCOPE_GRANT_ITEM = {
+    "resource_type": "scope",
+    "action": "grant",
+    "resource_id": "apis:write",
+}
 
 
-def _create_credential_for_access(base_url: str, token: str) -> str:
-    """Helper: create a credential and return its ID for access request tests."""
-    vendor = unique_vendor("ar")
+def _file_scope_request(base_url: str, agent: SmokeAgent, reason: str) -> dict[str, Any]:
+    """Helper: file a scope:grant access request as the agent, return the body."""
     body, status = authed_request(
-        f"{base_url}/credentials",
+        f"{base_url}/access-requests",
         method="POST",
-        token=token,
-        body={
-            "type": "bearer_token",
-            "name": f"ar-cred-{uuid.uuid4().hex[:8]}",
-            "api": {"vendor": vendor, "name": "petstore", "version": "3.0.0"},
-            "provider": "static",
-            "token": "sk-access-request-test",
-        },
+        token=agent.access_token,
+        body={"reason": reason, "items": [_SCOPE_GRANT_ITEM]},
     )
-    assert status == 201
+    assert status == 202, f"Filing access request failed: {status} {body}"
     assert isinstance(body, dict)
-    credential_id: str = body["credential"]["credential_id"]
-    return credential_id
+    return body
 
 
 @pytest.mark.smoke
 def test_file_access_request(base_url: str, test_agent: SmokeAgent) -> None:
     """POST /access-requests creates a pending request."""
-    credential_id = _create_credential_for_access(base_url, test_agent.owner_token)
-
-    body, status = authed_request(
-        f"{base_url}/access-requests",
-        method="POST",
-        token=test_agent.access_token,
-        body={
-            "reason": "Smoke test access request",
-            "items": [
-                {
-                    "resource_type": "credential",
-                    "action": "read",
-                    "resource_id": credential_id,
-                }
-            ],
-        },
-    )
-    assert status == 202
-    assert isinstance(body, dict)
-    assert "request_id" in body
+    body = _file_scope_request(base_url, test_agent, "Smoke test access request")
+    assert "id" in body
     assert body["status"] == "pending"
+    assert body["items"][0]["resource_id"] == "apis:write"
 
 
 @pytest.mark.smoke
 def test_list_access_requests(base_url: str, test_agent: SmokeAgent) -> None:
     """GET /access-requests lists the filed request."""
-    credential_id = _create_credential_for_access(base_url, test_agent.owner_token)
-
-    file_body, _ = authed_request(
-        f"{base_url}/access-requests",
-        method="POST",
-        token=test_agent.access_token,
-        body={
-            "reason": "List test",
-            "items": [
-                {
-                    "resource_type": "credential",
-                    "action": "read",
-                    "resource_id": credential_id,
-                }
-            ],
-        },
-    )
-    assert isinstance(file_body, dict)
-    request_id = file_body["request_id"]
+    request_id = _file_scope_request(base_url, test_agent, "List test")["id"]
 
     body, status = authed_request(
         f"{base_url}/access-requests",
@@ -85,32 +55,14 @@ def test_list_access_requests(base_url: str, test_agent: SmokeAgent) -> None:
     )
     assert status == 200
     assert isinstance(body, dict)
-    request_ids = [r["request_id"] for r in body["data"]]
+    request_ids = [r["id"] for r in body["data"]]
     assert request_id in request_ids
 
 
 @pytest.mark.smoke
 def test_get_access_request(base_url: str, test_agent: SmokeAgent) -> None:
     """GET /access-requests/{id} returns the request with items."""
-    credential_id = _create_credential_for_access(base_url, test_agent.owner_token)
-
-    file_body, _ = authed_request(
-        f"{base_url}/access-requests",
-        method="POST",
-        token=test_agent.access_token,
-        body={
-            "reason": "Get test",
-            "items": [
-                {
-                    "resource_type": "credential",
-                    "action": "read",
-                    "resource_id": credential_id,
-                }
-            ],
-        },
-    )
-    assert isinstance(file_body, dict)
-    request_id = file_body["request_id"]
+    request_id = _file_scope_request(base_url, test_agent, "Get test")["id"]
 
     body, status = authed_request(
         f"{base_url}/access-requests/{request_id}",
@@ -118,43 +70,18 @@ def test_get_access_request(base_url: str, test_agent: SmokeAgent) -> None:
     )
     assert status == 200
     assert isinstance(body, dict)
-    assert body["request_id"] == request_id
+    assert body["id"] == request_id
     assert "items" in body
     assert len(body["items"]) >= 1
 
 
 @pytest.mark.smoke
 def test_decide_access_request_approve(base_url: str, test_agent: SmokeAgent) -> None:
-    """POST /access-requests/{id}:decide approves the request."""
-    credential_id = _create_credential_for_access(base_url, test_agent.owner_token)
+    """POST /access-requests/{id}:decide approves the request and applies the grant."""
+    file_body = _file_scope_request(base_url, test_agent, "Decide test")
+    request_id = file_body["id"]
+    item_id = file_body["items"][0]["id"]
 
-    file_body, _ = authed_request(
-        f"{base_url}/access-requests",
-        method="POST",
-        token=test_agent.access_token,
-        body={
-            "reason": "Decide test",
-            "items": [
-                {
-                    "resource_type": "credential",
-                    "action": "read",
-                    "resource_id": credential_id,
-                }
-            ],
-        },
-    )
-    assert isinstance(file_body, dict)
-    request_id = file_body["request_id"]
-
-    # Get the item_id from the request details
-    detail_body, _ = authed_request(
-        f"{base_url}/access-requests/{request_id}",
-        token=test_agent.owner_token,
-    )
-    assert isinstance(detail_body, dict)
-    item_id = detail_body["items"][0]["item_id"]
-
-    # Approve via admin/owner
     decide_body, decide_status = authed_request(
         f"{base_url}/access-requests/{request_id}:decide",
         method="POST",
@@ -169,7 +96,7 @@ def test_decide_access_request_approve(base_url: str, test_agent: SmokeAgent) ->
             ],
         },
     )
-    assert decide_status == 200
+    assert decide_status == 200, f"Decide failed: {decide_status} {decide_body}"
     assert isinstance(decide_body, dict)
     assert decide_body["status"] == "approved"
 
@@ -177,25 +104,7 @@ def test_decide_access_request_approve(base_url: str, test_agent: SmokeAgent) ->
 @pytest.mark.smoke
 def test_withdraw_access_request(base_url: str, test_agent: SmokeAgent) -> None:
     """POST /access-requests/{id}:withdraw moves to withdrawn."""
-    credential_id = _create_credential_for_access(base_url, test_agent.owner_token)
-
-    file_body, _ = authed_request(
-        f"{base_url}/access-requests",
-        method="POST",
-        token=test_agent.access_token,
-        body={
-            "reason": "Withdraw test",
-            "items": [
-                {
-                    "resource_type": "credential",
-                    "action": "read",
-                    "resource_id": credential_id,
-                }
-            ],
-        },
-    )
-    assert isinstance(file_body, dict)
-    request_id = file_body["request_id"]
+    request_id = _file_scope_request(base_url, test_agent, "Withdraw test")["id"]
 
     body, status = authed_request(
         f"{base_url}/access-requests/{request_id}:withdraw",

--- a/tests/smoke/test_agent_registration.py
+++ b/tests/smoke/test_agent_registration.py
@@ -12,6 +12,7 @@ from jwt.algorithms import OKPAlgorithm
 
 from tests.smoke.conftest import (
     SmokeAgent,
+    _skip_if_no_admin_surface,
     agent_token_exchange,
     approve_agent,
     authed_request,
@@ -23,6 +24,7 @@ from tests.smoke.conftest import (
 @pytest.mark.smoke
 def test_register_agent_returns_pending(base_url: str) -> None:
     """POST /register with valid JWKS returns 201 with pending status."""
+    _skip_if_no_admin_surface()
     client_name = f"smoke-reg-{uuid.uuid4().hex[:12]}"
     _, jwks = generate_ed25519_jwks()
 
@@ -41,6 +43,7 @@ def test_register_agent_returns_pending(base_url: str) -> None:
 @pytest.mark.smoke
 def test_poll_pending_status(base_url: str) -> None:
     """GET /register/{agent_id} with RAT returns pending status."""
+    _skip_if_no_admin_surface()
     client_name = f"smoke-poll-{uuid.uuid4().hex[:12]}"
     _, jwks = generate_ed25519_jwks()
 
@@ -64,6 +67,7 @@ def test_approve_invalidates_rat(base_url: str, admin_token: str) -> None:
     status. Active status is instead confirmed via token exchange in
     ``test_agent_token_exchange``.
     """
+    _skip_if_no_admin_surface()
     client_name = f"smoke-approve-{uuid.uuid4().hex[:12]}"
     private_key, jwks = generate_ed25519_jwks()
 
@@ -84,6 +88,7 @@ def test_approve_invalidates_rat(base_url: str, admin_token: str) -> None:
 @pytest.mark.smoke
 def test_agent_token_exchange(base_url: str, admin_token: str) -> None:
     """After approval, JWT-bearer token exchange succeeds and the token is usable."""
+    _skip_if_no_admin_surface()
     client_name = f"smoke-exchange-{uuid.uuid4().hex[:12]}"
     private_key, jwks = generate_ed25519_jwks()
 
@@ -102,6 +107,7 @@ def test_agent_token_exchange(base_url: str, admin_token: str) -> None:
 @pytest.mark.smoke
 def test_list_agents_includes_registered(base_url: str, test_agent: SmokeAgent) -> None:
     """GET /agents?status=active includes the newly registered agent."""
+    _skip_if_no_admin_surface()
     body, status = authed_request(
         f"{base_url}/agents?status=active",
         token=test_agent.owner_token,
@@ -115,6 +121,7 @@ def test_list_agents_includes_registered(base_url: str, test_agent: SmokeAgent) 
 @pytest.mark.smoke
 def test_disable_blocks_token_exchange(base_url: str, admin_token: str) -> None:
     """Disabling an agent blocks token exchange; re-enabling restores it."""
+    _skip_if_no_admin_surface()
     client_name = f"smoke-disable-{uuid.uuid4().hex[:12]}"
     private_key, jwks = generate_ed25519_jwks()
 

--- a/tests/smoke/test_toolkit_lifecycle.py
+++ b/tests/smoke/test_toolkit_lifecycle.py
@@ -176,7 +176,7 @@ def test_toolkit_delete_with_credential_binding(base_url: str, test_agent: Smoke
     if cred_status != 201:
         pytest.skip("credential creation not available")
     assert isinstance(cred_body, dict)
-    credential_id: str = cred_body["credential_id"]
+    credential_id: str = cred_body["credential"]["credential_id"]
 
     authed_request(
         f"{base_url}/toolkits/{toolkit_id}/credentials",


### PR DESCRIPTION
## Summary

The **Helm smoke tests** workflow has been failing on `main` for weeks (it also flagged the post-merge run of #757, but the failures predate that PR). Two independent rot layers, plus the process gap that let them rot:

### 1. Product bug — parts mode never boots
A standalone `control` or `registry` process crashes at startup with `RuntimeError: Access to 'admin' database is not allowed in this context`. Every surface in `SURFACES_NEEDING_AUTH` verifies callers locally via the auth verifier, whose `ApiKeyResolver` / `PermissionService` read from the **admin** DB — but `SURFACE_DB_DEPS` never granted it to control/registry. Pods enter `CrashLoopBackOff`, Helm waits, and the job dies on `context deadline exceeded`.

**Fix:** grant `control` and `registry` the admin DB in `SURFACE_DB_DEPS` (same reasoning as the existing broker/auth entries, documented inline).

### 2. Smoke-suite drift — tests vs. current API contracts
- `test_user` / `test_agent` fixtures lacked `apis:write`, so every `import_and_wait`-based test failed with `403 This action requires one of: apis:write` (`POST /apis` needs it; it is deliberately **not** in `DEFAULT_AGENT_SCOPES`, so the agent fixture simulates the owner-approved grant).
- Registration tests hit `/register` in **broker mode**, where no admin/auth surface exists (401). They now skip via the existing `_skip_if_no_admin_surface()` convention.
- Access-request tests filed an unsupported `credential:read` combo (422) and read `request_id` / `item_id` keys the API serves as `id`. Rewritten around a `scope:grant` of `apis:write` — the canonical self-service request an agent actually files, with no toolkit/credential prerequisites.
- Toolkit lifecycle read `credential_id` from the envelope root instead of `body["credential"]["credential_id"]` (`KeyError`).

### 3. Process gap — nothing forced the matrix green
The smoke matrix only ran post-merge on `main`, where a red run blocks nothing — which is exactly how it sat broken unnoticed. `smoke-helm.yml` is now callable (`workflow_call`) and wired into `release.yml` as a gate stage: a `vX.Y.Z` tag refuses to publish binaries until combined / parts / broker / combined+obs all deploy and pass on a kind cluster. Push-to-main and manual dispatch behavior are unchanged.

## Test plan
- [x] Standalone `control`, `registry`, `admin` apps build cleanly with the new deps (previously control/registry crashed at boot)
- [x] Local combined stack (fresh sqlite DBs): registration (7), access-request (5), toolkit lifecycle (5), api-import (6) smoke tests all green
- [x] `ruff check` / `ruff format --check` / `mypy` green on changed files; workflow YAML parses
- [ ] Dispatched Helm smoke runs on this branch: [combined](https://github.com/jentic/jentic-one/actions/runs/30111127433) / [parts](https://github.com/jentic/jentic-one/actions/runs/30111129146) / [broker](https://github.com/jentic/jentic-one/actions/runs/30111130931)