### PR TITLE
fix(cli): make the skill-install funnel honest and agent-friendly

### DIFF
--- a/cli/internal/cmd/app.go
+++ b/cli/internal/cmd/app.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/jentic/jentic-one/cli/internal/config"
+	"github.com/jentic/jentic-one/cli/internal/skillgen"
 )
 
 // App is the dependency container threaded into every command constructor. It
@@ -20,4 +21,8 @@ type App struct {
 	// Out and Err are the standard output streams (overridable in tests).
 	Out io.Writer
 	Err io.Writer
+	// DetectEnv overrides the skill operator-detection probe (tests only);
+	// nil means the real OS probe. Injected here rather than a package var so
+	// the command tree stays constructor-built with no global state.
+	DetectEnv func() (skillgen.DetectEnv, error)
 }

--- a/cli/internal/cmd/bootstrap.go
+++ b/cli/internal/cmd/bootstrap.go
@@ -137,6 +137,17 @@ func (a *App) bootstrapE(ctx context.Context, opts *bootstrapOptions) error {
 		}
 		targets, err = a.chooseTargets(reg, env, opts.skillOptions())
 		if err != nil {
+			// Same cancel idiom as promptBootstrap above: Esc in the skill
+			// picker means "never mind", not a failed bootstrap.
+			if errors.Is(err, huh.ErrUserAborted) {
+				fmt.Fprintln(a.Out, theme.Dim.Render("Cancelled."))
+				return nil
+			}
+			// For bootstrap the natural escape hatch on a headless box with
+			// no detectable operator is identity-only provisioning — name it.
+			if errors.Is(err, errNothingDetected) {
+				return fmt.Errorf("%w — or pass --skip-skill to provision identity only", err)
+			}
 			return err
 		}
 		if len(targets) == 0 {

--- a/cli/internal/cmd/bootstrap.go
+++ b/cli/internal/cmd/bootstrap.go
@@ -112,18 +112,15 @@ func (a *App) bootstrapE(ctx context.Context, opts *bootstrapOptions) error {
 		return err
 	}
 
-	// Resolve the skill scope and target adapters up front, before any
-	// registration or activation. Identity provisioning has irreversible side
-	// effects (a registered agent, an activated profile); a selection error
-	// (e.g. no operators on a non-interactive shell) must surface here so we
-	// never half-complete the flow and then fail at the skill step.
-	scope, err := resolveScope(opts.scope)
-	if err != nil {
-		return err
-	}
+	// Resolve the skill targets (operators + placement scope) up front, before
+	// any registration or activation. Identity provisioning has irreversible
+	// side effects (a registered agent, an activated profile); a selection
+	// error (e.g. no operators resolvable on a non-interactive shell) must
+	// surface here so we never half-complete the flow and then fail at the
+	// skill step.
 	var (
-		adapters []skillgen.Adapter
-		env      skillgen.DetectEnv
+		targets []skillTarget
+		env     skillgen.DetectEnv
 	)
 	if !opts.skipSkill {
 		reg := skillgen.DefaultRegistry()
@@ -131,11 +128,11 @@ func (a *App) bootstrapE(ctx context.Context, opts *bootstrapOptions) error {
 		if err != nil {
 			return err
 		}
-		adapters, err = a.chooseAdapters(reg, env, opts.skillOptions())
+		targets, err = a.chooseTargets(reg, env, opts.skillOptions())
 		if err != nil {
 			return err
 		}
-		if len(adapters) == 0 {
+		if len(targets) == 0 {
 			// Interactive picker dismissed with nothing selected: treat as a
 			// no-skill run rather than registering for no reason.
 			opts.skipSkill = true
@@ -143,7 +140,7 @@ func (a *App) bootstrapE(ctx context.Context, opts *bootstrapOptions) error {
 	}
 
 	if opts.dryRun {
-		return a.bootstrapDryRun(profileName, baseURL, adapters, env, scope, opts)
+		return a.bootstrapDryRun(profileName, baseURL, targets, env, opts)
 	}
 
 	// Step 1+2: register (DCR) and wait for human approval, reusing the exact
@@ -166,7 +163,7 @@ func (a *App) bootstrapE(ctx context.Context, opts *bootstrapOptions) error {
 	// not fatal: the identity is already provisioned.
 	if !opts.skipSkill {
 		fmt.Fprintln(a.Out)
-		if err := a.writeSkill(adapters, env, scope, opts.skillOptions()); err != nil {
+		if err := a.writeSkill(targets, env, opts.skillOptions()); err != nil {
 			// Identity is already provisioned, so a skill-content failure is
 			// reported but not fatal — the agent can re-run `jentic skill init`.
 			fmt.Fprintln(a.Out, theme.Warnf("skill generation failed: %v", err))
@@ -199,7 +196,7 @@ func (a *App) bootstrapIdentity(ctx context.Context, profileName, baseURL string
 }
 
 // bootstrapDryRun describes the steps without registering or writing anything.
-func (a *App) bootstrapDryRun(profileName, baseURL string, adapters []skillgen.Adapter, env skillgen.DetectEnv, scope skillgen.Scope, opts *bootstrapOptions) error {
+func (a *App) bootstrapDryRun(profileName, baseURL string, targets []skillTarget, env skillgen.DetectEnv, opts *bootstrapOptions) error {
 	fmt.Fprintln(a.Out, theme.Infof("would register agent for profile %q at %s (or reuse an existing registration)", profileName, baseURL))
 	fmt.Fprintln(a.Out, theme.Infof("would wait up to %s for human approval if the agent is still pending, then mint tokens", opts.timeout))
 	if !opts.noActive {
@@ -211,7 +208,7 @@ func (a *App) bootstrapDryRun(profileName, baseURL string, adapters []skillgen.A
 		fmt.Fprintln(a.Out)
 		dry := opts.skillOptions()
 		dry.dryRun = true
-		if err := a.writeSkill(adapters, env, scope, dry); err != nil {
+		if err := a.writeSkill(targets, env, dry); err != nil {
 			return err
 		}
 	}

--- a/cli/internal/cmd/bootstrap.go
+++ b/cli/internal/cmd/bootstrap.go
@@ -88,7 +88,7 @@ func newBootstrapCmd(app *App) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.all, "all", false, "target every supported operator")
 	cmd.Flags().StringVar(&opts.scope, "scope", "", "skill placement scope: user or project (default: per-operator)")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "show what would happen without registering or writing")
-	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "non-interactive: use flags + defaults, no prompts")
+	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "non-interactive: no prompts; with no --operator/--all, the skill targets the detected operators")
 
 	return cmd
 }
@@ -112,6 +112,13 @@ func (a *App) bootstrapE(ctx context.Context, opts *bootstrapOptions) error {
 		return err
 	}
 
+	// Flag validation happens before anything else, even for paths a flag
+	// doesn't apply to: `--skip-skill --scope typo` should error, not be
+	// silently ignored (a typo the user meant to matter must never pass).
+	if _, err := resolveScope(opts.scope); err != nil {
+		return err
+	}
+
 	// Resolve the skill targets (operators + placement scope) up front, before
 	// any registration or activation. Identity provisioning has irreversible
 	// side effects (a registered agent, an activated profile); a selection
@@ -124,7 +131,7 @@ func (a *App) bootstrapE(ctx context.Context, opts *bootstrapOptions) error {
 	)
 	if !opts.skipSkill {
 		reg := skillgen.DefaultRegistry()
-		env, err = detectEnv()
+		env, err = a.detectEnv()
 		if err != nil {
 			return err
 		}

--- a/cli/internal/cmd/bootstrap_test.go
+++ b/cli/internal/cmd/bootstrap_test.go
@@ -195,6 +195,9 @@ func TestBootstrapSelectionErrorBeforeRegister(t *testing.T) {
 	if !strings.Contains(err.Error(), "no operators") {
 		t.Errorf("error = %v, want a 'no operators' selection error", err)
 	}
+	if !strings.Contains(err.Error(), "--skip-skill") {
+		t.Errorf("bootstrap's error should name --skip-skill as the identity-only escape hatch: %v", err)
+	}
 	if n := registers.Load(); n != 0 {
 		t.Errorf("registered %d times before the selection error; want 0 (no side effects)", n)
 	}

--- a/cli/internal/cmd/bootstrap_test.go
+++ b/cli/internal/cmd/bootstrap_test.go
@@ -164,11 +164,14 @@ func TestBootstrapWaitsThenApproves(t *testing.T) {
 }
 
 // TestBootstrapSelectionErrorBeforeRegister proves operator selection is
-// validated before any irreversible side effect: a non-interactive run with no
-// operators must fail without registering an agent or activating a profile.
+// validated before any irreversible side effect: a non-interactive run where
+// no operators are given AND none are detected must fail without registering
+// an agent or activating a profile. (With detected operators, the run
+// degrades to them instead — #755.)
 func TestBootstrapSelectionErrorBeforeRegister(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	stubDetect(t, home, t.TempDir()) // nothing detected
 	srv, registers := bootstrapServer(t, 0)
 
 	app := testApp(t)

--- a/cli/internal/cmd/bootstrap_test.go
+++ b/cli/internal/cmd/bootstrap_test.go
@@ -171,10 +171,10 @@ func TestBootstrapWaitsThenApproves(t *testing.T) {
 func TestBootstrapSelectionErrorBeforeRegister(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	stubDetect(t, home, t.TempDir()) // nothing detected
 	srv, registers := bootstrapServer(t, 0)
 
 	app := testApp(t)
+	stubDetect(t, app, home, t.TempDir()) // nothing detected
 	app.Out = new(bytes.Buffer)
 
 	root := newAPIRootCmd(app)
@@ -204,6 +204,36 @@ func TestBootstrapSelectionErrorBeforeRegister(t *testing.T) {
 	cfg, _ := config.Load(app.Paths)
 	if cfg.DefaultProfile == "demo" {
 		t.Errorf("profile must not be activated when selection fails up front")
+	}
+}
+
+// TestBootstrapSkipSkillRejectsInvalidScope pins that flag validation is not
+// silently skipped on paths a flag doesn't apply to: `--skip-skill` with a
+// mistyped --scope must error before any registration side effect.
+func TestBootstrapSkipSkillRejectsInvalidScope(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	srv, registers := bootstrapServer(t, 0)
+
+	app := testApp(t)
+	app.Out = new(bytes.Buffer)
+	root := newAPIRootCmd(app)
+	root.SetOut(app.Out)
+	root.SetErr(new(bytes.Buffer))
+	root.SetArgs([]string{
+		"bootstrap",
+		"--profile", "demo",
+		"--base-url", srv.URL,
+		"--skip-skill",
+		"--scope", "everywhere",
+		"--yes",
+	})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "invalid --scope") {
+		t.Fatalf("expected an invalid --scope error, got %v", err)
+	}
+	if n := registers.Load(); n != 0 {
+		t.Errorf("registered %d times despite an invalid flag; want 0", n)
 	}
 }
 

--- a/cli/internal/cmd/skill.go
+++ b/cli/internal/cmd/skill.go
@@ -21,6 +21,11 @@ import (
 // are mutually exclusive rather than silently letting --all win.
 var errOperatorAndAll = errors.New("--operator and --all are mutually exclusive; pass one or the other")
 
+// errNothingDetected is returned when a non-interactive run has no explicit
+// selection and detection finds nothing. A sentinel so callers with a better
+// escape hatch (bootstrap's --skip-skill) can append it to the message.
+var errNothingDetected = errors.New("no operators given and none detected")
+
 // skillOptions are shared across the skill subcommands.
 type skillOptions struct {
 	baseURL   string
@@ -227,8 +232,8 @@ func (a *App) chooseTargets(reg *skillgen.Registry, env skillgen.DetectEnv, opts
 		// scripts get a working install by default.
 		adapters = reg.Detected(env)
 		if len(adapters) == 0 {
-			return nil, errors.New("no operators given and none detected; pass --operator <names> or --all (supported: " +
-				strings.Join(reg.Names(), ", ") + ")")
+			return nil, fmt.Errorf("%w; pass --operator <names> or --all (supported: %s)",
+				errNothingDetected, strings.Join(reg.Names(), ", "))
 		}
 		targets := resolveTargets(adapters, flagScope)
 		a.echoDefaultedTargets(targets, env)
@@ -264,10 +269,33 @@ func resolveTargets(adapters []skillgen.Adapter, flagScope skillgen.Scope) []ski
 // echoDefaultedTargets announces an auto-defaulted selection (non-interactive,
 // nothing explicit) with each resolved scope+path *before* anything is
 // written, so a silent default can never place a file somewhere surprising.
+// A project-scope target inside a git worktree gets a real warning on top of
+// the echo: nobody explicitly asked for that write, and the file will show up
+// in `git status` — the #552 repo-pollution case.
 func (a *App) echoDefaultedTargets(targets []skillTarget, env skillgen.DetectEnv) {
 	fmt.Fprintln(a.Out, theme.Dim.Render("No --operator/--all given; defaulting to detected operators (--operator/--all overrides):"))
 	for _, t := range targets {
-		fmt.Fprintln(a.Out, "  "+theme.Infof("%-8s -> %s (%s scope)", t.adapter.Operator(), prettyPath(t.adapter.Target(t.scope, env)), t.scope))
+		target := t.adapter.Target(t.scope, env)
+		fmt.Fprintln(a.Out, "  "+theme.Infof("%-8s -> %s (%s scope)", t.adapter.Operator(), prettyPath(target), t.scope))
+		if t.scope == skillgen.ScopeProject && insideGitWorktree(filepath.Dir(target)) {
+			fmt.Fprintln(a.Out, "  "+theme.Warnf("%-8s this file is inside a git repo and will appear in git status; pass --scope user to keep it out of the checkout", t.adapter.Operator()))
+		}
+	}
+}
+
+// insideGitWorktree reports whether dir sits under a git checkout, by walking
+// up to the first `.git` entry (a dir for a normal clone, a file for a
+// worktree/submodule).
+func insideGitWorktree(dir string) bool {
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
 	}
 }
 
@@ -362,6 +390,13 @@ func (a *App) skillInit(_ *cobra.Command, opts *skillOptions) error {
 
 	targets, err := a.chooseTargets(reg, env, opts)
 	if err != nil {
+		// Esc/Ctrl-C in a picker is "never mind", not a failure — same
+		// Cancelled./exit-0 idiom as every other wizard in the CLI (and the
+		// same outcome as confirming an empty selection).
+		if errors.Is(err, huh.ErrUserAborted) {
+			fmt.Fprintln(a.Out, theme.Dim.Render("Cancelled."))
+			return nil
+		}
 		return err
 	}
 	if len(targets) == 0 {

--- a/cli/internal/cmd/skill.go
+++ b/cli/internal/cmd/skill.go
@@ -64,6 +64,9 @@ func newSkillInitCmd(app *App) *cobra.Command {
 		Long: "init detects which agent runtimes you have, lets you pick the targets\n" +
 			"and placement (or pass --operator/--scope), and writes the Jentic\n" +
 			"CLI-usage skill into each one's native layout.\n\n" +
+			"Passing --operator or --all skips every prompt, including the placement\n" +
+			"one: each operator uses its default scope unless --scope is given\n" +
+			"(preview with --dry-run).\n\n" +
 			"Non-interactively (--yes, pipes, agent sessions) it defaults to the\n" +
 			"detected operators, echoing each resolved path before writing.",
 		Example: "  jentic skill init\n" +
@@ -113,20 +116,22 @@ func newSkillRemoveCmd(app *App) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringSliceVar(&opts.operators, "operator", nil, "operators to clean up (repeatable or comma-separated)")
-	cmd.Flags().StringVar(&opts.scope, "scope", "", "placement scope: user or project (default: per-operator)")
+	cmd.Flags().StringVar(&opts.scope, "scope", "", "placement scope to remove from: user or project (default: every scope where the skill is installed)")
 	cmd.Flags().BoolVar(&opts.all, "all", false, "remove from every supported operator")
 	cmd.Flags().BoolVar(&opts.force, "force", false, "remove even a managed block you have manually edited")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "print what would be removed without deleting anything")
 	return cmd
 }
 
-// detectEnv builds the detection environment from the real OS, with PATH and
-// filesystem probes wired to the standard library. It errors if home or working
-// directory cannot be resolved, since every target path is rooted at one of
-// them and proceeding with empty bases would write files to surprising places.
-// It is a package variable so command tests can stub detection (the real probe
-// consults PATH, which varies by machine).
-var detectEnv = func() (skillgen.DetectEnv, error) {
+// detectEnv resolves the skill detection environment: the injected probe when
+// set (tests), otherwise the real OS — PATH and filesystem probes wired to the
+// standard library. The real probe errors if home or working directory cannot
+// be resolved, since every target path is rooted at one of them and proceeding
+// with empty bases would write files to surprising places.
+func (a *App) detectEnv() (skillgen.DetectEnv, error) {
+	if a.DetectEnv != nil {
+		return a.DetectEnv()
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return skillgen.DetectEnv{}, fmt.Errorf("resolve home directory: %w", err)
@@ -350,7 +355,7 @@ func scopeLabel(ad skillgen.Adapter, scope, def skillgen.Scope, env skillgen.Det
 
 func (a *App) skillInit(_ *cobra.Command, opts *skillOptions) error {
 	reg := skillgen.DefaultRegistry()
-	env, err := detectEnv()
+	env, err := a.detectEnv()
 	if err != nil {
 		return err
 	}
@@ -429,7 +434,7 @@ func (a *App) reportOutcome(out skillgen.Outcome, scope skillgen.Scope, dryRun b
 
 func (a *App) skillList(cmd *cobra.Command, opts *skillOptions) error {
 	reg := skillgen.DefaultRegistry()
-	env, err := detectEnv()
+	env, err := a.detectEnv()
 	if err != nil {
 		return err
 	}
@@ -441,9 +446,13 @@ func (a *App) skillList(cmd *cobra.Command, opts *skillOptions) error {
 	if jsonOrPretty(cmd, opts.json) {
 		return a.skillListJSON(reg, env, detected)
 	}
+	return a.skillListPretty(reg, env, detected)
+}
 
-	// "Detected" (the runtime looks present) and "installed" (a managed skill
-	// block actually exists on disk) are reported separately — #752.
+// skillListPretty renders the human listing. "Detected" (the runtime looks
+// present) and "installed" (a managed skill block actually exists on disk)
+// are reported separately — #752.
+func (a *App) skillListPretty(reg *skillgen.Registry, env skillgen.DetectEnv, detected map[skillgen.Operator]bool) error {
 	fmt.Fprintln(a.Out, theme.Heading.Render("Supported operators"))
 	for _, ad := range reg.Adapters() {
 		glyph := theme.Dim.Render(theme.SelectOff)
@@ -454,16 +463,25 @@ func (a *App) skillList(cmd *cobra.Command, opts *skillOptions) error {
 		}
 		fmt.Fprintln(a.Out, glyph+" "+theme.Accent.Render(string(ad.Operator()))+tag)
 
-		if st, ok := skillgen.Installed(ad, env); ok {
+		// Print every scope that actually holds a managed block: user and
+		// project installs can coexist, and hiding the second would make
+		// `skill list` lie by omission (the same conflation #752 fixed).
+		var shown int
+		for _, st := range skillgen.InstallStates(ad, env) {
+			if !st.Installed {
+				continue
+			}
 			line := theme.Field("installed", fmt.Sprintf("%s (%s scope)", prettyPath(st.Path), st.Scope))
 			if st.UserEdits {
 				line += " " + theme.Warn.Render("(manually edited)")
 			}
 			fmt.Fprintln(a.Out, "    "+line)
-			continue
+			shown++
 		}
-		fmt.Fprintln(a.Out, "    "+theme.Field("installed", "no"))
-		fmt.Fprintln(a.Out, "    "+theme.Field("target", prettyPath(ad.Target(ad.DefaultScope(), env))))
+		if shown == 0 {
+			fmt.Fprintln(a.Out, "    "+theme.Field("installed", "no"))
+			fmt.Fprintln(a.Out, "    "+theme.Field("target", prettyPath(ad.Target(ad.DefaultScope(), env))))
+		}
 	}
 	fmt.Fprintln(a.Out)
 	fmt.Fprintln(a.Out, theme.Dim.Render("Install with: jentic skill init [--operator <names>]"))
@@ -519,7 +537,7 @@ func (a *App) skillRemove(_ *cobra.Command, opts *skillOptions) error {
 		return err
 	}
 	reg := skillgen.DefaultRegistry()
-	env, err := detectEnv()
+	env, err := a.detectEnv()
 	if err != nil {
 		return err
 	}
@@ -544,23 +562,42 @@ func (a *App) skillRemove(_ *cobra.Command, opts *skillOptions) error {
 	fmt.Fprintln(a.Out, theme.Heading.Render("Remove Jentic skill"))
 	var blocked int
 	for _, ad := range adapters {
-		out, rerr := skillgen.Remove(ad, env, skillgen.RemoveOptions{
-			Scope:  scope,
-			Force:  opts.force,
-			DryRun: opts.dryRun,
-		})
-		switch {
-		case rerr != nil:
-			fmt.Fprintln(a.Out, "  "+theme.Warnf("%-8s %v", ad.Operator(), rerr))
-		case out.UserEdits:
-			blocked++
-			fmt.Fprintln(a.Out, "  "+theme.Warnf("%-8s %s — manual edits detected; re-run with --force to remove", ad.Operator(), prettyPath(out.Path)))
-		case out.Missing:
-			fmt.Fprintln(a.Out, "  "+theme.Dimf("%-8s nothing to remove (%s)", ad.Operator(), prettyPath(out.Path)))
-		case opts.dryRun:
-			fmt.Fprintln(a.Out, "  "+theme.Infof("%-8s would remove from %s", ad.Operator(), prettyPath(out.Path)))
-		case out.Removed:
-			fmt.Fprintln(a.Out, "  "+theme.Successf("%-8s removed from %s", ad.Operator(), prettyPath(out.Path)))
+		// No --scope means "remove my install", not "remove at the default
+		// placement": probe both scopes and strip every managed block found,
+		// so an install made with --scope project (or via the interactive
+		// scope prompt) is removable without the user re-deriving its scope.
+		scopes := []skillgen.Scope{scope}
+		if scope == "" {
+			scopes = scopes[:0]
+			for _, st := range skillgen.InstallStates(ad, env) {
+				if st.Installed {
+					scopes = append(scopes, st.Scope)
+				}
+			}
+			if len(scopes) == 0 {
+				fmt.Fprintln(a.Out, "  "+theme.Dimf("%-8s nothing to remove (%s)", ad.Operator(), prettyPath(ad.Target(ad.DefaultScope(), env))))
+				continue
+			}
+		}
+		for _, sc := range scopes {
+			out, rerr := skillgen.Remove(ad, env, skillgen.RemoveOptions{
+				Scope:  sc,
+				Force:  opts.force,
+				DryRun: opts.dryRun,
+			})
+			switch {
+			case rerr != nil:
+				fmt.Fprintln(a.Out, "  "+theme.Warnf("%-8s %v", ad.Operator(), rerr))
+			case out.UserEdits:
+				blocked++
+				fmt.Fprintln(a.Out, "  "+theme.Warnf("%-8s %s — manual edits detected; re-run with --force to remove", ad.Operator(), prettyPath(out.Path)))
+			case out.Missing:
+				fmt.Fprintln(a.Out, "  "+theme.Dimf("%-8s nothing to remove (%s)", ad.Operator(), prettyPath(out.Path)))
+			case opts.dryRun:
+				fmt.Fprintln(a.Out, "  "+theme.Infof("%-8s would remove from %s", ad.Operator(), prettyPath(out.Path)))
+			case out.Removed:
+				fmt.Fprintln(a.Out, "  "+theme.Successf("%-8s removed from %s", ad.Operator(), prettyPath(out.Path)))
+			}
 		}
 	}
 	if opts.dryRun {

--- a/cli/internal/cmd/skill.go
+++ b/cli/internal/cmd/skill.go
@@ -26,6 +26,17 @@ var errOperatorAndAll = errors.New("--operator and --all are mutually exclusive;
 // escape hatch (bootstrap's --skip-skill) can append it to the message.
 var errNothingDetected = errors.New("no operators given and none detected")
 
+// promptable reports whether the huh pickers can actually run interactively.
+// A TTY alone is not enough: on TERM=dumb (emacs shells, many agent
+// harnesses) huh silently falls back to its "accessible" numbered prompts,
+// which loop on stdin without honoring Esc, Ctrl-C, or the signal-cancelled
+// command context — an inescapable picker (jentic-one#841). Those sessions
+// are exactly the ones the #755 defaulting path is for, so treat them as
+// non-interactive instead.
+func promptable() bool {
+	return term.IsTerminal(os.Stdin.Fd()) && os.Getenv("TERM") != "dumb"
+}
+
 // skillOptions are shared across the skill subcommands.
 type skillOptions struct {
 	baseURL   string
@@ -201,11 +212,11 @@ type skillTarget struct {
 // flags + detection + the interactive pickers. A nil, error-free return means
 // the user dismissed the picker with nothing selected.
 //
-// Non-interactive runs (--yes or stdin is not a terminal — pipes, CI, agent
-// sessions) with no explicit --operator/--all fall back to the *detected*
-// operators instead of erroring (#755); the resolved targets are echoed before
-// anything is written. When nothing is detected either, the error spells out
-// the flags to pass.
+// Non-interactive runs (--yes or stdin is not promptable — pipes, CI, agent
+// sessions, dumb terminals) with no explicit --operator/--all fall back to the
+// *detected* operators instead of erroring (#755); the resolved targets are
+// echoed before anything is written. When nothing is detected either, the
+// error spells out the flags to pass.
 func (a *App) chooseTargets(reg *skillgen.Registry, env skillgen.DetectEnv, opts *skillOptions) ([]skillTarget, error) {
 	flagScope, err := resolveScope(opts.scope)
 	if err != nil {
@@ -226,7 +237,7 @@ func (a *App) chooseTargets(reg *skillgen.Registry, env skillgen.DetectEnv, opts
 				strings.Join(unknown, ", "), strings.Join(reg.Names(), ", "))
 		}
 		adapters = resolved
-	case opts.yes || !term.IsTerminal(os.Stdin.Fd()):
+	case opts.yes || !promptable():
 		// #755: no selection and no way (or wish) to prompt — degrade to the
 		// detected operators rather than aborting, so agent sessions and
 		// scripts get a working install by default.

--- a/cli/internal/cmd/skill.go
+++ b/cli/internal/cmd/skill.go
@@ -62,8 +62,10 @@ func newSkillInitCmd(app *App) *cobra.Command {
 		Use:   "init",
 		Short: "Generate the Jentic skill for one or more operators",
 		Long: "init detects which agent runtimes you have, lets you pick the targets\n" +
-			"(or pass --operator), and writes the Jentic CLI-usage skill into each\n" +
-			"one's native layout.",
+			"and placement (or pass --operator/--scope), and writes the Jentic\n" +
+			"CLI-usage skill into each one's native layout.\n\n" +
+			"Non-interactively (--yes, pipes, agent sessions) it defaults to the\n" +
+			"detected operators, echoing each resolved path before writing.",
 		Example: "  jentic skill init\n" +
 			"  jentic skill init --operator claude,cursor\n" +
 			"  jentic skill init --all --yes\n" +
@@ -76,7 +78,7 @@ func newSkillInitCmd(app *App) *cobra.Command {
 	cmd.Flags().StringSliceVar(&opts.operators, "operator", nil, "operators to target (repeatable or comma-separated)")
 	cmd.Flags().StringVar(&opts.scope, "scope", "", "placement scope: user or project (default: per-operator)")
 	cmd.Flags().BoolVar(&opts.force, "force", false, "overwrite a managed block you have manually edited")
-	cmd.Flags().BoolVar(&opts.yes, "yes", false, "skip the interactive picker (use --operator/--all)")
+	cmd.Flags().BoolVar(&opts.yes, "yes", false, "non-interactive: no pickers; with no --operator/--all, target the detected operators")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "print target paths without writing")
 	cmd.Flags().BoolVar(&opts.all, "all", false, "target every supported operator")
 	cmd.Flags().StringVar(&opts.baseURL, "base-url", "", "Jentic control-plane base URL")
@@ -87,7 +89,7 @@ func newSkillListCmd(app *App) *cobra.Command {
 	opts := &skillOptions{}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Show supported operators and which are detected in this environment",
+		Short: "Show supported operators: which are detected and where the skill is installed",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return app.skillList(cmd, opts)
@@ -122,7 +124,9 @@ func newSkillRemoveCmd(app *App) *cobra.Command {
 // filesystem probes wired to the standard library. It errors if home or working
 // directory cannot be resolved, since every target path is rooted at one of
 // them and proceeding with empty bases would write files to surprising places.
-func detectEnv() (skillgen.DetectEnv, error) {
+// It is a package variable so command tests can stub detection (the real probe
+// consults PATH, which varies by machine).
+var detectEnv = func() (skillgen.DetectEnv, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return skillgen.DetectEnv{}, fmt.Errorf("resolve home directory: %w", err)
@@ -161,7 +165,9 @@ func resolveScope(flag string) (skillgen.Scope, error) {
 }
 
 // canonicalContent loads the bundled skill, stamped with the resolved base URL.
-// The hosted (#277) source is wired here later; for now it always uses bundled.
+// The deployment also serves this same canonical content at /skills/jentic.md
+// (#651); a hosted-fetch source can be wired here later. For now it always
+// uses the bundled copy.
 func (a *App) canonicalContent(baseURLFlag string) (skillgen.Canonical, error) {
 	cfg, err := config.Load(a.Paths)
 	baseURL := config.DefaultBaseURL
@@ -173,29 +179,91 @@ func (a *App) canonicalContent(baseURLFlag string) (skillgen.Canonical, error) {
 	return skillgen.Bundled(baseURL)
 }
 
-// chooseAdapters resolves the target adapters from flags + detection + an
-// interactive picker. It returns the selected adapters or an error.
-func (a *App) chooseAdapters(reg *skillgen.Registry, env skillgen.DetectEnv, opts *skillOptions) ([]skillgen.Adapter, error) {
+// skillTarget pairs an adapter with the concrete placement scope resolved for
+// it (flag > interactive choice > adapter default), so the write path never
+// has to re-derive placement.
+type skillTarget struct {
+	adapter skillgen.Adapter
+	scope   skillgen.Scope
+}
+
+// chooseTargets resolves which operators to write and at which scope, from
+// flags + detection + the interactive pickers. A nil, error-free return means
+// the user dismissed the picker with nothing selected.
+//
+// Non-interactive runs (--yes or stdin is not a terminal — pipes, CI, agent
+// sessions) with no explicit --operator/--all fall back to the *detected*
+// operators instead of erroring (#755); the resolved targets are echoed before
+// anything is written. When nothing is detected either, the error spells out
+// the flags to pass.
+func (a *App) chooseTargets(reg *skillgen.Registry, env skillgen.DetectEnv, opts *skillOptions) ([]skillTarget, error) {
+	flagScope, err := resolveScope(opts.scope)
+	if err != nil {
+		return nil, err
+	}
 	if opts.all && len(opts.operators) > 0 {
 		return nil, errOperatorAndAll
 	}
-	if opts.all {
-		return reg.Adapters(), nil
-	}
-	if len(opts.operators) > 0 {
+
+	var adapters []skillgen.Adapter
+	switch {
+	case opts.all:
+		adapters = reg.Adapters()
+	case len(opts.operators) > 0:
 		resolved, unknown := reg.ResolveAll(opts.operators)
 		if len(unknown) > 0 {
 			return nil, fmt.Errorf("unknown operator(s): %s (supported: %s)",
 				strings.Join(unknown, ", "), strings.Join(reg.Names(), ", "))
 		}
-		return resolved, nil
+		adapters = resolved
+	case opts.yes || !term.IsTerminal(os.Stdin.Fd()):
+		// #755: no selection and no way (or wish) to prompt — degrade to the
+		// detected operators rather than aborting, so agent sessions and
+		// scripts get a working install by default.
+		adapters = reg.Detected(env)
+		if len(adapters) == 0 {
+			return nil, errors.New("no operators given and none detected; pass --operator <names> or --all (supported: " +
+				strings.Join(reg.Names(), ", ") + ")")
+		}
+		targets := resolveTargets(adapters, flagScope)
+		a.echoDefaultedTargets(targets, env)
+		return targets, nil
+	default:
+		adapters, err = a.pickOperators(reg, env)
+		if err != nil || len(adapters) == 0 {
+			return nil, err
+		}
+		if flagScope == "" {
+			// #552: placement is a real choice (user-global vs this repo), so
+			// ask instead of deciding silently when we're interactive anyway.
+			return a.pickScopes(adapters, env)
+		}
 	}
+	return resolveTargets(adapters, flagScope), nil
+}
 
-	// No explicit selection. On a non-TTY (or --yes) we cannot prompt.
-	if opts.yes || !term.IsTerminal(os.Stdin.Fd()) {
-		return nil, errors.New("no operators given; pass --operator <names> or --all (no terminal to prompt)")
+// resolveTargets pairs adapters with flagScope, or their per-operator default
+// (the #552-ratified policy) when no --scope was given.
+func resolveTargets(adapters []skillgen.Adapter, flagScope skillgen.Scope) []skillTarget {
+	targets := make([]skillTarget, 0, len(adapters))
+	for _, ad := range adapters {
+		scope := flagScope
+		if scope == "" {
+			scope = ad.DefaultScope()
+		}
+		targets = append(targets, skillTarget{adapter: ad, scope: scope})
 	}
-	return a.pickOperators(reg, env)
+	return targets
+}
+
+// echoDefaultedTargets announces an auto-defaulted selection (non-interactive,
+// nothing explicit) with each resolved scope+path *before* anything is
+// written, so a silent default can never place a file somewhere surprising.
+func (a *App) echoDefaultedTargets(targets []skillTarget, env skillgen.DetectEnv) {
+	fmt.Fprintln(a.Out, theme.Dim.Render("No --operator/--all given; defaulting to detected operators (--operator/--all overrides):"))
+	for _, t := range targets {
+		fmt.Fprintln(a.Out, "  "+theme.Infof("%-8s -> %s (%s scope)", t.adapter.Operator(), prettyPath(t.adapter.Target(t.scope, env)), t.scope))
+	}
 }
 
 // pickOperators runs the interactive multi-select with detected operators
@@ -236,33 +304,73 @@ func (a *App) pickOperators(reg *skillgen.Registry, env skillgen.DetectEnv) ([]s
 	return resolved, nil
 }
 
-func (a *App) skillInit(_ *cobra.Command, opts *skillOptions) error {
-	scope, err := resolveScope(opts.scope)
-	if err != nil {
-		return err
+// pickScopes asks, per selected operator, whether the skill goes user-global
+// or into the current project, showing the exact resolved path for each
+// choice. The #552-ratified per-operator default is pre-selected, so Enter
+// through keeps today's behavior — but the placement is now a visible choice.
+func (a *App) pickScopes(adapters []skillgen.Adapter, env skillgen.DetectEnv) ([]skillTarget, error) {
+	values := make([]string, len(adapters))
+	fields := make([]huh.Field, 0, len(adapters))
+	for i, ad := range adapters {
+		def := ad.DefaultScope()
+		values[i] = string(def)
+
+		userOpt := huh.NewOption(scopeLabel(ad, skillgen.ScopeUser, def, env), string(skillgen.ScopeUser))
+		projOpt := huh.NewOption(scopeLabel(ad, skillgen.ScopeProject, def, env), string(skillgen.ScopeProject))
+		ordered := []huh.Option[string]{userOpt, projOpt}
+		if def == skillgen.ScopeProject {
+			ordered = []huh.Option[string]{projOpt, userOpt}
+		}
+
+		fields = append(fields, huh.NewSelect[string]().
+			Title(fmt.Sprintf("Where should the %s skill go?", ad.Operator())).
+			Options(ordered...).
+			Value(&values[i]))
 	}
+
+	if err := install.NewForm(huh.NewGroup(fields...)).Run(); err != nil {
+		return nil, err
+	}
+
+	targets := make([]skillTarget, len(adapters))
+	for i, ad := range adapters {
+		targets[i] = skillTarget{adapter: ad, scope: skillgen.Scope(values[i])}
+	}
+	return targets, nil
+}
+
+// scopeLabel renders one scope choice with its resolved path and a default tag.
+func scopeLabel(ad skillgen.Adapter, scope, def skillgen.Scope, env skillgen.DetectEnv) string {
+	label := fmt.Sprintf("%s — %s", scope, prettyPath(ad.Target(scope, env)))
+	if scope == def {
+		label += " (default)"
+	}
+	return label
+}
+
+func (a *App) skillInit(_ *cobra.Command, opts *skillOptions) error {
 	reg := skillgen.DefaultRegistry()
 	env, err := detectEnv()
 	if err != nil {
 		return err
 	}
 
-	adapters, err := a.chooseAdapters(reg, env, opts)
+	targets, err := a.chooseTargets(reg, env, opts)
 	if err != nil {
 		return err
 	}
-	if len(adapters) == 0 {
+	if len(targets) == 0 {
 		return nil
 	}
 
-	return a.writeSkill(adapters, env, scope, opts)
+	return a.writeSkill(targets, env, opts)
 }
 
-// writeSkill renders the canonical skill into each adapter and prints the
+// writeSkill renders the canonical skill into each target and prints the
 // per-operator outcome plus a closing hint. It is the shared body of
-// `skill init` and `bootstrap` so both report writes identically. Adapters are
+// `skill init` and `bootstrap` so both report writes identically. Targets are
 // resolved by the caller (so selection errors surface before any side effects).
-func (a *App) writeSkill(adapters []skillgen.Adapter, env skillgen.DetectEnv, scope skillgen.Scope, opts *skillOptions) error {
+func (a *App) writeSkill(targets []skillTarget, env skillgen.DetectEnv, opts *skillOptions) error {
 	content, err := a.canonicalContent(opts.baseURL)
 	if err != nil {
 		return err
@@ -270,17 +378,17 @@ func (a *App) writeSkill(adapters []skillgen.Adapter, env skillgen.DetectEnv, sc
 	fmt.Fprintln(a.Out, theme.Heading.Render("Jentic skill"))
 
 	var wrote int
-	for _, ad := range adapters {
-		out, aerr := skillgen.Apply(ad, content, env, skillgen.ApplyOptions{
-			Scope:  scope,
+	for _, t := range targets {
+		out, aerr := skillgen.Apply(t.adapter, content, env, skillgen.ApplyOptions{
+			Scope:  t.scope,
 			Force:  opts.force,
 			DryRun: opts.dryRun,
 		})
 		if aerr != nil {
-			fmt.Fprintln(a.Out, "  "+theme.Warnf("%s: %v", ad.Operator(), aerr))
+			fmt.Fprintln(a.Out, "  "+theme.Warnf("%s: %v", t.adapter.Operator(), aerr))
 			continue
 		}
-		a.reportOutcome(out, opts.dryRun)
+		a.reportOutcome(out, t.scope, opts.dryRun)
 		if out.Changed && !opts.dryRun {
 			wrote++
 		}
@@ -297,9 +405,10 @@ func (a *App) writeSkill(adapters []skillgen.Adapter, env skillgen.DetectEnv, sc
 	return nil
 }
 
-// reportOutcome prints a single adapter's result line.
-func (a *App) reportOutcome(out skillgen.Outcome, dryRun bool) {
-	rel := prettyPath(out.Path)
+// reportOutcome prints a single adapter's result line, tagged with the scope
+// the write resolved to so placement is always visible in the output.
+func (a *App) reportOutcome(out skillgen.Outcome, scope skillgen.Scope, dryRun bool) {
+	rel := fmt.Sprintf("%s (%s scope)", prettyPath(out.Path), scope)
 	switch {
 	case out.UserEdits:
 		fmt.Fprintln(a.Out, "  "+theme.Warnf("%-8s %s — manual edits detected; re-run with --force to overwrite", out.Operator, rel))
@@ -333,6 +442,8 @@ func (a *App) skillList(cmd *cobra.Command, opts *skillOptions) error {
 		return a.skillListJSON(reg, env, detected)
 	}
 
+	// "Detected" (the runtime looks present) and "installed" (a managed skill
+	// block actually exists on disk) are reported separately — #752.
 	fmt.Fprintln(a.Out, theme.Heading.Render("Supported operators"))
 	for _, ad := range reg.Adapters() {
 		glyph := theme.Dim.Render(theme.SelectOff)
@@ -342,26 +453,62 @@ func (a *App) skillList(cmd *cobra.Command, opts *skillOptions) error {
 			tag = " " + theme.Dim.Render("(detected)")
 		}
 		fmt.Fprintln(a.Out, glyph+" "+theme.Accent.Render(string(ad.Operator()))+tag)
+
+		if st, ok := skillgen.Installed(ad, env); ok {
+			line := theme.Field("installed", fmt.Sprintf("%s (%s scope)", prettyPath(st.Path), st.Scope))
+			if st.UserEdits {
+				line += " " + theme.Warn.Render("(manually edited)")
+			}
+			fmt.Fprintln(a.Out, "    "+line)
+			continue
+		}
+		fmt.Fprintln(a.Out, "    "+theme.Field("installed", "no"))
 		fmt.Fprintln(a.Out, "    "+theme.Field("target", prettyPath(ad.Target(ad.DefaultScope(), env))))
 	}
+	fmt.Fprintln(a.Out)
+	fmt.Fprintln(a.Out, theme.Dim.Render("Install with: jentic skill init [--operator <names>]"))
 	return nil
 }
 
 func (a *App) skillListJSON(reg *skillgen.Registry, env skillgen.DetectEnv, detected map[skillgen.Operator]bool) error {
+	type installRow struct {
+		Scope     string `json:"scope"`
+		Path      string `json:"path"`
+		Installed bool   `json:"installed"`
+		UserEdits bool   `json:"user_edits"`
+	}
 	type row struct {
 		Operator string `json:"operator"`
 		Detected bool   `json:"detected"`
-		Target   string `json:"target"`
-		Scope    string `json:"scope"`
+		// Installed reports whether a managed skill block exists at any scope
+		// — detection alone never implies it (#752).
+		Installed     bool         `json:"installed"`
+		InstalledPath string       `json:"installed_path,omitempty"`
+		Target        string       `json:"target"`
+		Scope         string       `json:"scope"`
+		Installs      []installRow `json:"installs"`
 	}
 	rows := make([]row, 0, len(reg.Adapters()))
 	for _, ad := range reg.Adapters() {
-		rows = append(rows, row{
+		r := row{
 			Operator: string(ad.Operator()),
 			Detected: detected[ad.Operator()],
 			Target:   ad.Target(ad.DefaultScope(), env),
 			Scope:    string(ad.DefaultScope()),
-		})
+		}
+		for _, st := range skillgen.InstallStates(ad, env) {
+			r.Installs = append(r.Installs, installRow{
+				Scope:     string(st.Scope),
+				Path:      st.Path,
+				Installed: st.Installed,
+				UserEdits: st.UserEdits,
+			})
+			if st.Installed && !r.Installed {
+				r.Installed = true
+				r.InstalledPath = st.Path
+			}
+		}
+		rows = append(rows, r)
 	}
 	return writeJSON(a.Out, map[string]any{"operators": rows})
 }

--- a/cli/internal/cmd/skill_test.go
+++ b/cli/internal/cmd/skill_test.go
@@ -273,6 +273,42 @@ func TestSkillInitNonInteractiveDefaultsToDetectedProjectScope(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(home, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
 		t.Error("user-scope codex AGENTS.md written despite project default")
 	}
+	if strings.Contains(out.String(), "git status") {
+		t.Errorf("no git repo here; the repo-pollution warning must not fire:\n%s", out.String())
+	}
+}
+
+// TestSkillInitDefaultedProjectScopeWarnsInsideGitRepo pins the repo-pollution
+// guard: a *defaulted* (nobody explicitly asked) project-scope write into a
+// git worktree must carry a real warning, since the new AGENTS.md will show up
+// in git status and could get swept into someone's next commit.
+func TestSkillInitDefaultedProjectScopeWarnsInsideGitRepo(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	if err := os.Mkdir(filepath.Join(cwd, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Chdir(cwd)
+
+	out := new(bytes.Buffer)
+	app := testApp(t)
+	stubDetect(t, app, home, cwd, "codex")
+	app.Out = out
+	app.Err = out
+	cmd := newSkillCmd(app)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"init", "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init --yes with detected codex: %v", err)
+	}
+	if !strings.Contains(out.String(), "git status") || !strings.Contains(out.String(), "--scope user") {
+		t.Errorf("defaulted project-scope write inside a git repo must warn and name --scope user:\n%s", out.String())
+	}
+	if _, err := os.Stat(filepath.Join(cwd, "AGENTS.md")); err != nil {
+		t.Fatalf("the write itself must still happen (warning, not refusal): %v", err)
+	}
 }
 
 // TestSkillListPrettyShowsEveryInstall pins the human listing: detection and

--- a/cli/internal/cmd/skill_test.go
+++ b/cli/internal/cmd/skill_test.go
@@ -88,18 +88,16 @@ func TestSkillInitUnknownOperatorErrors(t *testing.T) {
 	}
 }
 
-// stubDetect replaces detectEnv for one test with a deterministic environment:
-// detection fires only for the named operators (via PATH lookup), never via
-// the real machine's state.
-func stubDetect(t *testing.T, home, cwd string, detected ...string) {
+// stubDetect injects a deterministic detection environment into one test's
+// App: detection fires only for the named operators (via PATH lookup), never
+// via the real machine's state.
+func stubDetect(t *testing.T, app *App, home, cwd string, detected ...string) {
 	t.Helper()
-	old := detectEnv
-	t.Cleanup(func() { detectEnv = old })
 	byName := map[string]bool{}
 	for _, d := range detected {
 		byName[d] = true
 	}
-	detectEnv = func() (skillgen.DetectEnv, error) {
+	app.DetectEnv = func() (skillgen.DetectEnv, error) {
 		return skillgen.DetectEnv{
 			Home:   home,
 			Cwd:    cwd,
@@ -113,8 +111,8 @@ func TestSkillInitNoOperatorNonInteractiveErrorsWhenNothingDetected(t *testing.T
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Chdir(tmp)
-	stubDetect(t, tmp, tmp) // nothing detected
 	app := testApp(t)
+	stubDetect(t, app, tmp, tmp) // nothing detected
 	app.Out = new(bytes.Buffer)
 	cmd := newSkillCmd(app)
 	cmd.SetOut(app.Out)
@@ -136,10 +134,10 @@ func TestSkillInitNoOperatorNonInteractiveDefaultsToDetected(t *testing.T) {
 	cwd := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Chdir(cwd)
-	stubDetect(t, home, cwd, "claude")
 
 	out := new(bytes.Buffer)
 	app := testApp(t)
+	stubDetect(t, app, home, cwd, "claude")
 	app.Out = out
 	app.Err = out
 	cmd := newSkillCmd(app)
@@ -197,11 +195,11 @@ func TestSkillListJSONReportsInstalledAfterInit(t *testing.T) {
 	cwd := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Chdir(cwd)
-	stubDetect(t, home, cwd)
 
 	run := func(args ...string) string {
 		out := new(bytes.Buffer)
 		app := testApp(t)
+		stubDetect(t, app, home, cwd)
 		app.Out = out
 		app.Err = out
 		cmd := newSkillCmd(app)
@@ -227,14 +225,136 @@ func TestSkillListJSONReportsInstalledAfterInit(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &payload); err != nil {
 		t.Fatalf("list --json not valid JSON: %v\n%s", err, out)
 	}
+	// Guard against a vacuous pass: the assertions below run per operator, so
+	// an empty (or claude-less) payload must fail loudly, not silently.
+	if len(payload.Operators) < 5 {
+		t.Fatalf("expected >=5 operators, got %d", len(payload.Operators))
+	}
+	var sawClaude bool
 	for _, op := range payload.Operators {
 		want := op.Operator == "claude"
+		sawClaude = sawClaude || want
 		if op.Installed != want {
 			t.Errorf("%s installed = %v, want %v", op.Operator, op.Installed, want)
 		}
 		if want && op.InstalledPath != filepath.Join(home, ".claude", "skills", "jentic", "SKILL.md") {
 			t.Errorf("claude installed_path = %q", op.InstalledPath)
 		}
+	}
+	if !sawClaude {
+		t.Error("claude missing from list output")
+	}
+}
+
+// TestSkillInitNonInteractiveDefaultsToDetectedProjectScope covers the #755
+// fallback for a project-scoped operator: a detected codex must default into
+// the *project* AGENTS.md (the #552-ratified default), not the user scope.
+func TestSkillInitNonInteractiveDefaultsToDetectedProjectScope(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(cwd)
+
+	out := new(bytes.Buffer)
+	app := testApp(t)
+	stubDetect(t, app, home, cwd, "codex")
+	app.Out = out
+	app.Err = out
+	cmd := newSkillCmd(app)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"init", "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init --yes with detected codex: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, "AGENTS.md")); err != nil {
+		t.Fatalf("codex default is project scope; AGENTS.md not in cwd: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Error("user-scope codex AGENTS.md written despite project default")
+	}
+}
+
+// TestSkillListPrettyShowsEveryInstall pins the human listing: detection and
+// install state are separate lines (#752), and *both* coexisting installs of
+// one operator are shown — hiding the second would lie by omission.
+func TestSkillListPrettyShowsEveryInstall(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	env := skillgen.DetectEnv{
+		Home:   home,
+		Cwd:    cwd,
+		Lookup: func(name string) bool { return name == "claude" },
+		Stat:   func(p string) bool { _, err := os.Stat(p); return err == nil },
+	}
+	reg := skillgen.DefaultRegistry()
+	ad, _ := reg.Resolve("claude")
+	content, err := skillgen.Bundled("http://example.test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, scope := range []skillgen.Scope{skillgen.ScopeUser, skillgen.ScopeProject} {
+		if _, err := skillgen.Apply(ad, content, env, skillgen.ApplyOptions{Scope: scope}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out := new(bytes.Buffer)
+	app := testApp(t)
+	app.Out = out
+	detected := map[skillgen.Operator]bool{ad.Operator(): true}
+	if err := app.skillListPretty(reg, env, detected); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "(detected)") {
+		t.Errorf("detected tag missing:\n%s", got)
+	}
+	if !strings.Contains(got, "(user scope)") || !strings.Contains(got, "(project scope)") {
+		t.Errorf("both coexisting installs must be listed:\n%s", got)
+	}
+	if !strings.Contains(got, "installed: no") {
+		t.Errorf("uninstalled operators must say so:\n%s", got)
+	}
+}
+
+// TestSkillRemoveFindsNonDefaultScope proves `skill remove` without --scope
+// removes the install where it actually is: a --scope project install of a
+// user-default operator must still be found and stripped.
+func TestSkillRemoveFindsNonDefaultScope(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(cwd)
+
+	run := func(args ...string) string {
+		out := new(bytes.Buffer)
+		app := testApp(t)
+		stubDetect(t, app, home, cwd)
+		app.Out = out
+		app.Err = out
+		cmd := newSkillCmd(app)
+		cmd.SetOut(out)
+		cmd.SetErr(out)
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("skill %v: %v", args, err)
+		}
+		return out.String()
+	}
+
+	run("init", "--operator", "cursor", "--scope", "project", "--yes")
+	projSkill := filepath.Join(cwd, ".cursor", "skills", "jentic", "SKILL.md")
+	if _, err := os.Stat(projSkill); err != nil {
+		t.Fatalf("project-scoped install missing: %v", err)
+	}
+
+	out := run("remove", "--operator", "cursor")
+	if !strings.Contains(out, "removed from") {
+		t.Errorf("expected a removal, got:\n%s", out)
+	}
+	if _, err := os.Stat(projSkill); !os.IsNotExist(err) {
+		t.Error("project-scoped skill still present after remove without --scope")
 	}
 }
 

--- a/cli/internal/cmd/skill_test.go
+++ b/cli/internal/cmd/skill_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jentic/jentic-one/cli/internal/skillgen"
 )
 
 func TestSkillRegisteredOnAPIRoot(t *testing.T) {
@@ -86,19 +88,78 @@ func TestSkillInitUnknownOperatorErrors(t *testing.T) {
 	}
 }
 
-func TestSkillInitNoOperatorNonInteractiveErrors(t *testing.T) {
+// stubDetect replaces detectEnv for one test with a deterministic environment:
+// detection fires only for the named operators (via PATH lookup), never via
+// the real machine's state.
+func stubDetect(t *testing.T, home, cwd string, detected ...string) {
+	t.Helper()
+	old := detectEnv
+	t.Cleanup(func() { detectEnv = old })
+	byName := map[string]bool{}
+	for _, d := range detected {
+		byName[d] = true
+	}
+	detectEnv = func() (skillgen.DetectEnv, error) {
+		return skillgen.DetectEnv{
+			Home:   home,
+			Cwd:    cwd,
+			Lookup: func(name string) bool { return byName[name] },
+			Stat:   func(p string) bool { _, err := os.Stat(p); return err == nil },
+		}, nil
+	}
+}
+
+func TestSkillInitNoOperatorNonInteractiveErrorsWhenNothingDetected(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Chdir(tmp)
+	stubDetect(t, tmp, tmp) // nothing detected
 	app := testApp(t)
 	app.Out = new(bytes.Buffer)
 	cmd := newSkillCmd(app)
 	cmd.SetOut(app.Out)
 	cmd.SetErr(app.Out)
-	// --yes with no --operator and no TTY: must error rather than hang.
+	// --yes with no --operator, nothing detected: must error rather than hang
+	// or write somewhere arbitrary, and must name the flags to pass.
 	cmd.SetArgs([]string{"init", "--yes"})
-	if err := cmd.Execute(); err == nil {
-		t.Fatal("expected error when no operators and non-interactive")
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no operators given and none detected")
+	}
+	if !strings.Contains(err.Error(), "--operator") || !strings.Contains(err.Error(), "--all") {
+		t.Errorf("error should point at --operator/--all: %v", err)
+	}
+}
+
+func TestSkillInitNoOperatorNonInteractiveDefaultsToDetected(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(cwd)
+	stubDetect(t, home, cwd, "claude")
+
+	out := new(bytes.Buffer)
+	app := testApp(t)
+	app.Out = out
+	app.Err = out
+	cmd := newSkillCmd(app)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	// #755: --yes (or no TTY) with no --operator degrades to the detected
+	// operators instead of erroring, echoing the resolved targets first.
+	cmd.SetArgs([]string{"init", "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init --yes with a detected operator should not error: %v", err)
+	}
+	if !strings.Contains(out.String(), "defaulting to detected operators") {
+		t.Errorf("missing pre-write default echo: %q", out.String())
+	}
+	skill := filepath.Join(home, ".claude", "skills", "jentic", "SKILL.md")
+	if _, err := os.Stat(skill); err != nil {
+		t.Fatalf("skill not written to detected operator's user target: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Error("no AGENTS.md operator was detected; cwd must stay untouched")
 	}
 }
 
@@ -106,8 +167,13 @@ func TestSkillListJSON(t *testing.T) {
 	_, out := runSkill(t, "list", "--json")
 	var payload struct {
 		Operators []struct {
-			Operator string `json:"operator"`
-			Target   string `json:"target"`
+			Operator  string `json:"operator"`
+			Target    string `json:"target"`
+			Installed bool   `json:"installed"`
+			Installs  []struct {
+				Scope     string `json:"scope"`
+				Installed bool   `json:"installed"`
+			} `json:"installs"`
 		} `json:"operators"`
 	}
 	if err := json.Unmarshal([]byte(out), &payload); err != nil {
@@ -115,6 +181,60 @@ func TestSkillListJSON(t *testing.T) {
 	}
 	if len(payload.Operators) < 5 {
 		t.Errorf("expected >=5 operators, got %d", len(payload.Operators))
+	}
+	for _, op := range payload.Operators {
+		if op.Installed {
+			t.Errorf("%s reports installed in a fresh environment (#752: detected must not imply installed)", op.Operator)
+		}
+		if len(op.Installs) == 0 {
+			t.Errorf("%s missing per-scope install states", op.Operator)
+		}
+	}
+}
+
+func TestSkillListJSONReportsInstalledAfterInit(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Chdir(cwd)
+	stubDetect(t, home, cwd)
+
+	run := func(args ...string) string {
+		out := new(bytes.Buffer)
+		app := testApp(t)
+		app.Out = out
+		app.Err = out
+		cmd := newSkillCmd(app)
+		cmd.SetOut(out)
+		cmd.SetErr(out)
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("skill %v: %v", args, err)
+		}
+		return out.String()
+	}
+
+	run("init", "--operator", "claude", "--yes")
+	out := run("list", "--json")
+
+	var payload struct {
+		Operators []struct {
+			Operator      string `json:"operator"`
+			Installed     bool   `json:"installed"`
+			InstalledPath string `json:"installed_path"`
+		} `json:"operators"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("list --json not valid JSON: %v\n%s", err, out)
+	}
+	for _, op := range payload.Operators {
+		want := op.Operator == "claude"
+		if op.Installed != want {
+			t.Errorf("%s installed = %v, want %v", op.Operator, op.Installed, want)
+		}
+		if want && op.InstalledPath != filepath.Join(home, ".claude", "skills", "jentic", "SKILL.md") {
+			t.Errorf("claude installed_path = %q", op.InstalledPath)
+		}
 	}
 }
 

--- a/cli/internal/skillgen/adapters.go
+++ b/cli/internal/skillgen/adapters.go
@@ -224,7 +224,8 @@ func (a agentsAdapter) Aliases() []string  { return a.aliases }
 // file, and codex only auto-loads a user-global copy from ~/.codex. Ratified
 // in #552 alongside the dir-skill user default; TestDefaultScopePolicy
 // tripwires any change. Interactive runs confirm placement via the scope
-// prompt; non-interactive runs echo the resolved target before writing.
+// prompt; defaulted non-interactive runs echo the resolved target before
+// writing (explicit --operator/--all runs already chose; --dry-run previews).
 func (a agentsAdapter) DefaultScope() Scope { return ScopeProject }
 
 func (a agentsAdapter) Target(scope Scope, env DetectEnv) string {

--- a/cli/internal/skillgen/adapters.go
+++ b/cli/internal/skillgen/adapters.go
@@ -108,6 +108,9 @@ func (a dirSkillAdapter) Aliases() []string  { return a.aliases }
 // skills dir behind). A "how to use Jentic" capability isn't tied to one repo,
 // so default to user scope (~/.claude|.cursor/skills), available everywhere.
 // Pass --scope project to pin it to a specific checkout.
+//
+// Ratified as the deliberate policy in #552 (claude/cursor/hermes → user,
+// codex/generic → project); TestDefaultScopePolicy tripwires any change.
 func (dirSkillAdapter) DefaultScope() Scope { return ScopeUser }
 
 func (a dirSkillAdapter) Target(scope Scope, env DetectEnv) string {
@@ -214,8 +217,14 @@ type agentsAdapter struct {
 	detect  func(env DetectEnv) bool
 }
 
-func (a agentsAdapter) Operator() Operator  { return a.op }
-func (a agentsAdapter) Aliases() []string   { return a.aliases }
+func (a agentsAdapter) Operator() Operator { return a.op }
+func (a agentsAdapter) Aliases() []string  { return a.aliases }
+
+// DefaultScope is project: AGENTS.md is the cross-tool *repo* instruction
+// file, and codex only auto-loads a user-global copy from ~/.codex. Ratified
+// in #552 alongside the dir-skill user default; TestDefaultScopePolicy
+// tripwires any change. Interactive runs confirm placement via the scope
+// prompt; non-interactive runs echo the resolved target before writing.
 func (a agentsAdapter) DefaultScope() Scope { return ScopeProject }
 
 func (a agentsAdapter) Target(scope Scope, env DetectEnv) string {

--- a/cli/internal/skillgen/status.go
+++ b/cli/internal/skillgen/status.go
@@ -19,6 +19,11 @@ type InstallState struct {
 // errors are treated as "not installed": list is a status probe, not a write
 // path, so a permission problem should degrade to a false rather than fail
 // the whole listing.
+//
+// Operators can share a target (codex and generic both splice into the
+// project AGENTS.md): a block written via either is reported as installed for
+// both. That is deliberate — "installed" describes the artifact on disk, which
+// both runtimes genuinely load, not which operator name wrote it.
 func InstallStates(a Adapter, env DetectEnv) []InstallState {
 	states := make([]InstallState, 0, 2)
 	seen := map[string]bool{}
@@ -39,17 +44,6 @@ func InstallStates(a Adapter, env DetectEnv) []InstallState {
 		states = append(states, st)
 	}
 	return states
-}
-
-// Installed reports whether any placement scope of the adapter holds a managed
-// block, returning the first installed state when so.
-func Installed(a Adapter, env DetectEnv) (InstallState, bool) {
-	for _, st := range InstallStates(a, env) {
-		if st.Installed {
-			return st, true
-		}
-	}
-	return InstallState{}, false
 }
 
 // otherScope returns the opposite placement scope.

--- a/cli/internal/skillgen/status.go
+++ b/cli/internal/skillgen/status.go
@@ -1,0 +1,61 @@
+package skillgen
+
+import "os"
+
+// InstallState reports whether one adapter target actually holds a managed
+// Jentic skill block. "Detected" (the operator looks present) and "installed"
+// (the skill file exists with our managed block) are different facts — see
+// jentic-one#752, where conflating them made `skill list` claim a skill that
+// was never written.
+type InstallState struct {
+	Scope     Scope  // placement the state was probed at
+	Path      string // resolved target for that scope
+	Installed bool   // the target exists and contains a managed block
+	UserEdits bool   // the managed block's body no longer matches its hash
+}
+
+// InstallStates probes every placement scope of one adapter and reports, per
+// scope, whether a managed skill block is actually installed there. Read
+// errors are treated as "not installed": list is a status probe, not a write
+// path, so a permission problem should degrade to a false rather than fail
+// the whole listing.
+func InstallStates(a Adapter, env DetectEnv) []InstallState {
+	states := make([]InstallState, 0, 2)
+	seen := map[string]bool{}
+	for _, scope := range []Scope{a.DefaultScope(), otherScope(a.DefaultScope())} {
+		target := a.Target(scope, env)
+		if seen[target] {
+			continue
+		}
+		seen[target] = true
+		st := InstallState{Scope: scope, Path: target}
+		if data, err := os.ReadFile(target); err == nil { //nolint:gosec // target comes from adapter rules + env, not user input.
+			norm := []byte(normalizeNewlines(string(data)))
+			if blk := findBlock(norm); blk.found {
+				st.Installed = true
+				st.UserEdits = blockUserEdited(norm, blk)
+			}
+		}
+		states = append(states, st)
+	}
+	return states
+}
+
+// Installed reports whether any placement scope of the adapter holds a managed
+// block, returning the first installed state when so.
+func Installed(a Adapter, env DetectEnv) (InstallState, bool) {
+	for _, st := range InstallStates(a, env) {
+		if st.Installed {
+			return st, true
+		}
+	}
+	return InstallState{}, false
+}
+
+// otherScope returns the opposite placement scope.
+func otherScope(s Scope) Scope {
+	if s == ScopeUser {
+		return ScopeProject
+	}
+	return ScopeUser
+}

--- a/cli/internal/skillgen/status_test.go
+++ b/cli/internal/skillgen/status_test.go
@@ -7,6 +7,19 @@ import (
 	"testing"
 )
 
+// installed reports whether any placement scope of the adapter holds a managed
+// block, returning the first installed state when so. Test-side convenience
+// over InstallStates (production callers want every state — a user and a
+// project install can coexist).
+func installed(a Adapter, env DetectEnv) (InstallState, bool) {
+	for _, st := range InstallStates(a, env) {
+		if st.Installed {
+			return st, true
+		}
+	}
+	return InstallState{}, false
+}
+
 // TestDefaultScopePolicy pins the placement policy ratified in #552: dir-skill
 // runtimes (claude/cursor) and hermes install user-globally so the skill is
 // available from any directory; AGENTS.md operators (codex/generic) install
@@ -50,16 +63,16 @@ func TestInstallStatesSeparatesDetectionFromInstall(t *testing.T) {
 	if !ad.Detect(env) {
 		t.Fatal("claude should be detected via PATH")
 	}
-	if _, ok := Installed(ad, env); ok {
-		t.Fatal("nothing written yet; Installed must be false even when detected")
+	if _, ok := installed(ad, env); ok {
+		t.Fatal("nothing written yet; installed must be false even when detected")
 	}
 
 	if _, err := Apply(ad, testContent(), env, ApplyOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	st, ok := Installed(ad, env)
+	st, ok := installed(ad, env)
 	if !ok {
-		t.Fatal("skill written; Installed must be true")
+		t.Fatal("skill written; installed must be true")
 	}
 	if st.Scope != ScopeUser {
 		t.Errorf("installed scope = %q, want user", st.Scope)
@@ -78,11 +91,11 @@ func TestInstallStatesProbesBothScopes(t *testing.T) {
 	env := DetectEnv{Home: home, Cwd: cwd}
 	ad, _ := DefaultRegistry().Resolve("cursor")
 
-	// Install into the NON-default (project) scope; Installed must still find it.
+	// Install into the NON-default (project) scope; it must still be found.
 	if _, err := Apply(ad, testContent(), env, ApplyOptions{Scope: ScopeProject}); err != nil {
 		t.Fatal(err)
 	}
-	st, ok := Installed(ad, env)
+	st, ok := installed(ad, env)
 	if !ok {
 		t.Fatal("project-scoped install not found")
 	}
@@ -114,11 +127,76 @@ func TestInstallStatesReportsUserEdits(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	st, ok := Installed(ad, env)
+	st, ok := installed(ad, env)
 	if !ok {
 		t.Fatal("edited block is still installed")
 	}
 	if !st.UserEdits {
 		t.Error("in-block edit must be reported as UserEdits")
+	}
+}
+
+// TestInstallStatesSharedTarget pins the deliberate cross-operator semantics:
+// codex and generic splice into the same project AGENTS.md, so a block written
+// via one reports as installed for both — "installed" describes the artifact
+// both runtimes load, not which operator name wrote it.
+func TestInstallStatesSharedTarget(t *testing.T) {
+	env := DetectEnv{Home: t.TempDir(), Cwd: t.TempDir()}
+	reg := DefaultRegistry()
+	codex, _ := reg.Resolve("codex")
+	generic, _ := reg.Resolve("generic")
+	if codex.Target(ScopeProject, env) != generic.Target(ScopeProject, env) {
+		t.Fatal("codex and generic no longer share the project AGENTS.md; update the shared-target semantics in InstallStates")
+	}
+
+	if _, err := Apply(codex, testContent(), env, ApplyOptions{Scope: ScopeProject}); err != nil {
+		t.Fatal(err)
+	}
+	st, ok := installed(generic, env)
+	if !ok || st.Scope != ScopeProject {
+		t.Fatalf("generic must report the codex-written project AGENTS.md as installed, got ok=%v state=%+v", ok, st)
+	}
+}
+
+// TestInstallStatesDedupesEqualTargets covers Home == Cwd (running from $HOME):
+// both scopes resolve to the same path, so only one state — labeled with the
+// adapter's default scope, which is probed first — must be reported.
+func TestInstallStatesDedupesEqualTargets(t *testing.T) {
+	dir := t.TempDir()
+	env := DetectEnv{Home: dir, Cwd: dir}
+	ad, _ := DefaultRegistry().Resolve("claude")
+
+	states := InstallStates(ad, env)
+	if len(states) != 1 {
+		t.Fatalf("equal targets must collapse to one state, got %d", len(states))
+	}
+	if states[0].Scope != ad.DefaultScope() {
+		t.Errorf("collapsed state labeled %q, want the default scope %q", states[0].Scope, ad.DefaultScope())
+	}
+}
+
+// TestInstallStatesReadErrorDegrades pins the documented policy that a probe
+// read error means "not installed" rather than failing the listing.
+func TestInstallStatesReadErrorDegrades(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root ignores file permissions")
+	}
+	home := t.TempDir()
+	env := DetectEnv{Home: home, Cwd: t.TempDir()}
+	ad, _ := DefaultRegistry().Resolve("claude")
+
+	out, err := Apply(ad, testContent(), env, ApplyOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(out.Path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(out.Path, 0o644) })
+
+	for _, st := range InstallStates(ad, env) {
+		if st.Path == out.Path && st.Installed {
+			t.Error("unreadable target must degrade to not-installed")
+		}
 	}
 }

--- a/cli/internal/skillgen/status_test.go
+++ b/cli/internal/skillgen/status_test.go
@@ -1,0 +1,124 @@
+package skillgen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDefaultScopePolicy pins the placement policy ratified in #552: dir-skill
+// runtimes (claude/cursor) and hermes install user-globally so the skill is
+// available from any directory; AGENTS.md operators (codex/generic) install
+// into the project. Changing a DefaultScope must be a deliberate decision —
+// update this test AND the #552 discussion, not just the adapter.
+func TestDefaultScopePolicy(t *testing.T) {
+	want := map[Operator]Scope{
+		OpClaude:  ScopeUser,
+		OpCursor:  ScopeUser,
+		OpHermes:  ScopeUser,
+		OpCodex:   ScopeProject,
+		OpGeneric: ScopeProject,
+	}
+	reg := DefaultRegistry()
+	if len(reg.Adapters()) != len(want) {
+		t.Fatalf("registry has %d adapters, policy table has %d — add the new operator to the #552 policy", len(reg.Adapters()), len(want))
+	}
+	for op, scope := range want {
+		ad, ok := reg.Resolve(string(op))
+		if !ok {
+			t.Fatalf("operator %s missing from registry", op)
+		}
+		if got := ad.DefaultScope(); got != scope {
+			t.Errorf("%s DefaultScope = %q, want %q (ratified in #552)", op, got, scope)
+		}
+	}
+}
+
+func TestInstallStatesSeparatesDetectionFromInstall(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	env := DetectEnv{
+		Home: home,
+		Cwd:  cwd,
+		// Detection fires (binary on PATH) even though nothing is installed —
+		// the exact #752 scenario.
+		Lookup: func(name string) bool { return name == "claude" },
+		Stat:   func(p string) bool { _, err := os.Stat(p); return err == nil },
+	}
+	ad, _ := DefaultRegistry().Resolve("claude")
+	if !ad.Detect(env) {
+		t.Fatal("claude should be detected via PATH")
+	}
+	if _, ok := Installed(ad, env); ok {
+		t.Fatal("nothing written yet; Installed must be false even when detected")
+	}
+
+	if _, err := Apply(ad, testContent(), env, ApplyOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	st, ok := Installed(ad, env)
+	if !ok {
+		t.Fatal("skill written; Installed must be true")
+	}
+	if st.Scope != ScopeUser {
+		t.Errorf("installed scope = %q, want user", st.Scope)
+	}
+	if want := filepath.Join(home, ".claude", "skills", "jentic", "SKILL.md"); st.Path != want {
+		t.Errorf("installed path = %q, want %q", st.Path, want)
+	}
+	if st.UserEdits {
+		t.Error("fresh install must not report user edits")
+	}
+}
+
+func TestInstallStatesProbesBothScopes(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	env := DetectEnv{Home: home, Cwd: cwd}
+	ad, _ := DefaultRegistry().Resolve("cursor")
+
+	// Install into the NON-default (project) scope; Installed must still find it.
+	if _, err := Apply(ad, testContent(), env, ApplyOptions{Scope: ScopeProject}); err != nil {
+		t.Fatal(err)
+	}
+	st, ok := Installed(ad, env)
+	if !ok {
+		t.Fatal("project-scoped install not found")
+	}
+	if st.Scope != ScopeProject {
+		t.Errorf("installed scope = %q, want project", st.Scope)
+	}
+
+	states := InstallStates(ad, env)
+	if len(states) != 2 {
+		t.Fatalf("cursor has two distinct targets, got %d states", len(states))
+	}
+}
+
+func TestInstallStatesReportsUserEdits(t *testing.T) {
+	home := t.TempDir()
+	env := DetectEnv{Home: home, Cwd: t.TempDir()}
+	ad, _ := DefaultRegistry().Resolve("generic")
+
+	out, err := Apply(ad, testContent(), env, ApplyOptions{Scope: ScopeUser})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(out.Path)
+	tampered := strings.Replace(string(data), "jentic register", "jentic register --tampered", 1)
+	if tampered == string(data) {
+		t.Fatal("tamper target not found in written skill")
+	}
+	if err := os.WriteFile(out.Path, []byte(tampered), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	st, ok := Installed(ad, env)
+	if !ok {
+		t.Fatal("edited block is still installed")
+	}
+	if !st.UserEdits {
+		t.Error("in-block edit must be reported as UserEdits")
+	}
+}

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -1171,7 +1171,7 @@
               "path": "jentic skill init",
               "use": "init",
               "short": "Generate the Jentic skill for one or more operators",
-              "long": "init detects which agent runtimes you have, lets you pick the targets\n(or pass --operator), and writes the Jentic CLI-usage skill into each\none's native layout.",
+              "long": "init detects which agent runtimes you have, lets you pick the targets\nand placement (or pass --operator/--scope), and writes the Jentic\nCLI-usage skill into each one's native layout.\n\nNon-interactively (--yes, pipes, agent sessions) it defaults to the\ndetected operators, echoing each resolved path before writing.",
               "example": "  jentic skill init\n  jentic skill init --operator claude,cursor\n  jentic skill init --all --yes\n  jentic skill init --operator generic --dry-run",
               "flags": [
                 {
@@ -1212,7 +1212,7 @@
                   "name": "yes",
                   "type": "bool",
                   "default": "false",
-                  "usage": "skip the interactive picker (use --operator/--all)"
+                  "usage": "non-interactive: no pickers; with no --operator/--all, target the detected operators"
                 }
               ]
             },
@@ -1220,7 +1220,7 @@
               "name": "list",
               "path": "jentic skill list",
               "use": "list",
-              "short": "Show supported operators and which are detected in this environment",
+              "short": "Show supported operators: which are detected and where the skill is installed",
               "flags": [
                 {
                   "name": "json",

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -83,7 +83,7 @@
               "shorthand": "y",
               "type": "bool",
               "default": "false",
-              "usage": "non-interactive: use flags + defaults, no prompts"
+              "usage": "non-interactive: no prompts; with no --operator/--all, the skill targets the detected operators"
             }
           ]
         },
@@ -1171,7 +1171,7 @@
               "path": "jentic skill init",
               "use": "init",
               "short": "Generate the Jentic skill for one or more operators",
-              "long": "init detects which agent runtimes you have, lets you pick the targets\nand placement (or pass --operator/--scope), and writes the Jentic\nCLI-usage skill into each one's native layout.\n\nNon-interactively (--yes, pipes, agent sessions) it defaults to the\ndetected operators, echoing each resolved path before writing.",
+              "long": "init detects which agent runtimes you have, lets you pick the targets\nand placement (or pass --operator/--scope), and writes the Jentic\nCLI-usage skill into each one's native layout.\n\nPassing --operator or --all skips every prompt, including the placement\none: each operator uses its default scope unless --scope is given\n(preview with --dry-run).\n\nNon-interactively (--yes, pipes, agent sessions) it defaults to the\ndetected operators, echoing each resolved path before writing.",
               "example": "  jentic skill init\n  jentic skill init --operator claude,cursor\n  jentic skill init --all --yes\n  jentic skill init --operator generic --dry-run",
               "flags": [
                 {
@@ -1264,7 +1264,7 @@
                 {
                   "name": "scope",
                   "type": "string",
-                  "usage": "placement scope: user or project (default: per-operator)"
+                  "usage": "placement scope to remove from: user or project (default: every scope where the skill is installed)"
                 }
               ]
             }


### PR DESCRIPTION
Closes #752. Closes #552. Advances #755 (the CLI dead-end half — see below).

## What broke (and for whom)

An agent session (Claude Code, Cursor, any scripted shell) trying to self-install the Jentic skill hit two walls:

1. **`jentic skill list` lied**: it showed `claude` as `detected: true` with a target path even when `~/.claude/skills/jentic/SKILL.md` was never written. "The runtime exists" and "the skill is installed" were conflated — the root cause of Claude Desktop silently not reaching self-hosted jentic-one (#752).
2. **`jentic skill init` was a dead end off-TTY**: with no `--operator`, it aborted with *"no operators given … no terminal to prompt"* — exactly in the non-interactive contexts where agents live (#755).

And underneath both, the **placement scope** (HOME vs CWD) was decided silently, per-operator, in code — flagged in #552 as an unratified drift from the design doc.

## What this PR does

### `skill list` — detection ≠ installation (#752)

New `skillgen.InstallStates` probes **both** placement scopes of every adapter for an actual managed block (and re-hashes it to spot manual edits). Human output now shows every scope that actually holds an install (a user and a project install can coexist), or `installed: no` + the would-be target; JSON adds `installed`, `installed_path`, and a per-scope `installs` array (existing fields untouched — additive only).

```
● claude (detected)
    installed ~/.claude/skills/jentic/SKILL.md (user scope)
● cursor (detected)
    installed no
    target ~/.cursor/skills/jentic/SKILL.md
```

### `skill init` / `bootstrap` — graceful non-interactive default (#755)

No TTY (pipes, CI, agent sessions) or `--yes`, and no `--operator`/`--all`? Instead of erroring, it now targets the **detected** operators and echoes every resolved scope+path **before** writing:

```
No --operator/--all given; defaulting to detected operators (--operator/--all overrides):
  claude   -> ~/.claude/skills/jentic/SKILL.md (user scope)
Jentic skill
  claude   created ~/.claude/skills/jentic/SKILL.md (user scope)
```

If nothing is detected either, the error now names the exact flags and supported operators. `bootstrap` inherits all of this (selection still validated before any irreversible registration).

**Why "Advances", not "Closes":** this fixes the CLI dead-end and the lying `list`, but #755's third ask — a first-class documented "connect this Claude Code session to self-hosted jentic-one" flow — is a docs deliverable that belongs with the roadmap's docs PR, so #755 stays open until that lands.

### Placement policy — ratified + visible (#552)

Decision (per maintainer): **keep the current split** — `claude`/`cursor`/`hermes` → user scope, `codex`/`generic` → project scope — and make it impossible to change silently or land somewhere invisible:

- `TestDefaultScopePolicy` tripwires every adapter's `DefaultScope()` (and fails if a new operator isn't added to the policy table).
- Interactive `skill init` now **asks placement per selected operator**, showing the exact resolved path for each choice, with the ratified default pre-selected (Enter keeps today's behavior).
- Every write path prints the scope next to the path; the non-interactive *defaulted* path echoes targets pre-write. Explicit `--operator`/`--all` runs deliberately don't get an extra pre-write echo (the user already chose; `--dry-run` previews placement) — the help text now spells this out.
- The design doc (`issue-592-operator-skill-generation.md`, private rules repo) got a "superseded — ratified in #552" note reconciling the drift.

## Selection flow after this PR

```mermaid
flowchart TD
    A["jentic skill init"] --> B{"--operator / --all?"}
    B -- yes --> T["resolve targets<br/>(flag scope or ratified default)"]
    B -- no --> C{"promptable?<br/>(TTY, TERM≠dumb, not --yes)"}
    C -- yes --> P["multi-select picker<br/>(detected pre-checked)"]
    P --> S{"--scope given?"}
    S -- no --> Q["per-operator scope prompt<br/>(paths shown, default pre-selected)"]
    S -- yes --> T
    Q --> T
    C -- no --> D{"any operators detected?"}
    D -- yes --> E["default to detected +<br/>echo scope+path pre-write"] --> T
    D -- no --> F["error: pass --operator &lt;names&gt; or --all"]
    T --> W["write managed blocks<br/>(outcome lines include scope)"]
```

## Review fixes (follow-up commits)

A multi-context review pass (Bugbot + five focused reviewers) produced these fixes.

In `a6afea0`:

- **`bootstrap --skip-skill --scope typo` no longer silently ignored** — flags are validated before anything else, with a regression test proving no registration happens.
- **Pretty `skill list` shows every install**, not just the first found scope (user + project can coexist).
- **`skill remove` without `--scope` removes the install where it actually is** — it probes both scopes instead of only the default, so a `--scope project` install of a user-default operator is found and stripped.
- **`detectEnv` is now an injected `App.DetectEnv` field** (nil = real OS probe) instead of a mutable package var, keeping commands constructor-built with no global state.
- **Shared-target semantics documented and pinned**: codex and generic splice into the same project `AGENTS.md`, so a block written via either reports as installed for both — deliberate ("installed" describes the artifact both runtimes load), now stated in `InstallStates`' doc and tripwired by a test.
- **New pinning tests**: Home==Cwd target dedupe, unreadable target degrades to "not installed", codex non-interactive fallback lands in project scope, vacuous-pass guard on the list-after-init assertion, human `skill list` output.
- Help text: `init` documents that `--operator`/`--all` skips prompts; `remove --scope` documents the "wherever installed" default; `bootstrap --yes` documents the detected-operator fallback. `cli-reference.json` regenerated.

In `73db42f` (agent-UX contract review, black-box verified on a pty):

- **Esc/Ctrl-C in the pickers now follows the CLI's cancel idiom** — dim `Cancelled.`, exit 0 — instead of `error: user aborted` with exit 1, in both `skill init` and bootstrap's skill step (bootstrap previously had *both* behaviors within one command).
- **Repo-pollution guard (#552)**: the defaulted non-interactive fallback warns when a project-scope target sits inside a git worktree ("will appear in git status; pass `--scope user` …"). Warning, not refusal — an agent asking for the skill in the repo it's working in is usually the intent; explicit `--operator codex` runs are unaffected. Pinned by tests both ways.
- **`bootstrap`'s nothing-detected error names `--skip-skill`** as the identity-only escape hatch for headless boxes (via a sentinel, so only that case gets the hint).

In `0c1de51` (found by exhaustive live testing on real ptys — see Verification):

- **`TERM=dumb` no longer opens an inescapable picker.** On a real TTY with `TERM=dumb` (emacs shells, expect/pty agent harnesses), `huh` silently falls back to numbered "accessible" prompts that ignore Esc **and** Ctrl-C (the CLI's process-wide `signal.NotifyContext` swallows the SIGINT; huh's accessible loop never checks the context) — only `kill -9` got you out. `promptable()` now requires a stdin TTY *and* `TERM != dumb`; dumb terminals take the #755 detected-operator default (or the exact-flags error) instead of a picker. The CLI-wide version of this bug (every other `huh` form still traps on `TERM=dumb`) is filed as #841.

## Also in here

- Stale `#277` reference in `canonicalContent` updated to #651 (the deployment now serves the same canonical skill — PR #810).
- `ui/public/cli-reference.json` regenerated (help texts updated for the new behavior).

## Verification

- `go test ./...`, `go test -race` on cmd+skillgen, `go vet`, `golangci-lint` — all green (re-run after each fix commit).
- **Exhaustive manual test of the whole funnel against the real binary** (isolated `$HOME`/`$CWD`/`PATH` sandboxes per scenario):
  - **55 scripted non-TTY scenarios, all passing**: fresh-env `list` JSON shape; nothing-detected errors (init + bare `jentic skill` + bootstrap w/ `--skip-skill` hint); detected→default→echo→create→idempotent re-run; git-worktree warning present inside a repo and absent outside; unknown operator / `--operator`+`--all` / bad `--scope` validation on init *and* remove; dry-run writes nothing (init, remove, bootstrap); manual-edit guard (list flags `user_edits`, init refuses then `--force` restores, remove refuses then `--force` strips); remove with no `--scope` finds non-default-scope installs and strips coexisting user+project installs; AGENTS.md user content survives init *and* remove; hermes `api/jentic` layout; `--all` writes all five; shared codex/generic AGENTS.md semantics; Home==Cwd dedupe; bootstrap echoes targets before the (failing) registration and writes no skill after the identity step fails.
  - **Full-TUI pty scenarios** (expect, answering the terminal's OSC11/CPR queries): Esc and Ctrl-C in the operator picker → `Cancelled.` exit 0; Esc in the scope prompt → same; Enter-through → user-scope write; arrow-down → project-scope write; `--scope` on a TTY skips the scope prompt; deselect-all → `No operators selected.`; bootstrap Esc cancels before registration; pretty `list` shows every install.
  - **Dumb-terminal pty scenarios** (Python pty, `TERM=dumb`): pre-fix these trapped the user (uncancellable numbered picker — confirmed by SIGQUIT goroutine dump); post-fix they take the defaulting path (detected → echo + write; nothing → exact-flags error).

## Out of scope (follow-ups)

- `jenticctl update`/`uninstall` don't refresh/remove installed skills — tracked in #825.
- The #755 docs flow ("connect a Claude Code session to self-hosted jentic-one") — lands with the roadmap's docs PR.

Made with [Cursor](https://cursor.com)

