### PR TITLE
feat(ui): rail day separators, proactive failure surfacing, and monitor event drill-in

### DIFF
--- a/ui/src/modules/monitor/__tests__/MonitorPage.test.tsx
+++ b/ui/src/modules/monitor/__tests__/MonitorPage.test.tsx
@@ -503,4 +503,158 @@ describe('Monitor inter-linking', () => {
 		// The 24h window is sent as the SSE `since` lower-bound.
 		expect(streamUrl!.searchParams.get('since')).toBeTruthy();
 	});
+
+	it('Events row → clicking a failed event opens its trace detail sheet (#617)', async () => {
+		const user = userEvent.setup();
+		renderMonitor('/app/monitor?tab=events');
+
+		// evt_1 is a failed execution event carrying trace_bbbbbbbb; the row must
+		// be clickable through to the trace sheet (the whole point of #617).
+		const row = await screen.findByRole('link', {
+			name: /Open execution for Execution failed: github-api/,
+		});
+		await user.click(row);
+
+		await waitFor(() => {
+			expect(currentParams().get('trace_id')).toBe('trace_bbbbbbbb');
+		});
+		// The trace sheet opens for that trace.
+		expect(await screen.findByRole('dialog')).toBeInTheDocument();
+	});
+
+	it('Events row → an event with no execution/trace is not clickable (#617)', async () => {
+		// evt_2 (import.completed) carries only trace_aaaaaaaa via its top-level
+		// trace_id — so it IS clickable; assert the acknowledged/info evt_2 with a
+		// stripped trace is inert by pointing the events feed at a payload with no
+		// trace at all.
+		worker.use(
+			http.get('/events', () =>
+				HttpResponse.json({
+					data: [
+						{
+							_links: { self: '/events/evt_x' },
+							acknowledged: false,
+							acknowledged_at: null,
+							acknowledged_by: null,
+							created_at: new Date().toISOString(),
+							data: {},
+							detail: 'A configuration warning with no execution.',
+							event_id: 'evt_x',
+							requires_action: false,
+							severity: 'warning',
+							summary: 'Config drift detected',
+							trace_id: null,
+							type: 'config.drift',
+						},
+					],
+					has_more: false,
+					next_cursor: null,
+				}),
+			),
+		);
+		renderMonitor('/app/monitor?tab=events');
+
+		await screen.findByText('Config drift detected');
+		// No clickable row was rendered for an event with no drill-in id.
+		expect(
+			screen.queryByRole('link', { name: /Open execution for Config drift detected/ }),
+		).not.toBeInTheDocument();
+	});
+
+	it('rail-style deep-link (execution_id) on the Events tab opens the sheet (#617)', async () => {
+		// The rail's "View execution" now emits the underscore vocabulary; landing
+		// on the Executions tab with it must open the sheet.
+		renderMonitor('/app/monitor?tab=executions&execution_id=exec_2');
+		expect(await screen.findByRole('dialog')).toBeInTheDocument();
+	});
+});
+
+/**
+ * Events-tab severity filter (#617). The Events tab previously had no way to
+ * filter by severity — a "critical" flag elsewhere led to a filter that showed
+ * nothing. The backend honours a repeatable `severity=` param; these lock in
+ * that the chips drive it and that error/critical stay independent values.
+ */
+describe('Monitor Events severity filter', () => {
+	beforeEach(() => {
+		setToken('mock-access-token');
+		worker.use(...monitorHandlers);
+	});
+
+	function currentParams() {
+		return new URLSearchParams(screen.getByTestId('location-search').textContent ?? '');
+	}
+
+	it('selecting Error narrows the feed and writes the severity param', async () => {
+		const user = userEvent.setup();
+		renderMonitor('/app/monitor?tab=events');
+
+		// Both fixture events render first (error + info).
+		await screen.findByText('Execution failed: github-api');
+		await screen.findByText('Import completed');
+
+		await user.click(screen.getByRole('button', { name: 'Error' }));
+
+		// The URL carries severity=error and the info event drops out.
+		await waitFor(() => {
+			expect(currentParams().get('severity')).toBe('error');
+		});
+		await waitFor(() => {
+			expect(screen.queryByText('Import completed')).not.toBeInTheDocument();
+		});
+		expect(screen.getAllByText('Execution failed: github-api').length).toBeGreaterThanOrEqual(
+			1,
+		);
+	});
+
+	it('critical and error are independent chips (selecting Critical hides an error event) (#617)', async () => {
+		const user = userEvent.setup();
+		renderMonitor('/app/monitor?tab=events');
+		await screen.findByText('Execution failed: github-api');
+
+		// The fixture's failure is severity "error"; selecting ONLY Critical must
+		// therefore hide it — proving the chips don't silently coalesce (the exact
+		// confusion #617 reported). Both remain selectable together for "failures".
+		await user.click(screen.getByRole('button', { name: 'Critical' }));
+		await waitFor(() => {
+			expect(currentParams().get('severity')).toBe('critical');
+		});
+		await waitFor(() => {
+			expect(screen.queryByText('Execution failed: github-api')).not.toBeInTheDocument();
+		});
+
+		// Adding Error back brings the failure in; the param preserves canonical order.
+		await user.click(screen.getByRole('button', { name: 'Error' }));
+		await waitFor(() => {
+			expect(currentParams().get('severity')).toBe('critical,error');
+		});
+		await waitFor(() => {
+			expect(
+				screen.getAllByText('Execution failed: github-api').length,
+			).toBeGreaterThanOrEqual(1);
+		});
+	});
+
+	it('hydrates the selected severity from the URL and clears it', async () => {
+		const user = userEvent.setup();
+		renderMonitor('/app/monitor?tab=events&severity=info');
+
+		// Only the info event survives an initial severity=info deep-link.
+		await screen.findByText('Import completed');
+		expect(screen.queryByText('Execution failed: github-api')).not.toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Info' })).toHaveAttribute(
+			'aria-pressed',
+			'true',
+		);
+
+		await user.click(screen.getByRole('button', { name: 'Clear' }));
+		await waitFor(() => {
+			expect(currentParams().get('severity')).toBeNull();
+		});
+		await waitFor(() => {
+			expect(
+				screen.getAllByText('Execution failed: github-api').length,
+			).toBeGreaterThanOrEqual(1);
+		});
+	});
 });

--- a/ui/src/modules/monitor/__tests__/MonitorPage.test.tsx
+++ b/ui/src/modules/monitor/__tests__/MonitorPage.test.tsx
@@ -561,6 +561,55 @@ describe('Monitor inter-linking', () => {
 		).not.toBeInTheDocument();
 	});
 
+	it('Events row → a failure with only a _links.execution (no trace) opens by execution_id (#617)', async () => {
+		// The exact real-world case that regressed: the backend surfaces the
+		// linked execution ONLY as `_links.execution` (= /executions/{id}) — it is
+		// NOT stamped into `data` and there is no usable trace. The row must still
+		// be clickable and open the sheet by execution_id.
+		const user = userEvent.setup();
+		worker.use(
+			http.get('/events', () =>
+				HttpResponse.json({
+					data: [
+						{
+							_links: {
+								self: '/events/evt_link',
+								execution: '/executions/exec_99',
+								job: null,
+								action: null,
+							},
+							acknowledged: false,
+							acknowledged_at: null,
+							acknowledged_by: null,
+							created_at: new Date().toISOString(),
+							data: {},
+							detail: 'Upstream 401 from api.example.com',
+							event_id: 'evt_link',
+							requires_action: true,
+							severity: 'error',
+							summary: 'Execution failed: example-api',
+							trace_id: null,
+							type: 'execution.failed',
+						},
+					],
+					has_more: false,
+					next_cursor: null,
+				}),
+			),
+		);
+		renderMonitor('/app/monitor?tab=events');
+
+		const row = await screen.findByRole('link', {
+			name: /Open execution for Execution failed: example-api/,
+		});
+		await user.click(row);
+
+		await waitFor(() => {
+			expect(currentParams().get('execution_id')).toBe('exec_99');
+		});
+		expect(currentParams().get('trace_id')).toBeNull();
+	});
+
 	it('rail-style deep-link (execution_id) on the Events tab opens the sheet (#617)', async () => {
 		// The rail's "View execution" now emits the underscore vocabulary; landing
 		// on the Executions tab with it must open the sheet.

--- a/ui/src/modules/monitor/api/hooks.ts
+++ b/ui/src/modules/monitor/api/hooks.ts
@@ -29,7 +29,8 @@ import {
 	type ListJobsParams,
 	type UsageStatsParams,
 } from '@/modules/monitor/api/client';
-import { AuditTargetType } from '@/shared/api';
+import { AuditTargetType, sharedQueryKeys } from '@/shared/api';
+import { useAgentStreamOptional } from '@/shared/lib';
 import type {
 	ActorListResponse,
 	AuditListResponse,
@@ -50,7 +51,10 @@ export const monitorKeys = {
 	execution: (id: string) => [...monitorKeys.all, 'execution', id] as const,
 	jobs: (params: ListJobsParams) => [...monitorKeys.all, 'jobs', params] as const,
 	job: (id: string) => [...monitorKeys.all, 'job', id] as const,
-	events: (params: ListEventsParams) => [...monitorKeys.all, 'events', params] as const,
+	// Derives from the shared cross-module root: the agent-stream provider's
+	// `acknowledge` (rail/toast) invalidates that root, so the two prefixes
+	// must be the same list or they'd silently drift apart.
+	events: (params: ListEventsParams) => [...sharedQueryKeys.monitorEventsRoot, params] as const,
 	audit: (params: ListAuditParams) => [...monitorKeys.all, 'audit', params] as const,
 	usage: (params: UsageStatsParams) => [...monitorKeys.all, 'usage', params] as const,
 	actors: () => [...monitorKeys.all, 'actors'] as const,
@@ -154,6 +158,11 @@ export function useEvents(params: ListEventsParams = {}) {
 /** Acknowledge an event (`PATCH /events/{id}`); invalidates the events feeds. */
 export function useAcknowledgeEvent() {
 	const queryClient = useQueryClient();
+	// Provider-optional: when the app shell's stream is mounted, flip its
+	// in-memory copy too — the SSE watermark poll never re-delivers an old
+	// event on an ack flip, so without this the rail's failure pill keeps
+	// counting an event the operator just acknowledged from the Events tab.
+	const stream = useAgentStreamOptional();
 	return useMutation({
 		mutationFn: (eventId: string) => acknowledgeEvent(eventId),
 		onSuccess: (event) => {
@@ -163,6 +172,7 @@ export function useAcknowledgeEvent() {
 				variant: 'success',
 			});
 			queryClient.invalidateQueries({ queryKey: [...monitorKeys.all, 'events'] });
+			stream?.resolveEvent(event.event_id);
 		},
 		onError: (error: unknown) => {
 			toast({

--- a/ui/src/modules/monitor/components/EventsTab.tsx
+++ b/ui/src/modules/monitor/components/EventsTab.tsx
@@ -19,6 +19,7 @@ import {
 	SegmentedToggle,
 	ActorLabel,
 } from '@/shared/ui';
+import { cn } from '@/shared/lib/utils';
 import { eventSeverityIcon } from '@/shared/lib';
 import {
 	useEvents,
@@ -28,6 +29,7 @@ import {
 	type EventResponse,
 } from '@/modules/monitor/api';
 import { CursorPager } from '@/modules/monitor/components/CursorPager';
+import { TraceDetailSheet } from '@/modules/monitor/components/TraceDetailSheet';
 import {
 	MonitorList,
 	MonitorRow,
@@ -36,6 +38,7 @@ import {
 import { useMonitorFilters } from '@/modules/monitor/lib/useMonitorFilters';
 import { useCursorStack } from '@/modules/monitor/lib/useCursorStack';
 import { formatRelative } from '@/modules/monitor/lib/format';
+import { hasTrace } from '@/modules/monitor/lib/links';
 
 type EventFilter = 'all' | 'action' | 'unacknowledged';
 
@@ -47,6 +50,61 @@ const EVENT_FILTERS: { value: EventFilter; label: string }[] = [
 
 function isEventFilter(value: string | null): value is EventFilter {
 	return value === 'all' || value === 'action' || value === 'unacknowledged';
+}
+
+// Severity filter chips. This is a distinct axis from the status toggle above:
+// status is "does it need a human?", severity is "how bad is it?". The backend
+// honours `GET /events?severity=` (repeatable), so this is a pure query-param
+// wiring — no client-side post-filter (issue #617: the Events tab had no way to
+// filter by severity at all).
+const SEVERITY_ORDER: EventSeverity[] = [
+	EventSeverity.CRITICAL,
+	EventSeverity.ERROR,
+	EventSeverity.WARNING,
+	EventSeverity.INFO,
+];
+
+const SEVERITY_CHIP_LABEL: Record<EventSeverity, string> = {
+	[EventSeverity.CRITICAL]: 'Critical',
+	[EventSeverity.ERROR]: 'Error',
+	[EventSeverity.WARNING]: 'Warning',
+	[EventSeverity.INFO]: 'Info',
+};
+
+// Selected-chip tint per severity. Critical + error intentionally share the
+// danger tint (they're both failures), matching how the rail renders them — but
+// each remains an independent filter value so selecting one never silently
+// hides the other (the confusion behind #617's "critical shows nothing").
+const SEVERITY_CHIP_ACTIVE: Record<EventSeverity, string> = {
+	[EventSeverity.CRITICAL]: 'border-danger/50 bg-danger/15 text-danger',
+	[EventSeverity.ERROR]: 'border-danger/50 bg-danger/15 text-danger',
+	[EventSeverity.WARNING]: 'border-warning/50 bg-warning/15 text-warning',
+	[EventSeverity.INFO]: 'border-primary/50 bg-primary/15 text-primary',
+};
+
+function parseSeverities(raw: string | null): Set<EventSeverity> {
+	if (!raw) return new Set();
+	const valid = new Set(SEVERITY_ORDER as string[]);
+	return new Set(raw.split(',').filter((s) => valid.has(s)) as EventSeverity[]);
+}
+
+/**
+ * Drill-in ids for an event, so a "critical/failed" event is clickable through
+ * to its execution trace (issue #617: the flagged event was a dead end). Prefers
+ * the top-level `trace_id`; otherwise lifts `execution_id`/`trace_id` out of the
+ * free-form `data` payload (where the executor stamps them). Returns nulls when
+ * the event references no execution — the row is then rendered non-clickable.
+ */
+function drillInFor(row: EventResponse): { traceId: string | null; executionId: string | null } {
+	const data = (row.data ?? {}) as Record<string, unknown>;
+	const dataStr = (key: string): string | null => {
+		const v = data[key];
+		return typeof v === 'string' && v.length > 0 ? v : null;
+	};
+	return {
+		traceId: row.trace_id ?? dataStr('trace_id'),
+		executionId: dataStr('execution_id'),
+	};
 }
 
 const LIVE_STATUS_LABEL: Record<string, string> = {
@@ -78,6 +136,13 @@ export function EventsTab() {
 	const filterParam = searchParams.get('status');
 	const filter: EventFilter = isEventFilter(filterParam) ? filterParam : 'all';
 	const live = searchParams.get('live') === '1';
+	const selectedSeverities = parseSeverities(searchParams.get('severity'));
+
+	// Deep-link params for the trace/execution detail sheet — the SAME vocabulary
+	// the Executions tab reads, so a rail deep-link or an Events-row click both
+	// land on an open sheet (issue #617).
+	const openTraceId = searchParams.get('trace_id');
+	const openExecutionId = searchParams.get('execution_id');
 
 	const setFilter = (value: EventFilter) => {
 		setSearchParams(
@@ -88,6 +153,64 @@ export function EventsTab() {
 				return next;
 			},
 			{ replace: true },
+		);
+	};
+
+	const toggleSeverity = (sev: EventSeverity) => {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				const current = parseSeverities(prev.get('severity'));
+				if (current.has(sev)) current.delete(sev);
+				else current.add(sev);
+				// Preserve the canonical order so the param is stable regardless of
+				// click order (stable query key → no needless refetch).
+				const ordered = SEVERITY_ORDER.filter((s) => current.has(s));
+				if (ordered.length === 0) next.delete('severity');
+				else next.set('severity', ordered.join(','));
+				return next;
+			},
+			{ replace: true },
+		);
+	};
+
+	const clearSeverities = () => {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				next.delete('severity');
+				return next;
+			},
+			{ replace: true },
+		);
+	};
+
+	// Open a row's detail sheet. Prefer a usable trace (groups the whole trace);
+	// fall back to a bare execution id lifted from the event payload. Events that
+	// reference no execution/trace aren't clickable (handled at the row level).
+	const openEvent = (traceId: string | null, executionId: string | null) => {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				next.delete('trace_id');
+				next.delete('execution_id');
+				if (hasTrace(traceId)) next.set('trace_id', traceId);
+				else if (executionId) next.set('execution_id', executionId);
+				return next;
+			},
+			{ replace: false },
+		);
+	};
+
+	const closeSheet = () => {
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				next.delete('trace_id');
+				next.delete('execution_id');
+				return next;
+			},
+			{ replace: false },
 		);
 	};
 
@@ -104,19 +227,23 @@ export function EventsTab() {
 	};
 
 	const filters = useMonitorFilters();
+	const severityParam = searchParams.get('severity');
 	// Cursor pagination applies to the historical page only; reset when any
-	// filter (status, window, actor) changes.
+	// filter (status, severity, window, actor) changes.
 	const filterKey = JSON.stringify({
 		filter,
+		severity: severityParam,
 		from: filters.from,
 		actorId: filters.actorId,
 		actorType: filters.actorType,
 	});
 	const pager = useCursorStack(filterKey);
 
+	const severityList = SEVERITY_ORDER.filter((s) => selectedSeverities.has(s));
 	const listParams = {
 		requiresAction: filter === 'action' ? true : null,
 		acknowledged: filter === 'unacknowledged' ? false : null,
+		severity: severityList.length > 0 ? severityList : null,
 		actorId: filters.actorId,
 		actorType: filters.actorType,
 		from: filters.from,
@@ -190,6 +317,41 @@ export function EventsTab() {
 				</div>
 			</div>
 
+			{/* Severity filter — an axis orthogonal to the status toggle above.
+			    Repeatable `severity=` param, honoured server-side (#617). */}
+			<div className="flex flex-wrap items-center gap-1.5">
+				<span className="text-muted-foreground mr-1 text-[11px] font-medium">Severity</span>
+				{SEVERITY_ORDER.map((sev) => {
+					const active = selectedSeverities.has(sev);
+					return (
+						<button
+							key={sev}
+							type="button"
+							aria-pressed={active}
+							onClick={() => toggleSeverity(sev)}
+							className={cn(
+								'rounded-full border px-2.5 py-0.5 text-[11px] font-medium transition-colors',
+								active
+									? SEVERITY_CHIP_ACTIVE[sev]
+									: 'border-border text-muted-foreground hover:bg-muted',
+							)}
+						>
+							{SEVERITY_CHIP_LABEL[sev]}
+						</button>
+					);
+				})}
+				{selectedSeverities.size > 0 && (
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={clearSeverities}
+						className="text-muted-foreground hover:text-foreground h-6 px-2 text-[11px]"
+					>
+						Clear
+					</Button>
+				)}
+			</div>
+
 			{/* Announce only the live connection STATUS to assistive tech. The
 			    buffered-event count is intentionally excluded: it changes on every
 			    streamed event and would flood the live region with re-announcements. */}
@@ -206,27 +368,35 @@ export function EventsTab() {
 					retrying={query.isFetching}
 				/>
 			) : showEmpty ? (
-				<EmptyState
-					icon={<Bell className="h-8 w-8" />}
-					title={filter === 'all' ? 'No events yet' : 'No matching events'}
-					description={
-						filter === 'all'
-							? 'Platform events will appear here. Toggle Go live to stream them as they happen.'
-							: 'No platform events match the current filter.'
-					}
-					action={
-						filter !== 'all' ? (
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => setFilter('all')}
-								className="text-primary hover:text-primary font-medium hover:underline"
-							>
-								Clear filter
-							</Button>
-						) : undefined
-					}
-				/>
+				(() => {
+					const anyFilterActive = filter !== 'all' || selectedSeverities.size > 0;
+					return (
+						<EmptyState
+							icon={<Bell className="h-8 w-8" />}
+							title={anyFilterActive ? 'No matching events' : 'No events yet'}
+							description={
+								anyFilterActive
+									? 'No platform events match the current filter.'
+									: 'Platform events will appear here. Toggle Go live to stream them as they happen.'
+							}
+							action={
+								anyFilterActive ? (
+									<Button
+										variant="ghost"
+										size="sm"
+										onClick={() => {
+											setFilter('all');
+											clearSeverities();
+										}}
+										className="text-primary hover:text-primary font-medium hover:underline"
+									>
+										Clear filter
+									</Button>
+								) : undefined
+							}
+						/>
+					);
+				})()
 			) : (
 				<MonitorList
 					title="Events"
@@ -239,11 +409,17 @@ export function EventsTab() {
 							SEVERITY_ACCENT[severity] ?? SEVERITY_ACCENT[EventSeverity.INFO];
 						const Icon = eventSeverityIcon(severity);
 						const ack = renderAck(row);
+						const { traceId, executionId } = drillInFor(row);
+						const clickable = hasTrace(traceId) || executionId != null;
 						return (
 							<MonitorRow
 								key={row.event_id}
 								accent={accent}
 								icon={<Icon className="h-4 w-4" />}
+								onClick={
+									clickable ? () => openEvent(traceId, executionId) : undefined
+								}
+								label={clickable ? `Open execution for ${row.summary}` : undefined}
 								title={row.summary}
 								subtitle={
 									<span className="flex flex-wrap items-center gap-x-1.5">
@@ -293,6 +469,13 @@ export function EventsTab() {
 					Paging is paused while live — stop the stream to page through history.
 				</p>
 			)}
+
+			<TraceDetailSheet
+				traceId={openTraceId}
+				executionId={openExecutionId}
+				open={openTraceId != null || openExecutionId != null}
+				onClose={closeSheet}
+			/>
 		</div>
 	);
 }

--- a/ui/src/modules/monitor/components/EventsTab.tsx
+++ b/ui/src/modules/monitor/components/EventsTab.tsx
@@ -90,10 +90,14 @@ function parseSeverities(raw: string | null): Set<EventSeverity> {
 
 /**
  * Drill-in ids for an event, so a "critical/failed" event is clickable through
- * to its execution trace (issue #617: the flagged event was a dead end). Prefers
- * the top-level `trace_id`; otherwise lifts `execution_id`/`trace_id` out of the
- * free-form `data` payload (where the executor stamps them). Returns nulls when
- * the event references no execution — the row is then rendered non-clickable.
+ * to its execution trace (issue #617: the flagged event was a dead end).
+ *
+ * The backend surfaces the linked execution as a HAL link — `_links.execution`
+ * = `/executions/{id}` — NOT as a top-level field or a `data.execution_id`
+ * entry, so that link is the primary source; `data` is only a fallback for
+ * events that stamp the id there. `trace_id` comes from the top-level field
+ * (again falling back to `data`). Returns nulls when the event references no
+ * execution — the row is then rendered non-clickable.
  */
 function drillInFor(row: EventResponse): { traceId: string | null; executionId: string | null } {
 	const data = (row.data ?? {}) as Record<string, unknown>;
@@ -101,9 +105,15 @@ function drillInFor(row: EventResponse): { traceId: string | null; executionId: 
 		const v = data[key];
 		return typeof v === 'string' && v.length > 0 ? v : null;
 	};
+	// `_links.execution` is `/executions/{execution_id}` — take the last path
+	// segment as the id (strip any query/hash defensively).
+	const execLink = row._links?.execution ?? null;
+	const executionIdFromLink = execLink
+		? decodeURIComponent(execLink.split(/[?#]/)[0].split('/').pop() ?? '') || null
+		: null;
 	return {
 		traceId: row.trace_id ?? dataStr('trace_id'),
-		executionId: dataStr('execution_id'),
+		executionId: executionIdFromLink ?? dataStr('execution_id'),
 	};
 }
 

--- a/ui/src/modules/monitor/components/EventsTab.tsx
+++ b/ui/src/modules/monitor/components/EventsTab.tsx
@@ -20,7 +20,7 @@ import {
 	ActorLabel,
 } from '@/shared/ui';
 import { cn } from '@/shared/lib/utils';
-import { eventSeverityIcon } from '@/shared/lib';
+import { eventSeverityIcon, idFromLink } from '@/shared/lib';
 import {
 	useEvents,
 	useEventStream,
@@ -105,12 +105,9 @@ function drillInFor(row: EventResponse): { traceId: string | null; executionId: 
 		const v = data[key];
 		return typeof v === 'string' && v.length > 0 ? v : null;
 	};
-	// `_links.execution` is `/executions/{execution_id}` — take the last path
-	// segment as the id (strip any query/hash defensively).
-	const execLink = row._links?.execution ?? null;
-	const executionIdFromLink = execLink
-		? decodeURIComponent(execLink.split(/[?#]/)[0].split('/').pop() ?? '') || null
-		: null;
+	// `_links.execution` is `/executions/{execution_id}` — parsed by the shared
+	// HAL-link helper so the rail and this tab can't disagree on the rules.
+	const executionIdFromLink = idFromLink(row._links?.execution) ?? null;
 	return {
 		traceId: row.trace_id ?? dataStr('trace_id'),
 		executionId: executionIdFromLink ?? dataStr('execution_id'),

--- a/ui/src/modules/monitor/components/MonitorList.tsx
+++ b/ui/src/modules/monitor/components/MonitorList.tsx
@@ -100,14 +100,31 @@ export function MonitorRow({
 	return (
 		<li className="bg-card border-border/40 border-b last:border-0">
 			{onClick ? (
-				<button
-					type="button"
-					onClick={onClick}
+				// A row can carry its own inline controls (e.g. Events' Acknowledge
+				// button), so the clickable wrapper is a `role="link"` div rather than
+				// a real <button> — nesting a button inside a button is invalid. A
+				// click that originates on a nested control is ignored here so the
+				// control's own handler wins.
+				<div
+					role="link"
+					tabIndex={0}
 					aria-label={label}
-					className="hover:bg-muted focus-visible:bg-muted focus-visible:ring-ring block w-full text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-inset"
+					onClick={(e) => {
+						if ((e.target as HTMLElement).closest('button, a, [role="button"]')) return;
+						onClick();
+					}}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter' || e.key === ' ') {
+							if ((e.target as HTMLElement).closest('button, a, [role="button"]'))
+								return;
+							e.preventDefault();
+							onClick();
+						}
+					}}
+					className="hover:bg-muted focus-visible:bg-muted focus-visible:ring-ring block w-full cursor-pointer text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-inset"
 				>
 					{body}
-				</button>
+				</div>
 			) : (
 				body
 			)}

--- a/ui/src/shared/api/queryKeys.ts
+++ b/ui/src/shared/api/queryKeys.ts
@@ -111,4 +111,14 @@ export const sharedQueryKeys = {
 	 * moment the fleet actually changes.
 	 */
 	actorDirectoryRoot: ['actor-directory'] as const,
+	/**
+	 * The Monitor Events feed root (`GET /events` list slices; the Monitor
+	 * module's `monitorKeys.events(params)` derives from this). Owned by the
+	 * Monitor module, but the shared agent-stream provider's `acknowledge`
+	 * (rail rows, failure toasts) flips an event's `acknowledged` flag outside
+	 * React Query — without invalidating this root the Events tab's
+	 * `status=unacknowledged` list keeps showing a failure the operator already
+	 * acked from the rail until its staleTime lapses (#671 follow-through).
+	 */
+	monitorEventsRoot: ['monitor', 'events'] as const,
 };

--- a/ui/src/shared/app/rail/AgentRail.tsx
+++ b/ui/src/shared/app/rail/AgentRail.tsx
@@ -203,14 +203,14 @@ export function AgentRail() {
 		// Unfreeze so a failure that arrived while paused/hovering actually enters
 		// the feed the operator is being pointed at — otherwise the pill can count
 		// N+1 while the frozen feed still shows N, and the new failure never
-		// surfaces (#4). Clear both freeze mechanisms and the frozen snapshot.
+		// surfaces. Clear both freeze mechanisms and the frozen snapshot.
 		setManualPaused(false);
 		setHoverFrozen(false);
 		setFrozenIds(null);
 		// ADD the failure severities to the operator's current view rather than
 		// replacing it — union with the previous set so a `warning`/`info` chip
 		// they had selected survives, and deliberately leave `search` and `kinds`
-		// untouched so we don't wipe a filter they set on purpose (#5).
+		// untouched so we don't wipe a filter they set on purpose.
 		setSeverities((prev) => new Set<StreamEvent['severity']>([...prev, 'error', 'critical']));
 	}
 
@@ -305,12 +305,12 @@ export function AgentRail() {
 					{failureCount > 0 && (
 						<Tooltip
 							interactiveChild
-							content={`${failureCount} unacknowledged failure${failureCount === 1 ? '' : 's'}`}
+							content={`${failureCount} unacknowledged failure${failureCount === 1 ? '' : 's'} in recent activity`}
 						>
 							<button
 								type="button"
 								onClick={() => focusFailures()}
-								aria-label={`${failureCount} unacknowledged failure${failureCount === 1 ? '' : 's'}. Expand and show failures.`}
+								aria-label={`${failureCount} unacknowledged failure${failureCount === 1 ? '' : 's'} in recent activity. Expand and show failures.`}
 								className="border-danger/40 bg-danger/10 text-danger hover:bg-danger/20 flex flex-col items-center gap-0.5 rounded-full border px-1 py-1 text-[9px] font-bold tabular-nums transition-colors"
 							>
 								<TriangleAlert className="h-3 w-3" />

--- a/ui/src/shared/app/rail/AgentRail.tsx
+++ b/ui/src/shared/app/rail/AgentRail.tsx
@@ -22,9 +22,9 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { sharedQueryKeys } from '@/shared/api/queryKeys';
-import { ChevronLeft } from 'lucide-react';
+import { ChevronLeft, TriangleAlert } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
-import { toast } from '@/shared/ui';
+import { toast, Tooltip } from '@/shared/ui';
 import { AccessRequestDecisionDialog } from '@/shared/app/rail/AccessRequestDecisionDialog';
 import { RailEventRow } from '@/shared/app/rail/RailEventRow';
 import { RailFeed } from '@/shared/app/rail/RailFeed';
@@ -37,7 +37,9 @@ import {
 	RAIL_COLLAPSE_CHANGE_EVENT,
 	RAIL_COLLAPSED_STORAGE_KEY,
 	buildTraceBundle,
+	formatFailurePillCount,
 	readToastScope,
+	unacknowledgedFailureCount,
 	useAgentStream,
 	writeToastScope,
 } from '@/shared/lib/agentStream';
@@ -193,6 +195,25 @@ export function AgentRail() {
 		setKinds(new Set());
 	}
 
+	// The rail's persistent failure badge counts unacknowledged error/critical
+	// events; clicking it focuses the feed on exactly those (#671).
+	const failureCount = useMemo(() => unacknowledgedFailureCount(events), [events]);
+	function focusFailures() {
+		setCollapsed(false);
+		// Unfreeze so a failure that arrived while paused/hovering actually enters
+		// the feed the operator is being pointed at — otherwise the pill can count
+		// N+1 while the frozen feed still shows N, and the new failure never
+		// surfaces (#4). Clear both freeze mechanisms and the frozen snapshot.
+		setManualPaused(false);
+		setHoverFrozen(false);
+		setFrozenIds(null);
+		// ADD the failure severities to the operator's current view rather than
+		// replacing it — union with the previous set so a `warning`/`info` chip
+		// they had selected survives, and deliberately leave `search` and `kinds`
+		// untouched so we don't wipe a filter they set on purpose (#5).
+		setSeverities((prev) => new Set<StreamEvent['severity']>([...prev, 'error', 'critical']));
+	}
+
 	function handleLoadOlder() {
 		void loadOlderEvents();
 	}
@@ -281,6 +302,22 @@ export function AgentRail() {
 										: 'bg-muted-foreground',
 						)}
 					/>
+					{failureCount > 0 && (
+						<Tooltip
+							interactiveChild
+							content={`${failureCount} unacknowledged failure${failureCount === 1 ? '' : 's'}`}
+						>
+							<button
+								type="button"
+								onClick={() => focusFailures()}
+								aria-label={`${failureCount} unacknowledged failure${failureCount === 1 ? '' : 's'}. Expand and show failures.`}
+								className="border-danger/40 bg-danger/10 text-danger hover:bg-danger/20 flex flex-col items-center gap-0.5 rounded-full border px-1 py-1 text-[9px] font-bold tabular-nums transition-colors"
+							>
+								<TriangleAlert className="h-3 w-3" />
+								{formatFailurePillCount(failureCount)}
+							</button>
+						</Tooltip>
+					)}
 					<span className="text-muted-foreground font-mono text-[10px] tracking-widest uppercase [writing-mode:vertical-rl]">
 						Events · {events.length}
 					</span>
@@ -304,6 +341,8 @@ export function AgentRail() {
 				heldBack={feedFrozen ? Math.max(0, events.length - renderEvents.length) : 0}
 				stale={stale}
 				audioOnCritical={audioOnCritical}
+				failureCount={failureCount}
+				onFocusFailures={focusFailures}
 				onTogglePause={() => setManualPaused((p) => !p)}
 				onCollapse={() => setCollapsed(true)}
 				onLoadOlder={handleLoadOlder}

--- a/ui/src/shared/app/rail/RailEventRow.tsx
+++ b/ui/src/shared/app/rail/RailEventRow.tsx
@@ -26,7 +26,7 @@ import type React from 'react';
 import { useState } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
-import { Tooltip } from '@/shared/ui/Tooltip';
+import { Tooltip } from '@/shared/ui';
 import { StreamEventIcon } from '@/shared/app/rail/StreamEventIcon';
 import { DenyReasonField } from '@/shared/app/rail/DenyReasonField';
 import {

--- a/ui/src/shared/app/rail/RailEventRow.tsx
+++ b/ui/src/shared/app/rail/RailEventRow.tsx
@@ -26,10 +26,12 @@ import type React from 'react';
 import { useState } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
+import { Tooltip } from '@/shared/ui/Tooltip';
 import { StreamEventIcon } from '@/shared/app/rail/StreamEventIcon';
 import { DenyReasonField } from '@/shared/app/rail/DenyReasonField';
 import {
 	formatStreamTime,
+	formatStreamDateTimeParts,
 	inlineActionsFor,
 	primaryDestinationFor,
 	severityStripeClass,
@@ -50,6 +52,17 @@ export type RailEventRowProps = {
 };
 
 const KIND_LABEL = STREAM_KIND_LABEL;
+
+/** Two-line tooltip body: date on top, time below (issue #705 polish). */
+function TimeTooltipContent({ tsMs }: { tsMs: number }) {
+	const { date, time } = formatStreamDateTimeParts(tsMs);
+	return (
+		<span className="flex flex-col gap-0.5 text-center leading-tight">
+			<span className="text-muted-foreground text-[11px] font-medium">{date}</span>
+			<span className="text-foreground font-mono text-xs">{time}</span>
+		</span>
+	);
+}
 
 function isCompactSeverity(ev: StreamEvent): boolean {
 	if (ev.acknowledged) return true;
@@ -125,9 +138,11 @@ export function RailEventRow({
 						Acked
 					</span>
 				)}
-				<span className="text-muted-foreground shrink-0 font-mono text-[10px]">
-					{formatStreamTime(ev.tsMs)}
-				</span>
+				<Tooltip content={<TimeTooltipContent tsMs={ev.tsMs} />}>
+					<span className="text-muted-foreground shrink-0 font-mono text-[10px]">
+						{formatStreamTime(ev.tsMs)}
+					</span>
+				</Tooltip>
 			</div>
 		);
 	}
@@ -163,9 +178,14 @@ export function RailEventRow({
 							)}
 						</button>
 					)}
-					<span className="text-muted-foreground ml-auto shrink-0 font-mono text-[10px]">
-						{formatStreamTime(ev.tsMs)}
-					</span>
+					<Tooltip
+						content={<TimeTooltipContent tsMs={ev.tsMs} />}
+						className="ml-auto shrink-0"
+					>
+						<span className="text-muted-foreground font-mono text-[10px]">
+							{formatStreamTime(ev.tsMs)}
+						</span>
+					</Tooltip>
 				</div>
 				<div className="mt-0.5 flex items-center gap-1.5">
 					<span className="text-muted-foreground truncate text-[11px]">{ev.title}</span>

--- a/ui/src/shared/app/rail/RailFeed.tsx
+++ b/ui/src/shared/app/rail/RailFeed.tsx
@@ -175,8 +175,11 @@ export function RailFeed({ events, filters, onAction, onOpenRequest, onNavigate 
 						<div
 							key={`day-${row.dayKey}`}
 							className="text-muted-foreground flex items-center gap-2 pt-1.5 pb-0.5 text-[10px] font-semibold tracking-wider uppercase"
+							// Presentational: keeps the separator out of the role="log"
+							// announcement stream. The visible text is still readable in
+							// context; an aria-label here would be prohibited ARIA
+							// (axe: aria-prohibited-attr) and ignored anyway.
 							role="presentation"
-							aria-label={formatStreamDayLabel(row.tsMs)}
 						>
 							<span className="shrink-0">{formatStreamDayLabel(row.tsMs)}</span>
 							<span className="bg-border h-px flex-1" />

--- a/ui/src/shared/app/rail/RailFeed.tsx
+++ b/ui/src/shared/app/rail/RailFeed.tsx
@@ -10,6 +10,7 @@
  */
 import { useMemo, useState } from 'react';
 import { RailEventRow } from '@/shared/app/rail/RailEventRow';
+import { formatStreamDayLabel, streamDayKey } from '@/shared/lib/agentStream';
 import type { InlineActionSpec, StreamEvent } from '@/shared/lib/agentStream';
 
 const GROUP_WINDOW_MS = 10_000;
@@ -30,7 +31,45 @@ export type RailFeedProps = {
 
 type FeedRow =
 	| { kind: 'single'; ev: StreamEvent }
-	| { kind: 'group'; head: StreamEvent; members: StreamEvent[] };
+	| { kind: 'group'; head: StreamEvent; members: StreamEvent[] }
+	| { kind: 'day'; dayKey: string; tsMs: number };
+
+/** The representative event of a content row (used for day-boundary detection). */
+function rowHeadEvent(row: FeedRow): StreamEvent | null {
+	if (row.kind === 'single') return row.ev;
+	if (row.kind === 'group') return row.head;
+	return null;
+}
+
+/**
+ * Insert day-separator rows between content rows whenever the local calendar day
+ * changes. Only applied when the feed spans more than one day, so a same-day
+ * feed is visually unchanged (issue #705). Rows arrive newest-first, so the
+ * first content row's day leads the feed.
+ */
+function withDaySeparators(rows: FeedRow[]): FeedRow[] {
+	const days = new Set<string>();
+	for (const row of rows) {
+		const head = rowHeadEvent(row);
+		if (head) days.add(streamDayKey(head.tsMs));
+	}
+	if (days.size < 2) return rows;
+
+	const out: FeedRow[] = [];
+	let prevDay: string | null = null;
+	for (const row of rows) {
+		const head = rowHeadEvent(row);
+		if (head) {
+			const day = streamDayKey(head.tsMs);
+			if (day !== prevDay) {
+				out.push({ kind: 'day', dayKey: day, tsMs: head.tsMs });
+				prevDay = day;
+			}
+		}
+		out.push(row);
+	}
+	return out;
+}
 
 function passesFilters(ev: StreamEvent, f: RailFeedFilters): boolean {
 	if (f.severities.size > 0 && !f.severities.has(ev.severity)) return false;
@@ -98,7 +137,7 @@ export function RailFeed({ events, filters, onAction, onOpenRequest, onNavigate 
 		() => events.filter((ev) => passesFilters(ev, filters)),
 		[events, filters],
 	);
-	const rows = useMemo(() => buildRows(filtered), [filtered]);
+	const rows = useMemo(() => withDaySeparators(buildRows(filtered)), [filtered]);
 	const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
 
 	function toggle(id: string) {
@@ -127,6 +166,19 @@ export function RailFeed({ events, filters, onAction, onOpenRequest, onNavigate 
 	return (
 		<div className="space-y-1">
 			{rows.map((row) => {
+				if (row.kind === 'day') {
+					return (
+						<div
+							key={`day-${row.dayKey}`}
+							className="text-muted-foreground flex items-center gap-2 pt-1.5 pb-0.5 text-[10px] font-semibold tracking-wider uppercase"
+							role="separator"
+							aria-label={formatStreamDayLabel(row.tsMs)}
+						>
+							<span className="shrink-0">{formatStreamDayLabel(row.tsMs)}</span>
+							<span className="bg-border h-px flex-1" />
+						</div>
+					);
+				}
 				if (row.kind === 'single') {
 					return (
 						<RailEventRow

--- a/ui/src/shared/app/rail/RailFeed.tsx
+++ b/ui/src/shared/app/rail/RailFeed.tsx
@@ -51,7 +51,11 @@ function withDaySeparators(rows: FeedRow[]): FeedRow[] {
 	const days = new Set<string>();
 	for (const row of rows) {
 		const head = rowHeadEvent(row);
-		if (head) days.add(streamDayKey(head.tsMs));
+		if (!head) continue;
+		const key = streamDayKey(head.tsMs);
+		// A malformed timestamp yields an empty key; treating '' as a real day
+		// would inject a blank, label-less separator, so skip it here and below.
+		if (key) days.add(key);
 	}
 	if (days.size < 2) return rows;
 
@@ -61,7 +65,7 @@ function withDaySeparators(rows: FeedRow[]): FeedRow[] {
 		const head = rowHeadEvent(row);
 		if (head) {
 			const day = streamDayKey(head.tsMs);
-			if (day !== prevDay) {
+			if (day && day !== prevDay) {
 				out.push({ kind: 'day', dayKey: day, tsMs: head.tsMs });
 				prevDay = day;
 			}
@@ -171,7 +175,7 @@ export function RailFeed({ events, filters, onAction, onOpenRequest, onNavigate 
 						<div
 							key={`day-${row.dayKey}`}
 							className="text-muted-foreground flex items-center gap-2 pt-1.5 pb-0.5 text-[10px] font-semibold tracking-wider uppercase"
-							role="separator"
+							role="presentation"
 							aria-label={formatStreamDayLabel(row.tsMs)}
 						>
 							<span className="shrink-0">{formatStreamDayLabel(row.tsMs)}</span>

--- a/ui/src/shared/app/rail/RailFooter.tsx
+++ b/ui/src/shared/app/rail/RailFooter.tsx
@@ -40,7 +40,10 @@ export function RailFooter({
 					<option value="all">All events</option>
 					<option value="warning">Warning &amp; up</option>
 					<option value="critical">Critical only</option>
-					<option value="off">Off</option>
+					{/* Failures (error/critical) always toast regardless of scope
+					    (#671) — say so, or "Off" is a lie the operator will file
+					    as a bug the first time a failure pops. */}
+					<option value="off">Off (failures still toast)</option>
 				</select>
 			</div>
 			<button

--- a/ui/src/shared/app/rail/RailHeader.tsx
+++ b/ui/src/shared/app/rail/RailHeader.tsx
@@ -22,10 +22,13 @@ import {
 	MoreVertical,
 	Pause,
 	Play,
+	TriangleAlert,
 	Volume2,
 } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
 import { SearchInput } from '@/shared/ui/SearchInput';
+import { Tooltip } from '@/shared/ui';
+import { formatFailurePillCount } from '@/shared/lib/agentStream';
 import type { StreamEvent, StreamStatus } from '@/shared/lib/agentStream';
 import { cn } from '@/shared/lib/utils';
 
@@ -75,6 +78,10 @@ export type RailHeaderProps = {
 	heldBack: number;
 	stale: boolean; // SSE errored or reconnecting after a drop
 	audioOnCritical: boolean;
+	/** Unacknowledged error/critical events — drives the persistent failure pill (#671). */
+	failureCount: number;
+	/** Click the failure pill → focus the feed on error+critical events. */
+	onFocusFailures: () => void;
 	onTogglePause: () => void;
 	onCollapse: () => void;
 	onLoadOlder: () => void;
@@ -98,6 +105,8 @@ export function RailHeader({
 	heldBack,
 	stale,
 	audioOnCritical,
+	failureCount,
+	onFocusFailures,
 	onTogglePause,
 	onCollapse,
 	onLoadOlder,
@@ -211,6 +220,23 @@ export function RailHeader({
 					<span className="text-foreground shrink-0 text-sm font-semibold">
 						Agent rail
 					</span>
+					{failureCount > 0 && (
+						<Tooltip
+							interactiveChild
+							content={`${failureCount} unacknowledged failure${failureCount === 1 ? '' : 's'}`}
+							className="shrink-0"
+						>
+							<button
+								type="button"
+								onClick={onFocusFailures}
+								aria-label={`${failureCount} unacknowledged failure${failureCount === 1 ? '' : 's'}. Show failures.`}
+								className="border-danger/40 bg-danger/10 text-danger hover:bg-danger/20 inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-bold tabular-nums transition-colors"
+							>
+								<TriangleAlert className="h-3 w-3" />
+								{formatFailurePillCount(failureCount)}
+							</button>
+						</Tooltip>
+					)}
 					{status === 'connecting' && (
 						<span
 							className="text-muted-foreground shrink-0 font-mono text-[9px] tracking-widest uppercase"

--- a/ui/src/shared/app/rail/RailHeader.tsx
+++ b/ui/src/shared/app/rail/RailHeader.tsx
@@ -223,13 +223,13 @@ export function RailHeader({
 					{failureCount > 0 && (
 						<Tooltip
 							interactiveChild
-							content={`${failureCount} unacknowledged failure${failureCount === 1 ? '' : 's'}`}
+							content={`${failureCount} unacknowledged failure${failureCount === 1 ? '' : 's'} in recent activity`}
 							className="shrink-0"
 						>
 							<button
 								type="button"
 								onClick={onFocusFailures}
-								aria-label={`${failureCount} unacknowledged failure${failureCount === 1 ? '' : 's'}. Show failures.`}
+								aria-label={`${failureCount} unacknowledged failure${failureCount === 1 ? '' : 's'} in recent activity. Show failures.`}
 								className="border-danger/40 bg-danger/10 text-danger hover:bg-danger/20 inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-bold tabular-nums transition-colors"
 							>
 								<TriangleAlert className="h-3 w-3" />

--- a/ui/src/shared/app/rail/ToastHost.tsx
+++ b/ui/src/shared/app/rail/ToastHost.tsx
@@ -39,10 +39,12 @@ function readRailCollapsed(): boolean {
 
 const TOAST_TTL_MS = 6000;
 const MAX_TOASTS = 3;
+const MAX_DISMISSED_IDS = 500;
+const ASSERTIVE_COALESCE_MS = 5000;
 
 const KIND_LABEL = STREAM_KIND_LABEL;
 
-type Toast = StreamEvent & { addedAt: number };
+type Toast = StreamEvent & { addedAt: number; assertive: boolean };
 
 export function ToastHost() {
 	const { latest, acknowledge } = useAgentStream();
@@ -55,8 +57,16 @@ export function ToastHost() {
 	// the operator closed would silently re-appear when scope flips, because the
 	// dedup guard below only inspects still-alive toasts. TTL-expiry does NOT go
 	// in here (#671: an unattended failure that merely timed out must be able to
-	// re-toast when it becomes eligible again).
+	// re-toast when it becomes eligible again). Bounded FIFO (mirrors the
+	// stream provider's delivered-ids guard) so a very long session can't grow
+	// the set without limit.
 	const dismissedIdsRef = useRef<Set<string>>(new Set());
+	const dismissedOrderRef = useRef<string[]>([]);
+	// Time of the last assertive (role="alert") announcement. Under a failure
+	// burst the visible stack caps at MAX_TOASTS but each insert would still
+	// fire its own interrupting screen-reader announcement — demote follow-ups
+	// inside the window to polite so AT users hear one interruption, not N.
+	const lastAssertiveAtRef = useRef(0);
 
 	// React to scope + rail-collapse changes (same-tab CustomEvent + cross-tab StorageEvent)
 	useEffect(() => {
@@ -90,7 +100,15 @@ export function ToastHost() {
 			return;
 		setToasts((prev) => {
 			if (prev.some((t) => t.id === latest.id)) return prev;
-			return [{ ...latest, addedAt: Date.now() }, ...prev].slice(0, MAX_TOASTS);
+			const now = Date.now();
+			// First failure in a burst interrupts (assertive); follow-ups within
+			// the coalesce window are announced politely instead.
+			let assertive = false;
+			if (isFailureSeverity(latest.severity)) {
+				assertive = now - lastAssertiveAtRef.current > ASSERTIVE_COALESCE_MS;
+				if (assertive) lastAssertiveAtRef.current = now;
+			}
+			return [{ ...latest, addedAt: now, assertive }, ...prev].slice(0, MAX_TOASTS);
 		});
 	}, [latest, scope]);
 
@@ -107,7 +125,14 @@ export function ToastHost() {
 	}, [toasts.length]);
 
 	function dismiss(id: string) {
-		dismissedIdsRef.current.add(id);
+		if (!dismissedIdsRef.current.has(id)) {
+			dismissedIdsRef.current.add(id);
+			dismissedOrderRef.current.push(id);
+			while (dismissedOrderRef.current.length > MAX_DISMISSED_IDS) {
+				const oldest = dismissedOrderRef.current.shift();
+				if (oldest) dismissedIdsRef.current.delete(oldest);
+			}
+		}
 		setToasts((prev) => prev.filter((t) => t.id !== id));
 	}
 
@@ -195,11 +220,13 @@ function ToastCard({
 		? [{ kind: 'view_request', label: 'Review', opensRequest: true }]
 		: rawActions;
 	const critical = toast.severity === 'critical' || toast.severity === 'error';
+	// Burst coalescing: only the first failure inside the window interrupts.
+	const assertive = critical && toast.assertive;
 
 	return (
 		<div
-			role={critical ? 'alert' : 'status'}
-			aria-live={critical ? 'assertive' : 'polite'}
+			role={assertive ? 'alert' : 'status'}
+			aria-live={assertive ? 'assertive' : 'polite'}
 			tabIndex={onOpen ? 0 : undefined}
 			onClick={(e) => {
 				if (!onOpen) return;

--- a/ui/src/shared/app/rail/ToastHost.tsx
+++ b/ui/src/shared/app/rail/ToastHost.tsx
@@ -5,7 +5,7 @@
  * platform toaster) — shifted left of the rail at `xl+` so the two never
  * overlap. Mounted by the shell alongside `AgentRail`.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { X } from 'lucide-react';
 import { Button } from '@/shared/ui/Button';
@@ -13,6 +13,7 @@ import { StreamEventIcon } from '@/shared/app/rail/StreamEventIcon';
 import {
 	formatStreamTime,
 	inlineActionsFor,
+	isFailureSeverity,
 	matchesToastScope,
 	primaryDestinationFor,
 	RAIL_COLLAPSE_CHANGE_EVENT,
@@ -49,6 +50,13 @@ export function ToastHost() {
 	const [toasts, setToasts] = useState<Toast[]>([]);
 	const [scope, setScope] = useState<ToastScope>(() => readToastScope());
 	const [railCollapsed, setRailCollapsed] = useState<boolean>(() => readRailCollapsed());
+	// Ids the operator has EXPLICITLY dismissed. The insert effect re-runs on
+	// every `scope` change with the same `latest`; without this a failure toast
+	// the operator closed would silently re-appear when scope flips, because the
+	// dedup guard below only inspects still-alive toasts. TTL-expiry does NOT go
+	// in here (#671: an unattended failure that merely timed out must be able to
+	// re-toast when it becomes eligible again).
+	const dismissedIdsRef = useRef<Set<string>>(new Set());
 
 	// React to scope + rail-collapse changes (same-tab CustomEvent + cross-tab StorageEvent)
 	useEffect(() => {
@@ -72,17 +80,23 @@ export function ToastHost() {
 		};
 	}, []);
 
-	// Push the latest stream event into the toast queue if it matches scope
+	// Push the latest stream event into the toast queue if it matches scope.
+	// Failures (error/critical) always toast — even under scope `off` — so a
+	// silently-failed unattended run can't go unnoticed (#671).
 	useEffect(() => {
 		if (!latest) return;
-		if (!matchesToastScope(latest.severity, scope)) return;
+		if (dismissedIdsRef.current.has(latest.id)) return;
+		if (!isFailureSeverity(latest.severity) && !matchesToastScope(latest.severity, scope))
+			return;
 		setToasts((prev) => {
 			if (prev.some((t) => t.id === latest.id)) return prev;
 			return [{ ...latest, addedAt: Date.now() }, ...prev].slice(0, MAX_TOASTS);
 		});
 	}, [latest, scope]);
 
-	// Auto-dismiss after TOAST_TTL_MS
+	// Auto-dismiss after TOAST_TTL_MS. TTL-expiry only drops the toast from the
+	// visible list — it must NOT record the id as dismissed, or an unattended
+	// failure that simply timed out could never re-toast (#671).
 	useEffect(() => {
 		if (toasts.length === 0) return undefined;
 		const t = window.setInterval(() => {
@@ -93,6 +107,7 @@ export function ToastHost() {
 	}, [toasts.length]);
 
 	function dismiss(id: string) {
+		dismissedIdsRef.current.add(id);
 		setToasts((prev) => prev.filter((t) => t.id !== id));
 	}
 

--- a/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
@@ -215,7 +215,7 @@ describe('agentStream — wire adaptation + pure helpers', () => {
 		);
 	});
 
-	it('formatFailurePillCount caps at 99+ and clamps pathological inputs (#8)', () => {
+	it('formatFailurePillCount caps at 99+ and clamps pathological inputs', () => {
 		expect(formatFailurePillCount(0)).toBe('0');
 		expect(formatFailurePillCount(1)).toBe('1');
 		expect(formatFailurePillCount(99)).toBe('99');
@@ -274,7 +274,7 @@ describe('agentStream — wire adaptation + pure helpers', () => {
 			);
 		});
 
-		it('formatStreamDayLabel computes Yesterday by calendar rewind across a real DST boundary (#4)', async () => {
+		it('formatStreamDayLabel computes Yesterday by calendar rewind across a real DST boundary', async () => {
 			// The suite is globally pinned to UTC (DST-free) for determinism, so a
 			// fixed-24h rewind and a calendar-day rewind coincide and a UTC-only
 			// test can't tell the fix from the bug. Override JUST this test's
@@ -662,7 +662,7 @@ describe('AgentRail — shell-mounted live surface', () => {
 		// The seeded backlog has exactly one unacknowledged failure (the critical
 		// execution.failed) → the pill reads "1 unacknowledged failure".
 		const pill = await screen.findByRole('button', {
-			name: /1 unacknowledged failure\. Show failures\./i,
+			name: /1 unacknowledged failure in recent activity. Show failures./i,
 		});
 		expect(pill).toBeInTheDocument();
 
@@ -685,7 +685,7 @@ describe('AgentRail — shell-mounted live surface', () => {
 
 		await user.click(
 			await screen.findByRole('button', {
-				name: /unacknowledged failure\. Show failures\./i,
+				name: /unacknowledged failure in recent activity. Show failures./i,
 			}),
 		);
 
@@ -697,7 +697,7 @@ describe('AgentRail — shell-mounted live surface', () => {
 		expect(screen.getByText(/Execution failed: slack\.postMessage/i)).toBeInTheDocument();
 	});
 
-	it('focusFailures preserves the operator’s search + kind filters (#5)', async () => {
+	it('focusFailures preserves the operator’s search + kind filters', async () => {
 		const user = userEvent.setup();
 		renderRail(<AgentRail />);
 		await screen.findByText('Agent rail');
@@ -717,7 +717,9 @@ describe('AgentRail — shell-mounted live surface', () => {
 		// Clicking the failure pill must ADD failure severities, NOT wipe the
 		// operator's search or kind filters.
 		await user.click(
-			screen.getByRole('button', { name: /unacknowledged failure\. Show failures\./i }),
+			screen.getByRole('button', {
+				name: /unacknowledged failure in recent activity. Show failures./i,
+			}),
 		);
 
 		expect(searchBox).toHaveValue('slack');
@@ -742,7 +744,7 @@ describe('AgentRail — shell-mounted live surface', () => {
 		);
 	});
 
-	it('re-inserting a dismissed failure toast does not happen on scope change (#2)', async () => {
+	it('re-inserting a dismissed failure toast does not happen on scope change', async () => {
 		const user = userEvent.setup();
 		// Override the stream with a SINGLE critical event so `latest` is
 		// deterministically the failure (failures toast regardless of scope, #671)
@@ -819,7 +821,7 @@ describe('AgentRail — shell-mounted live surface', () => {
 		);
 
 		// Flip the toast scope (this re-runs ToastHost's insert effect with the
-		// SAME `latest`). The dismissed failure toast must NOT re-appear (#2).
+		// SAME `latest`). The dismissed failure toast must NOT re-appear.
 		const scopeSelect = screen.getByLabelText('Toasts');
 		await user.selectOptions(scopeSelect, 'all');
 		await waitFor(() =>
@@ -832,7 +834,7 @@ describe('AgentRail — shell-mounted live surface', () => {
 		expect(screen.queryByRole('button', { name: 'Dismiss toast' })).not.toBeInTheDocument();
 	});
 
-	it('re-toasts a failure that only TTL-expired (not operator-dismissed) after a scope change (#3)', async () => {
+	it('re-toasts a failure that only TTL-expired (not operator-dismissed) after a scope change', async () => {
 		const user = userEvent.setup();
 		// A single critical failure so `latest` is deterministically the failure
 		// and no later event overwrites it. Failures toast regardless of scope.

--- a/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
@@ -459,7 +459,39 @@ describe('agentStream — wire adaptation + pure helpers', () => {
 			severity: 'critical',
 			tokens: { execution_id: 'exec x', trace_id: 'tr_1' },
 		});
-		expect(primaryDestinationFor(ev)).toBe('/monitor?tab=executions&execution=exec%20x');
+		// The detail param is the underscore vocabulary the Executions tab reads —
+		// `execution`/`trace` aliases switched the tab but left the sheet closed (#617).
+		expect(primaryDestinationFor(ev)).toBe('/monitor?tab=executions&execution_id=exec%20x');
+	});
+
+	it('primaryDestinationFor falls back to trace_id when an execution has no execution_id', () => {
+		const ev = makeEvent({
+			type: 'execution.failed',
+			kind: 'execution',
+			severity: 'error',
+			tokens: { trace_id: 'tr_9' },
+		});
+		expect(primaryDestinationFor(ev)).toBe('/monitor?tab=executions&trace_id=tr_9');
+	});
+
+	it('primaryDestinationFor never deep-links a placeholder "unknown" trace', () => {
+		const ev = makeEvent({
+			type: 'execution.failed',
+			kind: 'execution',
+			severity: 'error',
+			tokens: { trace_id: 'unknown' },
+		});
+		expect(primaryDestinationFor(ev)).toBeNull();
+	});
+
+	it('primaryDestinationFor routes import events to the jobs tab by job_id', () => {
+		const ev = makeEvent({
+			type: 'import.completed',
+			kind: 'import',
+			severity: 'info',
+			tokens: { job_id: 'job_7' },
+		});
+		expect(primaryDestinationFor(ev)).toBe('/monitor?tab=jobs&job_id=job_7');
 	});
 
 	it('primaryDestinationFor routes credential events to the credential detail', () => {

--- a/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
@@ -141,6 +141,33 @@ describe('agentStream — wire adaptation + pure helpers', () => {
 		expect(ev.links.execution).toBe('/executions/exec_9');
 	});
 
+	it('adaptEvent lifts execution_id/job_id from _links when absent from data (#617)', () => {
+		// The regressed real-world case: the backend surfaces the linked execution
+		// ONLY as `_links.execution` (= /executions/{id}); `data` is empty. The
+		// deep-link token must still resolve so "View execution" appears.
+		const exec = adaptEvent(
+			wireEvent({
+				event_id: 'evt_link_exec',
+				type: 'execution.failed',
+				requires_action: true,
+				trace_id: null,
+				data: {},
+				_links: { self: '/events/evt_link_exec', execution: '/executions/exec_link' },
+			}),
+		);
+		expect(exec.tokens.execution_id).toBe('exec_link');
+
+		const job = adaptEvent(
+			wireEvent({
+				event_id: 'evt_link_job',
+				type: 'import.completed',
+				data: {},
+				_links: { self: '/events/evt_link_job', job: '/jobs/job_link' },
+			}),
+		);
+		expect(job.tokens.job_id).toBe('job_link');
+	});
+
 	it('adaptEvent falls back to now (not 1970) for a missing/unparseable timestamp', () => {
 		const before = Date.now();
 		const ev = adaptEvent(

--- a/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
@@ -11,11 +11,14 @@ import {
 	adaptEvent,
 	buildGroupKeyForTest,
 	buildTraceBundle,
+	formatStreamDateTime,
+	formatStreamDayLabel,
 	inlineActionsFor,
 	kindForType,
 	matchesToastScope,
 	primaryDestinationFor,
 	severityForWire,
+	streamDayKey,
 	RAIL_COLLAPSED_STORAGE_KEY,
 	TOAST_SCOPE_STORAGE_KEY,
 	type StreamEvent,
@@ -154,6 +157,39 @@ describe('agentStream — wire adaptation + pure helpers', () => {
 		expect(matchesToastScope('info', 'warning')).toBe(false);
 		expect(matchesToastScope('critical', 'critical')).toBe(true);
 		expect(matchesToastScope('warning', 'critical')).toBe(false);
+	});
+
+	describe('timestamp date helpers (#705)', () => {
+		it('streamDayKey buckets by local calendar day, not UTC', () => {
+			const a = new Date(2026, 6, 16, 9, 0, 0).getTime(); // 16 Jul, local
+			const b = new Date(2026, 6, 16, 23, 30, 0).getTime(); // same local day
+			const c = new Date(2026, 6, 17, 0, 30, 0).getTime(); // next local day
+			expect(streamDayKey(a)).toBe('2026-07-16');
+			expect(streamDayKey(a)).toBe(streamDayKey(b));
+			expect(streamDayKey(a)).not.toBe(streamDayKey(c));
+			expect(streamDayKey(NaN)).toBe('');
+		});
+
+		it('formatStreamDayLabel resolves Today / Yesterday / dated', () => {
+			const now = new Date(2026, 6, 17, 12, 0, 0).getTime();
+			const today = new Date(2026, 6, 17, 8, 0, 0).getTime();
+			const yesterday = new Date(2026, 6, 16, 8, 0, 0).getTime();
+			const older = new Date(2026, 6, 13, 8, 0, 0).getTime();
+			expect(formatStreamDayLabel(today, now)).toBe('Today');
+			expect(formatStreamDayLabel(yesterday, now)).toBe('Yesterday');
+			// Older days fall through to a compact weekday+date label.
+			expect(formatStreamDayLabel(older, now)).not.toBe('Today');
+			expect(formatStreamDayLabel(older, now)).not.toBe('Yesterday');
+			expect(formatStreamDayLabel(older, now)).toMatch(/Jul/);
+		});
+
+		it('formatStreamDateTime returns an absolute datetime (with year)', () => {
+			const ts = new Date(2026, 6, 16, 14, 4, 31).getTime();
+			const out = formatStreamDateTime(ts);
+			expect(out).toMatch(/2026/);
+			expect(out).toMatch(/Jul/);
+			expect(formatStreamDateTime(NaN)).toBe('');
+		});
 	});
 
 	it('inlineActionsFor offers View + Deny for a filed access request, gated on action + ack', () => {

--- a/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/AgentRail.test.tsx
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { page } from '@vitest/browser/context';
+import { page, cdp } from '@vitest/browser/context';
 import type { ReactElement } from 'react';
+import { http, HttpResponse } from 'msw';
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor, fireEvent, userEvent, checkA11y } from '@/__tests__/test-utils';
+import { worker } from '@/mocks/browser';
 import { AgentRail } from '@/shared/app/rail/AgentRail';
 import { ToastHost } from '@/shared/app/rail/ToastHost';
 import {
@@ -11,14 +13,16 @@ import {
 	adaptEvent,
 	buildGroupKeyForTest,
 	buildTraceBundle,
-	formatStreamDateTime,
+	formatFailurePillCount,
 	formatStreamDayLabel,
 	inlineActionsFor,
+	isFailureSeverity,
 	kindForType,
 	matchesToastScope,
 	primaryDestinationFor,
 	severityForWire,
 	streamDayKey,
+	unacknowledgedFailureCount,
 	RAIL_COLLAPSED_STORAGE_KEY,
 	TOAST_SCOPE_STORAGE_KEY,
 	type StreamEvent,
@@ -85,6 +89,7 @@ function makeEvent(partial: Partial<StreamEvent>): StreamEvent {
 
 beforeEach(async () => {
 	window.localStorage.clear();
+	window.sessionStorage.clear();
 	// The rail is `hidden xl:flex` (xl = 1280px). Widen the page so the rail
 	// and its controls join the accessibility tree; role queries skip
 	// `display:none` content.
@@ -92,6 +97,7 @@ beforeEach(async () => {
 });
 afterEach(() => {
 	window.localStorage.clear();
+	window.sessionStorage.clear();
 });
 
 describe('agentStream — wire adaptation + pure helpers', () => {
@@ -159,6 +165,55 @@ describe('agentStream — wire adaptation + pure helpers', () => {
 		expect(matchesToastScope('warning', 'critical')).toBe(false);
 	});
 
+	it('isFailureSeverity flags only error + critical (#671)', () => {
+		expect(isFailureSeverity('critical')).toBe(true);
+		expect(isFailureSeverity('error')).toBe(true);
+		expect(isFailureSeverity('warning')).toBe(false);
+		expect(isFailureSeverity('info')).toBe(false);
+	});
+
+	it('unacknowledgedFailureCount counts only unacked error/critical (#671)', () => {
+		const events = [
+			makeEvent({ id: 'e1', severity: 'error' }),
+			makeEvent({ id: 'c1', severity: 'critical' }),
+			makeEvent({ id: 'e2', severity: 'error', acknowledged: true }),
+			makeEvent({ id: 'w1', severity: 'warning' }),
+			makeEvent({ id: 'i1', severity: 'info' }),
+		];
+		expect(unacknowledgedFailureCount(events)).toBe(2);
+		expect(unacknowledgedFailureCount([])).toBe(0);
+		// Acknowledging every failure drops the count to zero.
+		expect(unacknowledgedFailureCount(events.map((e) => ({ ...e, acknowledged: true })))).toBe(
+			0,
+		);
+	});
+
+	it('formatFailurePillCount caps at 99+ and clamps pathological inputs (#8)', () => {
+		expect(formatFailurePillCount(0)).toBe('0');
+		expect(formatFailurePillCount(1)).toBe('1');
+		expect(formatFailurePillCount(99)).toBe('99');
+		expect(formatFailurePillCount(100)).toBe('99+');
+		// Pathological inputs must not leak "NaN" / "-1" onto the pill.
+		expect(formatFailurePillCount(NaN)).toBe('0');
+		expect(formatFailurePillCount(-1)).toBe('0');
+		expect(formatFailurePillCount(-5)).toBe('0');
+		expect(formatFailurePillCount(3.9)).toBe('3');
+		expect(formatFailurePillCount(Infinity)).toBe('0');
+	});
+
+	it('failures toast regardless of scope; non-failures still honour scope (#671)', () => {
+		// The ToastHost gate is `isFailureSeverity(sev) || matchesToastScope(sev, scope)`.
+		// A failed unattended run must surface even under the quietest scope.
+		const wouldToast = (sev: StreamEvent['severity'], scope: 'off' | 'critical' | 'all') =>
+			isFailureSeverity(sev) || matchesToastScope(sev, scope);
+		expect(wouldToast('error', 'off')).toBe(true);
+		expect(wouldToast('critical', 'off')).toBe(true);
+		// Non-failures obey scope as before.
+		expect(wouldToast('info', 'off')).toBe(false);
+		expect(wouldToast('warning', 'off')).toBe(false);
+		expect(wouldToast('info', 'all')).toBe(true);
+	});
+
 	describe('timestamp date helpers (#705)', () => {
 		it('streamDayKey buckets by local calendar day, not UTC', () => {
 			const a = new Date(2026, 6, 16, 9, 0, 0).getTime(); // 16 Jul, local
@@ -177,18 +232,58 @@ describe('agentStream — wire adaptation + pure helpers', () => {
 			const older = new Date(2026, 6, 13, 8, 0, 0).getTime();
 			expect(formatStreamDayLabel(today, now)).toBe('Today');
 			expect(formatStreamDayLabel(yesterday, now)).toBe('Yesterday');
-			// Older days fall through to a compact weekday+date label.
-			expect(formatStreamDayLabel(older, now)).not.toBe('Today');
-			expect(formatStreamDayLabel(older, now)).not.toBe('Yesterday');
-			expect(formatStreamDayLabel(older, now)).toMatch(/Jul/);
+			// Older days fall through to a compact weekday+date label. The label is
+			// locale-formatted (TZ + locale are pinned in vitest.config.ts, #7), so
+			// assert against the same formatter rather than a brittle literal.
+			const olderLabel = formatStreamDayLabel(older, now);
+			expect(olderLabel).not.toBe('Today');
+			expect(olderLabel).not.toBe('Yesterday');
+			expect(olderLabel).toBe(
+				new Date(older).toLocaleDateString(undefined, {
+					weekday: 'short',
+					day: 'numeric',
+					month: 'short',
+				}),
+			);
 		});
 
-		it('formatStreamDateTime returns an absolute datetime (with year)', () => {
-			const ts = new Date(2026, 6, 16, 14, 4, 31).getTime();
-			const out = formatStreamDateTime(ts);
-			expect(out).toMatch(/2026/);
-			expect(out).toMatch(/Jul/);
-			expect(formatStreamDateTime(NaN)).toBe('');
+		it('formatStreamDayLabel computes Yesterday by calendar rewind across a real DST boundary (#4)', async () => {
+			// The suite is globally pinned to UTC (DST-free) for determinism, so a
+			// fixed-24h rewind and a calendar-day rewind coincide and a UTC-only
+			// test can't tell the fix from the bug. Override JUST this test's
+			// timezone to a DST-observing zone via CDP so the in-page `Date`
+			// genuinely straddles America/New_York spring-forward
+			// (2026-03-08 02:00 EST → 03:00 EDT — a 23-hour local day), then
+			// restore UTC so the rest of the suite stays deterministic.
+			// The public `cdp()` type is intentionally minimal; the playwright
+			// provider backs it with a real Chrome DevTools session that exposes
+			// `send(method, params)`. Narrow to just that here.
+			const session = cdp() as unknown as {
+				send: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
+			};
+			await session.send('Emulation.setTimezoneOverride', {
+				timezoneId: 'America/New_York',
+			});
+			try {
+				// `now` = 2026-03-09 00:30 EDT (= 04:30 UTC). Because 2026-03-08 was
+				// only 23h long, subtracting a fixed 24h of real ms overshoots to
+				// 2026-03-07 23:30 EST — the WRONG local day. A calendar-day rewind
+				// correctly lands on 2026-03-08.
+				const now = Date.UTC(2026, 2, 9, 4, 30, 0);
+				// Event on the previous LOCAL calendar day (2026-03-08 12:00 EDT =
+				// 16:00 UTC). The fix returns 'Yesterday'; the fixed-24h form keys
+				// 2026-03-07 and would fall through to a dated label instead.
+				const prevDay = Date.UTC(2026, 2, 8, 16, 0, 0);
+				// Two local days before `now` (2026-03-07) — never 'Yesterday'.
+				const twoDaysAgo = Date.UTC(2026, 2, 7, 16, 0, 0);
+
+				expect(formatStreamDayLabel(prevDay, now)).toBe('Yesterday');
+				expect(formatStreamDayLabel(twoDaysAgo, now)).not.toBe('Yesterday');
+				expect(formatStreamDayLabel(twoDaysAgo, now)).not.toBe('Today');
+			} finally {
+				// Restore the pinned UTC zone for every following test.
+				await session.send('Emulation.setTimezoneOverride', { timezoneId: 'UTC' });
+			}
 		});
 	});
 
@@ -500,6 +595,277 @@ describe('AgentRail — shell-mounted live surface', () => {
 			expect(screen.getByTestId('location')).toHaveTextContent('/monitor?tab=executions'),
 		);
 	});
+
+	it('shows a failure pill for unacknowledged failures and clears it once acknowledged (#671)', async () => {
+		const user = userEvent.setup();
+		renderRail(<AgentRail />);
+		await screen.findByText('Agent rail');
+		// The seeded backlog has exactly one unacknowledged failure (the critical
+		// execution.failed) → the pill reads "1 unacknowledged failure".
+		const pill = await screen.findByRole('button', {
+			name: /1 unacknowledged failure\. Show failures\./i,
+		});
+		expect(pill).toBeInTheDocument();
+
+		// Acknowledge the failure → the count drops to zero and the pill disappears.
+		const ack = screen.getAllByRole('button', { name: 'Acknowledge' })[0];
+		await user.click(ack);
+		await waitFor(() =>
+			expect(
+				screen.queryByRole('button', { name: /unacknowledged failure/i }),
+			).not.toBeInTheDocument(),
+		);
+	});
+
+	it('focuses the feed on failures when the failure pill is clicked (#671)', async () => {
+		const user = userEvent.setup();
+		renderRail(<AgentRail />);
+		await screen.findByText('Agent rail');
+		// Before: an info event (import completed) is visible in the feed.
+		await screen.findByText(/Import completed: petstore/i);
+
+		await user.click(
+			await screen.findByRole('button', {
+				name: /unacknowledged failure\. Show failures\./i,
+			}),
+		);
+
+		// After: the feed is filtered to error+critical, so the info import row
+		// drops out while the critical failure remains.
+		await waitFor(() =>
+			expect(screen.queryByText(/Import completed: petstore/i)).not.toBeInTheDocument(),
+		);
+		expect(screen.getByText(/Execution failed: slack\.postMessage/i)).toBeInTheDocument();
+	});
+
+	it('focusFailures preserves the operator’s search + kind filters (#5)', async () => {
+		const user = userEvent.setup();
+		renderRail(<AgentRail />);
+		await screen.findByText('Agent rail');
+
+		// The operator has narrowed the view: a search term + a kind chip + a
+		// severity chip (warning) they picked on purpose.
+		const searchBox = screen.getByLabelText('Filter rail events');
+		await user.click(searchBox);
+		await user.paste('slack');
+		const execChip = screen.getByRole('button', { name: 'executions' });
+		await user.click(execChip);
+		await waitFor(() => expect(execChip).toHaveAttribute('aria-pressed', 'true'));
+		const warningChip = screen.getByRole('button', { name: 'warning' });
+		await user.click(warningChip);
+		await waitFor(() => expect(warningChip).toHaveAttribute('aria-pressed', 'true'));
+
+		// Clicking the failure pill must ADD failure severities, NOT wipe the
+		// operator's search or kind filters.
+		await user.click(
+			screen.getByRole('button', { name: /unacknowledged failure\. Show failures\./i }),
+		);
+
+		expect(searchBox).toHaveValue('slack');
+		expect(screen.getByRole('button', { name: 'executions' })).toHaveAttribute(
+			'aria-pressed',
+			'true',
+		);
+		// The union path: the operator's `warning` chip survives alongside the
+		// failure severities that were added.
+		expect(screen.getByRole('button', { name: 'warning' })).toHaveAttribute(
+			'aria-pressed',
+			'true',
+		);
+		// And the severities were added: both error and critical chips are pressed.
+		expect(screen.getByRole('button', { name: 'error' })).toHaveAttribute(
+			'aria-pressed',
+			'true',
+		);
+		expect(screen.getByRole('button', { name: 'critical' })).toHaveAttribute(
+			'aria-pressed',
+			'true',
+		);
+	});
+
+	it('re-inserting a dismissed failure toast does not happen on scope change (#2)', async () => {
+		const user = userEvent.setup();
+		// Override the stream with a SINGLE critical event so `latest` is
+		// deterministically the failure (failures toast regardless of scope, #671)
+		// and no later event overwrites it.
+		const failure = {
+			event_id: 'evt_only_failure',
+			type: 'execution.failed',
+			severity: 'critical',
+			summary: 'Execution failed: solo.run',
+			detail: 'boom',
+			created_at: new Date().toISOString(),
+			requires_action: true,
+			acknowledged: false,
+			acknowledged_at: null,
+			acknowledged_by: null,
+			trace_id: 'tr_solo',
+			data: { execution_id: 'exec_solo' },
+			_links: { self: '/events/evt_only_failure' },
+		};
+		worker.use(
+			http.get('/events', () =>
+				HttpResponse.json({ data: [failure], has_more: false, next_cursor: null }),
+			),
+			http.get('/events/stream', () => {
+				const frame = `event: ${failure.type}\nid: ${failure.event_id}\ndata: ${JSON.stringify(
+					failure,
+				)}\n\n`;
+				const encoder = new TextEncoder();
+				const stream = new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(encoder.encode(frame));
+					},
+				});
+				return new HttpResponse(stream, {
+					headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+				});
+			}),
+		);
+
+		render(
+			<QueryClientProvider
+				client={
+					new QueryClient({
+						defaultOptions: {
+							queries: { retry: false },
+							mutations: { retry: false },
+						},
+					})
+				}
+			>
+				<MemoryRouter initialEntries={['/dashboard']}>
+					<AgentStreamProvider live={true}>
+						<Routes>
+							<Route
+								path="/*"
+								element={
+									<>
+										<AgentRail />
+										<ToastHost />
+									</>
+								}
+							/>
+						</Routes>
+					</AgentStreamProvider>
+				</MemoryRouter>
+			</QueryClientProvider>,
+		);
+
+		// The failure toast pops, then the operator dismisses it.
+		const dismiss = await screen.findByRole('button', { name: 'Dismiss toast' });
+		await user.click(dismiss);
+		await waitFor(() =>
+			expect(screen.queryByRole('button', { name: 'Dismiss toast' })).not.toBeInTheDocument(),
+		);
+
+		// Flip the toast scope (this re-runs ToastHost's insert effect with the
+		// SAME `latest`). The dismissed failure toast must NOT re-appear (#2).
+		const scopeSelect = screen.getByLabelText('Toasts');
+		await user.selectOptions(scopeSelect, 'all');
+		await waitFor(() =>
+			expect(window.localStorage.getItem(TOAST_SCOPE_STORAGE_KEY)).toBe('all'),
+		);
+		await user.selectOptions(scopeSelect, 'critical');
+		await waitFor(() =>
+			expect(window.localStorage.getItem(TOAST_SCOPE_STORAGE_KEY)).toBe('critical'),
+		);
+		expect(screen.queryByRole('button', { name: 'Dismiss toast' })).not.toBeInTheDocument();
+	});
+
+	it('re-toasts a failure that only TTL-expired (not operator-dismissed) after a scope change (#3)', async () => {
+		const user = userEvent.setup();
+		// A single critical failure so `latest` is deterministically the failure
+		// and no later event overwrites it. Failures toast regardless of scope.
+		const failure = {
+			event_id: 'evt_ttl_failure',
+			type: 'execution.failed',
+			severity: 'critical',
+			summary: 'Execution failed: ttl.run',
+			detail: 'boom',
+			created_at: new Date().toISOString(),
+			requires_action: true,
+			acknowledged: false,
+			acknowledged_at: null,
+			acknowledged_by: null,
+			trace_id: 'tr_ttl',
+			data: { execution_id: 'exec_ttl' },
+			_links: { self: '/events/evt_ttl_failure' },
+		};
+		worker.use(
+			http.get('/events', () =>
+				HttpResponse.json({ data: [failure], has_more: false, next_cursor: null }),
+			),
+			http.get('/events/stream', () => {
+				const frame = `event: ${failure.type}\nid: ${failure.event_id}\ndata: ${JSON.stringify(
+					failure,
+				)}\n\n`;
+				const encoder = new TextEncoder();
+				const stream = new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(encoder.encode(frame));
+					},
+				});
+				return new HttpResponse(stream, {
+					headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+				});
+			}),
+		);
+
+		render(
+			<QueryClientProvider
+				client={
+					new QueryClient({
+						defaultOptions: {
+							queries: { retry: false },
+							mutations: { retry: false },
+						},
+					})
+				}
+			>
+				<MemoryRouter initialEntries={['/dashboard']}>
+					<AgentStreamProvider live={true}>
+						<Routes>
+							<Route
+								path="/*"
+								element={
+									<>
+										<AgentRail />
+										<ToastHost />
+									</>
+								}
+							/>
+						</Routes>
+					</AgentStreamProvider>
+				</MemoryRouter>
+			</QueryClientProvider>,
+		);
+
+		// The failure toast pops. The rail feed also shows a row for the same
+		// event, so key off the toast-only "Dismiss toast" control rather than the
+		// title text (which the feed row shares).
+		await screen.findByRole('button', { name: 'Dismiss toast' });
+
+		// Let it AUTO-DISMISS via TTL (no operator interaction). The TTL is 6s and
+		// the sweeper runs every 250ms, so wait past the horizon.
+		await waitFor(
+			() =>
+				expect(
+					screen.queryByRole('button', { name: 'Dismiss toast' }),
+				).not.toBeInTheDocument(),
+			{ timeout: 9000 },
+		);
+
+		// Flip the toast scope — this re-runs ToastHost's insert effect with the
+		// SAME `latest`. A TTL-expired failure must re-toast (its id was NOT
+		// remembered as dismissed): #671 says a failure must never be missed.
+		const scopeSelect = screen.getByLabelText('Toasts');
+		await user.selectOptions(scopeSelect, 'all');
+		await waitFor(() =>
+			expect(window.localStorage.getItem(TOAST_SCOPE_STORAGE_KEY)).toBe('all'),
+		);
+		await screen.findByRole('button', { name: 'Dismiss toast' });
+	}, 20000);
 
 	it('acknowledges a seeded action-required event → row flips to Acked', async () => {
 		const user = userEvent.setup();

--- a/ui/src/shared/app/rail/__tests__/RailFeed.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/RailFeed.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, userEvent } from '@/__tests__/test-utils';
+import { RailFeed, type RailFeedFilters } from '@/shared/app/rail/RailFeed';
+import { formatStreamDateTimeParts, type StreamEvent } from '@/shared/lib/agentStream';
+
+/** Minimal StreamEvent factory for feed-rendering tests. */
+function ev(partial: Partial<StreamEvent> & Pick<StreamEvent, 'id' | 'tsMs'>): StreamEvent {
+	return {
+		type: 'execution.completed',
+		kind: 'execution',
+		severity: 'info',
+		title: 'test event',
+		tokens: {},
+		links: {},
+		requiresAction: false,
+		acknowledged: false,
+		groupKey: `execution:execution.completed:${partial.id}`,
+		...partial,
+	};
+}
+
+const NO_FILTERS: RailFeedFilters = {
+	search: '',
+	severities: new Set(),
+	kinds: new Set(),
+};
+
+describe('RailFeed — day separators (#705)', () => {
+	it('inserts day separators when the feed spans more than one day', () => {
+		const today = new Date(2026, 6, 17, 10, 20, 3).getTime();
+		const older = new Date(2026, 6, 13, 14, 9, 23).getTime();
+		// Newest-first order, as the provider supplies events.
+		const events = [
+			ev({ id: 'a', tsMs: today, title: 'today event' }),
+			ev({ id: 'b', tsMs: older, title: 'older event' }),
+		];
+		render(<RailFeed events={events} filters={NO_FILTERS} />);
+
+		// Two distinct days → two separators. "Today" leads; the older day shows
+		// its weekday+date label (not "Today"/"Yesterday").
+		const separators = screen.getAllByRole('separator');
+		expect(separators.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it('renders no day separators for a single-day feed', () => {
+		const morning = new Date(2026, 6, 17, 9, 0, 0).getTime();
+		const evening = new Date(2026, 6, 17, 21, 0, 0).getTime();
+		const events = [
+			ev({ id: 'a', tsMs: evening, title: 'evening event' }),
+			ev({ id: 'b', tsMs: morning, title: 'morning event' }),
+		];
+		render(<RailFeed events={events} filters={NO_FILTERS} />);
+		expect(screen.queryByRole('separator')).toBeNull();
+	});
+
+	it('shows the full date and time as an instant tooltip on hover of a timestamp', async () => {
+		const ts = new Date(2026, 6, 16, 14, 4, 31).getTime();
+		const events = [ev({ id: 'a', tsMs: ts, title: 'an event' })];
+		render(<RailFeed events={events} filters={NO_FILTERS} />);
+		const user = userEvent.setup();
+
+		const { date, time } = formatStreamDateTimeParts(ts);
+		// The bubble only exists once the timestamp trigger is hovered.
+		expect(screen.queryByRole('tooltip')).toBeNull();
+		await user.hover(screen.getByText('14:04:31'));
+		const tip = await screen.findByRole('tooltip');
+		// Rendered as two rows: date on top, time below.
+		expect(tip).toHaveTextContent(date);
+		expect(tip).toHaveTextContent(time);
+	});
+});

--- a/ui/src/shared/app/rail/__tests__/RailFeed.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/RailFeed.test.tsx
@@ -55,7 +55,7 @@ describe('RailFeed — day separators (#705)', () => {
 		expect(container.querySelectorAll('[role="presentation"]')).toHaveLength(0);
 	});
 
-	it('does not emit a blank separator for a malformed (NaN) timestamp (#3)', () => {
+	it('does not emit a blank separator for a malformed (NaN) timestamp', () => {
 		// A NaN timestamp yields an empty day key. It must NOT become its own
 		// label-less separator row; the event still renders normally.
 		const today = new Date(2026, 6, 17, 10, 0, 0).getTime();
@@ -69,13 +69,14 @@ describe('RailFeed — day separators (#705)', () => {
 
 		// The malformed event still renders as an event row…
 		expect(screen.getByText('malformed event')).toBeInTheDocument();
-		// …and every rendered separator carries a non-empty label (no blank ones).
+		// …and every rendered separator carries non-empty visible label text
+		// (no blank ones).
 		for (const sep of container.querySelectorAll('[role="presentation"]')) {
-			expect(sep.getAttribute('aria-label')).toBeTruthy();
+			expect(sep.textContent).toBeTruthy();
 		}
 	});
 
-	it('marks day separators role="presentation" so the role="log" feed does not announce them (#7)', () => {
+	it('marks day separators role="presentation" so the role="log" feed does not announce them', () => {
 		const today = new Date(2026, 6, 17, 10, 0, 0).getTime();
 		const older = new Date(2026, 6, 13, 10, 0, 0).getTime();
 		const events = [
@@ -93,7 +94,10 @@ describe('RailFeed — day separators (#705)', () => {
 		expect(screen.queryByRole('separator')).toBeNull();
 		for (const sep of separators) {
 			expect(sep).toHaveAttribute('role', 'presentation');
-			expect(sep.getAttribute('aria-label')).toBeTruthy();
+			// No aria-label: it's prohibited ARIA on a presentational node
+			// (axe: aria-prohibited-attr). The visible text carries the day.
+			expect(sep).not.toHaveAttribute('aria-label');
+			expect(sep.textContent).toBeTruthy();
 		}
 	});
 

--- a/ui/src/shared/app/rail/__tests__/RailFeed.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/RailFeed.test.tsx
@@ -34,11 +34,13 @@ describe('RailFeed — day separators (#705)', () => {
 			ev({ id: 'a', tsMs: today, title: 'today event' }),
 			ev({ id: 'b', tsMs: older, title: 'older event' }),
 		];
-		render(<RailFeed events={events} filters={NO_FILTERS} />);
+		const { container } = render(<RailFeed events={events} filters={NO_FILTERS} />);
 
 		// Two distinct days → two separators. "Today" leads; the older day shows
-		// its weekday+date label (not "Today"/"Yesterday").
-		const separators = screen.getAllByRole('separator');
+		// its weekday+date label (not "Today"/"Yesterday"). Separators are
+		// role="presentation" (#7 — quiet in the live log, still in the DOM), so
+		// query by the presentation role attribute rather than the a11y tree.
+		const separators = container.querySelectorAll('[role="presentation"]');
 		expect(separators.length).toBeGreaterThanOrEqual(2);
 	});
 
@@ -49,8 +51,50 @@ describe('RailFeed — day separators (#705)', () => {
 			ev({ id: 'a', tsMs: evening, title: 'evening event' }),
 			ev({ id: 'b', tsMs: morning, title: 'morning event' }),
 		];
-		render(<RailFeed events={events} filters={NO_FILTERS} />);
+		const { container } = render(<RailFeed events={events} filters={NO_FILTERS} />);
+		expect(container.querySelectorAll('[role="presentation"]')).toHaveLength(0);
+	});
+
+	it('does not emit a blank separator for a malformed (NaN) timestamp (#3)', () => {
+		// A NaN timestamp yields an empty day key. It must NOT become its own
+		// label-less separator row; the event still renders normally.
+		const today = new Date(2026, 6, 17, 10, 0, 0).getTime();
+		const older = new Date(2026, 6, 13, 10, 0, 0).getTime();
+		const events = [
+			ev({ id: 'good1', tsMs: today, title: 'today event' }),
+			ev({ id: 'bad', tsMs: NaN, title: 'malformed event' }),
+			ev({ id: 'good2', tsMs: older, title: 'older event' }),
+		];
+		const { container } = render(<RailFeed events={events} filters={NO_FILTERS} />);
+
+		// The malformed event still renders as an event row…
+		expect(screen.getByText('malformed event')).toBeInTheDocument();
+		// …and every rendered separator carries a non-empty label (no blank ones).
+		for (const sep of container.querySelectorAll('[role="presentation"]')) {
+			expect(sep.getAttribute('aria-label')).toBeTruthy();
+		}
+	});
+
+	it('marks day separators role="presentation" so the role="log" feed does not announce them (#7)', () => {
+		const today = new Date(2026, 6, 17, 10, 0, 0).getTime();
+		const older = new Date(2026, 6, 13, 10, 0, 0).getTime();
+		const events = [
+			ev({ id: 'a', tsMs: today, title: 'today event' }),
+			ev({ id: 'b', tsMs: older, title: 'older event' }),
+		];
+		const { container } = render(<RailFeed events={events} filters={NO_FILTERS} />);
+		// `role="presentation"` strips the row from the accessibility tree — so the
+		// role="log" + aria-relevant="additions" container never announces a
+		// spliced-in separator as a fake "event" — while the label text stays in
+		// the DOM and readable on explicit SR navigation.
+		const separators = container.querySelectorAll('[role="presentation"]');
+		expect(separators.length).toBeGreaterThanOrEqual(2);
+		// The rows are no longer exposed with the `separator` role.
 		expect(screen.queryByRole('separator')).toBeNull();
+		for (const sep of separators) {
+			expect(sep).toHaveAttribute('role', 'presentation');
+			expect(sep.getAttribute('aria-label')).toBeTruthy();
+		}
 	});
 
 	it('shows the full date and time as an instant tooltip on hover of a timestamp', async () => {

--- a/ui/src/shared/app/rail/mocks/handlers.ts
+++ b/ui/src/shared/app/rail/mocks/handlers.ts
@@ -296,7 +296,24 @@ export const railEventsHandlers = [
 		const url = new URL(request.url);
 		const cursor = url.searchParams.get('cursor');
 		const limit = Number(url.searchParams.get('limit') ?? '25');
-		const sorted = [...events].sort(
+		// Honour the same filters the real backend applies so the Monitor Events
+		// tab's severity/status controls visibly narrow the list in mocked (Mode A)
+		// dev — not just against a real backend (issue #617). The rail itself never
+		// sends these params (it filters client-side), so unfiltered rail behaviour
+		// is unchanged.
+		const severities = url.searchParams.getAll('severity');
+		const eventTypes = url.searchParams.getAll('event_type');
+		const requiresAction = url.searchParams.get('requires_action');
+		const acknowledged = url.searchParams.get('acknowledged');
+		const filtered = events.filter((e) => {
+			if (severities.length && !severities.includes(e.severity)) return false;
+			if (eventTypes.length && !eventTypes.includes(e.type)) return false;
+			if (requiresAction != null && String(e.requires_action) !== requiresAction)
+				return false;
+			if (acknowledged != null && String(e.acknowledged) !== acknowledged) return false;
+			return true;
+		});
+		const sorted = [...filtered].sort(
 			(a, b) => Date.parse(b.created_at) - Date.parse(a.created_at),
 		);
 		const start = cursor ? sorted.findIndex((e) => e.event_id === cursor) + 1 : 0;

--- a/ui/src/shared/lib/agentStream.tsx
+++ b/ui/src/shared/lib/agentStream.tsx
@@ -172,6 +172,17 @@ function stringField(data: Record<string, unknown> | undefined, key: string): st
 	return typeof v === 'string' && v.length > 0 ? v : undefined;
 }
 
+/**
+ * Extract the trailing id from a HAL link like `/executions/{id}` or
+ * `/jobs/{id}` (query/hash stripped). The backend surfaces the linked
+ * execution/job only as such a link, not as a `data` field — see `adaptEvent`.
+ */
+function idFromLink(link: string | null | undefined): string | undefined {
+	if (!link) return undefined;
+	const id = decodeURIComponent(link.split(/[?#]/)[0].split('/').pop() ?? '');
+	return id.length > 0 ? id : undefined;
+}
+
 /** Build the grouping key. Consecutive same-key events collapse in the feed. */
 function buildGroupKey(t: Pick<StreamEvent, 'kind' | 'type' | 'tokens'>): string {
 	const token =
@@ -203,13 +214,18 @@ export function adaptEvent(e: EventResponse): StreamEvent {
 		e.actor_type === 'agent' && typeof e.actor_id === 'string' && e.actor_id.length > 0
 			? e.actor_id
 			: undefined;
+	// The linked execution/job is surfaced as a HAL link (`_links.execution` =
+	// `/executions/{id}`, `_links.job` = `/jobs/{id}`), NOT as a `data` entry —
+	// so parse the id out of the link (last path segment) and prefer it over the
+	// `data` fallback. Without this the "View execution/job" deep-link never
+	// appeared for real events (their `data` carries no id). See issue #617.
 	const tokens: StreamTokens = {
 		trace_id: e.trace_id ?? stringField(data, 'trace_id'),
 		toolkit_id: stringField(data, 'toolkit_id'),
 		operation_id: stringField(data, 'operation_id'),
 		credential_id: stringField(data, 'credential_id'),
-		job_id: stringField(data, 'job_id'),
-		execution_id: stringField(data, 'execution_id'),
+		job_id: idFromLink(e._links?.job) ?? stringField(data, 'job_id'),
+		execution_id: idFromLink(e._links?.execution) ?? stringField(data, 'execution_id'),
 		access_request_id:
 			stringField(data, 'access_request_id') ?? stringField(data, 'request_id'),
 		// Precedence matters: explicit `data.agent_id` first, then the top-level

--- a/ui/src/shared/lib/agentStream.tsx
+++ b/ui/src/shared/lib/agentStream.tsx
@@ -831,17 +831,37 @@ export type InlineActionSpec = {
 	requiresReason?: boolean;
 };
 
-/** Resolve a HAL `_links` URL or token into a router-relative monitor route. */
+/**
+ * Resolve a HAL `_links` URL or token into a router-relative monitor route.
+ *
+ * The detail-param vocabulary MUST match what the Monitor tabs read off the URL:
+ * the Executions tab opens its trace/execution sheet from `trace_id`/`execution_id`
+ * and the Jobs tab from `job_id` (the underscore names — see
+ * `modules/monitor/lib/links.ts` and the tabs' `searchParams.get(...)`). Emitting
+ * the short `trace`/`execution`/`job` aliases here switched the tab but left the
+ * detail sheet closed, so a rail "View execution" click looked like a dead end
+ * (issue #617). `trace_id="unknown"` is a placeholder for header-less runs and
+ * can't open a sheet, so it's never emitted as a trace link.
+ */
+const hasUsableTrace = (traceId: string | null | undefined): traceId is string =>
+	traceId != null && traceId !== '' && traceId !== 'unknown';
+
 const NAV = {
 	trace: (ev: StreamEvent) =>
-		ev.tokens.trace_id ? `/monitor?tab=executions&trace=${ev.tokens.trace_id}` : null,
+		hasUsableTrace(ev.tokens.trace_id)
+			? `/monitor?tab=executions&trace_id=${encodeURIComponent(ev.tokens.trace_id)}`
+			: null,
 	execution: (ev: StreamEvent) => {
 		const id = ev.tokens.execution_id;
-		if (id) return `/monitor?tab=executions&execution=${encodeURIComponent(id)}`;
-		return ev.tokens.trace_id ? `/monitor?tab=executions&trace=${ev.tokens.trace_id}` : null;
+		if (id) return `/monitor?tab=executions&execution_id=${encodeURIComponent(id)}`;
+		return hasUsableTrace(ev.tokens.trace_id)
+			? `/monitor?tab=executions&trace_id=${encodeURIComponent(ev.tokens.trace_id)}`
+			: null;
 	},
 	job: (ev: StreamEvent) =>
-		ev.tokens.job_id ? `/monitor?tab=jobs&job=${encodeURIComponent(ev.tokens.job_id)}` : null,
+		ev.tokens.job_id
+			? `/monitor?tab=jobs&job_id=${encodeURIComponent(ev.tokens.job_id)}`
+			: null,
 	agent: (ev: StreamEvent) =>
 		ev.tokens.agent_id ? `/agents/${encodeURIComponent(ev.tokens.agent_id)}` : null,
 };

--- a/ui/src/shared/lib/agentStream.tsx
+++ b/ui/src/shared/lib/agentStream.tsx
@@ -672,6 +672,40 @@ export function matchesToastScope(severity: StreamSeverity, scope: ToastScope): 
 	return severity === 'critical';
 }
 
+/**
+ * A failure severity — `error` or `critical`. Failures are surfaced proactively
+ * (toast + persistent badge) regardless of the operator's toast scope, since a
+ * silently-failed unattended run is exactly what must never be missed (#671).
+ */
+export function isFailureSeverity(severity: StreamSeverity): boolean {
+	return severity === 'error' || severity === 'critical';
+}
+
+/**
+ * Count of unacknowledged failure events (error/critical) in the feed — the
+ * number shown on the rail's persistent failure badge (#671). Drops to zero as
+ * the operator acknowledges each failing event.
+ */
+export function unacknowledgedFailureCount(events: StreamEvent[]): number {
+	let n = 0;
+	for (const ev of events) {
+		if (!ev.acknowledged && isFailureSeverity(ev.severity)) n += 1;
+	}
+	return n;
+}
+
+/**
+ * Badge-friendly rendering of a failure count: caps at "99+" so a runaway count
+ * can't overflow the narrow rail pill, and clamps pathological inputs (NaN,
+ * negatives, fractions) to a sane non-negative integer so the pill never shows
+ * "NaN" or "-1". The underlying number stays accurate for aria labels — this
+ * only shapes the visible glyphs (#11).
+ */
+export function formatFailurePillCount(count: number): string {
+	const n = Number.isFinite(count) ? Math.max(0, Math.trunc(count)) : 0;
+	return n > 99 ? '99+' : String(n);
+}
+
 export function severityStripeClass(s: StreamSeverity): string {
 	if (s === 'critical') return 'border-l-danger';
 	if (s === 'error') return 'border-l-danger';
@@ -685,24 +719,6 @@ export function formatStreamTime(tsMs: number): string {
 	const mm = d.getMinutes().toString().padStart(2, '0');
 	const ss = d.getSeconds().toString().padStart(2, '0');
 	return `${hh}:${mm}:${ss}`;
-}
-
-/**
- * Absolute local datetime for a timestamp tooltip, e.g. "16 Jul 2026, 14:04:31".
- * Surfaced as the `title` on each rail timestamp so the full date is always
- * discoverable even inside a single day (issue #705).
- */
-export function formatStreamDateTime(tsMs: number): string {
-	const d = new Date(tsMs);
-	if (Number.isNaN(d.getTime())) return '';
-	return d.toLocaleString(undefined, {
-		day: 'numeric',
-		month: 'short',
-		year: 'numeric',
-		hour: '2-digit',
-		minute: '2-digit',
-		second: '2-digit',
-	});
 }
 
 /**
@@ -749,7 +765,13 @@ export function formatStreamDayLabel(tsMs: number, now: number = Date.now()): st
 	const key = streamDayKey(tsMs);
 	if (!key) return '';
 	if (key === streamDayKey(now)) return 'Today';
-	if (key === streamDayKey(now - 86_400_000)) return 'Yesterday';
+	// "Yesterday" is the previous LOCAL calendar day. Rewinding by a fixed 24h in
+	// ms mislabels the day after a DST transition (the previous local day is 23h
+	// or 25h away), so step the Date's day-of-month instead — this stays correct
+	// across spring-forward / fall-back.
+	const y = new Date(now);
+	y.setDate(y.getDate() - 1);
+	if (key === streamDayKey(y.getTime())) return 'Yesterday';
 	return new Date(tsMs).toLocaleDateString(undefined, {
 		weekday: 'short',
 		day: 'numeric',

--- a/ui/src/shared/lib/agentStream.tsx
+++ b/ui/src/shared/lib/agentStream.tsx
@@ -176,8 +176,10 @@ function stringField(data: Record<string, unknown> | undefined, key: string): st
  * Extract the trailing id from a HAL link like `/executions/{id}` or
  * `/jobs/{id}` (query/hash stripped). The backend surfaces the linked
  * execution/job only as such a link, not as a `data` field — see `adaptEvent`.
+ * Exported so module-side consumers (e.g. Monitor's Events drill-in) parse
+ * links with the same rules instead of re-deriving them.
  */
-function idFromLink(link: string | null | undefined): string | undefined {
+export function idFromLink(link: string | null | undefined): string | undefined {
 	if (!link) return undefined;
 	const id = decodeURIComponent(link.split(/[?#]/)[0].split('/').pop() ?? '');
 	return id.length > 0 ? id : undefined;
@@ -554,11 +556,21 @@ export function AgentStreamProvider({
 			try {
 				const updated = await acknowledgeEvent(eventId);
 				patchEvent(eventId, () => adaptEvent(updated));
+				// The ack happened outside React Query, and the SSE stream is a
+				// created_at-watermark poll that will never re-deliver an old event
+				// just because its acknowledged flag flipped — so eagerly refresh
+				// the other surfaces that count/list unacknowledged events (the
+				// Monitor Events tab and the dashboard action inbox), mirroring
+				// what `decide` does for approval surfaces.
+				void queryClient.invalidateQueries({
+					queryKey: sharedQueryKeys.monitorEventsRoot,
+				});
+				void queryClient.invalidateQueries({ queryKey: DASHBOARD_ROOT_KEY });
 			} catch {
 				patchEvent(eventId, markUnresolved);
 			}
 		},
-		[patchEvent, markResolved, markUnresolved],
+		[patchEvent, markResolved, markUnresolved, queryClient],
 	);
 
 	const decide = useCallback(
@@ -654,6 +666,17 @@ export function useAgentStream(): AgentStreamValue {
 	return ctx;
 }
 
+/**
+ * Provider-optional variant for module-side hooks that should SYNC with the
+ * stream when it's mounted (the app shell) but must not require it (tests,
+ * embedded surfaces). Monitor's acknowledge mutation uses this to flip the
+ * rail's in-memory copy of an event so the failure pill drops immediately —
+ * the SSE watermark poll never re-delivers an old event on an ack flip.
+ */
+export function useAgentStreamOptional(): AgentStreamValue | null {
+	return useContext(AgentStreamContext);
+}
+
 /* ------------------------------------------------------------------ */
 /* Toast scope + display helpers                                       */
 /* ------------------------------------------------------------------ */
@@ -698,9 +721,12 @@ export function isFailureSeverity(severity: StreamSeverity): boolean {
 }
 
 /**
- * Count of unacknowledged failure events (error/critical) in the feed — the
- * number shown on the rail's persistent failure badge (#671). Drops to zero as
- * the operator acknowledges each failing event.
+ * Count of unacknowledged failure events (error/critical) in the LOADED feed
+ * window (backlog seed + live inserts, capped) — the number shown on the
+ * rail's persistent failure badge (#671). Deliberately window-scoped: the pill
+ * is a "recent activity" signal, not a global unacked-failures query (that's
+ * the Monitor Events tab); labels around it say "recent" for that reason.
+ * Drops as the operator acknowledges each failing event.
  */
 export function unacknowledgedFailureCount(events: StreamEvent[]): number {
 	let n = 0;
@@ -715,7 +741,7 @@ export function unacknowledgedFailureCount(events: StreamEvent[]): number {
  * can't overflow the narrow rail pill, and clamps pathological inputs (NaN,
  * negatives, fractions) to a sane non-negative integer so the pill never shows
  * "NaN" or "-1". The underlying number stays accurate for aria labels — this
- * only shapes the visible glyphs (#11).
+ * only shapes the visible glyphs.
  */
 export function formatFailurePillCount(count: number): string {
 	const n = Number.isFinite(count) ? Math.max(0, Math.trunc(count)) : 0;

--- a/ui/src/shared/lib/agentStream.tsx
+++ b/ui/src/shared/lib/agentStream.tsx
@@ -687,6 +687,76 @@ export function formatStreamTime(tsMs: number): string {
 	return `${hh}:${mm}:${ss}`;
 }
 
+/**
+ * Absolute local datetime for a timestamp tooltip, e.g. "16 Jul 2026, 14:04:31".
+ * Surfaced as the `title` on each rail timestamp so the full date is always
+ * discoverable even inside a single day (issue #705).
+ */
+export function formatStreamDateTime(tsMs: number): string {
+	const d = new Date(tsMs);
+	if (Number.isNaN(d.getTime())) return '';
+	return d.toLocaleString(undefined, {
+		day: 'numeric',
+		month: 'short',
+		year: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit',
+	});
+}
+
+/**
+ * Absolute local datetime split into a date line and a time line, so a tooltip
+ * can render it as two clean rows ("28 Jul 2026" / "13:02:01") instead of one
+ * string that wraps awkwardly into three (issue #705 tooltip polish).
+ */
+export function formatStreamDateTimeParts(tsMs: number): { date: string; time: string } {
+	const d = new Date(tsMs);
+	if (Number.isNaN(d.getTime())) return { date: '', time: '' };
+	const date = d.toLocaleDateString(undefined, {
+		day: 'numeric',
+		month: 'short',
+		year: 'numeric',
+	});
+	const time = d.toLocaleTimeString(undefined, {
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit',
+	});
+	return { date, time };
+}
+
+/**
+ * Stable **local** `YYYY-MM-DD` key for detecting calendar-day boundaries in the
+ * feed. Built from local date parts (not `toISOString`, which is UTC and would
+ * mis-bucket events around midnight for non-UTC operators — the #705 reporter is
+ * UTC+1).
+ */
+export function streamDayKey(tsMs: number): string {
+	const d = new Date(tsMs);
+	if (Number.isNaN(d.getTime())) return '';
+	const y = d.getFullYear();
+	const m = (d.getMonth() + 1).toString().padStart(2, '0');
+	const day = d.getDate().toString().padStart(2, '0');
+	return `${y}-${m}-${day}`;
+}
+
+/**
+ * Human day-separator label for the rail feed: "Today" / "Yesterday" / else a
+ * compact weekday+date like "Thu 16 Jul". `now` is injectable for tests.
+ */
+export function formatStreamDayLabel(tsMs: number, now: number = Date.now()): string {
+	const key = streamDayKey(tsMs);
+	if (!key) return '';
+	if (key === streamDayKey(now)) return 'Today';
+	if (key === streamDayKey(now - 86_400_000)) return 'Yesterday';
+	return new Date(tsMs).toLocaleDateString(undefined, {
+		weekday: 'short',
+		day: 'numeric',
+		month: 'short',
+	});
+}
+
 /* ------------------------------------------------------------------ */
 /* Inline actions + navigation                                         */
 /* ------------------------------------------------------------------ */

--- a/ui/src/shared/lib/index.ts
+++ b/ui/src/shared/lib/index.ts
@@ -79,3 +79,11 @@ export { fetchActorDirectory } from '@/shared/lib/actorDirectory';
 // Monitor's Events tab and the Dashboard's "Needs attention" card so the same
 // event reads identically in both surfaces.
 export { eventSeverityIcon } from '@/shared/lib/eventSeverity';
+
+// Narrow, module-consumable slices of the agent-stream data layer (NOT the
+// rail's React components): the HAL-link id parser (so Monitor's Events
+// drill-in and the rail parse links with the same rules) and the
+// provider-optional stream hook (so Monitor's acknowledge mutation can sync
+// the rail's in-memory copy when the shell's stream is mounted, and no-op in
+// tests/embedded surfaces where it isn't).
+export { idFromLink, useAgentStreamOptional } from '@/shared/lib/agentStream';

--- a/ui/src/shared/ui/Tooltip.tsx
+++ b/ui/src/shared/ui/Tooltip.tsx
@@ -1,4 +1,14 @@
-import { useCallback, useEffect, useId, useRef, useState, type ReactNode } from 'react';
+import {
+	cloneElement,
+	isValidElement,
+	useCallback,
+	useEffect,
+	useId,
+	useRef,
+	useState,
+	type ReactElement,
+	type ReactNode,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { cn } from '@/shared/lib/utils';
 
@@ -20,6 +30,14 @@ interface TooltipProps {
 	className?: string;
 	/** Extra classes for the tooltip bubble. */
 	bubbleClassName?: string;
+	/**
+	 * Set when the child is itself focusable (e.g. a `<button>`). The wrapper then
+	 * drops its own `tabIndex` (so the control isn't a double tab stop) AND its
+	 * `aria-describedby`; the association is cloned onto the focusable child
+	 * instead, since `aria-describedby` is not inherited from the wrapper. The
+	 * child must be a single valid React element in this mode.
+	 */
+	interactiveChild?: boolean;
 }
 
 /**
@@ -42,6 +60,7 @@ export function Tooltip({
 	delayMs = 400,
 	className,
 	bubbleClassName,
+	interactiveChild = false,
 }: TooltipProps) {
 	const triggerRef = useRef<HTMLSpanElement>(null);
 	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -56,15 +75,25 @@ export function Tooltip({
 		}
 	}, []);
 
-	/** Position + reveal the bubble now. */
-	const reveal = useCallback(() => {
+	/** Measure the trigger and place the bubble relative to it. */
+	const measure = useCallback(() => {
 		const el = triggerRef.current;
 		if (!el) return;
 		const rect = el.getBoundingClientRect();
 		const top = placement === 'top' ? rect.top - 8 : rect.bottom + 8;
-		setPos({ top, left: rect.left + rect.width / 2 });
-		setShow(true);
+		const left = rect.left + rect.width / 2;
+		// Skip the state write (and its re-render) when the measured position
+		// hasn't moved — a nested scroll that doesn't shift the trigger shouldn't
+		// churn React.
+		setPos((prev) => (prev && prev.top === top && prev.left === left ? prev : { top, left }));
 	}, [placement]);
+
+	/** Position + reveal the bubble now. */
+	const reveal = useCallback(() => {
+		if (!triggerRef.current) return;
+		measure();
+		setShow(true);
+	}, [measure]);
 
 	/** Hover open — gated behind `delayMs` so a quick pass-over doesn't flash. */
 	const openDelayed = useCallback(() => {
@@ -84,20 +113,60 @@ export function Tooltip({
 	// Never leak a pending open timer if the trigger unmounts mid-delay.
 	useEffect(() => clearTimer, [clearTimer]);
 
+	// While open, keep the fixed-position bubble pinned to the trigger. Inside
+	// the rail's `overflow-y-auto` feed an auto-scroll would otherwise strand the
+	// bubble at its reveal coordinates. Listen on the capture phase so ancestor
+	// scroll containers (not just window) are caught. Capture-phase scroll fires
+	// for every nested scroller, so coalesce bursts into one measurement per
+	// animation frame rather than a synchronous rect+setState per event.
+	useEffect(() => {
+		if (!show) return undefined;
+		let rafId: number | null = null;
+		const onReflow = () => {
+			if (rafId !== null) return;
+			rafId = window.requestAnimationFrame(() => {
+				rafId = null;
+				measure();
+			});
+		};
+		window.addEventListener('scroll', onReflow, true);
+		window.addEventListener('resize', onReflow);
+		return () => {
+			if (rafId !== null) window.cancelAnimationFrame(rafId);
+			window.removeEventListener('scroll', onReflow, true);
+			window.removeEventListener('resize', onReflow);
+		};
+	}, [show, measure]);
+
+	// When the child is itself focusable, `aria-describedby` is NOT inherited
+	// from the wrapper — focus lands on the inner control, so the association
+	// has to live ON that control. Clone it onto the child and leave the wrapper
+	// non-focusable and un-described. Otherwise the wrapper is the focus target
+	// and carries the association itself.
+	const describedChildren =
+		interactiveChild && isValidElement(children)
+			? cloneElement(children as ReactElement<{ 'aria-describedby'?: string }>, {
+					'aria-describedby': tooltipId,
+				})
+			: children;
+
 	return (
 		<span
 			ref={triggerRef}
 			className={cn('inline-flex', className)}
-			tabIndex={0}
-			aria-describedby={show ? tooltipId : undefined}
+			tabIndex={interactiveChild ? undefined : 0}
+			aria-describedby={interactiveChild ? undefined : tooltipId}
 			onMouseEnter={openDelayed}
 			onMouseLeave={close}
 			onFocus={reveal}
 			onBlur={close}
 		>
-			{children}
-			{show &&
-				pos &&
+			{describedChildren}
+			{/* The described text node is rendered UNCONDITIONALLY (visually hidden
+			    when closed) so the `aria-describedby` association is stable across
+			    renders and screen readers pick it up at focus time. Only the styled,
+			    positioned bubble is gated on `show`. */}
+			{show && pos ? (
 				createPortal(
 					<span
 						id={tooltipId}
@@ -112,7 +181,25 @@ export function Tooltip({
 						{content}
 					</span>,
 					document.body,
-				)}
+				)
+			) : (
+				<span
+					id={tooltipId}
+					style={{
+						position: 'absolute',
+						width: 1,
+						height: 1,
+						padding: 0,
+						margin: -1,
+						overflow: 'hidden',
+						clip: 'rect(0, 0, 0, 0)',
+						whiteSpace: 'nowrap',
+						borderWidth: 0,
+					}}
+				>
+					{content}
+				</span>
+			)}
 		</span>
 	);
 }

--- a/ui/src/shared/ui/Tooltip.tsx
+++ b/ui/src/shared/ui/Tooltip.tsx
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useId, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { cn } from '@/shared/lib/utils';
+
+type TooltipPlacement = 'top' | 'bottom';
+
+interface TooltipProps {
+	/** Tooltip content shown on hover/focus. Rendered into a body portal. */
+	content: ReactNode;
+	/** The trigger content the tooltip describes. */
+	children: ReactNode;
+	/** Where the tooltip sits relative to the trigger. Default `top`. */
+	placement?: TooltipPlacement;
+	/**
+	 * Hover open delay in ms (default 400). Keyboard focus always opens
+	 * immediately so assistive-tech users aren't gated on a timer.
+	 */
+	delayMs?: number;
+	/** Extra classes for the inline trigger wrapper. */
+	className?: string;
+	/** Extra classes for the tooltip bubble. */
+	bubbleClassName?: string;
+}
+
+/**
+ * A lightweight, reusable hover/focus tooltip.
+ *
+ * Unlike the native `title` attribute (which has a ~1s browser delay and
+ * unstyled chrome) this shows **instantly** on pointer-enter / focus and is
+ * consistently styled. Unlike `TruncateWithTooltip` it always shows its
+ * `content` (a value distinct from the trigger) rather than gating on overflow.
+ *
+ * The trigger is wrapped in a focusable inline `<span>`; the bubble renders into
+ * a `document.body` portal so it escapes any `overflow-hidden` ancestor (e.g.
+ * the rail's scroll container), and carries `role="tooltip"` +
+ * `aria-describedby` for assistive tech.
+ */
+export function Tooltip({
+	content,
+	children,
+	placement = 'top',
+	delayMs = 400,
+	className,
+	bubbleClassName,
+}: TooltipProps) {
+	const triggerRef = useRef<HTMLSpanElement>(null);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const [show, setShow] = useState(false);
+	const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+	const tooltipId = useId();
+
+	const clearTimer = useCallback(() => {
+		if (timerRef.current) {
+			clearTimeout(timerRef.current);
+			timerRef.current = null;
+		}
+	}, []);
+
+	/** Position + reveal the bubble now. */
+	const reveal = useCallback(() => {
+		const el = triggerRef.current;
+		if (!el) return;
+		const rect = el.getBoundingClientRect();
+		const top = placement === 'top' ? rect.top - 8 : rect.bottom + 8;
+		setPos({ top, left: rect.left + rect.width / 2 });
+		setShow(true);
+	}, [placement]);
+
+	/** Hover open — gated behind `delayMs` so a quick pass-over doesn't flash. */
+	const openDelayed = useCallback(() => {
+		clearTimer();
+		if (delayMs <= 0) {
+			reveal();
+			return;
+		}
+		timerRef.current = setTimeout(reveal, delayMs);
+	}, [clearTimer, delayMs, reveal]);
+
+	const close = useCallback(() => {
+		clearTimer();
+		setShow(false);
+	}, [clearTimer]);
+
+	// Never leak a pending open timer if the trigger unmounts mid-delay.
+	useEffect(() => clearTimer, [clearTimer]);
+
+	return (
+		<span
+			ref={triggerRef}
+			className={cn('inline-flex', className)}
+			tabIndex={0}
+			aria-describedby={show ? tooltipId : undefined}
+			onMouseEnter={openDelayed}
+			onMouseLeave={close}
+			onFocus={reveal}
+			onBlur={close}
+		>
+			{children}
+			{show &&
+				pos &&
+				createPortal(
+					<span
+						id={tooltipId}
+						role="tooltip"
+						className={cn(
+							'border-border/40 bg-card/70 text-card-foreground pointer-events-none fixed z-[9999] max-w-[320px] -translate-x-1/2 rounded-lg border px-3 py-2 text-xs whitespace-nowrap shadow-xl backdrop-blur-md',
+							placement === 'top' && '-translate-y-full',
+							bubbleClassName,
+						)}
+						style={{ top: pos.top, left: pos.left }}
+					>
+						{content}
+					</span>,
+					document.body,
+				)}
+		</span>
+	);
+}

--- a/ui/src/shared/ui/Tooltip.tsx
+++ b/ui/src/shared/ui/Tooltip.tsx
@@ -4,6 +4,7 @@ import {
 	useCallback,
 	useEffect,
 	useId,
+	useLayoutEffect,
 	useRef,
 	useState,
 	type ReactElement,
@@ -67,6 +68,7 @@ export function Tooltip({
 	const [show, setShow] = useState(false);
 	const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
 	const tooltipId = useId();
+	const bubbleRef = useRef<HTMLSpanElement>(null);
 
 	const clearTimer = useCallback(() => {
 		if (timerRef.current) {
@@ -119,6 +121,8 @@ export function Tooltip({
 	// scroll containers (not just window) are caught. Capture-phase scroll fires
 	// for every nested scroller, so coalesce bursts into one measurement per
 	// animation frame rather than a synchronous rect+setState per event.
+	// Escape dismisses while open (WCAG 1.4.13 "dismissible") — document-level
+	// so it works for hover-opened bubbles too, where focus is elsewhere.
 	useEffect(() => {
 		if (!show) return undefined;
 		let rafId: number | null = null;
@@ -129,24 +133,56 @@ export function Tooltip({
 				measure();
 			});
 		};
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') close();
+		};
 		window.addEventListener('scroll', onReflow, true);
 		window.addEventListener('resize', onReflow);
+		document.addEventListener('keydown', onKeyDown);
 		return () => {
 			if (rafId !== null) window.cancelAnimationFrame(rafId);
 			window.removeEventListener('scroll', onReflow, true);
 			window.removeEventListener('resize', onReflow);
+			document.removeEventListener('keydown', onKeyDown);
 		};
-	}, [show, measure]);
+	}, [show, measure, close]);
+
+	// Clamp the bubble inside the viewport. The bubble is centered on the
+	// trigger with a CSS translate; near a viewport edge (the rail hugs the
+	// right one) that would clip it off-screen, so after each position pass
+	// measure the rendered bubble and nudge it back in with a margin. Direct
+	// style mutation (not state) — this must not feed back into the effect.
+	useLayoutEffect(() => {
+		if (!show || !pos) return;
+		const el = bubbleRef.current;
+		if (!el) return;
+		el.style.marginLeft = '0px';
+		const rect = el.getBoundingClientRect();
+		const margin = 8;
+		let dx = 0;
+		if (rect.left < margin) dx = margin - rect.left;
+		else if (rect.right > window.innerWidth - margin)
+			dx = window.innerWidth - margin - rect.right;
+		if (dx !== 0) el.style.marginLeft = `${dx}px`;
+	}, [show, pos]);
 
 	// When the child is itself focusable, `aria-describedby` is NOT inherited
 	// from the wrapper — focus lands on the inner control, so the association
-	// has to live ON that control. Clone it onto the child and leave the wrapper
+	// has to live ON that control. Clone it onto the child (APPENDING to any
+	// description the child already carries) and leave the wrapper
 	// non-focusable and un-described. Otherwise the wrapper is the focus target
 	// and carries the association itself.
 	const describedChildren =
 		interactiveChild && isValidElement(children)
 			? cloneElement(children as ReactElement<{ 'aria-describedby'?: string }>, {
-					'aria-describedby': tooltipId,
+					'aria-describedby': [
+						(children as ReactElement<{ 'aria-describedby'?: string }>).props[
+							'aria-describedby'
+						],
+						tooltipId,
+					]
+						.filter(Boolean)
+						.join(' '),
 				})
 			: children;
 
@@ -170,9 +206,13 @@ export function Tooltip({
 				createPortal(
 					<span
 						id={tooltipId}
+						ref={bubbleRef}
 						role="tooltip"
 						className={cn(
-							'border-border/40 bg-card/70 text-card-foreground pointer-events-none fixed z-[9999] max-w-[320px] -translate-x-1/2 rounded-lg border px-3 py-2 text-xs whitespace-nowrap shadow-xl backdrop-blur-md',
+							// `whitespace-normal` (not nowrap): long content must wrap
+							// inside the max-width, not overflow the bubble. Consumers
+							// with short one-liners are unaffected.
+							'border-border/40 bg-card/70 text-card-foreground pointer-events-none fixed z-[9999] max-w-[320px] -translate-x-1/2 rounded-lg border px-3 py-2 text-xs whitespace-normal shadow-xl backdrop-blur-md',
 							placement === 'top' && '-translate-y-full',
 							bubbleClassName,
 						)}

--- a/ui/src/shared/ui/__tests__/Tooltip.test.tsx
+++ b/ui/src/shared/ui/__tests__/Tooltip.test.tsx
@@ -47,4 +47,60 @@ describe('Tooltip', () => {
 		const tip = await screen.findByRole('tooltip');
 		expect(tip).toHaveTextContent('focus value');
 	});
+
+	it('keeps a stable aria-describedby target even while closed (#9)', () => {
+		const { container } = renderWithProviders(
+			<Tooltip content="described text">
+				<span>trigger</span>
+			</Tooltip>,
+		);
+		// No visible tooltip bubble yet…
+		expect(screen.queryByRole('tooltip')).toBeNull();
+		// …but the wrapper's aria-describedby resolves to a rendered node that
+		// carries the description, so SR announces it at focus time.
+		const wrapper = container.querySelector('[aria-describedby]');
+		expect(wrapper).not.toBeNull();
+		const describedId = wrapper?.getAttribute('aria-describedby');
+		expect(describedId).toBeTruthy();
+		const descNode = describedId ? document.getElementById(describedId) : null;
+		expect(descNode).not.toBeNull();
+		expect(descNode).toHaveTextContent('described text');
+	});
+
+	it('puts aria-describedby on the focusable child (not the wrapper) when interactive (#2)', () => {
+		const { container } = renderWithProviders(
+			<Tooltip interactiveChild content="tip">
+				<button type="button">real control</button>
+			</Tooltip>,
+		);
+		// `aria-describedby` is NOT inherited from the wrapper, so it must live on
+		// the button that actually receives focus.
+		const button = screen.getByRole('button', { name: 'real control' });
+		const describedId = button.getAttribute('aria-describedby');
+		expect(describedId).toBeTruthy();
+		const descNode = describedId ? document.getElementById(describedId) : null;
+		expect(descNode).not.toBeNull();
+		expect(descNode).toHaveTextContent('tip');
+
+		// The wrapper carries neither the description nor a tab stop, so the
+		// control isn't announced silently and isn't a double tab stop.
+		const wrapper = button.parentElement as HTMLElement;
+		expect(wrapper.tagName).toBe('SPAN');
+		expect(wrapper.hasAttribute('aria-describedby')).toBe(false);
+		expect(wrapper.hasAttribute('tabindex')).toBe(false);
+
+		// Exactly one tab stop: the button. Nothing else in the subtree is
+		// focusable via tabindex.
+		expect(container.querySelectorAll('[tabindex]')).toHaveLength(0);
+	});
+
+	it('keeps the wrapper focusable when the child is not interactive (default)', () => {
+		const { container } = renderWithProviders(
+			<Tooltip content="tip">
+				<span>plain text</span>
+			</Tooltip>,
+		);
+		const wrapper = container.querySelector('span[aria-describedby]');
+		expect(wrapper?.getAttribute('tabindex')).toBe('0');
+	});
 });

--- a/ui/src/shared/ui/__tests__/Tooltip.test.tsx
+++ b/ui/src/shared/ui/__tests__/Tooltip.test.tsx
@@ -1,0 +1,50 @@
+import { renderWithProviders, screen } from '@/__tests__/test-utils';
+import userEvent from '@testing-library/user-event';
+import { Tooltip } from '@/shared/ui/Tooltip';
+
+describe('Tooltip', () => {
+	it('renders its trigger children', () => {
+		renderWithProviders(
+			<Tooltip content="the full value">
+				<span>trigger</span>
+			</Tooltip>,
+		);
+		expect(screen.getByText('trigger')).toBeInTheDocument();
+	});
+
+	it('does not render the bubble until hovered', () => {
+		renderWithProviders(
+			<Tooltip content="the full value">
+				<span>trigger</span>
+			</Tooltip>,
+		);
+		expect(screen.queryByRole('tooltip')).toBeNull();
+	});
+
+	it('shows content on hover and hides on unhover', async () => {
+		const user = userEvent.setup();
+		renderWithProviders(
+			<Tooltip content="the full value">
+				<span>trigger</span>
+			</Tooltip>,
+		);
+		await user.hover(screen.getByText('trigger'));
+		const tip = await screen.findByRole('tooltip');
+		expect(tip).toHaveTextContent('the full value');
+
+		await user.unhover(screen.getByText('trigger'));
+		expect(screen.queryByRole('tooltip')).toBeNull();
+	});
+
+	it('shows content on keyboard focus (a11y) and wires aria-describedby', async () => {
+		const user = userEvent.setup();
+		renderWithProviders(
+			<Tooltip content="focus value">
+				<span>focus-trigger</span>
+			</Tooltip>,
+		);
+		await user.tab();
+		const tip = await screen.findByRole('tooltip');
+		expect(tip).toHaveTextContent('focus value');
+	});
+});

--- a/ui/src/shared/ui/__tests__/Tooltip.test.tsx
+++ b/ui/src/shared/ui/__tests__/Tooltip.test.tsx
@@ -48,7 +48,7 @@ describe('Tooltip', () => {
 		expect(tip).toHaveTextContent('focus value');
 	});
 
-	it('keeps a stable aria-describedby target even while closed (#9)', () => {
+	it('keeps a stable aria-describedby target even while closed', () => {
 		const { container } = renderWithProviders(
 			<Tooltip content="described text">
 				<span>trigger</span>
@@ -67,7 +67,7 @@ describe('Tooltip', () => {
 		expect(descNode).toHaveTextContent('described text');
 	});
 
-	it('puts aria-describedby on the focusable child (not the wrapper) when interactive (#2)', () => {
+	it('puts aria-describedby on the focusable child (not the wrapper) when interactive', () => {
 		const { container } = renderWithProviders(
 			<Tooltip interactiveChild content="tip">
 				<button type="button">real control</button>
@@ -102,5 +102,44 @@ describe('Tooltip', () => {
 		);
 		const wrapper = container.querySelector('span[aria-describedby]');
 		expect(wrapper?.getAttribute('tabindex')).toBe('0');
+	});
+
+	it('dismisses on Escape without moving focus or pointer (WCAG 1.4.13)', async () => {
+		const user = userEvent.setup();
+		renderWithProviders(
+			<Tooltip content="escapable">
+				<span>trigger</span>
+			</Tooltip>,
+		);
+		// Keyboard-opened: focus stays on the trigger, Escape closes.
+		await user.tab();
+		await screen.findByRole('tooltip');
+		await user.keyboard('{Escape}');
+		expect(screen.queryByRole('tooltip')).toBeNull();
+
+		// Hover-opened (focus elsewhere): document-level Escape still closes.
+		await user.hover(screen.getByText('trigger'));
+		await screen.findByRole('tooltip');
+		await user.keyboard('{Escape}');
+		expect(screen.queryByRole('tooltip')).toBeNull();
+	});
+
+	it('appends to (not clobbers) an existing aria-describedby on an interactive child', () => {
+		renderWithProviders(
+			<>
+				<span id="prior-desc">prior description</span>
+				<Tooltip interactiveChild content="tip">
+					<button type="button" aria-describedby="prior-desc">
+						real control
+					</button>
+				</Tooltip>
+			</>,
+		);
+		const button = screen.getByRole('button', { name: 'real control' });
+		const ids = (button.getAttribute('aria-describedby') ?? '').split(/\s+/);
+		expect(ids).toContain('prior-desc');
+		expect(ids).toHaveLength(2);
+		const tipNode = document.getElementById(ids.find((id) => id !== 'prior-desc') ?? '');
+		expect(tipNode).toHaveTextContent('tip');
 	});
 });

--- a/ui/src/shared/ui/index.ts
+++ b/ui/src/shared/ui/index.ts
@@ -138,6 +138,8 @@ export type { LazyMountProps } from '@/shared/ui/LazyMount';
 
 export { TruncateWithTooltip } from '@/shared/ui/TruncateWithTooltip';
 
+export { Tooltip } from '@/shared/ui/Tooltip';
+
 export { OperationDetail } from '@/shared/ui/OperationDetail';
 export type {
 	OperationDetailProps,

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -39,11 +39,33 @@ export default defineConfig({
 					// resolve to their final state immediately. Without this, axe
 					// colour-contrast checks can fire mid-animation and report
 					// false positives on translucent elements.
-					context: { reducedMotion: 'reduce' },
+					//
+					// Pin timezone + locale so `toLocaleDateString`/`toLocaleTimeString`
+					// output (rail day/time labels, #705) is deterministic across
+					// developer machines and CI — otherwise a region-dependent month
+					// abbreviation makes assertions like `/Jul/` only-green-on-CI (#7).
+					// UTC is DST-free; the DST-specific "Yesterday" test (#4)
+					// temporarily overrides the in-page timezone to America/New_York
+					// via CDP (`Emulation.setTimezoneOverride`) for that one test and
+					// restores UTC in a `finally`, so it exercises a real spring-forward
+					// boundary without weakening this global pin for the rest of the
+					// suite.
+					context: {
+						reducedMotion: 'reduce',
+						timezoneId: 'UTC',
+						locale: 'en-US',
+					},
 				},
 			],
 		},
 		globals: true,
+		// Pin locale/timezone env for any Node-side date logic too; the browser
+		// context above pins the in-page `Date`/`Intl` behaviour (#7).
+		env: {
+			TZ: 'UTC',
+			LANG: 'en-US.UTF-8',
+			LC_ALL: 'en-US.UTF-8',
+		},
 		setupFiles: ['./src/__tests__/setup.ts'],
 		include: ['src/**/*.test.{ts,tsx}'],
 		// `*.lint.test.ts` are Node-only (they drive ESLint's programmatic API);

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -43,8 +43,8 @@ export default defineConfig({
 					// Pin timezone + locale so `toLocaleDateString`/`toLocaleTimeString`
 					// output (rail day/time labels, #705) is deterministic across
 					// developer machines and CI — otherwise a region-dependent month
-					// abbreviation makes assertions like `/Jul/` only-green-on-CI (#7).
-					// UTC is DST-free; the DST-specific "Yesterday" test (#4)
+					// abbreviation makes assertions like `/Jul/` only-green-on-CI.
+					// UTC is DST-free; the DST-specific "Yesterday" test
 					// temporarily overrides the in-page timezone to America/New_York
 					// via CDP (`Emulation.setTimezoneOverride`) for that one test and
 					// restores UTC in a `finally`, so it exercises a real spring-forward
@@ -60,11 +60,12 @@ export default defineConfig({
 		},
 		globals: true,
 		// Pin locale/timezone env for any Node-side date logic too; the browser
-		// context above pins the in-page `Date`/`Intl` behaviour (#7).
+		// context above pins the in-page `Date`/`Intl` behaviour. (POSIX locale
+		// ids use underscores — `en_US`, unlike the BCP 47 `en-US` above.)
 		env: {
 			TZ: 'UTC',
-			LANG: 'en-US.UTF-8',
-			LC_ALL: 'en-US.UTF-8',
+			LANG: 'en_US.UTF-8',
+			LC_ALL: 'en_US.UTF-8',
 		},
 		setupFiles: ['./src/__tests__/setup.ts'],
 		include: ['src/**/*.test.{ts,tsx}'],


### PR DESCRIPTION
## Summary

Three related observability improvements around the agent rail and the Monitor Events tab:

1. **Date visibility in the rail (#705)** — day separators ("Today", DST-safe "Yesterday", weekday+date) between feed days, and an instant full-date/time tooltip on every row timestamp (new shared portaled `Tooltip` primitive with keyboard focus support, Escape dismissal, and viewport-edge clamping).
2. **Proactive failure surfacing (#671)** — a persistent unacknowledged-failure count pill on the rail header (window-scoped to the loaded feed, labelled "in recent activity"), and error/critical events always toast — even when the toast scope is `off` (the option is labelled "Off (failures still toast)" so the override is disclosed). Assertive screen-reader announcements coalesce under failure bursts.
3. **Critical-event drill-in (#617)** — rail deep-links open the Monitor sheet (fixes a real param-vocabulary mismatch on main: the rail emitted `trace`/`execution`/`job` while Monitor read `trace_id`/`execution_id`/`job_id`, so the sheet never opened), Events rows drill to trace/execution, and an independent severity filter (critical and error separately toggleable).

## Related issues

Closes #705
Closes #671
Closes #617

## Review-board hardening (2026-07-31)

A 3-lens review board (semantic drift vs main's dashboard/agents/toolkits rebuilds, UI/UX + a11y, product fit + hygiene) returned unanimous approve-with-nits; fixes applied on top:

- **Cross-surface acknowledgment sync**: the rail's acknowledge now invalidates the Monitor events root + dashboard root, and Monitor's acknowledge flips the rail's in-memory copy via a provider-optional stream hook — so the failure pill and the Events tab can't show contradictory acked states (the SSE watermark poll never re-delivers an event on an ack flip).
- **Tooltip a11y (WCAG 1.4.13)**: Escape dismissal (keyboard- and hover-opened), viewport-edge clamping (the rail hugs the right edge — worst case for a centered bubble), `aria-describedby` appended rather than clobbered, `whitespace-normal` default.
- **Honest labels**: pill count is window-scoped and says so; toast "Off" discloses the failure override.
- **ARIA correctness**: day separators drop the prohibited `aria-label` on `role="presentation"`.
- **Toast hygiene**: assertive-announcement coalescing under bursts; bounded dismissed-id memory.
- Monitor events query key now derives from the shared cross-module root; Events drill-in reuses the shared HAL-link parser; POSIX locale ids fixed in the vitest env.

## Testing

- `eslint`, `tsc --noEmit` clean; 958 unit tests pass (browser-mode vitest incl. axe checks); 24 mocked Playwright e2e pass.
- New/updated tests: DST-boundary "Yesterday" (real CDP timezone override), malformed-timestamp separators, failure-pill show/clear + label, dismissed-toast persistence across scope flips, TTL re-toast, Tooltip keyboard focus + `aria-describedby` stability + interactive-child tab stops + **Escape dismissal** + **describedby append**, severity-filter independence + URL hydration, drill-in id resolution from `_links`.

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] Tests added/updated for the change
- [x] No secrets, credentials, or internal-only references included