### PR TITLE
docs(skill): stopped-instance branch, backend-identity check, honest rule proposals

### DIFF
--- a/cli/internal/cmd/execute.go
+++ b/cli/internal/cmd/execute.go
@@ -106,7 +106,7 @@ func (a *App) executeE(cmd *cobra.Command, ident *identityOptions, opts *execute
 
 	// Resolve the broker target with precedence defaults < config.yaml < flags,
 	// mirroring `jentic run`. Without this, execute always targets the built-in
-	// default (broker.jentic.ai); a local install can point at its own broker via
+	// default (https://127.0.0.1:8100); an install can point at its own broker via
 	// ~/.jentic/config.yaml (broker.scheme/host) instead of passing flags on
 	// every call.
 	fileCfg, err := config.Load(a.Paths)

--- a/cli/internal/cmd/install.go
+++ b/cli/internal/cmd/install.go
@@ -285,8 +285,8 @@ func (a *App) recordManifest(draft *install.Draft) {
 // writeCLIConfig points the `jentic` CLI at the freshly installed local stack by
 // persisting the control-plane base URL and the local broker target into
 // ~/.jentic/config.yaml. Without this, `jentic execute` / `jentic run` fall back
-// to the built-in cloud defaults (https://broker.jentic.ai) and every brokered
-// call leaves the machine. Existing values are preserved (so a re-install or a
+// to the built-in defaults (https://127.0.0.1:8100), which may not match this
+// install's broker scheme/port. Existing values are preserved (so a re-install or a
 // hand-edited config is not clobbered); only unset fields are filled in. A
 // failure here is non-fatal: the stack is installed regardless, and the user can
 // set these by hand.

--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -94,15 +94,12 @@ after an approved `scope:grant` **and** only if `whoami` flags the scope as not
 yet on your token (see the stale-scope note it prints).
 
 **File once, richly — never thrash.** Work out the full access end-state up
-front — from `whoami`, the catalog, and the task — instead of discovering
-gaps one denied call at a time. A request's provisioning plan covers **one
-API**, so a job needing several APIs means several requests: file them all
-in one pass (one `--provision` per API, each complete: auth, rules, reason)
-rather than interleaving requests with failing executes — filed together,
-they read as one plan to the human approving them. Never
-file duplicate or per-operation requests for the same API, and don't
-file-withdraw-refile to tweak a proposal — approval is a human trust action,
-so once a request is filed, tell your operator an approval is waiting and
+front — from `whoami`, the catalog, and the task. A provisioning plan covers
+**one API**, so a job needing several APIs means several requests: file them
+all in one pass (one `--provision` per API, each complete: auth, rules,
+reason) — filed together they read as one plan to the approving human. Never
+file duplicate or per-operation requests, and don't withdraw-and-refile to
+tweak a proposal; once filed, tell your operator an approval is waiting and
 hand back (or `--wait`).
 
 If you'd rather be reactive, the broker also guides you: when `execute` is denied
@@ -308,17 +305,19 @@ jentic execute <operation_id> --query limit=10
 jentic execute GET:https://sheets.googleapis.com/v4/spreadsheets/{id}/values/{range} --path id=ABC --path range=A1:Z10
 ```
 
-**An `execute` failure splits three ways — check before you diagnose.** Only
-a broker **denial** (exit **2**, with an `agent_directive`) is an access
-problem. Exit **1** means the request never reached a broker at all, and that
-transport failure has two distinct causes with different recoveries:
+**Diagnose an `execute` failure by its symptom, not the exit code alone.** A
+broker **denial** prints an `agent_directive` on stderr (exit **2**). An
+error naming DNS, TLS, timeout, or connection refused is a **transport
+failure** — usually exit **1**, but exit **2** (`resolve … failed`) when the
+`operation_id` lookup hits an unreachable control plane — with two causes:
 
-- **Wrong target (DNS error).** The built-in default broker host is
-  `broker.jentic.ai`, which is unreachable on a local deployment — a DNS
-  error like `lookup broker.jentic.ai: no such host` means the broker target
-  is wrong, **not** an access problem. Point `execute` at the local broker
-  via `~/.jentic/config.yaml` (`broker.scheme` / `broker.host`) or per-call
-  flags:
+- **Wrong target (DNS or TLS error).** The broker target resolves as
+  built-in default (`https://127.0.0.1:8100`) < `~/.jentic/config.yaml`
+  (`broker.scheme` / `broker.host`, recorded by `jenticctl install`) <
+  flags. `lookup broker.jentic.ai: no such host` means the config points at
+  the hosted broker from a local install; a TLS error against a local
+  target usually means `broker.scheme` should be `http`. Fix the config, or
+  override per call:
 
 ```
 jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
@@ -363,8 +362,7 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
 - `jentic register` / `jentic bootstrap` — operator commands that create and
   approve this identity (they block on human approval; not for autonomous use).
 - `jenticctl status` / `jenticctl start` — health-check and restart the local
-  deployment (use when a **local** broker/control target refuses connections
-  before diagnosing anything else).
+  deployment; check this first when a local target refuses connections.
 - Add `--json` to force machine-readable output on a terminal.
 
 ## Pitfalls
@@ -388,16 +386,15 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   just imported "doesn't exist", credentials "disappeared", or operation ids
   from one surface don't resolve on the other. Before concluding anything is
   missing or broken, check where each surface points — `jentic profile list`
-  shows this CLI's `base_url` — and prefer this CLI for everything in one
-  deployment rather than mixing surfaces mid-task.
-- An `execute` failure is not always an access problem — exit **1** is a
-  transport failure, and its cause decides the recovery (see step 5): a DNS
-  error (`lookup broker.jentic.ai: no such host`) means the **broker target**
-  is wrong (point a local install at the local broker); connection refused on
-  a **local** target usually means the instance is **stopped** — run
-  `jenticctl status` to check, and if it's down tell the user to
+  shows this CLI's `base_url`; ask your operator which backend the MCP
+  server was configured against — and stick to one surface for the whole
+  task.
+- An `execute` failure is not always an access problem. A DNS or TLS error
+  means the **broker target** is misconfigured (see step 5); connection
+  refused on a **local** target usually means the instance is **stopped** —
+  run `jenticctl status`, and if it's down tell the user to
   `jenticctl start`, then retry rather than abandoning the task. Only a
-  broker **denial** (exit **2**, with an `agent_directive` on stderr) is an
+  broker **denial** (an `agent_directive` on stderr, exit **2**) is an
   access/credential issue:
   - **403 `no_toolkit_binding`** → check the directive's
     `parameters.toolkit_serves_api`. If `true`, a toolkit already serves the API

--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -93,6 +93,16 @@ bindings take effect live, and a plan grants no new token scope. Only refresh
 after an approved `scope:grant` **and** only if `whoami` flags the scope as not
 yet on your token (see the stale-scope note it prints).
 
+**File once, richly — never thrash.** Work out the full access end-state up
+front — from `whoami`, the catalog, and the task — instead of discovering
+gaps one denied call at a time. If the job needs several APIs, file the
+missing plans in one pass (one `--provision` per API, each complete: auth,
+rules, reason) rather than interleaving requests with failing executes. Never
+file duplicate or per-operation requests for the same API, and don't
+file-withdraw-refile to tweak a proposal — approval is a human trust action,
+so once a request is filed, tell your operator an approval is waiting and
+hand back (or `--wait`).
+
 If you'd rather be reactive, the broker also guides you: when `execute` is denied
 it prints a recovery line on stderr (the `agent_directive`) and **exits 2**, so
 you can branch on the exit code instead of mistaking the 4xx body for success.
@@ -161,6 +171,18 @@ approving. Do the work up front:
    `[{"effect":"allow","methods":["GET"],"path":".*"},
      {"effect":"allow","methods":["POST","PUT"],"path":"/boards/prod/.*"}]`.
    An `allow` rule must constrain at least one of `methods`/`path`/`operations`.
+   **Be honest at the enforcement seam.** The broker matches a rule against the
+   request's HTTP method, URL path, and OpenAPI operation id — **never the
+   request body**. An intent that hinges on a body field ("only allow messages
+   to the #general channel" when the channel is a POST-body field) **cannot be
+   enforced** by these rules. Don't propose a rule that silently won't fire —
+   say so, and offer the real choices: allow the operation broadly (the human
+   accepts the wider grant), deny the operation entirely, or allow it and
+   record the constraint as instructions you follow yourself (unenforced).
+   Also sanity-check your proposal before filing: rules evaluate
+   first-match-wins, so an early broad `allow` shadows every rule after it,
+   and a rule set that contradicts the intent you stated in `--reason` will
+   confuse the human reviewing it.
 4. You never enter the credential secret and you never approve — the human fills
    the secret in the dashboard and grants the plan. You propose; they decide.
 
@@ -284,15 +306,32 @@ jentic execute <operation_id> --query limit=10
 jentic execute GET:https://sheets.googleapis.com/v4/spreadsheets/{id}/values/{range} --path id=ABC --path range=A1:Z10
 ```
 
-**Local installs target a local broker.** The built-in default broker host is
-`broker.jentic.ai`, which is unreachable on a local deployment — a DNS error
-like `lookup broker.jentic.ai: no such host` means the broker target is wrong,
-**not** an access problem. Point `execute` at the local broker via
-`~/.jentic/config.yaml` (`broker.scheme` / `broker.host`) or per-call flags:
+**An `execute` failure splits three ways — check before you diagnose.** Only
+a broker **denial** (exit **2**, with an `agent_directive`) is an access
+problem. Exit **1** means the request never reached a broker at all, and that
+transport failure has two distinct causes with different recoveries:
+
+- **Wrong target (DNS error).** The built-in default broker host is
+  `broker.jentic.ai`, which is unreachable on a local deployment — a DNS
+  error like `lookup broker.jentic.ai: no such host` means the broker target
+  is wrong, **not** an access problem. Point `execute` at the local broker
+  via `~/.jentic/config.yaml` (`broker.scheme` / `broker.host`) or per-call
+  flags:
 
 ```
 jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
 ```
+
+- **Stopped instance (connection refused on a local target).** If the target
+  is already local (`127.0.0.1` / `localhost`) and the connection is
+  *refused*, the target is right and the instance is probably **not
+  running** (rebooted machine, Docker not started). Health-check before
+  concluding anything: `jenticctl status` reports whether the control-plane
+  server and broker are reachable. If they're down, do not retry, guess, or
+  quietly give up — tell the user plainly, e.g. *"Your Jentic One instance
+  appears to be stopped, which is why I can't reach {API}. Restart it with
+  `jenticctl start` (then `jenticctl status` to confirm), and I'll retry."*
+  After the restart, retry the original call and continue the task.
 
 ## Quick Reference
 
@@ -321,6 +360,9 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   forward proxy, not a path router).
 - `jentic register` / `jentic bootstrap` — operator commands that create and
   approve this identity (they block on human approval; not for autonomous use).
+- `jenticctl status` / `jenticctl start` — health-check and restart the local
+  deployment (use when a **local** broker/control target refuses connections
+  before diagnosing anything else).
 - Add `--json` to force machine-readable output on a terminal.
 
 ## Pitfalls
@@ -335,11 +377,26 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   `catalog:import` by default. (Importing arbitrary URL/inline specs via `POST
   /apis` is the only import path that needs `apis:write`.) Don't invent other
   "catalog read" scopes; they're rejected.
-- An `execute` failure is not always an access problem. A DNS/transport error
-  (`lookup broker.jentic.ai: no such host`, connection refused — exit **1**)
-  means the **broker target** is wrong; on a local install point at the local
-  broker. Only a broker **denial** (exit **2**, with an `agent_directive` on
-  stderr) is an access/credential issue:
+- **Verify which backend you're talking to before diagnosing "missing" APIs
+  or credentials.** If your session also has Jentic **MCP tools**
+  (`search_apis`, `list_credentials`, `execute`, …), they may be bound to a
+  **different backend** than this CLI — typically the hosted cloud workspace
+  vs the local install — and nothing in their responses says which one
+  replied. The symptom is *silent wrong answers*, not errors: an API the user
+  just imported "doesn't exist", credentials "disappeared", or operation ids
+  from one surface don't resolve on the other. Before concluding anything is
+  missing or broken, check where each surface points — `jentic profile list`
+  shows this CLI's `base_url` — and prefer this CLI for everything in one
+  deployment rather than mixing surfaces mid-task.
+- An `execute` failure is not always an access problem — exit **1** is a
+  transport failure, and its cause decides the recovery (see step 5): a DNS
+  error (`lookup broker.jentic.ai: no such host`) means the **broker target**
+  is wrong (point a local install at the local broker); connection refused on
+  a **local** target usually means the instance is **stopped** — run
+  `jenticctl status` to check, and if it's down tell the user to
+  `jenticctl start`, then retry rather than abandoning the task. Only a
+  broker **denial** (exit **2**, with an `agent_directive` on stderr) is an
+  access/credential issue:
   - **403 `no_toolkit_binding`** → check the directive's
     `parameters.toolkit_serves_api`. If `true`, a toolkit already serves the API
     and you just aren't bound — run the `jentic access request --toolkit …` it

--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -95,9 +95,11 @@ yet on your token (see the stale-scope note it prints).
 
 **File once, richly — never thrash.** Work out the full access end-state up
 front — from `whoami`, the catalog, and the task — instead of discovering
-gaps one denied call at a time. If the job needs several APIs, file the
-missing plans in one pass (one `--provision` per API, each complete: auth,
-rules, reason) rather than interleaving requests with failing executes. Never
+gaps one denied call at a time. A request's provisioning plan covers **one
+API**, so a job needing several APIs means several requests: file them all
+in one pass (one `--provision` per API, each complete: auth, rules, reason)
+rather than interleaving requests with failing executes — filed together,
+they read as one plan to the human approving them. Never
 file duplicate or per-operation requests for the same API, and don't
 file-withdraw-refile to tweak a proposal — approval is a human trust action,
 so once a request is filed, tell your operator an approval is waiting and

--- a/src/jentic_one/shared/web/content/jentic.md
+++ b/src/jentic_one/shared/web/content/jentic.md
@@ -94,15 +94,12 @@ after an approved `scope:grant` **and** only if `whoami` flags the scope as not
 yet on your token (see the stale-scope note it prints).
 
 **File once, richly — never thrash.** Work out the full access end-state up
-front — from `whoami`, the catalog, and the task — instead of discovering
-gaps one denied call at a time. A request's provisioning plan covers **one
-API**, so a job needing several APIs means several requests: file them all
-in one pass (one `--provision` per API, each complete: auth, rules, reason)
-rather than interleaving requests with failing executes — filed together,
-they read as one plan to the human approving them. Never
-file duplicate or per-operation requests for the same API, and don't
-file-withdraw-refile to tweak a proposal — approval is a human trust action,
-so once a request is filed, tell your operator an approval is waiting and
+front — from `whoami`, the catalog, and the task. A provisioning plan covers
+**one API**, so a job needing several APIs means several requests: file them
+all in one pass (one `--provision` per API, each complete: auth, rules,
+reason) — filed together they read as one plan to the approving human. Never
+file duplicate or per-operation requests, and don't withdraw-and-refile to
+tweak a proposal; once filed, tell your operator an approval is waiting and
 hand back (or `--wait`).
 
 If you'd rather be reactive, the broker also guides you: when `execute` is denied
@@ -308,17 +305,19 @@ jentic execute <operation_id> --query limit=10
 jentic execute GET:https://sheets.googleapis.com/v4/spreadsheets/{id}/values/{range} --path id=ABC --path range=A1:Z10
 ```
 
-**An `execute` failure splits three ways — check before you diagnose.** Only
-a broker **denial** (exit **2**, with an `agent_directive`) is an access
-problem. Exit **1** means the request never reached a broker at all, and that
-transport failure has two distinct causes with different recoveries:
+**Diagnose an `execute` failure by its symptom, not the exit code alone.** A
+broker **denial** prints an `agent_directive` on stderr (exit **2**). An
+error naming DNS, TLS, timeout, or connection refused is a **transport
+failure** — usually exit **1**, but exit **2** (`resolve … failed`) when the
+`operation_id` lookup hits an unreachable control plane — with two causes:
 
-- **Wrong target (DNS error).** The built-in default broker host is
-  `broker.jentic.ai`, which is unreachable on a local deployment — a DNS
-  error like `lookup broker.jentic.ai: no such host` means the broker target
-  is wrong, **not** an access problem. Point `execute` at the local broker
-  via `~/.jentic/config.yaml` (`broker.scheme` / `broker.host`) or per-call
-  flags:
+- **Wrong target (DNS or TLS error).** The broker target resolves as
+  built-in default (`https://127.0.0.1:8100`) < `~/.jentic/config.yaml`
+  (`broker.scheme` / `broker.host`, recorded by `jenticctl install`) <
+  flags. `lookup broker.jentic.ai: no such host` means the config points at
+  the hosted broker from a local install; a TLS error against a local
+  target usually means `broker.scheme` should be `http`. Fix the config, or
+  override per call:
 
 ```
 jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
@@ -363,8 +362,7 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
 - `jentic register` / `jentic bootstrap` — operator commands that create and
   approve this identity (they block on human approval; not for autonomous use).
 - `jenticctl status` / `jenticctl start` — health-check and restart the local
-  deployment (use when a **local** broker/control target refuses connections
-  before diagnosing anything else).
+  deployment; check this first when a local target refuses connections.
 - Add `--json` to force machine-readable output on a terminal.
 
 ## Pitfalls
@@ -388,16 +386,15 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   just imported "doesn't exist", credentials "disappeared", or operation ids
   from one surface don't resolve on the other. Before concluding anything is
   missing or broken, check where each surface points — `jentic profile list`
-  shows this CLI's `base_url` — and prefer this CLI for everything in one
-  deployment rather than mixing surfaces mid-task.
-- An `execute` failure is not always an access problem — exit **1** is a
-  transport failure, and its cause decides the recovery (see step 5): a DNS
-  error (`lookup broker.jentic.ai: no such host`) means the **broker target**
-  is wrong (point a local install at the local broker); connection refused on
-  a **local** target usually means the instance is **stopped** — run
-  `jenticctl status` to check, and if it's down tell the user to
+  shows this CLI's `base_url`; ask your operator which backend the MCP
+  server was configured against — and stick to one surface for the whole
+  task.
+- An `execute` failure is not always an access problem. A DNS or TLS error
+  means the **broker target** is misconfigured (see step 5); connection
+  refused on a **local** target usually means the instance is **stopped** —
+  run `jenticctl status`, and if it's down tell the user to
   `jenticctl start`, then retry rather than abandoning the task. Only a
-  broker **denial** (exit **2**, with an `agent_directive` on stderr) is an
+  broker **denial** (an `agent_directive` on stderr, exit **2**) is an
   access/credential issue:
   - **403 `no_toolkit_binding`** → check the directive's
     `parameters.toolkit_serves_api`. If `true`, a toolkit already serves the API

--- a/src/jentic_one/shared/web/content/jentic.md
+++ b/src/jentic_one/shared/web/content/jentic.md
@@ -93,6 +93,16 @@ bindings take effect live, and a plan grants no new token scope. Only refresh
 after an approved `scope:grant` **and** only if `whoami` flags the scope as not
 yet on your token (see the stale-scope note it prints).
 
+**File once, richly — never thrash.** Work out the full access end-state up
+front — from `whoami`, the catalog, and the task — instead of discovering
+gaps one denied call at a time. If the job needs several APIs, file the
+missing plans in one pass (one `--provision` per API, each complete: auth,
+rules, reason) rather than interleaving requests with failing executes. Never
+file duplicate or per-operation requests for the same API, and don't
+file-withdraw-refile to tweak a proposal — approval is a human trust action,
+so once a request is filed, tell your operator an approval is waiting and
+hand back (or `--wait`).
+
 If you'd rather be reactive, the broker also guides you: when `execute` is denied
 it prints a recovery line on stderr (the `agent_directive`) and **exits 2**, so
 you can branch on the exit code instead of mistaking the 4xx body for success.
@@ -161,6 +171,18 @@ approving. Do the work up front:
    `[{"effect":"allow","methods":["GET"],"path":".*"},
      {"effect":"allow","methods":["POST","PUT"],"path":"/boards/prod/.*"}]`.
    An `allow` rule must constrain at least one of `methods`/`path`/`operations`.
+   **Be honest at the enforcement seam.** The broker matches a rule against the
+   request's HTTP method, URL path, and OpenAPI operation id — **never the
+   request body**. An intent that hinges on a body field ("only allow messages
+   to the #general channel" when the channel is a POST-body field) **cannot be
+   enforced** by these rules. Don't propose a rule that silently won't fire —
+   say so, and offer the real choices: allow the operation broadly (the human
+   accepts the wider grant), deny the operation entirely, or allow it and
+   record the constraint as instructions you follow yourself (unenforced).
+   Also sanity-check your proposal before filing: rules evaluate
+   first-match-wins, so an early broad `allow` shadows every rule after it,
+   and a rule set that contradicts the intent you stated in `--reason` will
+   confuse the human reviewing it.
 4. You never enter the credential secret and you never approve — the human fills
    the secret in the dashboard and grants the plan. You propose; they decide.
 
@@ -284,15 +306,32 @@ jentic execute <operation_id> --query limit=10
 jentic execute GET:https://sheets.googleapis.com/v4/spreadsheets/{id}/values/{range} --path id=ABC --path range=A1:Z10
 ```
 
-**Local installs target a local broker.** The built-in default broker host is
-`broker.jentic.ai`, which is unreachable on a local deployment — a DNS error
-like `lookup broker.jentic.ai: no such host` means the broker target is wrong,
-**not** an access problem. Point `execute` at the local broker via
-`~/.jentic/config.yaml` (`broker.scheme` / `broker.host`) or per-call flags:
+**An `execute` failure splits three ways — check before you diagnose.** Only
+a broker **denial** (exit **2**, with an `agent_directive`) is an access
+problem. Exit **1** means the request never reached a broker at all, and that
+transport failure has two distinct causes with different recoveries:
+
+- **Wrong target (DNS error).** The built-in default broker host is
+  `broker.jentic.ai`, which is unreachable on a local deployment — a DNS
+  error like `lookup broker.jentic.ai: no such host` means the broker target
+  is wrong, **not** an access problem. Point `execute` at the local broker
+  via `~/.jentic/config.yaml` (`broker.scheme` / `broker.host`) or per-call
+  flags:
 
 ```
 jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
 ```
+
+- **Stopped instance (connection refused on a local target).** If the target
+  is already local (`127.0.0.1` / `localhost`) and the connection is
+  *refused*, the target is right and the instance is probably **not
+  running** (rebooted machine, Docker not started). Health-check before
+  concluding anything: `jenticctl status` reports whether the control-plane
+  server and broker are reachable. If they're down, do not retry, guess, or
+  quietly give up — tell the user plainly, e.g. *"Your Jentic One instance
+  appears to be stopped, which is why I can't reach {API}. Restart it with
+  `jenticctl start` (then `jenticctl status` to confirm), and I'll retry."*
+  After the restart, retry the original call and continue the task.
 
 ## Quick Reference
 
@@ -321,6 +360,9 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   forward proxy, not a path router).
 - `jentic register` / `jentic bootstrap` — operator commands that create and
   approve this identity (they block on human approval; not for autonomous use).
+- `jenticctl status` / `jenticctl start` — health-check and restart the local
+  deployment (use when a **local** broker/control target refuses connections
+  before diagnosing anything else).
 - Add `--json` to force machine-readable output on a terminal.
 
 ## Pitfalls
@@ -335,11 +377,26 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   `catalog:import` by default. (Importing arbitrary URL/inline specs via `POST
   /apis` is the only import path that needs `apis:write`.) Don't invent other
   "catalog read" scopes; they're rejected.
-- An `execute` failure is not always an access problem. A DNS/transport error
-  (`lookup broker.jentic.ai: no such host`, connection refused — exit **1**)
-  means the **broker target** is wrong; on a local install point at the local
-  broker. Only a broker **denial** (exit **2**, with an `agent_directive` on
-  stderr) is an access/credential issue:
+- **Verify which backend you're talking to before diagnosing "missing" APIs
+  or credentials.** If your session also has Jentic **MCP tools**
+  (`search_apis`, `list_credentials`, `execute`, …), they may be bound to a
+  **different backend** than this CLI — typically the hosted cloud workspace
+  vs the local install — and nothing in their responses says which one
+  replied. The symptom is *silent wrong answers*, not errors: an API the user
+  just imported "doesn't exist", credentials "disappeared", or operation ids
+  from one surface don't resolve on the other. Before concluding anything is
+  missing or broken, check where each surface points — `jentic profile list`
+  shows this CLI's `base_url` — and prefer this CLI for everything in one
+  deployment rather than mixing surfaces mid-task.
+- An `execute` failure is not always an access problem — exit **1** is a
+  transport failure, and its cause decides the recovery (see step 5): a DNS
+  error (`lookup broker.jentic.ai: no such host`) means the **broker target**
+  is wrong (point a local install at the local broker); connection refused on
+  a **local** target usually means the instance is **stopped** — run
+  `jenticctl status` to check, and if it's down tell the user to
+  `jenticctl start`, then retry rather than abandoning the task. Only a
+  broker **denial** (exit **2**, with an `agent_directive` on stderr) is an
+  access/credential issue:
   - **403 `no_toolkit_binding`** → check the directive's
     `parameters.toolkit_serves_api`. If `true`, a toolkit already serves the API
     and you just aren't bound — run the `jentic access request --toolkit …` it

--- a/src/jentic_one/shared/web/content/jentic.md
+++ b/src/jentic_one/shared/web/content/jentic.md
@@ -95,9 +95,11 @@ yet on your token (see the stale-scope note it prints).
 
 **File once, richly — never thrash.** Work out the full access end-state up
 front — from `whoami`, the catalog, and the task — instead of discovering
-gaps one denied call at a time. If the job needs several APIs, file the
-missing plans in one pass (one `--provision` per API, each complete: auth,
-rules, reason) rather than interleaving requests with failing executes. Never
+gaps one denied call at a time. A request's provisioning plan covers **one
+API**, so a job needing several APIs means several requests: file them all
+in one pass (one `--provision` per API, each complete: auth, rules, reason)
+rather than interleaving requests with failing executes — filed together,
+they read as one plan to the human approving them. Never
 file duplicate or per-operation requests for the same API, and don't
 file-withdraw-refile to tweak a proposal — approval is a human trust action,
 so once a request is filed, tell your operator an approval is waiting and


### PR DESCRIPTION
## Summary

PR 3 of the agent-discovery series (after #810 and #824). Hardens the agent skill (`jentic.md`, both the served canonical copy and the CLI-embedded copy) against the three failure modes reported from real dogfooding sessions, plus two stale code comments the review round surfaced.

- **Stopped instance is now a first-class branch (#783).** The old text read *every* transport failure as "wrong broker target", so a stopped local install surfaced as the agent silently losing capabilities. The guidance is now **symptom-first**: a broker denial carries an `agent_directive` (exit 2); a DNS/TLS error means the *config* targets the wrong broker; connection **refused on a local target** → health-check with `jenticctl status`, tell the user plainly to `jenticctl start`, then **retry the original call** instead of abandoning the task. `jenticctl status`/`start` added to the Quick Reference. The optional CLI-level hint from #783 is split out as #849.
- **Stale premise fixed (found in review):** the skill claimed the built-in broker default is `broker.jentic.ai`; it has been `https://127.0.0.1:8100` since the local-first defaults (cf. #724). The doc now states the real precedence (defaults < `config.yaml` < flags) and the two stale code comments (`execute.go`, `install.go`) are corrected. Also documented that the `operation_id` resolve leg reports transport failures as exit 2 (`resolve … failed`), so exit codes alone don't identify a denial — the `agent_directive` does.
- **Verify the backend before diagnosing "missing" data (#702, suggestion 3).** New pitfall for dual cloud-MCP + local-CLI sessions: the MCP tools and this CLI can silently address different backends, producing internally-consistent wrong answers. The skill says to check where each surface points (`jentic profile list` shows `base_url`; ask the operator what the MCP server is bound to) and stick to one surface per task.
- **Honest rule proposals + no-thrash access requests (#650, both P1 items).**
  - *Enforcement seam:* the broker matches method + URL path + operation id — **never the request body** (`shared/permissions/matching.py`, first-match-wins). The skill tells the agent to say when an intent can't be enforced by a rule and offer the real choices (allow broadly / deny / unenforced instructions), and to check for shadowing broad allows before filing.
  - *File once, richly:* the whole access end-state up front; a plan covers **one API**, so several APIs = several requests filed together in one pass (the composite multi-API request is CLI work tracked in #844); never per-operation requests or withdraw-and-refile loops.

## Review

Four parallel review passes (Bugbot, code-fact-check, agent-UX/conciseness, issue fidelity). Findings — one factual blocker (the stale `broker.jentic.ai` default), the exit-code non-exhaustiveness, wording tightenings, an unsupported "advances #755" claim (dropped), and the untracked #783 CLI half (now #849) — all fixed in `31141a7`.

## Fact-checking done against the code

- Broker default: `DefaultBrokerScheme`/`DefaultBrokerHost` = `https` / `127.0.0.1:8100` (`cli/internal/config/paths.go`); resolve precedence in `execute.go`.
- Exit codes: broker leg transport failure → 1; resolve-leg failure (incl. transport) → 2 with `resolve … failed`; denial → 2 with `agent_directive` (`execute.go`).
- `jenticctl status` reports install/server/broker/agent health, degrading gracefully (`status.go`); `jenticctl start` exists (`root.go`).
- `jentic profile list` prints each profile's `base_url` (`profile.go`).
- Rules match `(method, path, operation_id)` only, full-match regex/prefix/exact, first-match-wins; body never consulted (`shared/permissions/matching.py`, `permission_rules.py`).
- `--provision` takes exactly one `vendor/name` per invocation (`access.go`); composite requests tracked in #844.

## Test plan

- [x] `tests/arch/test_skill_drift.py` green (both copies identical).
- [x] `go build ./...` + `go test ./internal/skillgen/ ./internal/cmd/` green.
- [x] CI green on `0c1de51`-era heads; re-running on `31141a7`.

Closes #783. Advances #650 (P1 items), #702 (suggestion 3). Follow-ups: #844, #849.