### PR TITLE
fix(broker): reject unknown actor_type in JWT validator, log missing claim

### DIFF
--- a/src/jentic_one/broker/services/auth/token_validation.py
+++ b/src/jentic_one/broker/services/auth/token_validation.py
@@ -22,10 +22,13 @@ from enum import StrEnum
 from typing import Protocol
 
 import jwt
+import structlog
 
 from jentic_one.broker.core.token_validation import CachedTokenValidator
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.models import ActorType
+
+logger = structlog.get_logger(__name__)
 
 # Algorithms we accept for the self-contained-JWT path. HS256 only for the
 # minimal PR-A2 verifier; §08 widens/locks this down (and adds asymmetric/JWKS).
@@ -97,13 +100,32 @@ class JwtTokenValidator:
         if not isinstance(sub, str) or not isinstance(exp, int | float):
             raise ValueError("jwt_missing_required_claims")
 
-        actor_type_raw = claims.get(Claim.ACTOR_TYPE, ActorType.AGENT.value)
+        actor_type_raw = claims.get(Claim.ACTOR_TYPE)
+        if actor_type_raw is None:
+            # Unlike the shared admin gate (#862), the broker's JWT producers
+            # include *external* trusted issuers with no published claims
+            # contract requiring actor_type, so a missing claim keeps the
+            # least-privileged AGENT default. Log it so operators can see
+            # which issuers omit the claim before any future hard refusal.
+            logger.warning("jwt_actor_type_missing_defaulting_to_agent", sub=sub)
+            actor_type = ActorType.AGENT
+        else:
+            try:
+                actor_type = ActorType(str(actor_type_raw))
+            except ValueError:
+                # An unrecognised value is a malformed token, not a contract
+                # gap — refuse it deliberately (#864) with the same error
+                # shape as any other invalid JWT instead of letting the enum
+                # constructor's ValueError escape by accident.
+                logger.warning("jwt_actor_type_unknown", sub=sub, actor_type=str(actor_type_raw))
+                raise ValueError("jwt_unknown_actor_type") from None
+
         scopes_raw = claims.get(Claim.SCOPES, [])
         permissions = [str(s) for s in scopes_raw] if isinstance(scopes_raw, list) else []
 
         return Identity(
             sub=sub,
-            actor_type=ActorType(str(actor_type_raw)),
+            actor_type=actor_type,
             permissions=permissions,
             expires_at=datetime.fromtimestamp(float(exp), tz=UTC),
             active=True,

--- a/src/jentic_one/broker/services/auth/token_validation.py
+++ b/src/jentic_one/broker/services/auth/token_validation.py
@@ -51,8 +51,16 @@ class Claim(StrEnum):
 
     SUB = "sub"
     EXP = "exp"
+    ISS = "iss"
     ACTOR_TYPE = "actor_type"
     SCOPES = "scopes"
+
+
+# Dedup for the missing-actor_type warning: one line per (iss, sub) instead of
+# one per request, so a steady issuer that omits the claim doesn't flood the
+# logs. Bounded — reset wholesale rather than tracking recency.
+_MISSING_ACTOR_TYPE_SEEN: set[tuple[str, str]] = set()
+_MISSING_ACTOR_TYPE_SEEN_MAX = 1024
 
 
 def looks_like_jwt(token: str) -> bool:
@@ -89,36 +97,60 @@ class JwtVerifier:
 
 @dataclass(frozen=True, slots=True)
 class JwtTokenValidator:
-    """Validates a self-contained signed JWT into an ``Identity`` (no DB lookup)."""
+    """Validates a self-contained signed JWT into an ``Identity`` (no DB lookup).
+
+    ``actor_type`` claim handling (#864): a missing claim defaults to the
+    least-privileged AGENT (external trusted issuers have no claims contract
+    requiring it) and is logged; an unrecognised value is refused outright.
+    """
 
     verifier: TokenVerifier
 
     async def validate(self, token: str) -> Identity:
+        """Verify the JWT and map its claims to an ``Identity`` (fails closed)."""
         claims = self.verifier.verify(token)
         sub = claims.get(Claim.SUB)
         exp = claims.get(Claim.EXP)
         if not isinstance(sub, str) or not isinstance(exp, int | float):
             raise ValueError("jwt_missing_required_claims")
+        iss = str(claims.get(Claim.ISS, ""))
 
         actor_type_raw = claims.get(Claim.ACTOR_TYPE)
         if actor_type_raw is None:
             # Unlike the shared admin gate (#862), the broker's JWT producers
             # include *external* trusted issuers with no published claims
             # contract requiring actor_type, so a missing claim keeps the
-            # least-privileged AGENT default. Log it so operators can see
-            # which issuers omit the claim before any future hard refusal.
-            logger.warning("jwt_actor_type_missing_defaulting_to_agent", sub=sub)
+            # least-privileged AGENT default. Log it (deduped per issuer/sub)
+            # so operators can see which issuers omit the claim before any
+            # future hard refusal. Same event name as the shared gate so both
+            # aggregate together; ``outcome`` tells the two behaviours apart.
+            if (iss, sub) not in _MISSING_ACTOR_TYPE_SEEN:
+                if len(_MISSING_ACTOR_TYPE_SEEN) >= _MISSING_ACTOR_TYPE_SEEN_MAX:
+                    _MISSING_ACTOR_TYPE_SEEN.clear()
+                _MISSING_ACTOR_TYPE_SEEN.add((iss, sub))
+                logger.warning(
+                    "jwt_actor_type_missing",
+                    sub=sub,
+                    iss=iss,
+                    outcome="defaulted_to_agent",
+                )
             actor_type = ActorType.AGENT
         else:
             try:
                 actor_type = ActorType(str(actor_type_raw))
-            except ValueError:
+            except ValueError as exc:
                 # An unrecognised value is a malformed token, not a contract
                 # gap — refuse it deliberately (#864) with the same error
                 # shape as any other invalid JWT instead of letting the enum
-                # constructor's ValueError escape by accident.
-                logger.warning("jwt_actor_type_unknown", sub=sub, actor_type=str(actor_type_raw))
-                raise ValueError("jwt_unknown_actor_type") from None
+                # constructor's ValueError escape by accident. The claim value
+                # is attacker-influenced: truncate it before logging.
+                logger.warning(
+                    "jwt_actor_type_unknown",
+                    sub=sub,
+                    iss=iss,
+                    actor_type=str(actor_type_raw)[:64],
+                )
+                raise ValueError("jwt_actor_type_unknown") from exc
 
         scopes_raw = claims.get(Claim.SCOPES, [])
         permissions = [str(s) for s in scopes_raw] if isinstance(scopes_raw, list) else []

--- a/tests/unit/broker/test_token_form_selection.py
+++ b/tests/unit/broker/test_token_form_selection.py
@@ -123,6 +123,46 @@ async def test_expired_jwt_is_rejected() -> None:
 
 
 @pytest.mark.asyncio
+async def test_jwt_without_actor_type_defaults_to_agent() -> None:
+    """Missing actor_type keeps the least-privileged AGENT default (#864).
+
+    The broker's JWT producers include external trusted issuers with no
+    published claims contract requiring actor_type, so the claim stays
+    optional — unlike the shared admin gate, which fails closed (#862).
+    """
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+    exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
+    token = _sign({"sub": "agnt_jwt", "exp": exp, "scopes": [BROKER_EXECUTE_SCOPE]})
+
+    resolved = await validator.validate(token)
+
+    assert resolved.actor_type == ActorType.AGENT
+
+
+@pytest.mark.asyncio
+async def test_jwt_with_explicit_actor_type_is_honoured() -> None:
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+    exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
+    token = _sign({"sub": "usr_jwt", "exp": exp, "actor_type": "user"})
+
+    resolved = await validator.validate(token)
+
+    assert resolved.actor_type == ActorType.USER
+
+
+@pytest.mark.asyncio
+async def test_jwt_with_unknown_actor_type_is_rejected() -> None:
+    """An unrecognised actor_type is refused deliberately (#864), with the same
+    ValueError shape as any other invalid JWT — never a bare enum error."""
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+    exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
+    token = _sign({"sub": "agnt_jwt", "exp": exp, "actor_type": "definitely-not-a-real-actor"})
+
+    with pytest.raises(ValueError, match="jwt_unknown_actor_type"):
+        await validator.validate(token)
+
+
+@pytest.mark.asyncio
 async def test_jwt_path_disabled_when_no_verifier() -> None:
     """With ``jwt=None`` even a JWT-shaped token falls through to opaque resolution."""
     resolver = _StubResolver(_opaque_resolution())

--- a/tests/unit/broker/test_token_form_selection.py
+++ b/tests/unit/broker/test_token_form_selection.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 
 import jwt
 import pytest
+from structlog.testing import capture_logs
 
 from jentic_one.broker.core.token_validation import CachedTokenValidator
 from jentic_one.broker.services.auth import (
@@ -14,6 +15,7 @@ from jentic_one.broker.services.auth import (
     JwtVerifier,
     looks_like_jwt,
 )
+from jentic_one.broker.services.auth.token_validation import _MISSING_ACTOR_TYPE_SEEN
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.models import ActorType
 from jentic_one.shared.scopes import BROKER_EXECUTE_SCOPE
@@ -140,6 +142,24 @@ async def test_jwt_without_actor_type_defaults_to_agent() -> None:
 
 
 @pytest.mark.asyncio
+async def test_missing_actor_type_warning_is_deduped_per_issuer_sub() -> None:
+    """The missing-claim warning fires once per (iss, sub), not per request."""
+    _MISSING_ACTOR_TYPE_SEEN.clear()
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+    exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
+    token = _sign({"sub": "agnt_jwt", "exp": exp, "iss": "https://idp.example"})
+
+    with capture_logs() as logs:
+        await validator.validate(token)
+        await validator.validate(token)
+
+    missing = [log for log in logs if log["event"] == "jwt_actor_type_missing"]
+    assert len(missing) == 1
+    assert missing[0]["iss"] == "https://idp.example"
+    assert missing[0]["outcome"] == "defaulted_to_agent"
+
+
+@pytest.mark.asyncio
 async def test_jwt_with_explicit_actor_type_is_honoured() -> None:
     validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
     exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
@@ -150,15 +170,25 @@ async def test_jwt_with_explicit_actor_type_is_honoured() -> None:
     assert resolved.actor_type == ActorType.USER
 
 
+@pytest.mark.parametrize(
+    "bad_actor_type",
+    [
+        "definitely-not-a-real-actor",
+        "AGENT",  # StrEnum values are case-sensitive
+        "",  # empty string is unknown, not missing
+        5,
+        ["agent"],
+    ],
+)
 @pytest.mark.asyncio
-async def test_jwt_with_unknown_actor_type_is_rejected() -> None:
+async def test_jwt_with_unknown_actor_type_is_rejected(bad_actor_type: object) -> None:
     """An unrecognised actor_type is refused deliberately (#864), with the same
     ValueError shape as any other invalid JWT — never a bare enum error."""
     validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
     exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
-    token = _sign({"sub": "agnt_jwt", "exp": exp, "actor_type": "definitely-not-a-real-actor"})
+    token = _sign({"sub": "agnt_jwt", "exp": exp, "actor_type": bad_actor_type})
 
-    with pytest.raises(ValueError, match="jwt_unknown_actor_type"):
+    with pytest.raises(ValueError, match="jwt_actor_type_unknown"):
         await validator.validate(token)
 
 


### PR DESCRIPTION
Closes #864. Follow-up to #857 / #863.

## TL;DR (humans)

The broker's own JWT gate (`JwtTokenValidator`) had the same pattern flagged in #862: it guessed when a token's `actor_type` claim was absent or garbage. This PR makes it behave deliberately:

- **Unknown `actor_type` value** (e.g. `"superadmin"`, `"AGENT"`, `5`): **refused**. Same 401 as any other bad token, and the real reason is logged server-side with the issuer.
- **Missing `actor_type` claim**: still accepted as **AGENT** (the least-privileged interpretation) — but now **logged once per issuer/sub**, so operators can see which issuers omit the claim.

## Why not fail closed on a missing claim too? (the audit)

Issue #864 asked for a producer audit before flipping the default. The audit changed the answer:

| Gate | Producers | Verdict |
|---|---|---|
| Shared admin gate (#863) | Only our own minting paths — all carry `actor_type` since #857 | Fail closed on missing claim ✅ |
| Broker JWT gate (this PR) | **External trusted issuers** (JWKS path, `broker.jwt_verification.trusted_issuers`) + dev HS256 secret | Missing claim is a live external contract — hard-failing would break externally-issued agent tokens |

There is no published claims contract requiring `actor_type` from trusted issuers, existing tests mint broker JWTs with only `sub`/`exp`/`scopes`, and no internal jentic-one code mints JWTs for the broker path (login JWTs use a different secret and gate). So the missing-claim default stays — explicit, *least*-privileged (AGENT), and observable. Once `jwt_actor_type_missing` telemetry shows all real issuers send the claim, #867 flips this to a hard refusal.

An unrecognised *value* is different: that's a malformed token, not a contract gap, so it's refused outright (previously the enum constructor's bare `ValueError` escaped by accident; the web layer's catch-all still mapped it to 401, but the rejection is now typed-in-intent, deliberate, and logged).

## Behaviour matrix (agents: this is the contract)

| Token state | Before | After |
|---|---|---|
| `actor_type: "agent"` / `"user"` / `"service_account"` | honoured | honoured (unchanged) |
| `actor_type` absent | silent AGENT default | AGENT default + `jwt_actor_type_missing` warning (`iss`, `sub`, `outcome="defaulted_to_agent"`, deduped per issuer/sub) |
| `actor_type: <junk>` (unknown string, wrong case, empty, int, list) | accidental `ValueError` → catch-all 401 | deliberate `ValueError("jwt_actor_type_unknown")` → 401 + `jwt_actor_type_unknown` warning (`iss`, `sub`, value truncated to 64 chars) |
| Opaque / API-key / toolkit-key paths | untouched | untouched (DB rows carry `actor_type`) |

The `jwt_actor_type_missing` / `jwt_actor_type_unknown` event names match the shared gate's (#863), so one query aggregates both gates; the broker's missing-claim event is distinguished by `outcome`.

## Changes

- `src/jentic_one/broker/services/auth/token_validation.py` — explicit missing/unknown handling, structlog warnings with issuer context, per-(iss, sub) dedup of the missing-claim warning
- `tests/unit/broker/test_token_form_selection.py` — missing claim defaults to AGENT, explicit claim honoured, parametrized rejection over junk values, log-dedup assertion via `capture_logs`

## Reviews (all six passes done, all findings addressed)

- **Bugbot**: no bugs.
- **Security**: no issues — independently confirmed broker authorization is entirely scope/PBAC-based, so the AGENT default confers no privileges anywhere in the broker.
- **Feasibility**: sound — traced every `validate()` caller to a uniform 401 (never a 500) and confirmed the AGENT default is genuinely required. Fixed: warning dedup, claim-value truncation, naming alignment, junk-value test matrix.
- **Product fit**: fixed the one pre-merge must-have — the missing-claim warning now carries `iss` so operators can identify the IdP. Breadcrumb for the future hard flip filed as #867.
- **Architecture/rules**: compliant (layering, logging style, tests, commit conventions). Log event unified with the shared gate's name per its suggestion. `ValueError` kept for consistency with the file's existing contract (`deps.py` maps `ValueError` → 401); typed-error migration filed as #866. Gate-divergence rationale documented in the internal rules repo.
- **Code quality**: approve with nits — all applied (error-string/log-event alignment, non-string claim tests, truncation, `validate` docstring).

Follow-up issues filed from review findings: #866 (typed errors for the broker JWT path), #867 (flip missing-claim default to refusal once telemetry allows), #868 (pre-existing: JWT can claim an actor_type with no binding behind it).

## Rollout

No user-visible change for any well-formed token. No config, schema, or API changes. Externally-issued JWTs without the claim keep working (now with an operator-visible log trail).

## Verification

- `make lint` (ruff + mypy): clean
- `tests/unit/broker` + `tests/integration/broker`: 529 passed (2 pre-existing streaming-record failures unrelated to this diff, present on main-equivalent tree)