### PR TITLE
fix(auth): fail closed on missing or unknown actor_type in verify_token

### DIFF
--- a/src/jentic_one/shared/auth/identity.py
+++ b/src/jentic_one/shared/auth/identity.py
@@ -50,6 +50,10 @@ class Identity(BaseModel):
     parent_permissions: list[str] = []
 
     must_change_password: bool = False
+    # Convenience default for trusted constructors (tests, resolvers that
+    # already know the type). The *untrusted* boundary must never rely on
+    # it: verify_token fails closed on a token without an explicit
+    # actor_type claim (#862) — never default when parsing credentials.
     actor_type: ActorType = ActorType.USER
     parent_actor_id: str | None = None
 

--- a/src/jentic_one/shared/auth/verify.py
+++ b/src/jentic_one/shared/auth/verify.py
@@ -64,11 +64,19 @@ async def verify_token(token: str, *, secret: str, ctx: Context) -> Identity:
     claims = decode_jwt(token, secret)
     actor_type_claim = claims.get("actor_type")
     if actor_type_claim is None:
+        # The wire response is deliberately uniform with any other bad token
+        # (401, no oracle for forgers) — log the real cause so an operator
+        # can tell a claim-less token from a bad signature or wrong secret.
+        logger.warning("jwt_actor_type_missing", sub=claims.get("sub"))
         raise InvalidTokenError("Token does not declare an actor_type")
     try:
         actor_type = ActorType(actor_type_claim)
     except ValueError as exc:
-        # Unknown value: refuse cleanly (401) instead of leaking a 500.
+        # Typed, deliberate rejection instead of relying on the web layer's
+        # catch-all to absorb a ValueError from the enum constructor.
+        logger.warning(
+            "jwt_actor_type_unknown", sub=claims.get("sub"), actor_type=str(actor_type_claim)
+        )
         raise InvalidTokenError("Token declares an unknown actor_type") from exc
     sub = claims["sub"]
     parent_actor_id = claims.get("parent_actor_id")

--- a/src/jentic_one/shared/auth/verify.py
+++ b/src/jentic_one/shared/auth/verify.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import structlog
 
 from jentic_one.shared.auth.identity import Identity
-from jentic_one.shared.auth.tokens import decode_jwt
+from jentic_one.shared.auth.tokens import InvalidTokenError, decode_jwt
 from jentic_one.shared.context import Context
 from jentic_one.shared.models import ActorType
 
@@ -51,12 +51,25 @@ async def resolve_permissions_for_actor(
 async def verify_token(token: str, *, secret: str, ctx: Context) -> Identity:
     """Decode and verify a JWT, returning the Identity.
 
-    When the JWT already embeds ``permissions`` in its claims (e.g. login JWTs),
-    those are trusted directly — no DB lookup. Otherwise falls back to the
-    database-resolved permission path for backwards compatibility.
+    Fail-closed on the actor type (#862): every JWT we mint carries an
+    explicit ``actor_type`` claim, so a validly-signed token without one —
+    or with a value we don't recognise — is refused rather than assumed to
+    be a USER (the most-privileged interpretation). Raises the same
+    ``InvalidTokenError`` as a bad signature; the web layer maps it to 401.
+
+    When the JWT already embeds ``permissions`` in its claims (e.g. login
+    JWTs), those are trusted directly — no DB lookup. Otherwise falls back
+    to the database-resolved permission path for backwards compatibility.
     """
     claims = decode_jwt(token, secret)
-    actor_type = ActorType(claims.get("actor_type", ActorType.USER))
+    actor_type_claim = claims.get("actor_type")
+    if actor_type_claim is None:
+        raise InvalidTokenError("Token does not declare an actor_type")
+    try:
+        actor_type = ActorType(actor_type_claim)
+    except ValueError as exc:
+        # Unknown value: refuse cleanly (401) instead of leaking a 500.
+        raise InvalidTokenError("Token declares an unknown actor_type") from exc
     sub = claims["sub"]
     parent_actor_id = claims.get("parent_actor_id")
 

--- a/tests/unit/shared/auth/test_verify.py
+++ b/tests/unit/shared/auth/test_verify.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from jentic_one.shared.auth.tokens import issue_jwt
+from jentic_one.shared.auth.tokens import InvalidTokenError, issue_jwt
 from jentic_one.shared.auth.verify import verify_token
 
 
@@ -95,6 +95,7 @@ async def test_jwt_with_permissions_and_scopes_merges_both(
     claims = {
         "sub": "usr_4",
         "email": "user@example.com",
+        "actor_type": "user",
         "permissions": ["direct:perm"],
         "scopes": ["scope:a"],
     }
@@ -105,3 +106,34 @@ async def test_jwt_with_permissions_and_scopes_merges_both(
     assert "direct:perm" in identity.permissions
     assert "scope:a" in identity.permissions
     mock_resolve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_jwt_without_actor_type_rejected(mock_ctx: MagicMock) -> None:
+    """Fail closed (#862): a validly-signed JWT with no actor_type claim is refused."""
+    secret = "a" * 32
+    claims = {
+        "sub": "usr_5",
+        "email": "user@example.com",
+        "permissions": ["org:admin"],
+    }
+    token = issue_jwt(claims=claims, secret=secret, ttl_seconds=3600)
+
+    with pytest.raises(InvalidTokenError):
+        await verify_token(token, secret=secret, ctx=mock_ctx)
+
+
+@pytest.mark.asyncio
+async def test_jwt_with_unknown_actor_type_rejected(mock_ctx: MagicMock) -> None:
+    """An unrecognised actor_type raises InvalidTokenError (mapped to 401), not ValueError."""
+    secret = "a" * 32
+    claims = {
+        "sub": "usr_6",
+        "email": "user@example.com",
+        "actor_type": "definitely-not-a-real-actor",
+        "permissions": ["org:admin"],
+    }
+    token = issue_jwt(claims=claims, secret=secret, ttl_seconds=3600)
+
+    with pytest.raises(InvalidTokenError):
+        await verify_token(token, secret=secret, ctx=mock_ctx)

--- a/tests/unit/shared/auth/test_verify.py
+++ b/tests/unit/shared/auth/test_verify.py
@@ -109,30 +109,24 @@ async def test_jwt_with_permissions_and_scopes_merges_both(
 
 
 @pytest.mark.asyncio
-async def test_jwt_without_actor_type_rejected(mock_ctx: MagicMock) -> None:
-    """Fail closed (#862): a validly-signed JWT with no actor_type claim is refused."""
+@pytest.mark.parametrize(
+    "actor_type_claim",
+    [None, "definitely-not-a-real-actor"],
+    ids=["missing", "unknown"],
+)
+async def test_jwt_with_bad_actor_type_rejected(
+    mock_ctx: MagicMock, actor_type_claim: str | None
+) -> None:
+    """Fail closed (#862): a validly-signed JWT is refused when actor_type is
+    absent or unrecognised — typed InvalidTokenError, never a bare ValueError."""
     secret = "a" * 32
     claims = {
         "sub": "usr_5",
         "email": "user@example.com",
         "permissions": ["org:admin"],
     }
-    token = issue_jwt(claims=claims, secret=secret, ttl_seconds=3600)
-
-    with pytest.raises(InvalidTokenError):
-        await verify_token(token, secret=secret, ctx=mock_ctx)
-
-
-@pytest.mark.asyncio
-async def test_jwt_with_unknown_actor_type_rejected(mock_ctx: MagicMock) -> None:
-    """An unrecognised actor_type raises InvalidTokenError (mapped to 401), not ValueError."""
-    secret = "a" * 32
-    claims = {
-        "sub": "usr_6",
-        "email": "user@example.com",
-        "actor_type": "definitely-not-a-real-actor",
-        "permissions": ["org:admin"],
-    }
+    if actor_type_claim is not None:
+        claims["actor_type"] = actor_type_claim
     token = issue_jwt(claims=claims, secret=secret, ttl_seconds=3600)
 
     with pytest.raises(InvalidTokenError):

--- a/tests/web/admin/test_audit.py
+++ b/tests/web/admin/test_audit.py
@@ -23,6 +23,7 @@ def test_list_without_admin(unauthed_client: TestClient, web_context: Context) -
     claims = {
         "sub": "nonadmin-user",
         "email": "nonadmin@test.local",
+        "actor_type": "user",
         "permissions": ["users:read"],
         "must_change_password": False,
     }

--- a/tests/web/admin/test_auth.py
+++ b/tests/web/admin/test_auth.py
@@ -271,6 +271,40 @@ def test_refresh_non_user_token_rejected(
     assert resp.json()["type"] == "invalid_credentials"
 
 
+# ── Shared auth gate (verify_token fail-closed, #862) ───────────────────────
+
+
+@pytest.mark.parametrize(
+    "actor_type_claim",
+    [None, "definitely-not-a-real-actor"],
+    ids=["missing", "unknown"],
+)
+def test_token_with_bad_actor_type_is_401(
+    unauthed_client: TestClient,
+    web_context: Context,
+    admin_user_id: str,
+    actor_type_claim: str | None,
+) -> None:
+    """Fail closed (#862): the gate refuses a JWT whose actor_type is absent or unrecognised.
+
+    The wire response must stay uniform with any other bad token — 401
+    ``unauthorized`` Problem Details, no oracle about which check failed.
+    """
+    config = web_context.config.admin.auth
+    claims: dict[str, Any] = {
+        "sub": admin_user_id,
+        "email": ADMIN_EMAIL,
+        "permissions": ["org:admin"],
+        "must_change_password": False,
+    }
+    if actor_type_claim is not None:
+        claims["actor_type"] = actor_type_claim
+    token = issue_jwt(claims, config.jwt_secret.get_secret_value(), config.jwt_ttl_seconds)
+    resp = unauthed_client.get("/users/me", headers=_bearer(token))
+    assert resp.status_code == 401
+    assert resp.json()["type"] == "unauthorized"
+
+
 # ── First-run create-admin (one-time, unauthenticated setup) ───────────────
 
 

--- a/tests/web/admin/test_users.py
+++ b/tests/web/admin/test_users.py
@@ -193,39 +193,6 @@ def test_users_read_can_list(
     assert resp.status_code == 200
 
 
-def test_token_without_actor_type_is_401(
-    unauthed_client: TestClient, web_context: Context, reader_user_permissions: None
-) -> None:
-    """Fail closed (#862): a validly-signed JWT with no actor_type claim gets 401."""
-    config = web_context.config.admin.auth
-    claims = {
-        "sub": "reader-user",
-        "email": "reader@test.com",
-        "must_change_password": False,
-    }
-    token = issue_jwt(claims, config.jwt_secret.get_secret_value(), config.jwt_ttl_seconds)
-    resp = unauthed_client.get("/users", headers={"Authorization": f"Bearer {token}"})
-    assert resp.status_code == 401
-    assert resp.json()["type"] == "unauthorized"
-
-
-def test_token_with_unknown_actor_type_is_401_not_500(
-    unauthed_client: TestClient, web_context: Context, reader_user_permissions: None
-) -> None:
-    """An unrecognised actor_type claim is a clean 401, never a ValueError→500."""
-    config = web_context.config.admin.auth
-    claims = {
-        "sub": "reader-user",
-        "email": "reader@test.com",
-        "actor_type": "definitely-not-a-real-actor",
-        "must_change_password": False,
-    }
-    token = issue_jwt(claims, config.jwt_secret.get_secret_value(), config.jwt_ttl_seconds)
-    resp = unauthed_client.get("/users", headers={"Authorization": f"Bearer {token}"})
-    assert resp.status_code == 401
-    assert resp.json()["type"] == "unauthorized"
-
-
 def test_users_read_cannot_create(
     unauthed_client: TestClient, web_context: Context, reader_user_permissions: None
 ) -> None:

--- a/tests/web/admin/test_users.py
+++ b/tests/web/admin/test_users.py
@@ -193,6 +193,39 @@ def test_users_read_can_list(
     assert resp.status_code == 200
 
 
+def test_token_without_actor_type_is_401(
+    unauthed_client: TestClient, web_context: Context, reader_user_permissions: None
+) -> None:
+    """Fail closed (#862): a validly-signed JWT with no actor_type claim gets 401."""
+    config = web_context.config.admin.auth
+    claims = {
+        "sub": "reader-user",
+        "email": "reader@test.com",
+        "must_change_password": False,
+    }
+    token = issue_jwt(claims, config.jwt_secret.get_secret_value(), config.jwt_ttl_seconds)
+    resp = unauthed_client.get("/users", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+    assert resp.json()["type"] == "unauthorized"
+
+
+def test_token_with_unknown_actor_type_is_401_not_500(
+    unauthed_client: TestClient, web_context: Context, reader_user_permissions: None
+) -> None:
+    """An unrecognised actor_type claim is a clean 401, never a ValueError→500."""
+    config = web_context.config.admin.auth
+    claims = {
+        "sub": "reader-user",
+        "email": "reader@test.com",
+        "actor_type": "definitely-not-a-real-actor",
+        "must_change_password": False,
+    }
+    token = issue_jwt(claims, config.jwt_secret.get_secret_value(), config.jwt_ttl_seconds)
+    resp = unauthed_client.get("/users", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+    assert resp.json()["type"] == "unauthorized"
+
+
 def test_users_read_cannot_create(
     unauthed_client: TestClient, web_context: Context, reader_user_permissions: None
 ) -> None:
@@ -224,6 +257,7 @@ def test_password_expired_blocks_access(unauthed_client: TestClient, web_context
     claims = {
         "sub": "expired-pw-user",
         "email": "expired@test.com",
+        "actor_type": "user",
         "permissions": ["org:admin"],
         "must_change_password": True,
     }

--- a/tests/web/auth/conftest.py
+++ b/tests/web/auth/conftest.py
@@ -170,6 +170,7 @@ def _make_token(ctx: Context, user_id: str, email: str, permissions: list[str]) 
     claims = {
         "sub": user_id,
         "email": email,
+        "actor_type": "user",
         "permissions": permissions,
         "must_change_password": False,
     }

--- a/tests/web/auth/test_agents.py
+++ b/tests/web/auth/test_agents.py
@@ -424,6 +424,7 @@ def test_password_rotation_required(web_context: Context) -> None:
     claims = {
         "sub": "user-needs-rotation",
         "email": "rotation@test.local",
+        "actor_type": "user",
         "permissions": ["org:admin"],
         "must_change_password": True,
     }

--- a/tests/web/auth/test_service_accounts.py
+++ b/tests/web/auth/test_service_accounts.py
@@ -198,6 +198,7 @@ def test_password_rotation_required(web_context: Context) -> None:
     claims = {
         "sub": "user-needs-rotation",
         "email": "rotation@test.local",
+        "actor_type": "user",
         "permissions": ["org:admin"],
         "must_change_password": True,
     }

--- a/tests/web/registry/conftest.py
+++ b/tests/web/registry/conftest.py
@@ -58,6 +58,7 @@ def _make_token(ctx: Context) -> str:
     claims = {
         "sub": "usr_test_registry",
         "email": "registry-test@test.local",
+        "actor_type": "user",
         "permissions": ["apis:read", "apis:write", "capabilities:read"],
         "must_change_password": False,
     }


### PR DESCRIPTION
Closes #862.

## TL;DR (human)

The platform-wide auth gate (`verify_token`, used by every JWT-authenticated endpoint on the admin, auth, and broker surfaces) treated a validly-signed token **without** an `actor_type` claim as a USER — the most-privileged interpretation — and let an unrecognised value escape as a bare `ValueError` (absorbed by the web layer's catch-all rather than rejected deliberately). Since #857 every JWT we mint declares its `actor_type` explicitly, so the gate no longer needs to guess. Now it refuses: missing or unknown `actor_type` → `InvalidTokenError` → clean 401. Follow-up to the fail-closed refresh check that shipped in #857, extending the same posture from one endpoint to the whole gate.

## What changes for whom (scenarios)

**Normal users, agents, service accounts — nothing.** Every token minted since #857 carries an explicit `actor_type` claim, and API keys / opaque `at_` tokens are resolved by their own resolvers before the JWT path is reached.

**A token minted before #857 deploys (no `actor_type` claim):** rejected with 401 once this ships. Those tokens live at most `jwt_ttl_seconds` (default 1 h) past the #857 deploy, so shipping this one release later — which is exactly the situation, #857 is already on `main` — means real users are unaffected unless both changes land in the same deploy, in which case they sign in once more (same one-time cost #857 already accepted for refresh).

**A forged/foreign token with a junk `actor_type`:** still a 401 on the wire (the web layer's catch-all already absorbed the old `ValueError`), but now rejected deliberately with a typed `InvalidTokenError` — and the refusal cause is logged server-side (`jwt_actor_type_missing` / `jwt_actor_type_unknown`) so an operator can tell a claim-less token from a bad signature or a wrong secret. The client response stays uniform (no oracle for forgers).

## For agents / reviewers (machine-oriented map)

| Concern | File |
|---|---|
| Fail-closed gate | `src/jentic_one/shared/auth/verify.py` (`verify_token`: require claim, map unknown → `InvalidTokenError`) |
| Documented contract | `src/jentic_one/shared/auth/identity.py` (comment on `Identity.actor_type`) |
| New unit tests | `tests/unit/shared/auth/test_verify.py` (missing claim rejected, junk claim rejected) |
| New end-to-end web tests | `tests/web/admin/test_auth.py` (parametrized: missing/unknown claim → uniform 401) |
| Test claims updated to explicit shape | `tests/web/{auth,registry,admin}/…` (6 sites that minted claim-less tokens) |

Design decisions (and why):
- **`Identity.actor_type` keeps its `USER` default.** The issue suggested considering its removal; an audit found all ~120 default-relying construction sites are tests, and every production constructor passes it explicitly. The trust boundary is the *gate*, not the model — removing the default would churn ~120 test lines for zero runtime gain. Documented in a comment on the field instead.
- **`InvalidTokenError` (not a Problem Details type) is raised** so the gate stays web-framework-agnostic; `resolve_identity` in `shared/web/deps.py` already maps any verifier exception to 401 `unauthorized`.
- The OAuth connect-state JWT (`control/services/credentials/state.py`) is untouched: separate secret, internal round-trip, never flows through `verify_token`.

## Verification

- [x] `make lint` (ruff, format, mypy) clean
- [x] 307 tests green: `tests/unit/shared/auth`, all of `tests/web`, `tests/integration/admin/services/test_auth_service.py`
- [x] Two pre-existing local failures in `tests/integration/shared/auth/test_verify.py` reproduce on unmodified `main` (fixture/DB-state issue when run standalone) and are green in CI — not touched by this change

## Reviews

Five parallel reviews (security, Bugbot, feasibility, product fit, architecture/rules) were run on this branch; all actionable feedback is folded in:
- **Observability** (product fit, major): refusals are now logged with their real cause while the wire response stays uniform.
- **Accuracy** (architecture + product fit): the original "prevented a 500" rationale was wrong — `resolve_identity`'s catch-all already mapped the `ValueError` to 401; comment, tests, and this description now state the real win (typed, deliberate rejection).
- **Test placement/shape** (architecture, minor): gate tests moved beside the token-lifecycle tests and parametrized.
- **Broker parallel** (feasibility + architecture): the broker's independent JWT validator still defaults a missing claim (to AGENT, least-privileged) — deliberately out of scope here; filed as #864.
- Two "high" findings (missing `InvalidTokenError` export, mint paths without `actor_type`) were false positives from reviewing against a stale pre-#857 base; both landed in #857 and CI is green.

> Merge with **squash + merge** (repo convention — PR title becomes the squash commit).

Made with [Cursor](https://cursor.com)
