### PR TITLE
test: make two unit tests robust to registered overlays and local UI builds

### DIFF
--- a/tests/unit/control/test_control_scoping.py
+++ b/tests/unit/control/test_control_scoping.py
@@ -9,6 +9,7 @@ from jentic_one.control.core.schema.access_requests import AccessRequest
 from jentic_one.control.core.schema.credentials import Credential
 from jentic_one.control.core.schema.toolkit_keys import ToolkitKey
 from jentic_one.control.core.schema.toolkits import Toolkit
+from jentic_one.control.scoping import filters as scoping_filters
 from jentic_one.control.scoping.filters import (
     _ACCESS_FILTER_PROVIDERS,
     build_access_filters,
@@ -247,8 +248,16 @@ def test_include_shared_default_off_ignores_providers() -> None:
         _ACCESS_FILTER_PROVIDERS.remove(_provider)
 
 
-def test_no_providers_is_owner_only() -> None:
-    """Stock OSS (no providers) yields the plain owner filter even with include_shared."""
+def test_no_providers_is_owner_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Zero providers yields the plain owner filter even with include_shared.
+
+    The provider registry is pinned empty for the duration: this test is
+    about the no-provider BASELINE, not the process state — under an
+    overlay-loaded run (e.g. an extension's "OSS suite with the extension
+    registered" harness) providers legitimately exist, and asserting on
+    whatever happens to be     registered would make the test flip there.
+    """
+    monkeypatch.setattr(scoping_filters, "_ACCESS_FILTER_PROVIDERS", [])
     identity = _identity(sub="user_share", permissions=[])
     filters = build_access_filters(identity, Toolkit, include_shared=True)
     assert len(filters) == 1

--- a/tests/unit/test_app_factory.py
+++ b/tests/unit/test_app_factory.py
@@ -201,6 +201,10 @@ def test_html_post_401_keeps_problem_details(ctx: Context) -> None:
 def test_html_get_401_without_spa_keeps_problem_details(ctx: Context) -> None:
     """Headless deployments (no UI bundle) never redirect."""
     app = create_combined_app(ctx, ["admin"])
+    # Force headless: a developer's local `ui/dist` build would otherwise get
+    # auto-mounted and flip this test into the redirect path (mirror of the
+    # `spa_mounted = True` forcing in the redirect tests above).
+    app.state.spa_mounted = False
     client = TestClient(app, raise_server_exceptions=False, follow_redirects=False)
     resp = client.get("/users", headers=_html_headers())
     assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Two unit tests asserted ambient process state instead of pinning the state they claim to test, so they fail under legitimate environments (found by the enterprise repo's `oss-tests-*` harness, which runs this suite with the enterprise overlay registered — tracked in jentic/jentic-one-enterprise#23):

- `test_no_providers_is_owner_only` asserts the no-provider baseline of `build_access_filters` — but read whatever providers the process had registered. Now pins the registry empty via `monkeypatch`, same spirit as the sibling provider tests that append/remove their own provider.
- `test_html_get_401_without_spa_keeps_problem_details` asserts the headless (no SPA) 401 — but relied on `ui/dist` not existing, so any local UI build flipped it into the redirect path. Now forces `app.state.spa_mounted = False`, mirroring the `= True` forcing in the sibling redirect tests.

No production code changes; stock behavior asserted is identical.

## Test plan

- [x] Stock: `tests/unit tests/arch` — 2,316 passed
- [x] Overlay-loaded: enterprise `make oss-tests-fast` (OSS suite + enterprise seams registered) — 2,316 passed, previously 2 failed
- [x] With a local `ui/dist` present — both tests stay green
- [x] ruff format/check + mypy clean

Made with [Cursor](https://cursor.com)