### PR TITLE
fix(catalog): rank whole-word api_id matches above substring matches

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -371,7 +371,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 16326
+        "line_number": 16327
       }
     ],
     "release-please-config.json": [
@@ -1070,7 +1070,7 @@
         "filename": "tests/integration/registry/ingest/test_ingestor_openapi.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 69
+        "line_number": 72
       }
     ],
     "tests/integration/shared/auth/test_verify.py": [
@@ -1618,5 +1618,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T08:59:32Z"
+  "generated_at": "2026-07-31T10:31:03Z"
 }

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -9750,7 +9750,8 @@ paths:
         required: false
         schema:
           anyOf:
-          - type: string
+          - maxLength: 500
+            type: string
           - type: 'null'
           title: Q
       - in: query

--- a/src/jentic_one/registry/services/catalog/manifest_builder.py
+++ b/src/jentic_one/registry/services/catalog/manifest_builder.py
@@ -134,39 +134,56 @@ def _tokenise(text: str) -> list[str]:
     return re.findall(r"[a-z0-9]+", (text or "").lower())
 
 
-#: Points for a query token that equals a whole ``api_id`` token (e.g. query
-#: "stripe" vs the id token "stripe" in ``stripe.com``) — the strongest signal.
-_WHOLE_TOKEN_POINTS = 3
-#: Points for a query token that is only a substring of an ``api_id`` token
-#: (e.g. query "box" buried inside "mapbox") — a weak, incidental match.
-_SUBSTRING_POINTS = 1
+#: Encoding of the two ranking signals into one sortable integer (the cursor
+#: carries a single number). ``coverage`` — how many query tokens matched at
+#: all — is the dominant signal and preserves the pre-existing recall-fraction
+#: ordering exactly: matching more of the query always outranks matching less
+#: of it, no matter how "strong" the individual hits are (so a multi-word query
+#: like "google api" still ranks ``googleapis.com`` — both words covered —
+#: above the hundreds of ids that merely contain the whole word "api").
+#: ``whole`` — how many of those matches are whole ``api_id`` tokens rather
+#: than substrings buried in longer tokens — only breaks ties *within* a
+#: coverage class (the #604 fix: query "stripe" ranks ``stripe.com``, a whole
+#: token, above ``soundstripe.com``, a substring).
+#:
+#: ``score = coverage * (len(q_tokens) + 1) + whole`` is order-isomorphic to
+#: the tuple ``(coverage, whole)`` because ``whole <= coverage <= len(q_tokens)
+#: < len(q_tokens) + 1`` — the quality digit can never carry into the coverage
+#: digit. Scores are only ever compared within one query (the cursor is
+#: re-paired with the same ``q`` on each page), so the query-length-dependent
+#: base is safe.
 
 
 def score_entry(api_id: str, q_tokens: list[str]) -> int:
-    """Relevance score for an ``api_id`` against query tokens.
+    """Relevance score for an ``api_id`` against (deduplicated) query tokens.
 
-    Grades each query token by *how* it matches, not merely *whether* it does:
-    a whole-token match (the query word IS one of the id's words) scores higher
-    than an incidental substring match (the query word is buried inside a longer
-    id word). Scores are summed across query tokens, so an entry matching more of
-    the query — and matching it more strongly — ranks first.
+    Two signals, folded into one integer (see the encoding note above):
 
-    Integer points (not a 0-1 fraction) so match tiers add up cleanly and the
-    score is an exact, hashable sort key. A whole-token hit and a substring hit
-    are mutually exclusive per query token — a whole-token match already satisfies
-    the substring test, so it is scored once at the higher tier.
+    - **coverage** (dominant): the number of query tokens that match at all —
+      as a whole ``api_id`` token or as a substring of one. Identical to the
+      membership/recall predicate used since the original scorer.
+    - **whole-token quality** (tie-break): of the covered tokens, how many are
+      whole ``api_id`` tokens (query "stripe" IS the id token "stripe") rather
+      than incidental substrings ("box" buried inside "mapbox").
+
+    A whole-token hit and a substring hit are mutually exclusive per query
+    token — a whole-token match already satisfies the substring test, so it is
+    counted once, at the higher tier. Integer scores add and compare exactly,
+    so the sort key and the cursor round-trip without float error.
     """
     name_tokens = _tokenise(api_id)
-    if not name_tokens:
+    if not name_tokens or not q_tokens:
         return 0
     name_token_set = set(name_tokens)
-    score = 0
+    coverage = 0
+    whole = 0
     for t in q_tokens:
         if t in name_token_set:
-            score += _WHOLE_TOKEN_POINTS
+            coverage += 1
+            whole += 1
         elif any(t in nt for nt in name_tokens):
-            score += _SUBSTRING_POINTS
-    return score
+            coverage += 1
+    return coverage * (len(q_tokens) + 1) + whole
 
 
 def score_entries(
@@ -189,7 +206,10 @@ def score_entries(
     """
     if not q or not q.strip():
         return [(e, None) for e in sorted(entries, key=lambda e: e.api_id)]
-    q_tokens = _tokenise(q)
+    # Dedupe tokens (order-preserving): duplicates would scale every entry's
+    # score uniformly — no ranking effect — while inflating scan cost, and the
+    # coverage encoding assumes each query token counts once.
+    q_tokens = list(dict.fromkeys(_tokenise(q)))
     if not q_tokens:
         return [(e, None) for e in sorted(entries, key=lambda e: e.api_id)]
     scored = [(e, score_entry(e.api_id, q_tokens)) for e in entries]

--- a/src/jentic_one/registry/services/catalog/manifest_builder.py
+++ b/src/jentic_one/registry/services/catalog/manifest_builder.py
@@ -134,26 +134,58 @@ def _tokenise(text: str) -> list[str]:
     return re.findall(r"[a-z0-9]+", (text or "").lower())
 
 
-def score_entry(api_id: str, q_tokens: list[str]) -> float:
-    """Token-overlap score for an api_id against query tokens (0.0-1.0)."""
+#: Points for a query token that equals a whole ``api_id`` token (e.g. query
+#: "stripe" vs the id token "stripe" in ``stripe.com``) — the strongest signal.
+_WHOLE_TOKEN_POINTS = 3
+#: Points for a query token that is only a substring of an ``api_id`` token
+#: (e.g. query "box" buried inside "mapbox") — a weak, incidental match.
+_SUBSTRING_POINTS = 1
+
+
+def score_entry(api_id: str, q_tokens: list[str]) -> int:
+    """Relevance score for an ``api_id`` against query tokens.
+
+    Grades each query token by *how* it matches, not merely *whether* it does:
+    a whole-token match (the query word IS one of the id's words) scores higher
+    than an incidental substring match (the query word is buried inside a longer
+    id word). Scores are summed across query tokens, so an entry matching more of
+    the query — and matching it more strongly — ranks first.
+
+    Integer points (not a 0-1 fraction) so match tiers add up cleanly and the
+    score is an exact, hashable sort key. A whole-token hit and a substring hit
+    are mutually exclusive per query token — a whole-token match already satisfies
+    the substring test, so it is scored once at the higher tier.
+    """
     name_tokens = _tokenise(api_id)
     if not name_tokens:
-        return 0.0
-    matches = sum(1.0 for t in q_tokens if any(t in nt for nt in name_tokens))
-    return matches / max(len(q_tokens), 1)
+        return 0
+    name_token_set = set(name_tokens)
+    score = 0
+    for t in q_tokens:
+        if t in name_token_set:
+            score += _WHOLE_TOKEN_POINTS
+        elif any(t in nt for nt in name_tokens):
+            score += _SUBSTRING_POINTS
+    return score
 
 
 def score_entries(
     entries: list[ManifestEntry], q: str | None
-) -> list[tuple[ManifestEntry, float | None]]:
+) -> list[tuple[ManifestEntry, int | None]]:
     """Order entries for paging, returning each with its sort score.
 
     Two stable orderings, each with a unique tail key (``api_id``) so keyset
     paging never skips or repeats:
 
     - **Browse** (empty ``q``): the natural ``api_id`` order, score ``None``.
-    - **Search**: matches only, sorted by ``(-score, api_id)``; the score is
-      carried in the cursor so the next page resumes at the exact tie-break.
+    - **Search**: matches only, sorted by ``(-score, api_id)``; the integer score
+      is carried in the cursor so the next page resumes at the exact tie-break.
+
+    Membership (which entries appear at all) is unchanged from the original
+    token-overlap behaviour: an entry qualifies iff at least one query token
+    substring-matches one of its ``api_id`` tokens. Only the *scoring* — and thus
+    the *order* — is graded by match quality (see ``score_entry``); recall is
+    identical to before.
     """
     if not q or not q.strip():
         return [(e, None) for e in sorted(entries, key=lambda e: e.api_id)]
@@ -176,11 +208,11 @@ class EntryPage:
     items: list[ManifestEntry]
     has_more: bool
     next_api_id: str | None
-    next_score: float | None
+    next_score: int | None
 
 
 def paginate_entries(
-    scored: list[tuple[ManifestEntry, float | None]],
+    scored: list[tuple[ManifestEntry, int | None]],
     *,
     after_api_id: str | None,
     after_score: float | None,
@@ -193,6 +225,10 @@ def paginate_entries(
     request resumes at the first item strictly after it in that same order. This
     is an in-memory slice — the whole catalog is a ~1 MB cached blob — so there
     is no DB cost to paging.
+
+    ``after_score`` is decoded from a client cursor and typed ``float`` so any
+    historical/foreign cursor value round-trips; our own scores are integers, and
+    ``int``/``float`` compare exactly for these small values in ``_is_after_cursor``.
     """
     if after_api_id is not None:
         start = 0
@@ -229,7 +265,7 @@ def paginate_entries(
 
 
 def _is_after_cursor(
-    score: float | None, api_id: str, cursor_score: float | None, cursor_api_id: str
+    score: int | None, api_id: str, cursor_score: float | None, cursor_api_id: str
 ) -> bool:
     """Whether ``(score, api_id)`` sorts strictly after the cursor position.
 

--- a/src/jentic_one/registry/web/routers/catalog.py
+++ b/src/jentic_one/registry/web/routers/catalog.py
@@ -66,7 +66,7 @@ async def list_catalog(
     request: Request,
     identity: Identity = get_current_identity(required_permissions=["capabilities:read"]),
     svc: CatalogService = Depends(get_catalog_service),
-    q: str | None = None,
+    q: str | None = Query(default=None, max_length=500),
     registered_only: bool = False,
     unregistered_only: bool = False,
     cursor: str | None = None,

--- a/src/jentic_one/shared/pagination.py
+++ b/src/jentic_one/shared/pagination.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import uuid
 from base64 import b64decode, b64encode
 from datetime import UTC, datetime
@@ -113,6 +114,8 @@ def decode_catalog_cursor(cursor: str) -> tuple[str, float | None]:
             raise ValueError("id must be a string")
         raw_score = payload.get("s")
         score = None if raw_score is None else float(raw_score)
+        if score is not None and not math.isfinite(score):
+            raise ValueError("score must be finite")
         return api_id, score
     except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
         raise InvalidCursorError("Invalid pagination cursor") from exc

--- a/tests/unit/registry/services/test_catalog_manifest_builder.py
+++ b/tests/unit/registry/services/test_catalog_manifest_builder.py
@@ -121,9 +121,9 @@ def test_whole_word_match_outranks_substring_match() -> None:
     entries = _entries("soundstripe.com", "stripe.com")
     scored = mb.score_entries(entries, "stripe")
     assert [e.api_id for e, _ in scored] == ["stripe.com", "soundstripe.com"]
-    # whole-token hit (3) strictly beats substring-only hit (1)
-    assert scored[0][1] == 3
-    assert scored[1][1] == 1
+    # same coverage (1 of 1 tokens, base 2), whole-token hit breaks the tie
+    assert scored[0][1] == 3  # coverage 1 x 2 + whole 1
+    assert scored[1][1] == 2  # coverage 1 x 2 + whole 0
 
 
 def test_whole_word_match_wins_regardless_of_alphabetical_order() -> None:
@@ -132,6 +132,36 @@ def test_whole_word_match_wins_regardless_of_alphabetical_order() -> None:
     entries = _entries("Mapbox", "box.com")
     scored = mb.score_entries(entries, "box")
     assert [e.api_id for e, _ in scored] == ["box.com", "Mapbox"]
+
+
+def test_whole_and_substring_hits_on_same_id_count_once_at_the_higher_tier() -> None:
+    # "box" matches box.mapbox.com both as the whole token "box" AND as a
+    # substring of "mapbox" — per query token it must count once, at the
+    # whole-token tier, never both (the if/elif in score_entry).
+    assert mb.score_entry("box.mapbox.com", ["box"]) == 3  # coverage 1 x 2 + whole 1
+
+
+def test_coverage_dominates_match_quality_on_multi_word_queries() -> None:
+    # Covering MORE of the query must always outrank covering less of it more
+    # "cleanly": for "google api", googleapis.com (both words, as substrings)
+    # must beat rest-api.com (one word, as a whole token) — otherwise every
+    # *-api.com entry in the catalog buries the obvious intent match.
+    entries = _entries("rest-api.com", "googleapis.com")
+    scored = mb.score_entries(entries, "google api")
+    assert [e.api_id for e, _ in scored] == ["googleapis.com", "rest-api.com"]
+    assert scored[0][1] == 6  # coverage 2 x 3 + whole 0
+    assert scored[1][1] == 4  # coverage 1 x 3 + whole 1
+
+
+def test_duplicate_query_tokens_are_deduplicated() -> None:
+    # "stripe stripe" ranks and scores exactly like "stripe" — duplicates would
+    # scale every entry uniformly (no ranking effect) at double the scan cost.
+    entries = _entries("soundstripe.com", "stripe.com")
+    assert mb.score_entries(entries, "stripe stripe") == mb.score_entries(entries, "stripe")
+
+
+def test_score_entry_empty_api_id_scores_zero() -> None:
+    assert mb.score_entry("", ["stripe"]) == 0
 
 
 def test_search_membership_unchanged_only_order_differs() -> None:
@@ -165,15 +195,15 @@ def test_score_entries_search_sorted_by_score_then_api_id() -> None:
 
 
 def test_score_entries_distinct_scores_rank_higher_first() -> None:
-    # A 2-token query yields distinct scores: matching both tokens as whole
-    # id-tokens (3+3=6) outranks matching only one (3).
+    # A 2-token query yields distinct scores: covering both tokens as whole
+    # id-tokens (2x3+2=8) outranks covering only one (1x3+1=4).
     entries = _entries("foo-bar.com", "foo-only.com", "bar-only.com", "nope.com")
     scored = mb.score_entries(entries, "foo bar")
     ids = [e.api_id for e, _ in scored]
-    # full match (6) first, then the two single-token hits (3) in api_id order, nope excluded
+    # full match (8) first, then the two single-token hits (4) in api_id order, nope excluded
     assert ids == ["foo-bar.com", "bar-only.com", "foo-only.com"]
-    assert scored[0][1] == 6
-    assert scored[1][1] == 3
+    assert scored[0][1] == 8
+    assert scored[1][1] == 4
 
 
 def _paginate_all(scored: list[tuple[mb.ManifestEntry, int | None]], limit: int) -> list[str]:
@@ -227,19 +257,19 @@ def test_paginate_last_full_page_reports_no_more() -> None:
 
 
 def test_paginate_search_walks_ranked_results_in_order_across_pages() -> None:
-    # Distinct scores via a 2-token query: the full match (both tokens whole, 6)
-    # must come out before the single-token hits (3), and the walk order must be
+    # Distinct scores via a 2-token query: the full match (both tokens whole, 8)
+    # must come out before the single-token hits (4), and the walk order must be
     # preserved across pages.
     entries = _entries("foo-bar.com", "foo-x.com", "bar-y.com", "unrelated.com")
     scored = mb.score_entries(entries, "foo bar")
     walked = _paginate_all(scored, limit=1)
-    # foo-bar (6) first; then the two single-token hits (3) in api_id order
+    # foo-bar (8) first; then the two single-token hits (4) in api_id order
     assert walked == ["foo-bar.com", "bar-y.com", "foo-x.com"]
     assert "unrelated.com" not in walked
 
 
 def test_paginate_search_equal_scores_walk_in_api_id_order() -> None:
-    # Single-token query => all matches score equally (the whole-token tier, 3);
+    # Single-token query => all matches score equally (whole-token hit, 3);
     # the (score, api_id) tie-break must yield ascending api_id order, with no
     # skips/dups, across pages.
     entries = _entries("foo-c.com", "foo-a.com", "foo-b.com", "nope.com")

--- a/tests/unit/registry/services/test_catalog_manifest_builder.py
+++ b/tests/unit/registry/services/test_catalog_manifest_builder.py
@@ -113,6 +113,36 @@ def test_search_no_match_returns_empty() -> None:
     assert mb.score_entries(_search_entries(), "zzz") == []
 
 
+def test_whole_word_match_outranks_substring_match() -> None:
+    # The real #604 pain: an exact-name match must beat an entry that merely
+    # contains the query as a substring of a longer token. "stripe" should rank
+    # stripe.com (whole token "stripe") above soundstripe.com (buried in the
+    # token "soundstripe"), even though "soundstripe" sorts first alphabetically.
+    entries = _entries("soundstripe.com", "stripe.com")
+    scored = mb.score_entries(entries, "stripe")
+    assert [e.api_id for e, _ in scored] == ["stripe.com", "soundstripe.com"]
+    # whole-token hit (3) strictly beats substring-only hit (1)
+    assert scored[0][1] == 3
+    assert scored[1][1] == 1
+
+
+def test_whole_word_match_wins_regardless_of_alphabetical_order() -> None:
+    # "box" — box.com is the wanted API but Mapbox sorts earlier; the old flat
+    # scorer tied them and alphabetised, burying box.com. Quality tiers fix it.
+    entries = _entries("Mapbox", "box.com")
+    scored = mb.score_entries(entries, "box")
+    assert [e.api_id for e, _ in scored] == ["box.com", "Mapbox"]
+
+
+def test_search_membership_unchanged_only_order_differs() -> None:
+    # Guardrail: grading match quality must never change *which* entries appear
+    # (recall), only their order. Any entry with at least one substring hit on a
+    # query token still qualifies, exactly as before.
+    entries = _entries("stripe.com", "soundstripe.com", "unrelated.com")
+    result_ids = {e.api_id for e, _ in mb.score_entries(entries, "stripe")}
+    assert result_ids == {"stripe.com", "soundstripe.com"}
+
+
 # ── score_entries / paginate_entries (keyset paging) ──────────────────────────
 
 
@@ -135,17 +165,18 @@ def test_score_entries_search_sorted_by_score_then_api_id() -> None:
 
 
 def test_score_entries_distinct_scores_rank_higher_first() -> None:
-    # A 2-token query yields distinct scores: 2/2=1.0 (both tokens) vs 1/2=0.5.
+    # A 2-token query yields distinct scores: matching both tokens as whole
+    # id-tokens (3+3=6) outranks matching only one (3).
     entries = _entries("foo-bar.com", "foo-only.com", "bar-only.com", "nope.com")
     scored = mb.score_entries(entries, "foo bar")
     ids = [e.api_id for e, _ in scored]
-    # full match first, then the two half-matches (api_id tie-break), nope excluded
+    # full match (6) first, then the two single-token hits (3) in api_id order, nope excluded
     assert ids == ["foo-bar.com", "bar-only.com", "foo-only.com"]
-    assert scored[0][1] == pytest.approx(1.0)
-    assert scored[1][1] == pytest.approx(0.5)
+    assert scored[0][1] == 6
+    assert scored[1][1] == 3
 
 
-def _paginate_all(scored: list[tuple[mb.ManifestEntry, float | None]], limit: int) -> list[str]:
+def _paginate_all(scored: list[tuple[mb.ManifestEntry, int | None]], limit: int) -> list[str]:
     """Walk every page via cursors and return the flat api_id sequence."""
     out: list[str] = []
     after_id: str | None = None
@@ -196,19 +227,21 @@ def test_paginate_last_full_page_reports_no_more() -> None:
 
 
 def test_paginate_search_walks_ranked_results_in_order_across_pages() -> None:
-    # Distinct scores via a 2-token query: full match (1.0) must come out before
-    # the half-matches (0.5), and the walk order must be preserved across pages.
+    # Distinct scores via a 2-token query: the full match (both tokens whole, 6)
+    # must come out before the single-token hits (3), and the walk order must be
+    # preserved across pages.
     entries = _entries("foo-bar.com", "foo-x.com", "bar-y.com", "unrelated.com")
     scored = mb.score_entries(entries, "foo bar")
     walked = _paginate_all(scored, limit=1)
-    # foo-bar (1.0) first; then the two 0.5 matches in api_id order
+    # foo-bar (6) first; then the two single-token hits (3) in api_id order
     assert walked == ["foo-bar.com", "bar-y.com", "foo-x.com"]
     assert "unrelated.com" not in walked
 
 
 def test_paginate_search_equal_scores_walk_in_api_id_order() -> None:
-    # Single-token query => all matches score 1.0; the (score, api_id) tie-break
-    # must yield ascending api_id order, with no skips/dups, across pages.
+    # Single-token query => all matches score equally (the whole-token tier, 3);
+    # the (score, api_id) tie-break must yield ascending api_id order, with no
+    # skips/dups, across pages.
     entries = _entries("foo-c.com", "foo-a.com", "foo-b.com", "nope.com")
     scored = mb.score_entries(entries, "foo")
     walked = _paginate_all(scored, limit=1)

--- a/tests/unit/shared/test_pagination.py
+++ b/tests/unit/shared/test_pagination.py
@@ -143,3 +143,14 @@ def test_catalog_cursor_non_numeric_score_raises_invalid_cursor() -> None:
     bad = base64.b64encode(json.dumps({"id": "x", "s": [1, 2]}).encode()).decode()
     with pytest.raises(InvalidCursorError):
         decode_catalog_cursor(bad)
+
+
+@pytest.mark.parametrize("raw_score", ["NaN", "Infinity", "-Infinity", '"nan"', '"inf"', "1e400"])
+def test_catalog_cursor_non_finite_score_raises_invalid_cursor(raw_score: str) -> None:
+    # We only ever mint finite scores; a non-finite "s" is a crafted cursor.
+    # NaN in particular compares False against everything, which would make the
+    # keyset comparator's behavior depend on non-obvious fallthrough — reject at
+    # the decode boundary instead (400, not a silently weird page).
+    bad = base64.b64encode(f'{{"id": "x", "s": {raw_score}}}'.encode()).decode()
+    with pytest.raises(InvalidCursorError):
+        decode_catalog_cursor(bad)

--- a/tests/web/registry/test_catalog.py
+++ b/tests/web/registry/test_catalog.py
@@ -240,13 +240,13 @@ async def test_final_page_has_no_more_and_null_cursor(
 async def test_search_pagination_walks_ranked_results_in_order(
     admin_client: TestClient, web_context: Context
 ) -> None:
-    # 2-token query gives distinct scores: foo-bar (both tokens, 6) outranks the
-    # single-token halves (3 each).
+    # 2-token query gives distinct scores: foo-bar (both tokens covered, 8)
+    # outranks the single-token halves (4 each).
     ids = ["foo-bar.com", "foo-x.com", "bar-y.com", "unrelated.com"]
     await _seed_snapshot(web_context, ids)
 
     walked = _walk_catalog(admin_client, q="foo bar", limit=1)
-    # order must be preserved across pages: full match first, then the 3s by api_id
+    # order must be preserved across pages: full match first, then the 4s by api_id
     assert walked == ["foo-bar.com", "bar-y.com", "foo-x.com"]
     assert "unrelated.com" not in walked
 

--- a/tests/web/registry/test_catalog.py
+++ b/tests/web/registry/test_catalog.py
@@ -240,12 +240,13 @@ async def test_final_page_has_no_more_and_null_cursor(
 async def test_search_pagination_walks_ranked_results_in_order(
     admin_client: TestClient, web_context: Context
 ) -> None:
-    # 2-token query gives distinct scores: foo-bar (1.0) outranks the 0.5 halves.
+    # 2-token query gives distinct scores: foo-bar (both tokens, 6) outranks the
+    # single-token halves (3 each).
     ids = ["foo-bar.com", "foo-x.com", "bar-y.com", "unrelated.com"]
     await _seed_snapshot(web_context, ids)
 
     walked = _walk_catalog(admin_client, q="foo bar", limit=1)
-    # order must be preserved across pages: full match first, then 0.5 by api_id
+    # order must be preserved across pages: full match first, then the 3s by api_id
     assert walked == ["foo-bar.com", "bar-y.com", "foo-x.com"]
     assert "unrelated.com" not in walked
 

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -17399,6 +17399,7 @@
             "schema": {
               "anyOf": [
                 {
+                  "maxLength": 500,
                   "type": "string"
                 },
                 {


### PR DESCRIPTION
## Summary

Catalog search (`GET /catalog?q=…`) ranked poorly: an exact-name match tied with an incidental substring hit and fell back to **alphabetical** order, so searching `stripe` surfaced `soundstripe.com` above `stripe.com`, and `box` surfaced `Mapbox` above `box.com`. The old scorer awarded a flat `1.0` per query token that appeared *anywhere* as a substring of the `api_id`, so for a single-word query every match tied and the order collapsed to the `api_id` alphabetical tie-break.

This regrades match **quality** without ever sacrificing match **coverage**: the score encodes `(coverage, whole-token hits)` as a single integer — `coverage * (len(q_tokens)+1) + whole` — so covering more of the query always outranks covering less of it (exactly the old scorer's ordering), and *within* a coverage class, whole-token matches (query "stripe" IS the id token "stripe") outrank substring-only matches ("box" buried in "mapbox"). Across the real ~6,300-entry public catalog this fixes the top result for hundreds of single-word queries (`stripe`, `box`, `google`, `openai`, `mysql`, `nasa`, `plex`, …) with **zero ordering contradictions vs the old scorer** (empirically verified). **Which** entries appear is unchanged — only the order — so recall is identical (guardrail test).

Because this scorer backs the shared `GET /catalog` endpoint, the ranking improvement lands on **three surfaces**: the Discover page, the credentials "Choose an API" picker's catalog results, and the CLI's `jentic catalog search` (which the agent skill routes discovery through). (The picker's separate "in your workspace" list uses a client-side substring filter over `GET /apis` and is unaffected.)

**Key decisions**

- **Coverage dominates quality.** An earlier revision used flat 3:1 points, which let one whole-token hit (3) beat full two-token substring coverage (2) — burying `googleapis.com` behind ~978 `*-api` entries for "google api". The review board caught it on real data; the encoding above makes that class of regression structurally impossible (the quality digit can't carry into the coverage digit).
- **Scoped to the `api_id` only.** Indexing the manifest's human titles was rejected for this fix — and note it would **not** fix the "New York Times" case anyway (no NYT sub-API title contains "New York"). The durable fix is an alias/synonym map — tracked in #899.
- **The literal "New York Times" → nytimes.com case is NOT durably fixed.** Amusingly, `nytimes.com/times_tags` now ranks #1 for that exact query — but only because that one sub-API id contains the standalone token "times" (tokenisation luck, fragile against renames). Hence **Related to #604**, not Closes: the friendly-name capability #604 asks for is #899's job.
- **Recall is a hard guardrail.** The membership filter (`s > 0`) is untouched, so the result set is exactly as before; only scoring/ordering changed — locked in by a dedicated test.
- **Integer scores** give clean, exact tier ordering and cursor round-trips. The keyset-cursor decode boundary stays `float | None` so any historical cursor value still round-trips; non-finite values (`NaN`/`Infinity`) are now rejected at decode (400) since we only ever mint finite ints.
- **No cursor versioning.** Paginating a catalog search *across a backend restart* may show one empty page (old cursor vs new scores); it self-heals on the next search/refresh — negligible on a self-hosted single-operator tool, so skipped.

## Related issue

Related to #604 (ranking/relevance half; the friendly-name/alias half is #899)

## Changes

- `src/jentic_one/registry/services/catalog/manifest_builder.py`: coverage-first integer scoring (see above); query tokens deduplicated (order-preserving) — duplicates scaled every entry uniformly at double the scan cost.
- `src/jentic_one/registry/web/routers/catalog.py`: `q` capped at `max_length=500` (parity with the preview endpoint) — the scorer is synchronous CPU work in an async handler and an unbounded `q` was a cheap event-loop-blocking primitive. Spec artifacts regenerated.
- `src/jentic_one/shared/pagination.py`: `decode_catalog_cursor` rejects non-finite scores.
- Tests: whole-word-beats-substring pins (#604 cases), coverage-dominance pin ("google api"), mutual-exclusivity pin (whole+substring on the same id counts once), duplicate-token dedupe, empty `api_id`, recall guardrail, non-finite-cursor rejection, keyset-paging walks updated to the new scores.

## Review-board hardening

Four independent lenses (correctness+security, code quality+architecture, product fit, ranking/relevance QA with real-data probes) reviewed the rebased branch. The ranking-QA lens found the 3:1 multi-word regression (fixed as above); the other lenses' findings are folded in: `q` length cap, cursor NaN/Infinity rejection, mutual-exclusivity test, dedupe, docstring corrections. Verified across lenses: recall equivalence (proven), keyset paging never skips/repeats incl. adversarial cursors, no injection surface, endpoint authenticated, cursor opaque to SPA/CLI, correct architectural seam (catalog scoring is not part of the operations SearchStrategy registry).

## Testing

- `ruff` + `ruff format` + `mypy` clean; detect-secrets clean
- `pytest tests/unit/registry tests/unit/shared` — 760 passed
- `pytest tests/arch` — 262 passed (after `make openapi` regen; zero further drift)
- `make test-integration-sqlite` — 541 passed
- Empirical probe over the real 6,310-include catalog: all headline single-word queries verified fixed; multi-word queries ("google api", "drop box", "sound stripe", "new york times") verified regression-free; recall identical old-vs-new for every probed query; zero coverage-ordering contradictions vs the old scorer
- `tests/web/registry/**` (Postgres) — relies on CI

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] `make check` passes (lint, type check, secrets audit, arch tests)
- [x] Tests added/updated for the change
- [x] Docs updated where relevant (ranking lands in the changelog via the `fix(catalog)` commit; no user-facing doc describes ordering semantics)
- [x] No secrets, credentials, or internal-only references included