### PR TITLE
feat(cli): delegate Homebrew-managed CLI updates to `brew upgrade`

### DIFF
--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -38,9 +38,9 @@ func newUpdateCmd(app *App) *cobra.Command {
 			"--check) rebuilds and replaces the jenticctl and jentic binaries in place,\n" +
 			"then rebuilds the installed stack. Use --cli-only or --stack-only to update\n" +
 			"just one half.\n\n" +
-			"A Homebrew-installed CLI is never swapped in place: update it with\n" +
-			"`brew upgrade jentic` (a combined update then refreshes only the stack,\n" +
-			"and --cli-only fails).",
+			"A Homebrew-installed CLI is never swapped in place: the CLI half runs\n" +
+			"`brew upgrade jentic` instead, so brew's bookkeeping stays consistent\n" +
+			"(--ref cannot pin a Homebrew-managed CLI).",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return app.updateE(cmd.Context(), opts)
@@ -78,7 +78,7 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 		fmt.Fprintln(a.Out, theme.Dim.Render("  (no install manifest; using build-time metadata)"))
 	}
 	if brewManaged {
-		fmt.Fprintln(a.Out, theme.Field("managed by", "Homebrew — update the CLI with `"+update.BrewUpgradeCommand+"`"))
+		fmt.Fprintln(a.Out, theme.Field("managed by", "Homebrew — CLI updates delegate to `"+update.BrewUpgradeCommand+"`"))
 	}
 
 	// Resolve the update target. By default we track the latest release tag; an
@@ -111,15 +111,13 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 	doCLI := !opts.stackOnly
 	doStack := !opts.cliOnly
 
-	// A brew-managed CLI is never swapped by us: brew's bookkeeping would
-	// desync and the next `brew upgrade` would clobber the swapped binaries.
-	// The stack (in ~/.jentic) is ours regardless of how the CLI arrived, so a
-	// combined update degrades to stack-only rather than failing.
-	if brewManaged && doCLI {
-		if opts.cliOnly {
-			return fmt.Errorf("this CLI is managed by Homebrew; update it with `%s`", update.BrewUpgradeCommand)
-		}
-		doCLI = false
+	// A brew-managed CLI is never swapped by us — the CLI half delegates to
+	// `brew upgrade jentic` (flyctl-style) so brew's bookkeeping stays
+	// consistent. brew can only ship the latest release, so an explicit --ref
+	// cannot be honored for the CLI half and is refused rather than silently
+	// updating to something else.
+	if brewManaged && doCLI && pinned {
+		return errors.New("--ref cannot pin a Homebrew-managed CLI (brew only ships the latest release); use --stack-only, or reinstall from source via tools/install.sh")
 	}
 
 	// When the latest release is not newer than what's installed there's
@@ -136,16 +134,16 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 		return nil
 	}
 
-	// Announce the brew degrade only when something will actually run; a
-	// brew-managed install that is already up to date returns above without a
-	// spurious "skipping" warning.
-	if brewManaged && !opts.stackOnly {
+	// Only the stack lags: don't invoke brew for a CLI that is already at the
+	// latest release (brew would just report "already up to date").
+	if brewManaged && doCLI && latestKnown && !update.NewerAvailable(cliVersion, latest) {
+		doCLI = false
 		fmt.Fprintln(a.Out)
-		fmt.Fprintln(a.Out, theme.Warnf("CLI is managed by Homebrew — skipping the CLI update; run `%s` instead.", update.BrewUpgradeCommand))
+		fmt.Fprintln(a.Out, theme.Dim.Render("  CLI already at the latest release; updating the stack only."))
 	}
 
 	if !opts.yes {
-		ok, err := confirmApply(doCLI, doStack, repo, ref)
+		ok, err := confirmApply(doCLI, doStack, brewManaged, repo, ref)
 		if err != nil {
 			return err
 		}
@@ -156,7 +154,11 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 	}
 
 	if doCLI {
-		if err := a.updateCLI(ctx, repo, ref, ctlTarget); err != nil {
+		if brewManaged {
+			if err := a.brewUpgradeCLI(ctx); err != nil {
+				return err
+			}
+		} else if err := a.updateCLI(ctx, repo, ref, ctlTarget); err != nil {
 			return err
 		}
 	}
@@ -165,6 +167,20 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 			return err
 		}
 	}
+	return nil
+}
+
+// brewUpgradeCLI refreshes a Homebrew-managed CLI by delegating to
+// `brew upgrade jentic`, streaming brew's output. brew swaps both binaries
+// (they ship in one cask) and its bookkeeping stays consistent.
+func (a *App) brewUpgradeCLI(ctx context.Context) error {
+	fmt.Fprintln(a.Out)
+	fmt.Fprintln(a.Out, theme.Heading.Render("Updating CLI via Homebrew"))
+	fmt.Fprintln(a.Out, theme.Dimf("  running: %s", update.BrewUpgradeCommand))
+	if err := update.BrewUpgrade(ctx, a.Out, a.Err); err != nil {
+		return err
+	}
+	fmt.Fprintln(a.Out, theme.Successf("CLI updated via Homebrew."))
 	return nil
 }
 
@@ -429,23 +445,14 @@ func (a *App) restartLocalIfRunning() {
 	_ = a.startE(&startOptions{})
 }
 
-func confirmApply(doCLI, doStack bool, repo, ref string) (bool, error) {
-	var what string
-	switch {
-	case doCLI && doStack:
-		what = "the CLI and the stack"
-	case doCLI:
-		what = "the CLI"
-	default:
-		what = "the stack"
-	}
+func confirmApply(doCLI, doStack, brewCLI bool, repo, ref string) (bool, error) {
 	// This prompt is only reached when an update is available, so default the
 	// focused selection to "Yes, update": the user already invoked `update`, so
 	// a reflexive Enter should proceed rather than cancel (#765).
 	confirm := true
 	if err := install.RunConfirm(
 		huh.NewConfirm().
-			Title(fmt.Sprintf("Update %s to %s@%s?", what, repo, ref)).
+			Title(applyPromptTitle(doCLI, doStack, brewCLI, repo, ref)).
 			Affirmative("Yes, update").
 			Negative("Cancel").
 			Value(&confirm),
@@ -456,6 +463,24 @@ func confirmApply(doCLI, doStack bool, repo, ref string) (bool, error) {
 		return false, err
 	}
 	return confirm, nil
+}
+
+// applyPromptTitle words the confirmation prompt for the halves about to run.
+// A brew-managed CLI is updated by brew at brew's latest, not from repo@ref,
+// so the prompt must not promise a ref it cannot honor.
+func applyPromptTitle(doCLI, doStack, brewCLI bool, repo, ref string) string {
+	switch {
+	case brewCLI && doCLI && doStack:
+		return fmt.Sprintf("Update the CLI (via `%s`) and the stack (from %s@%s)?", update.BrewUpgradeCommand, repo, ref)
+	case brewCLI && doCLI:
+		return fmt.Sprintf("Update the CLI via `%s`?", update.BrewUpgradeCommand)
+	case doCLI && doStack:
+		return fmt.Sprintf("Update the CLI and the stack to %s@%s?", repo, ref)
+	case doCLI:
+		return fmt.Sprintf("Update the CLI to %s@%s?", repo, ref)
+	default:
+		return fmt.Sprintf("Update the stack to %s@%s?", repo, ref)
+	}
 }
 
 // printVerdict reports up-to-date / update-available based on the installed CLI

--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -155,7 +155,7 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 
 	if doCLI {
 		if brewManaged {
-			if err := a.brewUpgradeCLI(ctx); err != nil {
+			if err := a.brewUpgradeCLI(ctx, latest, latestKnown); err != nil {
 				return err
 			}
 		} else if err := a.updateCLI(ctx, repo, ref, ctlTarget); err != nil {
@@ -173,12 +173,21 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 // brewUpgradeCLI refreshes a Homebrew-managed CLI by delegating to
 // `brew upgrade jentic`, streaming brew's output. brew swaps both binaries
 // (they ship in one cask) and its bookkeeping stays consistent.
-func (a *App) brewUpgradeCLI(ctx context.Context) error {
+//
+// brew can only install what the cask currently ships, and the cask bump lags
+// the GitHub release tag by a bit; inside that window `brew upgrade` is a
+// clean no-op, so success is only claimed after verifying the installed cask
+// actually reached latest.
+func (a *App) brewUpgradeCLI(ctx context.Context, latest string, latestKnown bool) error {
 	fmt.Fprintln(a.Out)
 	fmt.Fprintln(a.Out, theme.Heading.Render("Updating CLI via Homebrew"))
 	fmt.Fprintln(a.Out, theme.Dimf("  running: %s", update.BrewUpgradeCommand))
 	if err := update.BrewUpgrade(ctx, a.Out, a.Err); err != nil {
 		return err
+	}
+	if caskVersion := update.BrewCaskVersion(ctx); latestKnown && caskVersion != "" && update.NewerAvailable(caskVersion, latest) {
+		fmt.Fprintln(a.Out, theme.Warnf("Homebrew's jentic cask is still at %s (release %s not yet published to the tap) — re-run `%s` in a while.", caskVersion, latest, update.BrewUpgradeCommand))
+		return nil
 	}
 	fmt.Fprintln(a.Out, theme.Successf("CLI updated via Homebrew."))
 	return nil

--- a/cli/internal/cmd/update_test.go
+++ b/cli/internal/cmd/update_test.go
@@ -98,3 +98,30 @@ func TestResolveCtlTargetFallsBackToExecutable(t *testing.T) {
 		t.Error("resolveCtlTarget returned empty path for executable fallback")
 	}
 }
+
+// TestApplyPromptTitle: the confirm prompt must not promise repo@ref for a
+// brew-managed CLI half (brew ships only its latest cask), while non-brew
+// wording is unchanged.
+func TestApplyPromptTitle(t *testing.T) {
+	const repo, ref = "jentic/jentic-one", "v0.21.0"
+	tests := []struct {
+		name                 string
+		doCLI, doStack, brew bool
+		want                 string
+	}{
+		{"source combined", true, true, false, "Update the CLI and the stack to jentic/jentic-one@v0.21.0?"},
+		{"source cli-only", true, false, false, "Update the CLI to jentic/jentic-one@v0.21.0?"},
+		{"stack-only", false, true, false, "Update the stack to jentic/jentic-one@v0.21.0?"},
+		{"brew combined", true, true, true, "Update the CLI (via `brew upgrade jentic`) and the stack (from jentic/jentic-one@v0.21.0)?"},
+		{"brew cli-only", true, false, true, "Update the CLI via `brew upgrade jentic`?"},
+		{"brew stack-only unaffected", false, true, true, "Update the stack to jentic/jentic-one@v0.21.0?"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applyPromptTitle(tt.doCLI, tt.doStack, tt.brew, repo, ref)
+			if got != tt.want {
+				t.Errorf("applyPromptTitle(%v, %v, %v) = %q, want %q", tt.doCLI, tt.doStack, tt.brew, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/internal/update/brew.go
+++ b/cli/internal/update/brew.go
@@ -32,13 +32,36 @@ func BrewUpgrade(ctx context.Context, out, errW io.Writer) error {
 	return nil
 }
 
+// BrewCaskVersion returns the installed version of the jentic cask as reported
+// by brew (`brew list --cask --versions jentic`), or "" when it cannot be
+// determined. Callers use it to verify that an upgrade actually moved the
+// cask: brew can only install what the cask ships, and the cask bump lags the
+// GitHub release tag, so a `brew upgrade` inside that window is a no-op.
+func BrewCaskVersion(ctx context.Context) string {
+	brew, err := exec.LookPath("brew")
+	if err != nil {
+		return ""
+	}
+	out, err := exec.CommandContext(ctx, brew, "list", "--cask", "--versions", "jentic").Output() //nolint:gosec // brew resolved via LookPath with fixed args.
+	if err != nil {
+		return ""
+	}
+	// Output is "jentic <version> [<version>...]"; brew lists oldest first, so
+	// the last field is the newest installed version.
+	fields := strings.Fields(string(out))
+	if len(fields) < 2 || fields[0] != "jentic" {
+		return ""
+	}
+	return fields[len(fields)-1]
+}
+
 // BrewManaged reports whether the binary at target is managed by Homebrew.
 //
 // Self-updating a brew-managed binary desyncs brew's bookkeeping (`brew
 // outdated` keeps reporting the old version and the next `brew upgrade`
-// clobbers the swapped binary), so `update` refuses the CLI swap and points at
-// BrewUpgradeCommand instead — the policy family flyctl, gh, and friends use:
-// hint at brew rather than swapping behind its back.
+// clobbers the swapped binary), so `update` never swaps the CLI in place and
+// instead delegates the CLI half to BrewUpgrade — the policy family flyctl,
+// gh, and friends use: let brew do the swap rather than going behind its back.
 //
 // Two signals mark a brew-managed install:
 //

--- a/cli/internal/update/brew.go
+++ b/cli/internal/update/brew.go
@@ -1,6 +1,9 @@
 package update
 
 import (
+	"context"
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +13,24 @@ import (
 // BrewUpgradeCommand is the user-facing command that updates a Homebrew-managed
 // install of the CLIs (both binaries ship in the `jentic` cask).
 const BrewUpgradeCommand = "brew upgrade jentic"
+
+// BrewUpgrade runs `brew upgrade jentic`, streaming its output, to refresh a
+// Homebrew-managed install. It is the CLI half of `jenticctl update` for
+// brew-managed binaries (flyctl-style delegation): brew performs the swap so
+// its bookkeeping stays consistent.
+func BrewUpgrade(ctx context.Context, out, errW io.Writer) error {
+	brew, err := exec.LookPath("brew")
+	if err != nil {
+		return fmt.Errorf("brew not found on PATH; update the CLI with `%s` from a brew-enabled shell", BrewUpgradeCommand)
+	}
+	cmd := exec.CommandContext(ctx, brew, "upgrade", "jentic") //nolint:gosec // brew resolved via LookPath with fixed args; delegating the upgrade to brew is the point.
+	cmd.Stdout = out
+	cmd.Stderr = errW
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("`%s` failed: %w", BrewUpgradeCommand, err)
+	}
+	return nil
+}
 
 // BrewManaged reports whether the binary at target is managed by Homebrew.
 //

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -1684,7 +1684,7 @@
           "path": "jenticctl update",
           "use": "update",
           "short": "Update the jentic CLIs (and check the stack) to the latest release",
-          "long": "update reports the installed CLI and server versions, compares the\ninstalled version against the latest release tag on GitHub, and (unless\n--check) rebuilds and replaces the jenticctl and jentic binaries in place,\nthen rebuilds the installed stack. Use --cli-only or --stack-only to update\njust one half.\n\nA Homebrew-installed CLI is never swapped in place: update it with\n`brew upgrade jentic` (a combined update then refreshes only the stack,\nand --cli-only fails).",
+          "long": "update reports the installed CLI and server versions, compares the\ninstalled version against the latest release tag on GitHub, and (unless\n--check) rebuilds and replaces the jenticctl and jentic binaries in place,\nthen rebuilds the installed stack. Use --cli-only or --stack-only to update\njust one half.\n\nA Homebrew-installed CLI is never swapped in place: the CLI half runs\n`brew upgrade jentic` instead, so brew's bookkeeping stays consistent\n(--ref cannot pin a Homebrew-managed CLI).",
           "group_title": "Setup \u0026 lifecycle",
           "flags": [
             {


### PR DESCRIPTION
## Summary

Follow-up to #854. There we taught `jenticctl update` to *refuse* touching a Homebrew-managed CLI and print a hint. This PR closes the loop flyctl-style: instead of telling the user to run `brew upgrade jentic`, the CLI half of `update` now **runs it for them** — behind the same confirmation prompt (or `--yes`) as the rest of the update.

### Behavior on a brew-managed install

| Command | Before (#854) | Now |
|---|---|---|
| `update` (combined) | warned + stack-only | prompts, then runs `brew upgrade jentic` + stack update |
| `update --cli-only` | hard error with hint | prompts, then runs `brew upgrade jentic` |
| `update --ref X` | silently degraded to stack-only | explicit error: brew only ships the latest release |
| `update`, CLI current but stack stale | stack-only | stack-only, with a quiet note (no pointless brew call) |
| `update --check` | status + hint | status + "CLI updates delegate to `brew upgrade jentic`" |

Source installs are completely unaffected — same prompt, same in-place swap as before.

### Details worth knowing

- The confirm prompt is honest about what runs where: *"Update the CLI (via `brew upgrade jentic`) and the stack (from repo@ref)?"* — brew installs its cask's latest, not our `repo@ref`.
- **Tap-lag window**: right after a release is tagged, the cask bump can lag and `brew upgrade` is a clean no-op. We verify via `brew list --cask --versions jentic` that the cask actually reached latest before claiming success; otherwise we explain the lag and suggest retrying later.
- `brew` missing from PATH (but binary in Caskroom) fails with a clear message rather than a confusing swap.

### Testing

- Unit tests for the new prompt wording (`applyPromptTitle`) alongside the existing `updateNeeded` / `resolveCtlTarget` / brew-detection suites.
- Manual smoke tests with a fake brew + Caskroom harness: check mode, `--yes` auto-run (verified via brew call log), `--ref` refusal, up-to-date short-circuit, stack-lag path, tap-lag window, missing brew, and a non-brew source install (unaffected).
- `make lint` (golangci-lint v2.12.2): 0 issues; `make cli-reference` regenerated.

Reviewed by Bugbot; both findings (false success in the tap-lag window, stale doc comment) fixed in the second commit.

Made with [Cursor](https://cursor.com)