### PR TITLE
docs(monitor): correct stale trend-length and NULL-key comments

### DIFF
--- a/ui/src/modules/monitor/api/client.ts
+++ b/ui/src/modules/monitor/api/client.ts
@@ -133,7 +133,8 @@ export interface UsageStatsParams {
 /**
  * Full-parity usage aggregation (`GET /monitoring/usage`): overall stats
  * (incl. latency percentiles), time buckets for the volume chart, and top
- * api/toolkit/agent rows with 12-point sparkline trends.
+ * api/toolkit/agent rows with sparkline trends (one point per aggregate
+ * bucket in the window).
  */
 export async function getUsageStats(params: UsageStatsParams = {}): Promise<UsageResponse> {
 	try {

--- a/ui/src/modules/monitor/components/SparklineChart.tsx
+++ b/ui/src/modules/monitor/components/SparklineChart.tsx
@@ -1,7 +1,9 @@
 /**
  * SparklineChart — tiny inline trend line, ported 1:1 from jentic-mini
  * (`ui/src/components/monitor/shared/SparklineChart.tsx`). Renders the
- * 12-point `trend` arrays the usage endpoint returns per top row.
+ * `trend` arrays the usage endpoint returns per top row (one point per
+ * aggregate bucket — 24/28/30 for the standard windows); the path scales
+ * to any length ≥ 2.
  */
 import { useMemo } from 'react';
 import { cn } from '@/shared/lib/utils';

--- a/ui/src/modules/monitor/lib/usage.ts
+++ b/ui/src/modules/monitor/lib/usage.ts
@@ -53,11 +53,11 @@ export function usageToOverview(usage: UsageResponse): UsageOverview {
  * Format a top-row key into a display label, per grouping dimension. The
  * backend composes keys/labels mechanically (see monitoring_repo.grouped_top):
  *   api     → "vendor/name" with NULL columns coalesced to "unknown"
- *   toolkit → the raw toolkit_id (nullable → SQL NULL key)
- *   agent   → "actor_type/actor_id" (NULL propagates: `||` yields NULL, so
- *              unattributed executions arrive as a single null-key row)
- * We strip the mechanical prefixes for display and surface null/unknown
- * groups as an explicit "Unattributed" bucket, matching jentic-mini.
+ *   toolkit → the raw toolkit_id (NOT NULL column)
+ *   agent   → "actor_type/actor_id" (both NOT NULL columns)
+ * Keys are therefore never NULL on the wire today; the null branches below
+ * are defensive display fallbacks (surfaced as "Unattributed", matching
+ * jentic-mini) rather than a backend contract.
  */
 function formatEntityLabel(groupBy: string, key: string | null | undefined): string {
 	if (!key) return 'Unattributed';
@@ -76,9 +76,9 @@ function formatEntityLabel(groupBy: string, key: string | null | undefined): str
 
 /**
  * Map the response's `top` rows into entity rows, sorted busiest-first.
- * Null-key rows are executions with no attribution (NULL toolkit/actor
- * columns) — surfaced as an explicit "Unattributed" bucket rather than
- * silently dropped, matching jentic-mini.
+ * The attribution columns are NOT NULL so keys are always present today;
+ * empty/missing keys are still mapped to an explicit "Unattributed" bucket
+ * as a display fallback rather than silently dropped, matching jentic-mini.
  */
 export function usageToEntityRows(usage: UsageResponse | undefined): EntityUsageRow[] {
 	if (!usage) return [];
@@ -86,8 +86,6 @@ export function usageToEntityRows(usage: UsageResponse | undefined): EntityUsage
 		.map((row) => {
 			const total = row.total ?? 0;
 			const success = row.success ?? 0;
-			// The generated type says `key: string`, but the SQL key expression
-			// is nullable on the wire for toolkit/agent groupings.
 			const key = (row.key ?? null) as string | null;
 			return {
 				id: key || '__unattributed__',


### PR DESCRIPTION
## Summary
- Follow-up to #839, found while auditing the bubble chart and breakdown for the same windowing problems (both are clean — no code changes needed).
- `SparklineChart.tsx` and `api/client.ts` still described the old fixed "12-point" trend arrays; the trend length is now adaptive (one point per aggregate bucket: 24/28/30 for the standard windows).
- `lib/usage.ts` claimed toolkit/agent keys arrive as SQL `NULL` for unattributed executions — the attribution columns are `NOT NULL` and api columns are coalesced, so keys are never NULL on the wire. The "Unattributed" handling stays, re-documented as a defensive display fallback rather than a backend contract.

Comment-only change; no behavior differences.

## Test plan
- [x] `npm run lint`, `tsc -b --noEmit`
- [x] Full UI suite: 739 tests / 99 files pass
- [x] Visual check of bubble chart + breakdown at 375px and 1280px against the mocked dev server

Please squash + merge.

Made with [Cursor](https://cursor.com)