### PR TITLE
fix(ui): reset catalog scroll to top on new search or filter

### DIFF
--- a/ui/src/__tests__/test-utils.tsx
+++ b/ui/src/__tests__/test-utils.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement, ReactNode } from 'react';
-import { StrictMode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Routes, Route } from 'react-router';
 import { render, type RenderOptions } from '@testing-library/react';
@@ -17,10 +16,6 @@ interface Options extends Omit<RenderOptions, 'wrapper'> {
  * QueryClient (retries off so error states render immediately) and a
  * MemoryRouter. Returns the testing-library result plus the `queryClient`.
  *
- * Wraps in `<StrictMode>` to match the app root (src/main.tsx), so effects run
- * with the same double-invocation semantics prod dev uses — mount-guarded
- * effects that aren't StrictMode-safe fail here instead of only in the browser.
- *
  * MSW is started globally in src/__tests__/setup.ts; override per-test with
  * `worker.use(createErrorHandler(...))`.
  */
@@ -36,19 +31,17 @@ export function renderWithProviders(ui: ReactElement, options: Options = {}) {
 
 	function Wrapper({ children }: { children: ReactNode }) {
 		return (
-			<StrictMode>
-				<QueryClientProvider client={queryClient}>
-					<MemoryRouter initialEntries={[route]}>
-						{path ? (
-							<Routes>
-								<Route path={path} element={children} />
-							</Routes>
-						) : (
-							children
-						)}
-					</MemoryRouter>
-				</QueryClientProvider>
-			</StrictMode>
+			<QueryClientProvider client={queryClient}>
+				<MemoryRouter initialEntries={[route]}>
+					{path ? (
+						<Routes>
+							<Route path={path} element={children} />
+						</Routes>
+					) : (
+						children
+					)}
+				</MemoryRouter>
+			</QueryClientProvider>
 		);
 	}
 

--- a/ui/src/__tests__/test-utils.tsx
+++ b/ui/src/__tests__/test-utils.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement, ReactNode } from 'react';
+import { StrictMode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Routes, Route } from 'react-router';
 import { render, type RenderOptions } from '@testing-library/react';
@@ -16,6 +17,10 @@ interface Options extends Omit<RenderOptions, 'wrapper'> {
  * QueryClient (retries off so error states render immediately) and a
  * MemoryRouter. Returns the testing-library result plus the `queryClient`.
  *
+ * Wraps in `<StrictMode>` to match the app root (src/main.tsx), so effects run
+ * with the same double-invocation semantics prod dev uses — mount-guarded
+ * effects that aren't StrictMode-safe fail here instead of only in the browser.
+ *
  * MSW is started globally in src/__tests__/setup.ts; override per-test with
  * `worker.use(createErrorHandler(...))`.
  */
@@ -31,17 +36,19 @@ export function renderWithProviders(ui: ReactElement, options: Options = {}) {
 
 	function Wrapper({ children }: { children: ReactNode }) {
 		return (
-			<QueryClientProvider client={queryClient}>
-				<MemoryRouter initialEntries={[route]}>
-					{path ? (
-						<Routes>
-							<Route path={path} element={children} />
-						</Routes>
-					) : (
-						children
-					)}
-				</MemoryRouter>
-			</QueryClientProvider>
+			<StrictMode>
+				<QueryClientProvider client={queryClient}>
+					<MemoryRouter initialEntries={[route]}>
+						{path ? (
+							<Routes>
+								<Route path={path} element={children} />
+							</Routes>
+						) : (
+							children
+						)}
+					</MemoryRouter>
+				</QueryClientProvider>
+			</StrictMode>
 		);
 	}
 

--- a/ui/src/modules/discover/__tests__/DiscoverPage.test.tsx
+++ b/ui/src/modules/discover/__tests__/DiscoverPage.test.tsx
@@ -101,9 +101,6 @@ describe('DiscoverPage', () => {
 		const user = userEvent.setup();
 		const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
 		try {
-			// renderWithProviders wraps in <StrictMode> (matching src/main.tsx), so
-			// its dev-only double effect invocation must not defeat the initial-mount
-			// guard — a boolean "have I mounted" ref would fire scrollTo here.
 			renderWithProviders(<DiscoverPage />);
 			await screen.findByText('stripe.com');
 

--- a/ui/src/modules/discover/__tests__/DiscoverPage.test.tsx
+++ b/ui/src/modules/discover/__tests__/DiscoverPage.test.tsx
@@ -28,6 +28,7 @@ describe('DiscoverPage', () => {
 	afterEach(() => {
 		restorePollInterval?.();
 		restorePollInterval = null;
+		vi.restoreAllMocks();
 	});
 
 	it('renders the public catalog with imported/available badges', async () => {
@@ -99,48 +100,43 @@ describe('DiscoverPage', () => {
 
 	it('resets scroll to the top when the search query changes (#602)', async () => {
 		const user = userEvent.setup();
+		// Restored by the describe-level afterEach (vi.restoreAllMocks).
 		const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
-		try {
-			renderWithProviders(<DiscoverPage />);
-			await screen.findByText('stripe.com');
 
-			// Initial mount must not yank the viewport.
-			expect(scrollSpy).not.toHaveBeenCalled();
+		renderWithProviders(<DiscoverPage />);
+		await screen.findByText('stripe.com');
 
-			await user.type(screen.getByLabelText('Search APIs'), 'github');
-			await screen.findByText('github.com');
+		// Initial mount must not yank the viewport.
+		expect(scrollSpy).not.toHaveBeenCalled();
 
-			// The committed (debounced) query change snaps back to the top so the
-			// freshly-ranked results are in view.
-			await waitFor(() => {
-				expect(scrollSpy).toHaveBeenCalledWith({ top: 0 });
-			});
-		} finally {
-			scrollSpy.mockRestore();
-		}
+		await user.type(screen.getByLabelText('Search APIs'), 'github');
+		await screen.findByText('github.com');
+
+		// The committed (debounced) query change snaps back to the top so the
+		// freshly-ranked results are in view.
+		await waitFor(() => {
+			expect(scrollSpy).toHaveBeenCalledWith({ top: 0, left: 0 });
+		});
 	});
 
 	it('resets scroll to the top when the registration filter changes (#602)', async () => {
 		const user = userEvent.setup();
 		const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
-		try {
-			renderWithProviders(<DiscoverPage />);
-			await screen.findByText('stripe.com');
-			expect(scrollSpy).not.toHaveBeenCalled();
 
-			// Toggling the filter re-ranks the visible list (imported rows drop out),
-			// so the viewport must snap back to the top too — same UX as a new query.
-			await user.click(screen.getByRole('button', { name: 'Available' }));
-			await waitFor(() => {
-				expect(screen.queryByText('stripe.com')).not.toBeInTheDocument();
-			});
+		renderWithProviders(<DiscoverPage />);
+		await screen.findByText('stripe.com');
+		expect(scrollSpy).not.toHaveBeenCalled();
 
-			await waitFor(() => {
-				expect(scrollSpy).toHaveBeenCalledWith({ top: 0 });
-			});
-		} finally {
-			scrollSpy.mockRestore();
-		}
+		// Toggling the filter re-ranks the visible list (imported rows drop out),
+		// so the viewport must snap back to the top too — same UX as a new query.
+		await user.click(screen.getByRole('button', { name: 'Available' }));
+		await waitFor(() => {
+			expect(screen.queryByText('stripe.com')).not.toBeInTheDocument();
+		});
+
+		await waitFor(() => {
+			expect(scrollSpy).toHaveBeenCalledWith({ top: 0, left: 0 });
+		});
 	});
 
 	it('filters by registration state (Available hides imported rows)', async () => {

--- a/ui/src/modules/discover/__tests__/DiscoverPage.test.tsx
+++ b/ui/src/modules/discover/__tests__/DiscoverPage.test.tsx
@@ -97,6 +97,55 @@ describe('DiscoverPage', () => {
 		expect(await screen.findByText('github.com')).toBeInTheDocument();
 	});
 
+	it('resets scroll to the top when the search query changes (#602)', async () => {
+		const user = userEvent.setup();
+		const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+		try {
+			// renderWithProviders wraps in <StrictMode> (matching src/main.tsx), so
+			// its dev-only double effect invocation must not defeat the initial-mount
+			// guard — a boolean "have I mounted" ref would fire scrollTo here.
+			renderWithProviders(<DiscoverPage />);
+			await screen.findByText('stripe.com');
+
+			// Initial mount must not yank the viewport.
+			expect(scrollSpy).not.toHaveBeenCalled();
+
+			await user.type(screen.getByLabelText('Search APIs'), 'github');
+			await screen.findByText('github.com');
+
+			// The committed (debounced) query change snaps back to the top so the
+			// freshly-ranked results are in view.
+			await waitFor(() => {
+				expect(scrollSpy).toHaveBeenCalledWith({ top: 0 });
+			});
+		} finally {
+			scrollSpy.mockRestore();
+		}
+	});
+
+	it('resets scroll to the top when the registration filter changes (#602)', async () => {
+		const user = userEvent.setup();
+		const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+		try {
+			renderWithProviders(<DiscoverPage />);
+			await screen.findByText('stripe.com');
+			expect(scrollSpy).not.toHaveBeenCalled();
+
+			// Toggling the filter re-ranks the visible list (imported rows drop out),
+			// so the viewport must snap back to the top too — same UX as a new query.
+			await user.click(screen.getByRole('button', { name: 'Available' }));
+			await waitFor(() => {
+				expect(screen.queryByText('stripe.com')).not.toBeInTheDocument();
+			});
+
+			await waitFor(() => {
+				expect(scrollSpy).toHaveBeenCalledWith({ top: 0 });
+			});
+		} finally {
+			scrollSpy.mockRestore();
+		}
+	});
+
 	it('filters by registration state (Available hides imported rows)', async () => {
 		const user = userEvent.setup();
 		renderWithProviders(<DiscoverPage />);

--- a/ui/src/modules/discover/pages/DiscoverPage.tsx
+++ b/ui/src/modules/discover/pages/DiscoverPage.tsx
@@ -12,7 +12,7 @@
  * `api/hooks` (useDiscoverCatalog / useImportCatalogApi / useOperationPreview).
  * It never touches `@/shared/api` directly (ESLint-enforced).
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Upload } from 'lucide-react';
 import { PageShell, PageHeader, PageHelp, AppLink } from '@/shared/ui';
 import { ROUTES } from '@/shared/app/routes';
@@ -50,6 +50,24 @@ export default function DiscoverPage() {
 	useEffect(() => {
 		reconcileImported(catalog.entities);
 	}, [catalog.entities, reconcileImported]);
+
+	// The catalog scrolls on the window (no bounded results container), so a new
+	// query or filter re-ranks the list but leaves the viewport wherever the user
+	// last scrolled — burying the freshly-ranked top matches off-screen (#602).
+	// Snap back to the top whenever the committed query or filter actually
+	// changes. Comparing the previous values (rather than a "have I mounted"
+	// boolean) is StrictMode-safe: the effect's double-invocation on mount reads
+	// the ref back as the current value and no-ops, so first load isn't yanked.
+	const prevQueryRef = useRef(debouncedQuery);
+	const prevFilterRef = useRef(filter);
+	useEffect(() => {
+		if (prevQueryRef.current === debouncedQuery && prevFilterRef.current === filter) {
+			return;
+		}
+		prevQueryRef.current = debouncedQuery;
+		prevFilterRef.current = filter;
+		window.scrollTo({ top: 0 });
+	}, [debouncedQuery, filter]);
 
 	function handleOpen(entity: DiscoveryEntity) {
 		setSelected(entity);

--- a/ui/src/modules/discover/pages/DiscoverPage.tsx
+++ b/ui/src/modules/discover/pages/DiscoverPage.tsx
@@ -58,6 +58,9 @@ export default function DiscoverPage() {
 	// changes. Comparing the previous values (rather than a "have I mounted"
 	// boolean) is StrictMode-safe: the effect's double-invocation on mount reads
 	// the ref back as the current value and no-ops, so first load isn't yanked.
+	// The snap fires at debounce-commit, before results land — deliberately, so
+	// the viewport is already in place when they swap in; if the fetch errors
+	// instead, the error alert renders at the top the user was just snapped to.
 	const prevQueryRef = useRef(debouncedQuery);
 	const prevFilterRef = useRef(filter);
 	useEffect(() => {
@@ -66,7 +69,7 @@ export default function DiscoverPage() {
 		}
 		prevQueryRef.current = debouncedQuery;
 		prevFilterRef.current = filter;
-		window.scrollTo({ top: 0 });
+		window.scrollTo({ top: 0, left: 0 });
 	}, [debouncedQuery, filter]);
 
 	function handleOpen(entity: DiscoveryEntity) {


### PR DESCRIPTION
## Summary

In Discover (the public API catalog), entering a new search term after scrolling
down didn't return the view to the top, so the freshly-ranked top results were
hidden until the user manually scrolled up.

Root cause: the results grid scrolls on the **window** (there's no bounded results
container), and nothing reset scroll position when the query or filter changed.
`keepPreviousData` avoids skeleton flashing but does nothing for scroll. The same
issue applied to toggling the registration filter (`All` → `Available`), which
re-ranks the visible list the same way — this fixes both paths.

## Related issue

Closes #602

## Changes

- `DiscoverPage.tsx`: reset `window.scrollTo({ top: 0, left: 0 })` when the
  committed (debounced) `query` or the `filter` actually changes. Uses a
  previous-value ref comparison (not a boolean mount guard) so it's
  **StrictMode-safe** — the dev-only double effect invocation doesn't yank the
  viewport on first load. The snap deliberately fires at debounce-commit (before
  results land), so the viewport is in place when they swap in; if the fetch
  errors, the error alert renders at the top (documented inline).
- Tests: scroll-reset coverage for both the query-change and filter-change
  paths, plus an initial-mount no-scroll pin. Spy restoration is owned by the
  describe-level `afterEach` (`vi.restoreAllMocks()`).

> **Scope note (review round 1):** an earlier revision also wrapped
> `renderWithProviders` in `<StrictMode>`; that harness change was dropped per
> review — `test-utils.tsx` is untouched by this PR. Real StrictMode enablement
> (via RTL's `reactStrictMode` render option, incl. the `OAuthPopupReturn`
> fallout) is tracked as a follow-up.

## Testing

- `cd ui && npm run lint && npm run build` — clean
- `cd ui && npm run test:run` — full browser-mode suite: 104 files / 884 tests pass (rebased on current main)
- Manual: in Discover, scroll deep into results, enter a new search term → view snaps to top
- Manual: scroll deep, toggle `All` → `Available` → view snaps to top
- Manual (dev/StrictMode): open `/app/discover` fresh → viewport is **not** yanked on first load

## Review-board hardening (round 2, post-rebase)

Four independent lenses (code quality, correctness/edge cases, product fit/UX,
prior-review disposition) reviewed the rebased branch — unanimous
approve-with-nits; all in-PR nits folded in:

- `left: 0` added to the snap for axis symmetry
- fires-at-commit / fires-on-error trade-off documented at the effect
- per-test `try/finally` spy scaffolding replaced by `afterEach` restore

Follow-ups (tracked separately, see linked issues): shared
`useScrollResetOnChange` hook for the sibling sticky-toolbar pages
(Toolkits/Workspace), real StrictMode test enablement, `useDebouncedValue`
dedup.

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] `make check` passes (lint, type check, secrets audit, arch tests)
- [x] Tests added/updated for the change
- [ ] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included