### PR TITLE
docs(onboarding): disambiguate self-hosted Jentic One from the Jentic cloud platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/instal
 AI agents increasingly need to call real third-party APIs — but handing an agent your raw API keys is a security problem. Jentic One is a **self-hosted gateway** that keeps that from happening: you register the APIs an agent may use, store the credentials once, and the agent calls out through the Broker. The Broker injects the right credential at execution time and forwards the request, so **secrets never leave your infrastructure** and never reach the agent. Every call is governed by fine-grained permissions and recorded in an append-only audit log.
 
 > [!NOTE]
-> **Jentic One is not the Jentic cloud platform.** Agents integrate with a self-hosted deployment through the `jentic` CLI and its generated skill (or raw HTTP via `/llms.txt`) — a Jentic One deployment exposes **no MCP endpoint**. The hosted platform at `app.jentic.com` / `api.jentic.com` (with its remote MCP server) is a separate product with separate state. Using both, or migrating from cloud to self-hosted? Read [Cloud vs self-hosted](docs/cloud-vs-self-hosted.md) first.
+> **Jentic One is not the Jentic cloud platform.** The hosted platform at `app.jentic.com` / `api.jentic.com` (with its remote MCP server) is a separate product with separate state; a self-hosted deployment exposes **no MCP endpoint** — agents integrate through the `jentic` CLI + generated skill, or raw HTTP via `/llms.txt`. Using both, or migrating? Read [Cloud vs self-hosted](docs/cloud-vs-self-hosted.md) first.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/instal
 
 AI agents increasingly need to call real third-party APIs — but handing an agent your raw API keys is a security problem. Jentic One is a **self-hosted gateway** that keeps that from happening: you register the APIs an agent may use, store the credentials once, and the agent calls out through the Broker. The Broker injects the right credential at execution time and forwards the request, so **secrets never leave your infrastructure** and never reach the agent. Every call is governed by fine-grained permissions and recorded in an append-only audit log.
 
+> [!NOTE]
+> **Jentic One is not the Jentic cloud platform.** Agents integrate with a self-hosted deployment through the `jentic` CLI and its generated skill (or raw HTTP via `/llms.txt`) — a Jentic One deployment exposes **no MCP endpoint**. The hosted platform at `app.jentic.com` / `api.jentic.com` (with its remote MCP server) is a separate product with separate state. Using both, or migrating from cloud to self-hosted? Read [Cloud vs self-hosted](docs/cloud-vs-self-hosted.md) first.
+
 ## Architecture
 
 The system deploys as two peer units — **App** (the control plane, combining Registry + Admin + Control surfaces) and **Broker** (the data plane) — above a shared PostgreSQL database layer.
@@ -110,6 +113,7 @@ Full reference: [`cli/README.md`](cli/README.md).
 | Guide | Description |
 | ----- | ----------- |
 | [Build & Deploy](deploy/README.md) | Docker, Helm, Terraform, versioning, local kind cluster, and observability |
+| [Cloud vs self-hosted](docs/cloud-vs-self-hosted.md) | How Jentic One differs from the Jentic cloud platform, why there is no MCP endpoint, and how to run both (or migrate) without silent cross-talk |
 | [API Specs](openapi/) | OpenAPI specifications (broker, control) |
 | [Endpoint & scope reference](docs/reference/endpoints.md) | Generated map of every HTTP route, its scope, and who may call it |
 | Reference docs (in-app) | Open `/app/docs` on a running deployment for the rendered HTTP API, Broker API, and CLI references — all generated from code (`/docs` serves the interactive Swagger UI) |

--- a/docs/cloud-vs-self-hosted.md
+++ b/docs/cloud-vs-self-hosted.md
@@ -1,7 +1,7 @@
-# Jentic Cloud vs Self-Hosted Jentic One
+# The Jentic cloud platform vs self-hosted Jentic One
 
-Jentic offers two distinct products that are easy to conflate — especially for
-an AI agent (or its operator) that has used both:
+Jentic offers two distinct products that are easy to conflate —
+especially for an AI agent (or its operator) that has used both:
 
 |  | Jentic cloud platform | Jentic One (this repo) |
 | --- | --- | --- |
@@ -9,17 +9,20 @@ an AI agent (or its operator) that has used both:
 | How agents connect | Remote **MCP server** (`https://api.jentic.com/mcp`) configured in the agent runtime with a workspace API key | **`jentic` CLI + generated skill** (or the raw HTTP flow) — see below |
 | Agent identity | Workspace API key | Per-agent Ed25519 keypair via dynamic client registration (`jentic register` / `jentic bootstrap`) |
 | Dashboard | `app.jentic.com` | The bundled UI on your deployment (`/app`) |
-| Data | Jentic-hosted workspace | Stays on your infrastructure; credentials never leave your Broker |
+| Data | Jentic-hosted workspace | Stays on your infrastructure; stored secrets are decrypted only inside your Broker at execution time |
 
 They do not share state: an API imported or a credential stored in one is
 invisible to the other.
 
 ## Self-hosted Jentic One exposes no MCP endpoint
 
-There is **no `/mcp` endpoint** on a Jentic One deployment — not on the
-control plane (`:8000/mcp`, `/v1/mcp`, `/api/mcp`, `/sse`) and not on the
-broker (`:8100/mcp`). Probing them returns 404. Do not configure an MCP server
-entry pointing at your self-hosted host; it cannot work.
+There is **no `/mcp` endpoint** on a Jentic One deployment. Probing the
+control plane (`:8000/mcp`, `/v1/mcp`, `/api/mcp`, `/sse`) returns 404. The
+broker (`:8100`) answers 401 to an unauthenticated `/mcp` probe — that is
+**not** a hidden MCP server behind auth; it is the broker's credential-injecting
+forward proxy rejecting the request, like it would any other unauthenticated
+path. Do not configure an MCP server entry pointing at your self-hosted host;
+it cannot work.
 
 The supported integration paths for agents are:
 
@@ -34,7 +37,7 @@ The supported integration paths for agents are:
 
 ## Running both side by side (coexistence)
 
-Anyone who used the cloud platform first and later installed Jentic One ends
+If you used the cloud platform first and later installed Jentic One, you end
 up with a **dual setup**: the agent runtime's MCP tools (`search_apis`,
 `list_credentials`, `execute`, …) still point at the cloud workspace, while
 the `jentic` CLI points at the local install. Nothing in any tool response
@@ -62,7 +65,7 @@ half the tools are talking to a different product.
 **Rule of thumb:** pick one surface per task and stay on it. If you work
 against the self-hosted install, use the `jentic` CLI for everything, and
 consider removing (or disabling) the stale cloud MCP entry so an agent can't
-half-answer from the wrong backend.
+answer from the wrong backend.
 
 ## Migrating from the cloud MCP to a self-hosted install
 

--- a/docs/cloud-vs-self-hosted.md
+++ b/docs/cloud-vs-self-hosted.md
@@ -1,0 +1,76 @@
+# Jentic Cloud vs Self-Hosted Jentic One
+
+Jentic offers two distinct products that are easy to conflate — especially for
+an AI agent (or its operator) that has used both:
+
+|  | Jentic cloud platform | Jentic One (this repo) |
+| --- | --- | --- |
+| Where it runs | Hosted by Jentic — dashboard at `app.jentic.com`, API at `api.jentic.com` | Your infrastructure (laptop, VM, Kubernetes) |
+| How agents connect | Remote **MCP server** (`https://api.jentic.com/mcp`) configured in the agent runtime with a workspace API key | **`jentic` CLI + generated skill** (or the raw HTTP flow) — see below |
+| Agent identity | Workspace API key | Per-agent Ed25519 keypair via dynamic client registration (`jentic register` / `jentic bootstrap`) |
+| Dashboard | `app.jentic.com` | The bundled UI on your deployment (`/app`) |
+| Data | Jentic-hosted workspace | Stays on your infrastructure; credentials never leave your Broker |
+
+They do not share state: an API imported or a credential stored in one is
+invisible to the other.
+
+## Self-hosted Jentic One exposes no MCP endpoint
+
+There is **no `/mcp` endpoint** on a Jentic One deployment — not on the
+control plane (`:8000/mcp`, `/v1/mcp`, `/api/mcp`, `/sse`) and not on the
+broker (`:8100/mcp`). Probing them returns 404. Do not configure an MCP server
+entry pointing at your self-hosted host; it cannot work.
+
+The supported integration paths for agents are:
+
+1. **CLI + skill (recommended).** Your operator runs `jentic bootstrap` — it
+   registers the agent identity, waits for human approval, and installs the
+   onboarding skill into detected agent runtimes (Claude Code, Cursor, Codex,
+   Hermes, or a generic `AGENTS.md`). The skill teaches the agent to drive
+   `jentic search` → `jentic inspect` → `jentic execute`.
+2. **Raw HTTP.** For runtimes without the CLI, every deployment self-describes
+   at `GET /llms.txt`: dynamic client registration, token exchange, discovery,
+   access requests, and brokered execution — no MCP required.
+
+## Running both side by side (coexistence)
+
+Anyone who used the cloud platform first and later installed Jentic One ends
+up with a **dual setup**: the agent runtime's MCP tools (`search_apis`,
+`list_credentials`, `execute`, …) still point at the cloud workspace, while
+the `jentic` CLI points at the local install. Nothing in any tool response
+says which backend replied, so the failure mode is *silent wrong answers*,
+not errors:
+
+- an API you just imported locally "doesn't exist" (the MCP search answered
+  from the cloud workspace),
+- credentials "disappeared" (the cloud workspace never had them),
+- operation IDs from one surface don't resolve on the other (different ID
+  namespaces).
+
+The debugging transcript reads like data loss; everything is actually fine —
+half the tools are talking to a different product.
+
+**How to check which backend each surface is bound to:**
+
+- **MCP server** — inspect the MCP entry in the agent runtime's config (e.g.
+  Claude Desktop's `claude_desktop_config.json`, Cursor's MCP settings): a
+  URL on `api.jentic.com` is the cloud platform. A self-hosted install is
+  never behind an MCP entry.
+- **CLI** — `jentic profile list` prints each profile's `base_url`; local
+  installs point at your own host (e.g. `http://127.0.0.1:8000`).
+
+**Rule of thumb:** pick one surface per task and stay on it. If you work
+against the self-hosted install, use the `jentic` CLI for everything, and
+consider removing (or disabling) the stale cloud MCP entry so an agent can't
+half-answer from the wrong backend.
+
+## Migrating from the cloud MCP to a self-hosted install
+
+1. Install the stack: `curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh`, then `jenticctl install`.
+2. Re-import the APIs you need (`jentic catalog import`, or the dashboard) —
+   catalog state does not transfer from the cloud workspace.
+3. Re-enter credentials in your deployment's dashboard — secrets cannot be
+   exported from the cloud platform (nor from Jentic One; that's the point).
+4. Register your agents against the local install (`jentic bootstrap`).
+5. Remove the cloud MCP server entry from your agent runtime's config to
+   avoid the split-brain scenario above.

--- a/src/jentic_one/shared/web/agent_discovery.py
+++ b/src/jentic_one/shared/web/agent_discovery.py
@@ -66,9 +66,10 @@ Agents: read the onboarding skill at {base}{SKILL_PATH} first. It is the
 canonical guide to the identity → discover → request access → execute loop —
 the same canonical guide the `jentic` CLI renders into agent runtimes.
 
-This deployment exposes **no MCP endpoint** (`/mcp` and friends return 404 —
-that transport belongs to the separately hosted Jentic cloud platform). The
-integration paths here are the `jentic` CLI + skill, or the raw HTTP
+This deployment exposes **no MCP endpoint** — that transport belongs to the
+separately hosted Jentic cloud platform. Probing `/mcp` returns 404 on the
+control plane; a 401 from the broker is its auth-gated forward proxy, not a
+hidden MCP server. Integrate via the `jentic` CLI + skill or the raw HTTP
 sequence below; if your session also carries Jentic MCP tools, they answer
 from a different backend than this deployment.
 

--- a/src/jentic_one/shared/web/agent_discovery.py
+++ b/src/jentic_one/shared/web/agent_discovery.py
@@ -66,6 +66,12 @@ Agents: read the onboarding skill at {base}{SKILL_PATH} first. It is the
 canonical guide to the identity → discover → request access → execute loop —
 the same canonical guide the `jentic` CLI renders into agent runtimes.
 
+This deployment exposes **no MCP endpoint** (`/mcp` and friends return 404 —
+that transport belongs to the separately hosted Jentic cloud platform). The
+integration paths here are the `jentic` CLI + skill, or the raw HTTP
+sequence below; if your session also carries Jentic MCP tools, they answer
+from a different backend than this deployment.
+
 ## Quickstart (agent onboarding)
 
 Prefer the `jentic` CLI where available: your operator runs `jentic bootstrap`

--- a/tests/unit/shared/web/test_agent_discovery.py
+++ b/tests/unit/shared/web/test_agent_discovery.py
@@ -152,6 +152,17 @@ def test_llms_txt_quickstart_matches_backend_contract(client: TestClient) -> Non
     assert "300 seconds in the future" in body
 
 
+def test_llms_txt_disclaims_mcp_endpoint(client: TestClient) -> None:
+    """llms.txt tells agents there is no MCP endpoint on this deployment (#753).
+
+    Agents arriving from the Jentic cloud platform probe ``/mcp`` and then
+    misdiagnose the 404; the document must state the integration path is the
+    CLI + skill (or raw HTTP), not MCP.
+    """
+    body = client.get(LLMS_TXT_PATH).text
+    assert "no MCP endpoint" in body
+
+
 def test_render_llms_txt_stamps_base_everywhere() -> None:
     """No hardcoded host survives rendering; every link uses the given base."""
     body = render_llms_txt("https://example.test", assertion_max_ttl_seconds=300)


### PR DESCRIPTION
## Summary

PR 4 of the agent-discovery series (after #810, #824, #843). Closes #753; advances #702 (suggestion 2 — the docs half). Related context for readers: #737 (no visibility into which instance a connector is bound to), #755 (reaching a self-hosted install from inside an agent session).

The trigger (#753): a Claude Desktop config still carried the Jentic **cloud** MCP entry (`https://api.jentic.com/mcp`), while the user had moved to a self-hosted install. The self-hosted stack exposes **no MCP endpoint at all**, and nothing in the repo said so — or explained that self-hosted integration is the `jentic` CLI + generated skill. Combined with #702, the result was an agent silently answering from the wrong backend and a debugging transcript that read like data loss.

### What this adds

- **`docs/cloud-vs-self-hosted.md`** (new): a product table (hosted `app.jentic.com`/`api.jentic.com` + remote MCP + workspace API key **vs** self-hosted + CLI/skill + per-agent Ed25519 identity, no shared state); an explicit *"self-hosted exposes no MCP endpoint"* section with the two supported integration paths (CLI + skill via `jentic bootstrap`, raw HTTP via `/llms.txt`); a **coexistence** section describing the dual-setup failure mode from #702 (silent wrong answers, not errors) and how to check what each surface is bound to (MCP entry host in the runtime config; `jentic profile list` → `base_url`); and a **migration** checklist (re-import catalog, re-enter secrets — they are not exportable by design, re-register agents, remove the stale MCP entry).
- **README**: a `[!NOTE]` callout under *What is Jentic One?* naming the distinction up front, plus a Documentation-table row.
- **`llms.txt`** (served, `agent_discovery.py`): a short agent-facing paragraph — no MCP endpoint here, that transport belongs to the hosted platform; integrate via CLI + skill or the raw HTTP sequence; MCP tools in your session answer from a different backend. Guarded by a new regression test (`test_llms_txt_disclaims_mcp_endpoint`).

## Review

Four parallel review passes (Bugbot, code fact-check, docs-quality/IA, issue fidelity). All four converged on one real error, fixed in `c7bfa0a`: the first draft claimed `/mcp` probes "return 404" everywhere, but the **broker's auth-gated catch-all forward proxy answers 401** to an unauthenticated probe — which this doc's own audience would read as "MCP exists behind auth", the exact misdiagnosis the page exists to prevent. The doc and llms.txt now state both behaviors (control plane 404s; broker 401 = the forward proxy, not a hidden MCP server). Nits also fixed: consistent product naming in the H1, tighter README callout, precise credential-locality wording. Issue-fidelity pass confirmed closing #753 is justified and #702 correctly stays open (its suggestion 1 — backend identity in MCP responses — is cloud-product work).

### Fact-checking done against the code

- No MCP surface exists anywhere in the repo (or the enterprise overlay); broker `/mcp` behavior verified empirically (401 from `RequireToolkitAccess` on the catch-all `/{upstream_url:path}`), control plane 404s.
- Skill adapters offered: Claude Code, Cursor, Codex, Hermes, generic `AGENTS.md` (`cli/internal/skillgen/adapters.go`).
- `jentic catalog import <api_id>` and `jentic profile list` (prints `base_url`) exist as documented.
- Control-plane default port 8000, broker 8100 (`shared/config.py`, `cli/internal/config/paths.go`); dashboard at `/app`; install one-liner matches `tools/install.sh`.
- Credential endpoints only ever return redacted material; secrets decrypt inside the Broker only.

## Test plan

- [x] `pytest tests/unit/shared/web/test_agent_discovery.py tests/arch/` — green (incl. new `test_llms_txt_disclaims_mcp_endpoint` and the skill drift test).
- [x] `ruff check` / `ruff format --check` / `mypy` clean on touched files.
- [x] Four-pass subagent review; findings fixed in `c7bfa0a`.

Closes #753. Advances #702 (suggestion 2). Related: #737, #755.