### PR TITLE
feat(cli): refuse self-update of Homebrew-managed installs

### DIFF
--- a/cli/internal/cmd/install.go
+++ b/cli/internal/cmd/install.go
@@ -274,6 +274,12 @@ func (a *App) recordManifest(draft *install.Draft) {
 	}
 	if m.BinaryPath == "" {
 		if exe, err := os.Executable(); err == nil {
+			// Record the real file, not a PATH symlink to it (e.g. Homebrew's
+			// bin link), so later consumers of BinaryPath see the actual
+			// install location.
+			if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+				exe = resolved
+			}
 			m.BinaryPath = exe
 		}
 	}

--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -62,11 +62,20 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 	installed := firstNonEmpty(manifest.Commit, commit)
 	cliVersion := firstNonEmpty(manifest.CLIVersion, version)
 
+	ctlTarget, err := resolveCtlTarget(manifest)
+	if err != nil {
+		return err
+	}
+	brewManaged := update.BrewManaged(ctlTarget)
+
 	fmt.Fprint(a.Out, a.brandHeader(opts.baseURL, cliVersion))
 	fmt.Fprintln(a.Out)
 	fmt.Fprintln(a.Out, theme.Field("cli", cliLine(cliVersion, installed)))
 	if !found {
 		fmt.Fprintln(a.Out, theme.Dim.Render("  (no install manifest; using build-time metadata)"))
+	}
+	if brewManaged {
+		fmt.Fprintln(a.Out, theme.Field("managed by", "Homebrew — update the CLI with `"+update.BrewUpgradeCommand+"`"))
 	}
 
 	// Resolve the update target. By default we track the latest release tag; an
@@ -99,6 +108,19 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 	doCLI := !opts.stackOnly
 	doStack := !opts.cliOnly
 
+	// A brew-managed CLI is never swapped by us: brew's bookkeeping would
+	// desync and the next `brew upgrade` would clobber the swapped binaries.
+	// The stack (in ~/.jentic) is ours regardless of how the CLI arrived, so a
+	// combined update degrades to stack-only rather than failing.
+	if brewManaged && doCLI {
+		if opts.cliOnly {
+			return fmt.Errorf("this CLI is managed by Homebrew; update it with `%s`", update.BrewUpgradeCommand)
+		}
+		doCLI = false
+		fmt.Fprintln(a.Out)
+		fmt.Fprintln(a.Out, theme.Warnf("CLI is managed by Homebrew — skipping the CLI update; run `%s` instead.", update.BrewUpgradeCommand))
+	}
+
 	// When the latest release is not newer than what's installed there's nothing
 	// to rebuild. A --ref override always proceeds (the user asked for a specific
 	// build); re-run with --ref to force a rebuild at a pinned version.
@@ -120,7 +142,7 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 	}
 
 	if doCLI {
-		if err := a.updateCLI(ctx, manifest, repo, ref); err != nil {
+		if err := a.updateCLI(ctx, repo, ref, ctlTarget); err != nil {
 			return err
 		}
 	}
@@ -132,23 +154,37 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 	return nil
 }
 
+// resolveCtlTarget locates the installed jenticctl binary that an update would
+// replace: the manifest's recorded path when present, else the running
+// executable. Symlinks are resolved in both cases so the swap replaces the real
+// file rather than a PATH symlink pointing at it (e.g. Homebrew's bin link or
+// the link tools/install.sh drops into /usr/local/bin) — renaming over the
+// symlink would orphan the real install.
+func resolveCtlTarget(manifest *config.Manifest) (string, error) {
+	target := manifest.BinaryPath
+	if target == "" {
+		exe, err := os.Executable()
+		if err != nil {
+			return "", fmt.Errorf("locate current binary: %w", err)
+		}
+		target = exe
+	}
+	// A dangling/missing path fails EvalSymlinks; keep it verbatim and let the
+	// swap create it fresh.
+	if resolved, err := filepath.EvalSymlinks(target); err == nil {
+		target = resolved
+	}
+	return target, nil
+}
+
 // updateCLI rebuilds and replaces both CLI binaries (jenticctl and jentic) by
 // delegating the build to tools/install.sh (single source of truth) into a
 // staging dir, then atomically swapping each into place with a .bak rollback
 // copy. jenticctl update is the sole updater for both binaries; they are
-// assumed co-located (install.sh installs both into the same dir).
-func (a *App) updateCLI(ctx context.Context, manifest *config.Manifest, repo, ref string) error {
-	ctlTarget := manifest.BinaryPath
-	if ctlTarget == "" {
-		exe, err := os.Executable()
-		if err != nil {
-			return fmt.Errorf("locate current binary: %w", err)
-		}
-		if resolved, err := filepath.EvalSymlinks(exe); err == nil {
-			exe = resolved
-		}
-		ctlTarget = exe
-	}
+// assumed co-located (install.sh installs both into the same dir). ctlTarget
+// is the symlink-resolved jenticctl location (see resolveCtlTarget); callers
+// must have already ruled out package-manager-owned locations.
+func (a *App) updateCLI(ctx context.Context, repo, ref, ctlTarget string) error {
 	// The sibling jentic binary lives next to jenticctl (install.sh co-locates
 	// both in JENTIC_INSTALL_DIR).
 	installDir := filepath.Dir(ctlTarget)

--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -37,7 +37,10 @@ func newUpdateCmd(app *App) *cobra.Command {
 			"installed version against the latest release tag on GitHub, and (unless\n" +
 			"--check) rebuilds and replaces the jenticctl and jentic binaries in place,\n" +
 			"then rebuilds the installed stack. Use --cli-only or --stack-only to update\n" +
-			"just one half.",
+			"just one half.\n\n" +
+			"A Homebrew-installed CLI is never swapped in place: update it with\n" +
+			"`brew upgrade jentic` (a combined update then refreshes only the stack,\n" +
+			"and --cli-only fails).",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return app.updateE(cmd.Context(), opts)
@@ -117,17 +120,28 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 			return fmt.Errorf("this CLI is managed by Homebrew; update it with `%s`", update.BrewUpgradeCommand)
 		}
 		doCLI = false
-		fmt.Fprintln(a.Out)
-		fmt.Fprintln(a.Out, theme.Warnf("CLI is managed by Homebrew — skipping the CLI update; run `%s` instead.", update.BrewUpgradeCommand))
 	}
 
-	// When the latest release is not newer than what's installed there's nothing
-	// to rebuild. A --ref override always proceeds (the user asked for a specific
-	// build); re-run with --ref to force a rebuild at a pinned version.
-	if !pinned && latestKnown && !update.NewerAvailable(cliVersion, latest) {
+	// When the latest release is not newer than what's installed there's
+	// nothing to rebuild. Each requested half is gated on its own recorded
+	// version (see updateNeeded): they normally move in lockstep, but a
+	// brew-managed CLI is refreshed out-of-band by `brew upgrade` while the
+	// stack may lag behind, so the stack half must not key off the CLI binary.
+	// A --ref override always proceeds (the user asked for a specific build);
+	// re-run with --ref to force a rebuild at a pinned version.
+	stackVersion := firstNonEmpty(manifest.Ref, cliVersion)
+	if !pinned && latestKnown && !updateNeeded(doCLI, doStack, cliVersion, stackVersion, latest) {
 		fmt.Fprintln(a.Out)
 		fmt.Fprintln(a.Out, theme.Successf("Already up to date (%s); nothing to rebuild.", latest))
 		return nil
+	}
+
+	// Announce the brew degrade only when something will actually run; a
+	// brew-managed install that is already up to date returns above without a
+	// spurious "skipping" warning.
+	if brewManaged && !opts.stackOnly {
+		fmt.Fprintln(a.Out)
+		fmt.Fprintln(a.Out, theme.Warnf("CLI is managed by Homebrew — skipping the CLI update; run `%s` instead.", update.BrewUpgradeCommand))
 	}
 
 	if !opts.yes {
@@ -152,6 +166,16 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 		}
 	}
 	return nil
+}
+
+// updateNeeded reports whether any requested update half is behind latest.
+// Each half is compared against its own recorded version: cliVersion is what
+// the installed binary reports, stackVersion is the ref the stack was last
+// built from (the two normally match, but a Homebrew-managed CLI is updated
+// out-of-band while the stack in ~/.jentic may lag behind).
+func updateNeeded(doCLI, doStack bool, cliVersion, stackVersion, latest string) bool {
+	return (doCLI && update.NewerAvailable(cliVersion, latest)) ||
+		(doStack && update.NewerAvailable(stackVersion, latest))
 }
 
 // resolveCtlTarget locates the installed jenticctl binary that an update would

--- a/cli/internal/cmd/update_test.go
+++ b/cli/internal/cmd/update_test.go
@@ -9,6 +9,36 @@ import (
 	"github.com/jentic/jentic-one/cli/internal/config"
 )
 
+// TestUpdateNeeded covers the per-half gating: the stack half must be gated on
+// its own recorded ref, not the CLI binary's version (a brew-managed CLI is
+// refreshed out-of-band while the stack lags).
+func TestUpdateNeeded(t *testing.T) {
+	tests := []struct {
+		name                             string
+		doCLI, doStack                   bool
+		cliVersion, stackVersion, latest string
+		want                             bool
+	}{
+		{"lockstep source install up to date", true, true, "0.16.0", "v0.16.0", "v0.16.0", false},
+		{"lockstep source install behind", true, true, "0.15.0", "v0.15.0", "v0.16.0", true},
+		{"brew degrade: fresh CLI, stale stack", false, true, "0.16.0", "v0.15.0", "v0.16.0", true},
+		{"brew degrade: fresh CLI, fresh stack", false, true, "0.16.0", "v0.16.0", "v0.16.0", false},
+		{"brew degrade: no stack manifest falls back to cli version", false, true, "0.16.0", "0.16.0", "v0.16.0", false},
+		{"cli-only behind", true, false, "0.15.0", "v0.16.0", "v0.16.0", true},
+		{"cli-only current, stack stale but not requested", true, false, "0.16.0", "v0.15.0", "v0.16.0", false},
+		{"unparseable stack ref (branch install) always offers rebuild", false, true, "0.16.0", "main", "v0.16.0", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := updateNeeded(tt.doCLI, tt.doStack, tt.cliVersion, tt.stackVersion, tt.latest)
+			if got != tt.want {
+				t.Errorf("updateNeeded(%v, %v, %q, %q, %q) = %v, want %v",
+					tt.doCLI, tt.doStack, tt.cliVersion, tt.stackVersion, tt.latest, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestResolveCtlTargetResolvesManifestSymlink covers the manifest branch: a
 // recorded BinaryPath that is a PATH symlink (what `jenticctl install` records
 // under a linked install) must resolve to the real file so the update swaps

--- a/cli/internal/cmd/update_test.go
+++ b/cli/internal/cmd/update_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/jentic/jentic-one/cli/internal/config"
+)
+
+// TestResolveCtlTargetResolvesManifestSymlink covers the manifest branch: a
+// recorded BinaryPath that is a PATH symlink (what `jenticctl install` records
+// under a linked install) must resolve to the real file so the update swaps
+// the binary, not the link.
+func TestResolveCtlTargetResolvesManifestSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test targets unix")
+	}
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	linkDir := filepath.Join(root, "linkbin")
+	for _, d := range []string{realDir, linkDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	realBin := filepath.Join(realDir, "jenticctl")
+	if err := os.WriteFile(realBin, []byte("bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(linkDir, "jenticctl")
+	if err := os.Symlink(realBin, link); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveCtlTarget(&config.Manifest{BinaryPath: link})
+	if err != nil {
+		t.Fatalf("resolveCtlTarget: %v", err)
+	}
+	want, _ := filepath.EvalSymlinks(realBin) // temp dirs may themselves be symlinked (macOS /tmp)
+	if got != want {
+		t.Errorf("resolveCtlTarget = %q, want %q", got, want)
+	}
+}
+
+// TestResolveCtlTargetKeepsMissingManifestPath: a stale manifest path that no
+// longer exists is returned verbatim (the swap recreates it).
+func TestResolveCtlTargetKeepsMissingManifestPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "gone", "jenticctl")
+	got, err := resolveCtlTarget(&config.Manifest{BinaryPath: missing})
+	if err != nil {
+		t.Fatalf("resolveCtlTarget: %v", err)
+	}
+	if got != missing {
+		t.Errorf("resolveCtlTarget = %q, want %q", got, missing)
+	}
+}
+
+// TestResolveCtlTargetFallsBackToExecutable: with no manifest path the running
+// executable is used.
+func TestResolveCtlTargetFallsBackToExecutable(t *testing.T) {
+	got, err := resolveCtlTarget(&config.Manifest{})
+	if err != nil {
+		t.Fatalf("resolveCtlTarget: %v", err)
+	}
+	if got == "" {
+		t.Error("resolveCtlTarget returned empty path for executable fallback")
+	}
+}

--- a/cli/internal/update/brew.go
+++ b/cli/internal/update/brew.go
@@ -1,6 +1,7 @@
 package update
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -15,15 +16,19 @@ const BrewUpgradeCommand = "brew upgrade jentic"
 // Self-updating a brew-managed binary desyncs brew's bookkeeping (`brew
 // outdated` keeps reporting the old version and the next `brew upgrade`
 // clobbers the swapped binary), so `update` refuses the CLI swap and points at
-// BrewUpgradeCommand instead — the same policy as flyctl, gh, and friends.
+// BrewUpgradeCommand instead — the policy family flyctl, gh, and friends use:
+// hint at brew rather than swapping behind its back.
 //
 // Two signals mark a brew-managed install:
 //
 //   - the symlink-resolved path has a Cellar or Caskroom segment (brew keeps
 //     the real files there and links them into <prefix>/bin), or
-//   - the resolved path sits directly in `$(brew --prefix)/bin` — a regular
-//     file there is brew territory (e.g. a brew link that an older self-update
-//     overwrote in place).
+//   - the resolved path sits directly in `$(brew --prefix)/bin` *and* the
+//     jentic cask is present in the Caskroom — a regular file there is then a
+//     brew link that an older self-update overwrote in place. The cask check
+//     keeps a deliberate `JENTIC_INSTALL_DIR=/usr/local/bin` source install on
+//     an Intel mac (where /usr/local is the brew prefix but not brew-owned)
+//     from being misdetected.
 //
 // The decision deliberately uses the *resolved* path: a source install linked
 // onto PATH by tools/install.sh (e.g. /usr/local/bin/jenticctl ->
@@ -34,22 +39,33 @@ func BrewManaged(target string) bool {
 	if r, err := filepath.EvalSymlinks(target); err == nil {
 		resolved = r
 	}
-	return brewManaged(resolved, brewBinDir())
+	// Path-only signal first; it decides without spawning `brew --prefix`.
+	if brewManaged(resolved, "", false) {
+		return true
+	}
+	prefix := brewPrefix()
+	if prefix == "" {
+		return false
+	}
+	return brewManaged(resolved, prefix, dirExists(filepath.Join(prefix, "Caskroom", "jentic")))
 }
 
 // brewManaged is the pure decision core behind BrewManaged: resolved is the
-// symlink-resolved binary path and brewBin is `$(brew --prefix)/bin`, or ""
-// when brew is not installed.
-func brewManaged(resolved, brewBin string) bool {
+// symlink-resolved binary path, prefix is the (symlink-resolved) brew prefix or
+// "" when brew is not installed, and caskInstalled reports whether the jentic
+// cask exists under <prefix>/Caskroom.
+func brewManaged(resolved, prefix string, caskInstalled bool) bool {
 	if hasPathSegment(resolved, "Cellar") || hasPathSegment(resolved, "Caskroom") {
 		return true
 	}
-	return brewBin != "" && filepath.Dir(resolved) == filepath.Clean(brewBin)
+	return caskInstalled && prefix != "" && filepath.Dir(resolved) == filepath.Join(prefix, "bin")
 }
 
-// brewBinDir returns `$(brew --prefix)/bin`, or "" when brew is not on PATH or
-// cannot report its prefix.
-func brewBinDir() string {
+// brewPrefix returns the symlink-resolved `$(brew --prefix)`, or "" when brew
+// is not on PATH or cannot report its prefix. Resolving keeps the comparison
+// against an EvalSymlinks'd binary path meaningful on setups where the prefix
+// itself sits behind a symlink.
+func brewPrefix() string {
 	brew, err := exec.LookPath("brew")
 	if err != nil {
 		return ""
@@ -62,7 +78,15 @@ func brewBinDir() string {
 	if prefix == "" {
 		return ""
 	}
-	return filepath.Join(prefix, "bin")
+	if resolved, err := filepath.EvalSymlinks(prefix); err == nil {
+		prefix = resolved
+	}
+	return prefix
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
 }
 
 // hasPathSegment reports whether path contains dir as a whole path segment.

--- a/cli/internal/update/brew.go
+++ b/cli/internal/update/brew.go
@@ -1,0 +1,76 @@
+package update
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// BrewUpgradeCommand is the user-facing command that updates a Homebrew-managed
+// install of the CLIs (both binaries ship in the `jentic` cask).
+const BrewUpgradeCommand = "brew upgrade jentic"
+
+// BrewManaged reports whether the binary at target is managed by Homebrew.
+//
+// Self-updating a brew-managed binary desyncs brew's bookkeeping (`brew
+// outdated` keeps reporting the old version and the next `brew upgrade`
+// clobbers the swapped binary), so `update` refuses the CLI swap and points at
+// BrewUpgradeCommand instead — the same policy as flyctl, gh, and friends.
+//
+// Two signals mark a brew-managed install:
+//
+//   - the symlink-resolved path has a Cellar or Caskroom segment (brew keeps
+//     the real files there and links them into <prefix>/bin), or
+//   - the resolved path sits directly in `$(brew --prefix)/bin` — a regular
+//     file there is brew territory (e.g. a brew link that an older self-update
+//     overwrote in place).
+//
+// The decision deliberately uses the *resolved* path: a source install linked
+// onto PATH by tools/install.sh (e.g. /usr/local/bin/jenticctl ->
+// ~/.jentic/bin/jenticctl) resolves outside brew's tree and must not be
+// misdetected just because /usr/local happens to be the brew prefix.
+func BrewManaged(target string) bool {
+	resolved := target
+	if r, err := filepath.EvalSymlinks(target); err == nil {
+		resolved = r
+	}
+	return brewManaged(resolved, brewBinDir())
+}
+
+// brewManaged is the pure decision core behind BrewManaged: resolved is the
+// symlink-resolved binary path and brewBin is `$(brew --prefix)/bin`, or ""
+// when brew is not installed.
+func brewManaged(resolved, brewBin string) bool {
+	if hasPathSegment(resolved, "Cellar") || hasPathSegment(resolved, "Caskroom") {
+		return true
+	}
+	return brewBin != "" && filepath.Dir(resolved) == filepath.Clean(brewBin)
+}
+
+// brewBinDir returns `$(brew --prefix)/bin`, or "" when brew is not on PATH or
+// cannot report its prefix.
+func brewBinDir() string {
+	brew, err := exec.LookPath("brew")
+	if err != nil {
+		return ""
+	}
+	out, err := exec.Command(brew, "--prefix").Output() //nolint:gosec // brew resolved via LookPath; asking it for its prefix is the point.
+	if err != nil {
+		return ""
+	}
+	prefix := strings.TrimSpace(string(out))
+	if prefix == "" {
+		return ""
+	}
+	return filepath.Join(prefix, "bin")
+}
+
+// hasPathSegment reports whether path contains dir as a whole path segment.
+func hasPathSegment(path, dir string) bool {
+	for _, seg := range strings.Split(filepath.ToSlash(path), "/") {
+		if seg == dir {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/update/brew_test.go
+++ b/cli/internal/update/brew_test.go
@@ -9,70 +9,80 @@ import (
 
 func TestBrewManaged(t *testing.T) {
 	tests := []struct {
-		name     string
-		resolved string
-		brewBin  string
-		want     bool
+		name          string
+		resolved      string
+		prefix        string
+		caskInstalled bool
+		want          bool
 	}{
 		{
 			name:     "cask install resolved into Caskroom",
 			resolved: "/opt/homebrew/Caskroom/jentic/0.16.0/jenticctl",
-			brewBin:  "/opt/homebrew/bin",
+			prefix:   "/opt/homebrew",
 			want:     true,
 		},
 		{
 			name:     "formula install resolved into Cellar",
 			resolved: "/usr/local/Cellar/jentic/0.16.0/bin/jenticctl",
-			brewBin:  "/usr/local/bin",
+			prefix:   "/usr/local",
 			want:     true,
 		},
 		{
 			name:     "Caskroom detected even without brew on PATH",
 			resolved: "/opt/homebrew/Caskroom/jentic/0.16.0/jenticctl",
-			brewBin:  "",
+			prefix:   "",
 			want:     true,
 		},
 		{
-			name:     "regular file directly in brew bin",
-			resolved: "/opt/homebrew/bin/jenticctl",
-			brewBin:  "/opt/homebrew/bin",
-			want:     true,
+			name:          "regular file in brew bin with the cask installed (overwritten link)",
+			resolved:      "/opt/homebrew/bin/jenticctl",
+			prefix:        "/opt/homebrew",
+			caskInstalled: true,
+			want:          true,
+		},
+		{
+			name:     "regular file in brew bin without the cask (deliberate /usr/local/bin source install)",
+			resolved: "/usr/local/bin/jenticctl",
+			prefix:   "/usr/local",
+			want:     false,
 		},
 		{
 			name:     "source install under ~/.jentic/bin",
 			resolved: "/home/u/.jentic/bin/jenticctl",
-			brewBin:  "/home/linuxbrew/.linuxbrew/bin",
+			prefix:   "/home/linuxbrew/.linuxbrew",
 			want:     false,
 		},
 		{
-			name:     "source install resolved out of the brew prefix",
-			resolved: "/Users/u/.jentic/bin/jenticctl",
-			brewBin:  "/usr/local/bin",
-			want:     false,
+			name:          "source install resolved out of the brew prefix",
+			resolved:      "/Users/u/.jentic/bin/jenticctl",
+			prefix:        "/usr/local",
+			caskInstalled: true,
+			want:          false,
 		},
 		{
 			name:     "no brew installed, generic path",
 			resolved: "/usr/local/bin/jenticctl",
-			brewBin:  "",
+			prefix:   "",
 			want:     false,
 		},
 		{
-			name:     "nested under brew bin but not directly in it",
-			resolved: "/opt/homebrew/bin/sub/jenticctl",
-			brewBin:  "/opt/homebrew/bin",
-			want:     false,
+			name:          "nested under brew bin but not directly in it",
+			resolved:      "/opt/homebrew/bin/sub/jenticctl",
+			prefix:        "/opt/homebrew",
+			caskInstalled: true,
+			want:          false,
 		},
 		{
 			name:     "Cellar as a filename component, not a segment",
 			resolved: "/data/myCellar/bin/jenticctl",
-			brewBin:  "",
+			prefix:   "",
 			want:     false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := brewManaged(tt.resolved, tt.brewBin); got != tt.want {
-				t.Errorf("brewManaged(%q, %q) = %v, want %v", tt.resolved, tt.brewBin, got, tt.want)
+			if got := brewManaged(tt.resolved, tt.prefix, tt.caskInstalled); got != tt.want {
+				t.Errorf("brewManaged(%q, %q, %v) = %v, want %v", tt.resolved, tt.prefix, tt.caskInstalled, got, tt.want)
 			}
 		})
 	}

--- a/cli/internal/update/brew_test.go
+++ b/cli/internal/update/brew_test.go
@@ -1,0 +1,121 @@
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestBrewManaged(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolved string
+		brewBin  string
+		want     bool
+	}{
+		{
+			name:     "cask install resolved into Caskroom",
+			resolved: "/opt/homebrew/Caskroom/jentic/0.16.0/jenticctl",
+			brewBin:  "/opt/homebrew/bin",
+			want:     true,
+		},
+		{
+			name:     "formula install resolved into Cellar",
+			resolved: "/usr/local/Cellar/jentic/0.16.0/bin/jenticctl",
+			brewBin:  "/usr/local/bin",
+			want:     true,
+		},
+		{
+			name:     "Caskroom detected even without brew on PATH",
+			resolved: "/opt/homebrew/Caskroom/jentic/0.16.0/jenticctl",
+			brewBin:  "",
+			want:     true,
+		},
+		{
+			name:     "regular file directly in brew bin",
+			resolved: "/opt/homebrew/bin/jenticctl",
+			brewBin:  "/opt/homebrew/bin",
+			want:     true,
+		},
+		{
+			name:     "source install under ~/.jentic/bin",
+			resolved: "/home/u/.jentic/bin/jenticctl",
+			brewBin:  "/home/linuxbrew/.linuxbrew/bin",
+			want:     false,
+		},
+		{
+			name:     "source install resolved out of the brew prefix",
+			resolved: "/Users/u/.jentic/bin/jenticctl",
+			brewBin:  "/usr/local/bin",
+			want:     false,
+		},
+		{
+			name:     "no brew installed, generic path",
+			resolved: "/usr/local/bin/jenticctl",
+			brewBin:  "",
+			want:     false,
+		},
+		{
+			name:     "nested under brew bin but not directly in it",
+			resolved: "/opt/homebrew/bin/sub/jenticctl",
+			brewBin:  "/opt/homebrew/bin",
+			want:     false,
+		},
+		{
+			name:     "Cellar as a filename component, not a segment",
+			resolved: "/data/myCellar/bin/jenticctl",
+			brewBin:  "",
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := brewManaged(tt.resolved, tt.brewBin); got != tt.want {
+				t.Errorf("brewManaged(%q, %q) = %v, want %v", tt.resolved, tt.brewBin, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBrewManagedResolvesSymlinks builds a Caskroom-shaped layout in a temp dir
+// with a bin symlink pointing into it (the shape `brew install --cask` leaves
+// behind) and checks the symlink is detected as brew-managed.
+func TestBrewManagedResolvesSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink layout test targets unix")
+	}
+	root := t.TempDir()
+	caskDir := filepath.Join(root, "Caskroom", "jentic", "0.16.0")
+	binDir := filepath.Join(root, "bin")
+	for _, d := range []string{caskDir, binDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	realBin := filepath.Join(caskDir, "jenticctl")
+	if err := os.WriteFile(realBin, []byte("bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(binDir, "jenticctl")
+	if err := os.Symlink(realBin, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if !BrewManaged(link) {
+		t.Errorf("BrewManaged(%q) = false, want true (resolves into Caskroom)", link)
+	}
+	if !BrewManaged(realBin) {
+		t.Errorf("BrewManaged(%q) = false, want true", realBin)
+	}
+	outside := filepath.Join(root, "elsewhere", "jenticctl")
+	if err := os.MkdirAll(filepath.Dir(outside), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outside, []byte("bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if BrewManaged(outside) {
+		t.Errorf("BrewManaged(%q) = true, want false", outside)
+	}
+}

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -1684,7 +1684,7 @@
           "path": "jenticctl update",
           "use": "update",
           "short": "Update the jentic CLIs (and check the stack) to the latest release",
-          "long": "update reports the installed CLI and server versions, compares the\ninstalled version against the latest release tag on GitHub, and (unless\n--check) rebuilds and replaces the jenticctl and jentic binaries in place,\nthen rebuilds the installed stack. Use --cli-only or --stack-only to update\njust one half.",
+          "long": "update reports the installed CLI and server versions, compares the\ninstalled version against the latest release tag on GitHub, and (unless\n--check) rebuilds and replaces the jenticctl and jentic binaries in place,\nthen rebuilds the installed stack. Use --cli-only or --stack-only to update\njust one half.\n\nA Homebrew-installed CLI is never swapped in place: update it with\n`brew upgrade jentic` (a combined update then refreshes only the stack,\nand --cli-only fails).",
           "group_title": "Setup \u0026 lifecycle",
           "flags": [
             {


### PR DESCRIPTION
## The problem, in one line

`brew install jentic` + `jenticctl update` = brew never finds out.

`jenticctl update` rebuilt from source and swapped the binaries wherever they lived. For a Homebrew install that meant:

- **Overwriting files inside the Caskroom** — `brew outdated` keeps reporting the old version forever, and the next `brew upgrade` clobbers the self-updated binaries (including any `--ref`-pinned build).
- **Worse, with a recorded manifest:** `binary_path` held brew's *symlink* (`/opt/homebrew/bin/jenticctl`), and the swap renamed a real file over it — breaking brew's link farm and orphaning the Caskroom install.
- Stray `.bak` files accumulating in directories brew thinks it owns.

## What this PR does

Follows the same playbook as flyctl, gh, and par-term: **detect the Homebrew install and delegate to brew instead of swapping behind its back.**

### Detection (`internal/update/brew.go`)

The binary is brew-managed when, after resolving symlinks:

1. its path has a `Cellar/` or `Caskroom/` segment (brew keeps the real files there), **or**
2. it's a regular file directly in `$(brew --prefix)/bin` *and* the `jentic` cask is present in the Caskroom (catches links a pre-fix self-update already overwrote).

Guardrails: the check uses the *resolved* path and requires the cask for signal 2, so a source install linked or placed into `/usr/local/bin` on an Intel mac (brew prefix, but not brew-owned) is never misdetected. `brew --prefix` is only spawned when the cheap path checks miss.

### Behavior (`internal/cmd/update.go`)

| Command | Homebrew install | Source install |
|---|---|---|
| `update --check` | shows `managed by: Homebrew — update the CLI with 'brew upgrade jentic'` | unchanged |
| `update` | skips the CLI swap with a warning, still updates the stack | unchanged |
| `update --cli-only` | errors with the `brew upgrade jentic` hint | unchanged |
| `update --stack-only` | unchanged | unchanged |

The stack in `~/.jentic` stays ours regardless of how the CLI arrived, so the two-step flow becomes: `brew upgrade jentic` for the binaries, `jenticctl update` for the stack.

### Bug fixes that fell out

- **Stack starvation:** "Already up to date" was gated on the CLI version alone. A brew user whose CLI is fresh (via `brew upgrade`) but whose stack is stale got "nothing to rebuild". Each half is now gated on its own recorded version (`updateNeeded`).
- **Symlink swap:** the manifest branch of the target resolution didn't follow symlinks (the executable branch did). Both now resolve via `resolveCtlTarget`, and `jenticctl install` records the resolved path going forward.

## Review & testing

- Reviewed by three independent passes (bugs, security, feasibility/UX); all 9 findings fixed. Security review: no issues (all inputs are user-owned local state).
- `golangci-lint`: 0 issues · `go vet` clean · full `go test ./...` green (20+ new unit tests for the detector, target resolution, and update gating).
- Manually tested with fake Caskroom/prefix layouts and a stubbed `brew`: cask symlink, `--cli-only` refusal, combined-update degrade, non-brew binary, overwritten-link with/without cask, fresh-CLI + stale-stack, fresh-CLI + fresh-stack.

## Not in scope

- Auto-running `brew upgrade` for the user (flyctl does this; we just hint — easy follow-up if wanted).
- The `cli-conventions` rule's "sole updater" wording could gain a one-line Homebrew exception (separate repo).

Please squash-merge.

Made with [Cursor](https://cursor.com)