### PR TITLE
fix(ui): upgrade react-router to v8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,7 +64,7 @@ updates:
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
-          - "react-router-dom"
+          - "react-router"
       testing:
         patterns:
           - "@testing-library/*"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -15,7 +15,7 @@
 				"react": "^19.2.7",
 				"react-dom": "^19.2.7",
 				"react-markdown": "^10.1.0",
-				"react-router-dom": "^7.18.1",
+				"react-router": "^8.3.0",
 				"rehype-raw": "^7.0.0",
 				"rehype-sanitize": "^6.0.0",
 				"remark-gfm": "^4.0.1",
@@ -719,9 +719,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -739,9 +736,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -759,9 +753,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -779,9 +770,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -799,9 +787,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -819,9 +804,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -839,9 +821,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -859,9 +838,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -879,9 +855,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -905,9 +878,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -931,9 +901,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -957,9 +924,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -983,9 +947,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1009,9 +970,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1035,9 +993,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1061,9 +1016,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1549,9 +1501,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1569,9 +1518,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1589,9 +1535,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1609,9 +1552,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1629,9 +1569,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1649,9 +1586,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1912,9 +1846,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1932,9 +1863,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1952,9 +1880,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1972,9 +1897,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3858,6 +3780,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
 			"integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -3866,6 +3789,12 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
 			}
+		},
+		"node_modules/cookie-es": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+			"integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -8671,48 +8600,25 @@
 			}
 		},
 		"node_modules/react-router": {
-			"version": "7.18.1",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-			"integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+			"integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
 			"license": "MIT",
 			"dependencies": {
-				"cookie": "^1.0.1",
-				"set-cookie-parser": "^2.6.0"
+				"cookie-es": "^3.1.1"
 			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=22.22.0"
 			},
 			"peerDependencies": {
-				"react": ">=18",
-				"react-dom": ">=18"
+				"react": ">=19.2.7",
+				"react-dom": ">=19.2.7"
 			},
 			"peerDependenciesMeta": {
 				"react-dom": {
 					"optional": true
 				}
 			}
-		},
-		"node_modules/react-router-dom": {
-			"version": "7.18.1",
-			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-			"integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-			"license": "MIT",
-			"dependencies": {
-				"react-router": "7.18.1"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"peerDependencies": {
-				"react": ">=18",
-				"react-dom": ">=18"
-			}
-		},
-		"node_modules/react-router/node_modules/set-cookie-parser": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-			"integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-			"license": "MIT"
 		},
 		"node_modules/redent": {
 			"version": "3.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,7 +27,7 @@
 		"react": "^19.2.7",
 		"react-dom": "^19.2.7",
 		"react-markdown": "^10.1.0",
-		"react-router-dom": "^7.18.1",
+		"react-router": "^8.3.0",
 		"rehype-raw": "^7.0.0",
 		"rehype-sanitize": "^6.0.0",
 		"remark-gfm": "^4.0.1",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useRoutes, type RouteObject } from 'react-router-dom';
+import { Navigate, useRoutes, type RouteObject } from 'react-router';
 import { useEffect } from 'react';
 import { AuthGuard } from '@/shared/auth/AuthGuard';
 import { SetupGate } from '@/shared/auth/SetupGate';

--- a/ui/src/__tests__/test-utils.tsx
+++ b/ui/src/__tests__/test-utils.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { render, type RenderOptions } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { MotionConfig } from 'framer-motion';
 import { App } from '@/App';

--- a/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router';
 import {
 	renderWithProviders,
 	screen,

--- a/ui/src/modules/agents/__tests__/AgentsPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/AgentsPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router';
 import {
 	renderWithProviders,
 	screen,

--- a/ui/src/modules/agents/__tests__/ServiceAccountDetailPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/ServiceAccountDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router';
 import { renderWithProviders, screen, within, userEvent, checkA11y } from '@/__tests__/test-utils';
 import { setToken } from '@/shared/api';
 import { Toaster } from '@/shared/ui';

--- a/ui/src/modules/agents/components/ActorRoster.tsx
+++ b/ui/src/modules/agents/components/ActorRoster.tsx
@@ -18,7 +18,7 @@
  * lifecycle via the module hooks, and `pending|active|rejected|disabled|archived`
  * in place of mini's `pending|approved|denied|disabled`.
  */
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Bot, ChevronRight } from 'lucide-react';
 import { AgentBadge, Badge, Button, Card, ErrorAlert, LoadingState } from '@/shared/ui';
 import { cn, formatTimestamp, timeAgo } from '@/shared/lib/utils';

--- a/ui/src/modules/agents/pages/AgentDetailPage.tsx
+++ b/ui/src/modules/agents/pages/AgentDetailPage.tsx
@@ -13,7 +13,7 @@
  * metadata). We link out to Monitor for cross-agent execution history instead.
  */
 import { useState, type ReactNode } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { ArrowRight, KeyRound, Shield, Activity, Ban, History } from 'lucide-react';
 import {
 	AgentBadge,

--- a/ui/src/modules/agents/pages/ServiceAccountDetailPage.tsx
+++ b/ui/src/modules/agents/pages/ServiceAccountDetailPage.tsx
@@ -16,7 +16,7 @@
  * plaintext via {@link ApiKeyDialog}.
  */
 import { useState, type ReactNode } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { KeyRound } from 'lucide-react';
 import {
 	AgentBadge,

--- a/ui/src/modules/agents/routes.tsx
+++ b/ui/src/modules/agents/routes.tsx
@@ -2,7 +2,7 @@
  * Agents module routes. Path is RELATIVE to the `/app` shell, so this mounts at
  * `/app/agents`. Registered additively into `@/shared/app/routes.ts`.
  */
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 import AgentsPage from '@/modules/agents/pages/AgentsPage';
 import AgentDetailPage from '@/modules/agents/pages/AgentDetailPage';
 import ServiceAccountDetailPage from '@/modules/agents/pages/ServiceAccountDetailPage';

--- a/ui/src/modules/credentials/routes.tsx
+++ b/ui/src/modules/credentials/routes.tsx
@@ -1,4 +1,4 @@
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 import { CredentialsPage } from './pages/CredentialsPage';
 
 /**

--- a/ui/src/modules/dashboard/components/AlertsCard.tsx
+++ b/ui/src/modules/dashboard/components/AlertsCard.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Bell, BellOff } from 'lucide-react';
 import {
 	Card,

--- a/ui/src/modules/dashboard/components/PendingAgentsCard.tsx
+++ b/ui/src/modules/dashboard/components/PendingAgentsCard.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Users, CheckCircle2 } from 'lucide-react';
 import {
 	Card,

--- a/ui/src/modules/dashboard/routes.tsx
+++ b/ui/src/modules/dashboard/routes.tsx
@@ -9,7 +9,7 @@
  * swaps that single line there rather than spreading into `moduleRoutes`. See
  * STATUS.md (coord-with-shell note) + COLLABORATION.md §3.
  */
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 import DashboardPage from '@/modules/dashboard/pages/DashboardPage';
 import AccessRequestsPage from '@/modules/dashboard/pages/AccessRequestsPage';
 

--- a/ui/src/modules/discover/routes.tsx
+++ b/ui/src/modules/discover/routes.tsx
@@ -2,7 +2,7 @@
  * Discover module routes. Path is RELATIVE to the `/app` shell, so this mounts
  * at `/app/discover`. Registered additively into `@/shared/app/routes.ts`.
  */
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 import DiscoverPage from '@/modules/discover/pages/DiscoverPage';
 
 export const discoverRoutes: RouteObject[] = [{ path: 'discover', element: <DiscoverPage /> }];

--- a/ui/src/modules/docs/components/DocsTopNav.tsx
+++ b/ui/src/modules/docs/components/DocsTopNav.tsx
@@ -11,7 +11,7 @@
  * dismiss) and closes on outside click via `useDismissable`.
  */
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Search, FileText, SquareTerminal, ShieldCheck, Plug, Box } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { JenticLogo, Input, useDismissable } from '@/shared/ui';

--- a/ui/src/modules/docs/routes.tsx
+++ b/ui/src/modules/docs/routes.tsx
@@ -8,7 +8,7 @@
  * its own chunk that loads only when a user navigates to /app/docs.
  */
 import { Suspense, lazy } from 'react';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 import { LoadingState, ErrorBoundary } from '@/shared/ui';
 
 const DocsPage = lazy(() => import('@/modules/docs/pages/DocsPage'));

--- a/ui/src/modules/monitor/__tests__/MonitorPage.test.tsx
+++ b/ui/src/modules/monitor/__tests__/MonitorPage.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import {
 	renderWithProviders,
 	screen,

--- a/ui/src/modules/monitor/components/AuditTab.tsx
+++ b/ui/src/modules/monitor/components/AuditTab.tsx
@@ -13,7 +13,7 @@
  * loop in both directions.
  */
 import { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { ArrowUpRight, ShieldAlert, ShieldX, User } from 'lucide-react';
 import { AppLink, Badge, EmptyState, ErrorAlert, RefreshButton, ActorLabel } from '@/shared/ui';
 import {

--- a/ui/src/modules/monitor/components/EventsTab.tsx
+++ b/ui/src/modules/monitor/components/EventsTab.tsx
@@ -8,7 +8,7 @@
  * that `requires_action` and aren't acknowledged get an Acknowledge button.
  */
 import { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { Bell, Radio } from 'lucide-react';
 import {
 	Badge,

--- a/ui/src/modules/monitor/components/ExecutionsTab.tsx
+++ b/ui/src/modules/monitor/components/ExecutionsTab.tsx
@@ -7,7 +7,7 @@
  * neutral pill rather than a broken colour. Clicking a row opens the trace
  * detail sheet.
  */
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { Activity, CheckCircle2, XCircle, Loader2, Ban, CircleDot } from 'lucide-react';
 import {
 	Button,

--- a/ui/src/modules/monitor/components/JobsTab.tsx
+++ b/ui/src/modules/monitor/components/JobsTab.tsx
@@ -6,7 +6,7 @@
  * carries the Cancel action (org:admin only). Jobs carry no actor on the wire,
  * so detail resolves "who" from the audit log by `job_id`.
  */
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { ListChecks, CheckCircle2, XCircle, Loader2, Ban, Clock, Skull } from 'lucide-react';
 import { Button, EmptyState, ErrorAlert, RefreshButton, SegmentedToggle } from '@/shared/ui';
 import { useJobs, toJobStatus, type JobStatusUi } from '@/modules/monitor/api';

--- a/ui/src/modules/monitor/components/OverviewTab.tsx
+++ b/ui/src/modules/monitor/components/OverviewTab.tsx
@@ -10,7 +10,7 @@
  * endpoint — tracked in jentic-one#561. Those surfaces degrade gracefully here.
  */
 import { BarChart3 } from 'lucide-react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { EmptyState, ErrorAlert, LoadingState, SegmentedToggle } from '@/shared/ui';
 import { useExecutionStats } from '@/modules/monitor/api';
 import { HealthStrip } from '@/modules/monitor/components/HealthStrip';

--- a/ui/src/modules/monitor/lib/useMonitorFilters.ts
+++ b/ui/src/modules/monitor/lib/useMonitorFilters.ts
@@ -14,7 +14,7 @@
  * omits it. Tabs fold `{ from, actorId, actorType }` into their list params.
  */
 import { useCallback, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 export type WindowValue = 'all' | '1' | '7' | '30';
 

--- a/ui/src/modules/monitor/pages/MonitorPage.tsx
+++ b/ui/src/modules/monitor/pages/MonitorPage.tsx
@@ -12,7 +12,7 @@
  * the per-tab todos; this page owns the shell + tab switching.
  */
 import { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { PageShell, PageHeader, PageHelp, SegmentedToggle } from '@/shared/ui';
 import { MONITOR_TABS, type MonitorTab } from '@/modules/monitor/api';
 import { OverviewTab } from '@/modules/monitor/components/OverviewTab';

--- a/ui/src/modules/monitor/routes.tsx
+++ b/ui/src/modules/monitor/routes.tsx
@@ -8,7 +8,7 @@
  * `/app/monitor?tab=executions&trace_id=…` opens the trace detail sheet, and
  * `/app/monitor?tab=jobs&job_id=…` opens the job detail sheet.
  */
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 import MonitorPage from '@/modules/monitor/pages/MonitorPage';
 
 export const monitorRoutes: RouteObject[] = [{ path: 'monitor', element: <MonitorPage /> }];

--- a/ui/src/modules/toolkits/pages/ToolkitDetailPage.tsx
+++ b/ui/src/modules/toolkits/pages/ToolkitDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { BackButton, PageHeader, PageShell } from '@/shared/ui';
 import { useToolkit } from '@/modules/toolkits/api';
 import { ToolkitDetailBody } from '@/modules/toolkits/components/ToolkitDetailBody';

--- a/ui/src/modules/toolkits/routes.tsx
+++ b/ui/src/modules/toolkits/routes.tsx
@@ -1,4 +1,4 @@
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 import { ToolkitsPage } from '@/modules/toolkits/pages/ToolkitsPage';
 import { ToolkitDetailPage } from '@/modules/toolkits/pages/ToolkitDetailPage';
 

--- a/ui/src/modules/workspace/pages/ApiDetailPage.tsx
+++ b/ui/src/modules/workspace/pages/ApiDetailPage.tsx
@@ -13,7 +13,7 @@
  * state rather than issuing a bad request.
  */
 import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { FileJson, Trash2 } from 'lucide-react';
 import {
 	PageShell,

--- a/ui/src/modules/workspace/pages/WorkspacePage.tsx
+++ b/ui/src/modules/workspace/pages/WorkspacePage.tsx
@@ -9,7 +9,7 @@
  * the loaded rows. Catalog-wide search lives in Discover, not here.
  */
 import { useEffect, useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { Upload } from 'lucide-react';
 import { PageShell, PageHeader, PageHelp, Button } from '@/shared/ui';
 import { ApiGrid } from '@/modules/workspace/components/ApiGrid';

--- a/ui/src/modules/workspace/routes.tsx
+++ b/ui/src/modules/workspace/routes.tsx
@@ -10,7 +10,7 @@
  * (which percent-encodes each segment); the page reads them back from
  * `useParams`.
  */
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 import WorkspacePage from '@/modules/workspace/pages/WorkspacePage';
 import ApiDetailPage from '@/modules/workspace/pages/ApiDetailPage';
 

--- a/ui/src/shared/app/BottomNavbar.tsx
+++ b/ui/src/shared/app/BottomNavbar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { MoreHorizontal, X } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { sortedNavItems, visibleNavItems, isNavItemActive, type NavItem } from '@/shared/app/nav';

--- a/ui/src/shared/app/Layout.tsx
+++ b/ui/src/shared/app/Layout.tsx
@@ -1,4 +1,4 @@
-import { useLocation, Outlet } from 'react-router-dom';
+import { useLocation, Outlet } from 'react-router';
 import { BottomNavbar } from '@/shared/app/BottomNavbar';
 import { TopNavbar } from '@/shared/app/TopNavbar';
 import { AgentRail } from '@/shared/app/rail/AgentRail';

--- a/ui/src/shared/app/NavTabs.tsx
+++ b/ui/src/shared/app/NavTabs.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { ChevronDown } from 'lucide-react';
 import { LayoutGroup, motion } from 'framer-motion';
 import { sortedNavItems, visibleNavItems, isNavItemActive, type NavItem } from '@/shared/app/nav';

--- a/ui/src/shared/app/rail/AgentRail.tsx
+++ b/ui/src/shared/app/rail/AgentRail.tsx
@@ -19,7 +19,7 @@
  * `/events` carries no actor filter (tracked: jentic/jentic-one#387).
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { sharedQueryKeys } from '@/shared/api/queryKeys';
 import { ChevronLeft } from 'lucide-react';

--- a/ui/src/shared/app/rail/ToastHost.tsx
+++ b/ui/src/shared/app/rail/ToastHost.tsx
@@ -6,7 +6,7 @@
  * overlap. Mounted by the shell alongside `AgentRail`.
  */
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { X } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
 import { StreamEventIcon } from '@/shared/app/rail/StreamEventIcon';

--- a/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { page } from '@vitest/browser/context';
 import type { ReactElement } from 'react';
-import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor, userEvent, checkA11y } from '@/__tests__/test-utils';
 import { AgentRail } from '@/shared/app/rail/AgentRail';

--- a/ui/src/shared/app/routes.ts
+++ b/ui/src/shared/app/routes.ts
@@ -1,4 +1,4 @@
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 /**
  * Canonical client route paths, ALL root-relative to the router `basename`

--- a/ui/src/shared/auth/AuthGuard.tsx
+++ b/ui/src/shared/auth/AuthGuard.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router';
 import { useAuth } from '@/shared/auth/AuthContext';
 import { ROUTES } from '@/shared/app/routes';
 

--- a/ui/src/shared/auth/ChangePasswordPage.tsx
+++ b/ui/src/shared/auth/ChangePasswordPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useAuth } from '@/shared/auth/AuthContext';
 import { ApiError } from '@/shared/api';
 import { ROUTES } from '@/shared/app/routes';

--- a/ui/src/shared/auth/LoginPage.tsx
+++ b/ui/src/shared/auth/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { useAuth } from '@/shared/auth/AuthContext';
 import { ApiError } from '@/shared/api';
 import { ROUTES } from '@/shared/app/routes';

--- a/ui/src/shared/auth/OAuthPopupReturn.tsx
+++ b/ui/src/shared/auth/OAuthPopupReturn.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { Button } from '@/shared/ui/Button';
 import { AppLink } from '@/shared/ui/AppLink';
 import { ROUTES } from '@/shared/app/routes';

--- a/ui/src/shared/auth/RedeemInvitePage.tsx
+++ b/ui/src/shared/auth/RedeemInvitePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useNavigate, useSearchParams } from 'react-router';
 import { useAuth } from '@/shared/auth/AuthContext';
 import { ApiError } from '@/shared/api';
 import { ROUTES } from '@/shared/app/routes';

--- a/ui/src/shared/auth/RequirePermission.tsx
+++ b/ui/src/shared/auth/RequirePermission.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet } from 'react-router';
 import { usePermission } from '@/shared/auth/usePermission';
 import { ROUTES } from '@/shared/app/routes';
 

--- a/ui/src/shared/auth/SetupGate.tsx
+++ b/ui/src/shared/auth/SetupGate.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { getHealth, HEALTH_QUERY_KEY } from '@/shared/api';
 import { ROUTES } from '@/shared/app/routes';

--- a/ui/src/shared/auth/SetupPage.tsx
+++ b/ui/src/shared/auth/SetupPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/shared/auth/AuthContext';
 import { ApiError, HEALTH_QUERY_KEY } from '@/shared/api';

--- a/ui/src/shared/ui/AppLink.tsx
+++ b/ui/src/shared/ui/AppLink.tsx
@@ -1,5 +1,5 @@
 import type { AnchorHTMLAttributes } from 'react';
-import { Link, type LinkProps } from 'react-router-dom';
+import { Link, type LinkProps } from 'react-router';
 import { cn } from '@/shared/lib/utils';
 import {
 	buttonBase,

--- a/ui/src/shared/ui/BackButton.tsx
+++ b/ui/src/shared/ui/BackButton.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft } from 'lucide-react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import { cn } from '@/shared/lib/utils';
 
 interface BackButtonProps {

--- a/ui/src/shared/ui/__tests__/AppLink.test.tsx
+++ b/ui/src/shared/ui/__tests__/AppLink.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { renderWithProviders, screen, checkA11y } from '@/__tests__/test-utils';
 import { AppLink } from '@/shared/ui/AppLink';
 

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
 	optimizeDeps: {
 		include: [
 			'@tanstack/react-query',
-			'react-router-dom',
+			'react-router',
 			'@testing-library/react',
 			'@testing-library/user-event',
 			'axe-core',


### PR DESCRIPTION
## Summary

- Upgrades `react-router` to **8.3.0**, fixing [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) (RSC-mode CSRF bypass, HIGH), which was published against `>= 7.12.0 < 8.3.0` and currently fails the Trivy security gate on **every** PR (e.g. #810).
- v8 removed the `react-router-dom` mirror package, so the dependency is swapped and all 49 import sites rewritten to `react-router`. Every symbol we use (`BrowserRouter`, `Link`, `Routes`, hooks, …) is a plain `react-router` export; nothing needs `react-router/dom` (that's only `RouterProvider`/`HydratedRouter`, which we don't use).
- No behavioral changes: the app already meets the v8 baseline (React 19.2.7, Vite 8, Node 22 in CI) and uses declarative `<BrowserRouter>` only — all v8 breaking changes are in framework/RSC mode.
- Also updates the vitest `optimizeDeps` pin and the dependabot `react` group to the new package name.

## Test plan

- [x] `tsc -b --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run test:run` — 714/714 pass
- [x] `npm run build` succeeds
- [ ] CI: UI e2e (mocked + real backend) and Security scan green

Made with [Cursor](https://cursor.com)