### PR TITLE
fix(web): serve SPA shell for dotted deep-link navigations

### DIFF
--- a/scripts/spa_packaging_smoke.py
+++ b/scripts/spa_packaging_smoke.py
@@ -112,6 +112,32 @@ def _check_serving() -> None:
     if deep.status_code != 200 or "<!doctype html" not in deep.text.lower():
         raise AssertionError("client-routed deep link did not fall back to index.html")
 
+    # The #647 case: a versioned deep-link whose final segment looks like a file
+    # extension (``/1.0``) must still boot the shell for a browser navigation
+    # (rescued by the SPA navigation fallback), and must NOT be cacheable —
+    # the same URL answers 404 to non-navigation clients.
+    dotted = client.get(
+        f"{SPA_MOUNT_PATH}/workspace/stripe-com/stripe-com-api/1.0", headers=html_headers
+    )
+    if dotted.status_code != 200 or "<!doctype html" not in dotted.text.lower():
+        raise AssertionError(
+            f"dotted versioned deep-link did not serve the SPA shell (#647) "
+            f"(got {dotted.status_code})"
+        )
+    if dotted.headers.get("cache-control") != "no-store":
+        raise AssertionError("rescued dotted deep-link shell must be Cache-Control: no-store")
+    dotted_api = client.get(
+        f"{SPA_MOUNT_PATH}/workspace/stripe-com/stripe-com-api/1.0",
+        headers={"Accept": "application/json"},
+    )
+    if dotted_api.status_code != 404:
+        raise AssertionError("dotted deep-link must stay a 404 for non-navigation clients")
+    # A missing *recognized* asset type must stay a 404 even for a navigation
+    # (a broken deploy surfaces as an error, never a silent shell boot).
+    missing_asset = client.get(f"{SPA_MOUNT_PATH}/assets/missing-xyz.js", headers=html_headers)
+    if missing_asset.status_code != 404 or "<!doctype" in missing_asset.text.lower():
+        raise AssertionError("missing recognized asset was rescued into the shell")
+
     # Anything OUTSIDE the /app namespace is unambiguously a backend call: an
     # unknown path is a true 404 for every client (no Accept-header guesswork),
     # so the SPA mount can never shadow the API.
@@ -164,8 +190,9 @@ def _check_serving() -> None:
             )
 
     print(
-        "OK  bare root redirects to /app/, SPA served under /app, "
-        "non-/app 404 preserved, root icon probes 307 into /app and resolve, "
+        "OK  bare root redirects to /app/, SPA served under /app "
+        "(incl. dotted versioned deep-links, #647), non-/app 404 preserved, "
+        "root icon probes 307 into /app and resolve, "
         "runtime config exposed, no database required"
     )
 

--- a/src/jentic_one/shared/web/static.py
+++ b/src/jentic_one/shared/web/static.py
@@ -16,7 +16,17 @@ backend call*. An unknown non-``/app`` path is a plain 404 regardless of the
 ``Accept`` header — there is no content-negotiation guesswork and no
 hand-maintained "API-owned prefix" allow-list. Within ``/app/*`` the
 ``fallback="auto"`` behaviour still applies so SPA deep-link refreshes
-(``/app/agents/123``) serve ``index.html``.
+(``/app/agents/123``) serve ``index.html``. A dedicated HTML-navigation
+fallback additionally covers *dotted* deep-links (e.g. an API-version segment
+``/app/workspace/<vendor>/<name>/1.0``) that ``fallback="auto"``'s final-segment
+extension heuristic would otherwise mis-classify as a static file and 404
+(issue #647); real bundle files and non-navigation requests still resolve/404 as
+before. That fallback distinguishes a *route* from an *asset* by whether the
+final segment names a recognized static-file type (by :mod:`mimetypes`, so it
+tracks real asset extensions instead of drifting from ``ui/vite.config.ts``),
+not by a curated directory-prefix list — so a missing/renamed asset anywhere in
+the bundle (``assets/…`` *or* a mount-root file like ``broker-openapi.json``)
+still surfaces as a ``404`` rather than a silent app boot.
 
 ``app.frontend()`` registers the bundle as *low-priority* routes: real API
 path operations are matched first, and the static files are only consulted when
@@ -41,13 +51,19 @@ in, so it exposes that path to the SPA via a tiny JSON config endpoint
 
 from __future__ import annotations
 
+import contextlib
+import email.message
 import importlib.resources
-from collections.abc import Awaitable, Callable
+import mimetypes
+import os
+from collections.abc import Awaitable, Callable, Iterator
 from pathlib import Path
 
 import structlog
 from fastapi import FastAPI
-from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
+from starlette.middleware import Middleware
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 _logger = structlog.get_logger(__name__)
 
@@ -76,6 +92,272 @@ _ROOT_ICON_PROBES = {
     "apple-touch-icon.png": "apple-touch-icon.png",
     "apple-touch-icon-precomposed.png": "apple-touch-icon.png",
 }
+
+
+def _accept_header(scope: Scope) -> str:
+    """Return the request's combined ``Accept`` header value from an ASGI scope.
+
+    Reads only the ``accept`` header (avoids materialising a full header dict on
+    the hot SPA path) and RFC 7230-combines repeated header lines with commas —
+    a client/intermediary may split ``Accept`` across multiple lines, and taking
+    only the last would drop an earlier ``text/html`` and 404 a real navigation.
+    """
+    values = [
+        value.decode("latin-1") for key, value in scope.get("headers", []) if key == b"accept"
+    ]
+    return ",".join(values)
+
+
+def _iter_accept_media_types(accept: str) -> Iterator[tuple[str, float]]:
+    """Yield ``(media_type, quality)`` pairs from an ``Accept`` header value.
+
+    Mirrors FastAPI's own header parsing (``fastapi.routing``) so our navigation
+    check agrees with the framework on what "the client accepts HTML" means.
+    """
+    for raw_value in accept.split(","):
+        message = email.message.Message()
+        message["content-type"] = raw_value.strip()
+        q = message.get_param("q")
+        quality = 1.0
+        if isinstance(q, str):
+            with contextlib.suppress(ValueError):
+                quality = float(q)
+        yield (
+            f"{message.get_content_maintype()}/{message.get_content_subtype()}",
+            quality,
+        )
+
+
+def _looks_like_static_asset(spa_path: str) -> bool:
+    """True when the final path segment names a *recognized* static file type.
+
+    Keys off :mod:`mimetypes` (``.json``, ``.svg``, ``.png``, ``.js``, ``.css``,
+    ``.webmanifest``, …) rather than a hardcoded directory-prefix list, so it
+    tracks real asset types instead of drifting from ``ui/vite.config.ts``. The
+    bundle ships assets both under ``assets/`` *and* at the mount root
+    (``broker-openapi.json``, ``favicon.svg``, ``site.webmanifest``, …), so a
+    prefix list can't cover them; a MIME-mapped extension can.
+
+    A missing/renamed asset of a recognized type must surface as a ``404`` (a
+    broken deploy), never the SPA shell — so callers refuse the shell fallback
+    for these. Version-like segments (``1.0`` → ``.0``, ``2.1.3`` → ``.3``) and
+    unknown extensions are *not* recognized asset types and stay ambiguous
+    (handled by the explicit-``text/html`` rule).
+    """
+    ext = os.path.splitext(spa_path.rsplit("/", 1)[-1])[1].lower()
+    return bool(ext) and ext in mimetypes.types_map
+
+
+def _has_extension(spa_path: str) -> bool:
+    """True when the final path segment has *any* extension (dot-suffix).
+
+    Matches FastAPI's ``fallback="auto"`` heuristic (``os.path.splitext`` on the
+    last segment). Used to decide *how strict* the navigation check must be for
+    a path that is not a recognized static asset: an extension-less path is
+    unambiguously an app route, whereas a dotted-but-unrecognized final segment
+    (e.g. an API version ``1.0``) is ambiguous and so demands an explicit
+    ``text/html`` accept.
+    """
+    return bool(os.path.splitext(spa_path.rsplit("/", 1)[-1])[1])
+
+
+def _is_html_navigation(accept: str, *, require_explicit_html: bool) -> bool:
+    """True when the request is a genuine browser navigation (wants HTML).
+
+    ``accept`` is the request's combined ``Accept`` header value (see
+    :func:`_accept_header`). The dotted-final-segment case (issue #647) is the
+    tricky one: FastAPI's ``fallback="auto"`` mis-reads a versioned deep-link
+    (``/app/.../1.0``) as a static-file request and 404s it. We relax that — but
+    *carefully*, to avoid turning every missing ``foo.json``/``bar.js`` into a
+    silent app boot:
+
+    * ``require_explicit_html=False`` (extension-less path, unambiguously a
+      route): accept a browser navigation the way FastAPI does — explicit
+      ``text/html`` **or** a ``*/*`` wildcard.
+    * ``require_explicit_html=True`` (dotted final segment, ambiguous): require
+      an **explicit** ``text/html`` (or ``application/xhtml+xml``) accept. Real
+      top-level browser navigations always send ``text/html``; asset/XHR/CLI
+      clients send ``*/*`` or a specific non-HTML type, so a missing dotted asset
+      still 404s.
+    """
+    wildcard_accepted = False
+    html_rejected = False
+    for media_type, quality in _iter_accept_media_types(accept):
+        if media_type in {"text/html", "application/xhtml+xml"}:
+            if quality == 0:
+                html_rejected = True
+            else:
+                return True
+        elif media_type == "*/*" and quality != 0:
+            wildcard_accepted = True
+    if require_explicit_html:
+        return False
+    return wildcard_accepted and not html_rejected
+
+
+class _SpaNavigationFallbackMiddleware:
+    """Serve the SPA shell for a browser navigation the app 404'd (issue #647).
+
+    A thin ASGI shim registered as the **innermost** user middleware (see
+    :func:`mount_spa`), so the shell it rescues still flows back out through the
+    request-id and telemetry middleware — the rescued deep-link boot carries
+    ``x-request-id`` and is recorded as the ``200`` the client actually receives,
+    not the inner ``404``.
+
+    It delegates every request to the wrapped app untouched and only rewrites the
+    response when **all** of these hold:
+
+    * method is GET or HEAD,
+    * the path is under the SPA mount (``/app/…``),
+    * the wrapped app produced a ``404`` status, and
+    * the request is a genuine browser navigation (see :func:`_is_html_navigation`),
+      with the extra strictness for dotted final segments, and the final segment
+      is *not* a recognized static-file type (by :mod:`mimetypes`) so a missing
+      asset still 404s (no shell leak) — see :func:`_looks_like_static_asset`.
+
+    In that one case the 404 is swapped for the SPA shell (``200`` +
+    ``index.html``) so the client router can resolve the deep-link. This keeps
+    the framework's ``app.frontend()`` static serving fully authoritative for
+    real files (conditional ``304`` revalidation, ``Range``, directory index,
+    symlink policy) — we never re-serve assets by hand; we only reinterpret a
+    navigation miss.
+    """
+
+    def __init__(self, app: ASGIApp, *, index_file: Path, mount_prefix: str) -> None:
+        self.app = app
+        self.index_file = index_file
+        self.mount_prefix = mount_prefix
+
+    def _should_consider(self, scope: Scope) -> bool:
+        if scope["type"] != "http":
+            return False
+        if scope["method"] not in ("GET", "HEAD"):
+            return False
+        # Compare against the *routing* path (root_path stripped): behind a
+        # path-prefix proxy ``scope["path"]`` carries the mount prefix (e.g.
+        # ``/console/app/…``) that Starlette's routing already strips, so a raw
+        # ``startswith("/app/")`` would miss the deep-link and reintroduce #647.
+        # Strip only on a segment boundary so ``/consoleX/…`` isn't mis-stripped.
+        route_path = self._strip_root_path(scope)
+        if not route_path.startswith(self.mount_prefix):
+            return False
+        spa_path = route_path[len(self.mount_prefix) :]
+        # Refuse traversal-looking paths (``/app/../x``, encoded ``%2e%2e``
+        # arrives here decoded). The shell is a constant public file so nothing
+        # could leak, but a dot-segment URL is never a legitimate SPA route and
+        # rescuing it would hand caches/scanners a 200 for a path the router
+        # can't resolve — keep those as honest 404s.
+        if any(segment in (".", "..") for segment in spa_path.split("/")):
+            return False
+        # A recognized static asset (``.json``/``.svg``/``.png``/``.js``/… by
+        # MIME type, at the mount root or under ``assets/``) that the app 404'd
+        # is a missing/renamed file — it must stay a 404, never the SPA shell, so
+        # a broken deploy surfaces as an error instead of silently booting the
+        # app. Version-like/unknown extensions are not assets and stay ambiguous.
+        if _looks_like_static_asset(spa_path):
+            return False
+        # Dotted-but-unrecognized final segments (e.g. an API version ``1.0``)
+        # are ambiguous (asset vs. route) so require an explicit ``text/html``
+        # accept; extension-less paths accept the looser ``*/*`` navigation form.
+        return _is_html_navigation(
+            _accept_header(scope), require_explicit_html=_has_extension(spa_path)
+        )
+
+    def _strip_root_path(self, scope: Scope) -> str:
+        """Return ``scope['path']`` with any ``root_path`` prefix removed.
+
+        Only strips on a path-segment boundary so a coincidental non-boundary
+        prefix (``root_path='/console'`` vs ``path='/consoleX/…'``) is left
+        intact rather than mangled to ``X/…``.
+        """
+        root_path: str = scope.get("root_path", "")
+        path: str = scope["path"]
+        if not root_path:
+            return path
+        if path == root_path:
+            return "/"
+        if path.startswith(root_path + "/"):
+            return path[len(root_path) :]
+        return path
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if not self._should_consider(scope):
+            await self.app(scope, receive, send)
+            return
+
+        # Peek at the wrapped app's response start. If it's a 404 we serve the
+        # shell instead; otherwise we replay the captured start and stream the
+        # rest of the body through untouched (no buffering of real responses).
+        started = False
+        is_404 = False
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal started, is_404
+            if message["type"] == "http.response.start" and not started:
+                started = True
+                is_404 = message["status"] == 404
+                if is_404:
+                    # Swallow the 404 start; the shell is sent after the wrapped
+                    # app finishes (below).
+                    return
+                await send(message)
+                return
+            # Once we've decided to rescue a 404, drop *every* inner message
+            # (body chunks, and defensively any trailers/pathsend), so nothing
+            # from the discarded 404 response interleaves with the shell's start.
+            if is_404:
+                return
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+        if not is_404:
+            return
+
+        # The bundle could be mid-swap / incomplete (atomic redeploy) — if the
+        # shell isn't on disk, don't 500; replay a clean 404 instead.
+        if not self.index_file.is_file():
+            await _send_plain_404(send)
+            return
+
+        # Serve the shell as a full 200. Strip Range/If-Range so a navigation
+        # that happens to carry a range (resumed nav, some prefetchers) gets the
+        # whole shell, not a 206/416 partial that fails to boot the SPA. The
+        # wrapped app already drained ``receive`` (request body consumed), so hand
+        # FileResponse a receive that only reports a disconnect — otherwise its
+        # disconnect-listener could await a drained stream and stall completion.
+        #
+        # ``Cache-Control: no-store``: this URL answers 404 (JSON accept) or the
+        # shell (HTML accept) depending on the request, and the rescue path never
+        # honours conditional revalidation — so keep shared caches out of it
+        # entirely rather than emitting validators we'd never answer with a 304.
+        # Real shell fetches (``/app/``, extension-less routes) are served by the
+        # framework mount and keep its caching semantics.
+        shell_scope = dict(scope)
+        shell_scope["headers"] = [
+            (name, value)
+            for name, value in scope.get("headers", [])
+            if name not in (b"range", b"if-range")
+        ]
+
+        async def _disconnected_receive() -> Message:
+            return {"type": "http.disconnect"}
+
+        await FileResponse(self.index_file, status_code=200, headers={"Cache-Control": "no-store"})(
+            shell_scope, _disconnected_receive, send
+        )
+
+
+async def _send_plain_404(send: Send) -> None:
+    """Emit a minimal ``404`` when the rescued shell is unexpectedly absent."""
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 404,
+            "headers": [(b"content-type", b"text/plain; charset=utf-8")],
+        }
+    )
+    await send({"type": "http.response.body", "body": b"Not Found"})
 
 
 def _repo_root() -> Path:
@@ -208,6 +490,54 @@ def mount_spa(app: FastAPI, *, health_path: str = "/health") -> bool:
     # is actually mounted does an anonymous HTML navigation that 401s get
     # redirected into the app instead of receiving raw problem+json (#813).
     app.state.spa_mounted = True
+
+    # HTML-navigation fallback for dotted deep-links (issue #647).
+    #
+    # ``app.frontend(fallback="auto")`` above already serves index.html for
+    # extension-less deep-link navigations (``/app/agents/123``) and serves every
+    # real bundle file with the framework's full refinements (conditional 304
+    # revalidation, Range, directory index, symlink policy). But its navigation
+    # heuristic treats any path whose final segment has a file extension as a
+    # static-file request — so a versioned API deep-link like
+    # ``/app/workspace/<vendor>/<name>/1.0`` (final segment ``1.0``) is mis-read
+    # as a file and 404s even for a browser navigation.
+    #
+    # We close *only* that gap, and deliberately do NOT re-serve assets by hand:
+    # a thin ASGI shim delegates everything to the app untouched and only
+    # rewrites the response when ALL hold — GET/HEAD, path under ``/app/``, the
+    # app produced a 404, and the request is a genuine browser navigation. In
+    # that one case it swaps the 404 for the SPA shell (200) so the client router
+    # can resolve the route. Real files (200/206/304), real API 404s, non-``/app``
+    # paths, and non-navigation ``/app`` misses all pass through byte-for-byte.
+    #
+    # Registered as the **innermost** user middleware (appended, not
+    # ``add_middleware`` which prepends): the request-id + telemetry middleware
+    # are added earlier (outermost) in the app factory, so the rescued shell
+    # flows back out through them — it carries ``x-request-id`` and is recorded as
+    # the 200 the client receives, not the inner 404.
+    index_file = static_dir / "index.html"
+
+    # Idempotency: never stack a second shim (a duplicate would risk two
+    # http.response.start on a rescued 404). If already mounted, no-op.
+    if any(
+        getattr(m, "cls", None) is _SpaNavigationFallbackMiddleware for m in app.user_middleware
+    ):
+        _logger.info("spa_navigation_fallback_already_mounted")
+    else:
+        # ``add_middleware`` prepends (outermost) — we append so the shim lands
+        # *inside* request-id/telemetry. Starlette builds the stack lazily on
+        # the first request, so an entry appended before then is picked up; an
+        # append after the stack is built would be silently ignored, so fail
+        # loudly instead (mirrors Starlette's own "add after start" guard).
+        if app.middleware_stack is not None:
+            raise RuntimeError("SPA fallback must be mounted before the middleware stack is built")
+        app.user_middleware.append(
+            Middleware(
+                _SpaNavigationFallbackMiddleware,
+                index_file=index_file,
+                mount_prefix=f"{SPA_MOUNT_PATH}/",
+            )
+        )
 
     _logger.info(
         "spa_mounted",

--- a/tests/unit/shared/test_static_spa_real_app.py
+++ b/tests/unit/shared/test_static_spa_real_app.py
@@ -60,6 +60,11 @@ def _make_realistic_bundle(tmp_path: Path) -> Path:
     (static_dir / "assets" / "index-abc123.css").write_text("body{}", encoding="utf-8")
     (static_dir / "favicon.ico").write_text("ico", encoding="utf-8")
     (static_dir / "apple-touch-icon.png").write_text("png", encoding="utf-8")
+    # Root-level (non-``assets/``) bundle files, like the real Vite build ships
+    # (broker-openapi.json, cli-reference.json, favicon.svg, site.webmanifest…).
+    # A missing/renamed one must 404, never boot the shell (issue #647 rev.3 #1).
+    (static_dir / "broker-openapi.json").write_text('{"openapi":"3.1.0"}', encoding="utf-8")
+    (static_dir / "site.webmanifest").write_text("{}", encoding="utf-8")
     return static_dir
 
 
@@ -201,6 +206,242 @@ def test_combined_app_deep_link_head(ctx: Context, bundle: Path) -> None:
     # HEAD on an /app deep link must work (browsers/CDNs/probes issue HEAD).
     head = client.head(f"{SPA_MOUNT_PATH}/agents/some-id/settings", headers=HTML)
     assert head.status_code == 200
+
+
+def test_combined_app_versioned_deep_link_serves_shell(ctx: Context, bundle: Path) -> None:
+    """Issue #647: a dotted final segment (an API version) must still boot the SPA.
+
+    FastAPI's ``fallback="auto"`` treats a final segment with a "file extension"
+    as a static-file request, so a versioned deep-link like
+    ``/app/workspace/<vendor>/<name>/1.0`` (final segment ``1.0``) 404s for a
+    browser navigation. The dedicated HTML-navigation fallback closes that gap
+    while keeping real assets and non-navigation requests 404-ing.
+    """
+    app = create_combined_app(ctx, ["admin"])
+    client = _client(app)
+
+    def _is_shell(resp: object) -> bool:
+        return "<title>Jentic One</title>" in resp.text  # type: ignore[attr-defined]
+
+    # The literal URL from the issue: browser navigation to a versioned API page.
+    deep = f"{SPA_MOUNT_PATH}/workspace/posthog-com/posthog-com-posthog-api/1.0"
+    r = client.get(deep, headers=HTML)
+    assert r.status_code == 200 and _is_shell(r)
+    # HEAD on the versioned deep-link works too.
+    assert client.head(deep, headers=HTML).status_code == 200
+    # Multi-dot versions (e.g. 2.1.3) resolve the same way.
+    r = client.get(
+        f"{SPA_MOUNT_PATH}/workspace/posthog-com/posthog-com-posthog-api/2.1.3", headers=HTML
+    )
+    assert r.status_code == 200 and _is_shell(r)
+
+    # Guard rails — the fallback must not leak the shell for real/non-navigation:
+    # a real hashed asset is still served as the asset, not the shell.
+    r = client.get(f"{SPA_MOUNT_PATH}/assets/index-abc123.js")
+    assert r.status_code == 200 and not _is_shell(r)
+    # a MISSING asset under the hashed namespace 404s (never the shell), even for
+    # a browser navigation.
+    r = client.get(f"{SPA_MOUNT_PATH}/assets/missing-xyz.js", headers=HTML)
+    assert r.status_code == 404 and not _is_shell(r)
+    # a non-navigation client (JSON) hitting the versioned deep-link still 404s.
+    r = client.get(deep, headers=JSON)
+    assert r.status_code == 404 and not _is_shell(r)
+    # a dotted path with a wildcard-only Accept (curl/XHR, not a real browser
+    # navigation) 404s — dotted segments demand an explicit text/html accept.
+    r = client.get(f"{SPA_MOUNT_PATH}/nope.json", headers={"Accept": "*/*"})
+    assert r.status_code == 404 and not _is_shell(r)
+
+    # rev.3 #1/#2: a MISSING *root-level* bundle asset (the real build ships
+    # broker-openapi.json, favicon.svg, site.webmanifest… at the mount root, not
+    # under assets/) must 404 even for a top-level text/html navigation — a
+    # broken deploy that drops it must surface as an error, not a silent shell.
+    # The decision keys off the recognized file extension (.json/.svg/.png…),
+    # not a hardcoded prefix list, so root-level assets are covered.
+    r = client.get(f"{SPA_MOUNT_PATH}/broker-openapi-MISSING.json", headers=HTML)
+    assert r.status_code == 404 and not _is_shell(r)
+    r = client.get(f"{SPA_MOUNT_PATH}/favicon-MISSING.svg", headers=HTML)
+    assert r.status_code == 404 and not _is_shell(r)
+    # and a real root-level asset is still served as itself (never the shell).
+    r = client.get(f"{SPA_MOUNT_PATH}/broker-openapi.json")
+    assert r.status_code == 200 and not _is_shell(r)
+
+
+def test_combined_app_asset_serving_keeps_framework_refinements(ctx: Context, bundle: Path) -> None:
+    """The #647 fallback must not regress the framework's asset serving.
+
+    The navigation fallback is an *innermost* shim (see
+    :func:`mount_spa` — appended to ``user_middleware`` so it sits inside
+    request-id/telemetry) that only reinterprets a 404 for a browser navigation;
+    it must never front-run ``app.frontend()``'s static serving. So a real asset
+    keeps its conditional-revalidation (``304``) and ``Range`` (``206``)
+    behaviour, and a missing asset is a clean ``404`` (not a ``500`` from a
+    hand-rolled re-stat).
+    """
+    app = create_combined_app(ctx, ["admin"])
+    client = _client(app)
+    asset = f"{SPA_MOUNT_PATH}/assets/index-abc123.js"
+
+    # Baseline: the asset is served with a validator.
+    first = client.get(asset)
+    assert first.status_code == 200
+    etag = first.headers.get("etag")
+    assert etag, "asset response should carry an ETag validator"
+
+    # Conditional revalidation returns 304 with an empty body (not a full 200).
+    revalidated = client.get(asset, headers={"If-None-Match": etag})
+    assert revalidated.status_code == 304
+    assert revalidated.content == b""
+
+    # Range requests are honoured (206 Partial Content).
+    ranged = client.get(asset, headers={"Range": "bytes=0-3"})
+    assert ranged.status_code == 206
+    assert ranged.headers.get("content-range", "").startswith("bytes 0-3/")
+
+    # A missing asset is a clean 404 (framework behaviour), never a 500.
+    missing = client.get(f"{SPA_MOUNT_PATH}/assets/missing-xyz.js")
+    assert missing.status_code == 404
+
+
+def test_combined_app_rescued_shell_keeps_request_id(ctx: Context, bundle: Path) -> None:
+    """The rescued deep-link shell must flow through the inner middleware.
+
+    The fallback is the *innermost* user middleware, so the shell it swaps in for
+    a navigation 404 still passes back out through ``RequestIDMiddleware`` — the
+    rescued boot carries ``x-request-id`` like every other response (and, by the
+    same token, telemetry records the 200 the client receives, not the inner
+    404). Were the fallback outermost, the rescued response would bypass those
+    wrappers.
+    """
+    app = create_combined_app(ctx, ["admin"])
+    client = _client(app)
+
+    deep = f"{SPA_MOUNT_PATH}/workspace/posthog-com/posthog-com-posthog-api/1.0"
+    rescued = client.get(deep, headers=HTML)
+    assert rescued.status_code == 200
+    assert "<title>Jentic One</title>" in rescued.text
+    assert rescued.headers.get("x-request-id"), (
+        "rescued deep-link shell must carry x-request-id (inner middleware ran)"
+    )
+
+    # Parity check: the extension-less shell (served by app.frontend) also carries
+    # it — the rescued path must match, not diverge.
+    extless = client.get(f"{SPA_MOUNT_PATH}/agents/some-id/settings", headers=HTML)
+    assert extless.headers.get("x-request-id")
+
+
+def test_combined_app_rescued_shell_ignores_range_header(ctx: Context, bundle: Path) -> None:
+    """A navigation carrying ``Range`` must get the whole shell, not a 206/416.
+
+    rev.3 #3: the rescued shell is a full ``200`` — the docstring promises
+    ``200 + index.html``. A navigation that happens to carry a ``Range`` (resumed
+    navigation, some prefetchers/download managers) must still boot the SPA, so
+    ``Range``/``If-Range`` are stripped before serving the shell. Otherwise a
+    range-aware ``FileResponse`` would answer with a partial ``206`` (or ``416``)
+    shell that fails to boot.
+    """
+    app = create_combined_app(ctx, ["admin"])
+    client = _client(app)
+
+    deep = f"{SPA_MOUNT_PATH}/workspace/posthog-com/posthog-com-posthog-api/1.0"
+    ranged = client.get(deep, headers={**HTML, "Range": "bytes=0-3"})
+    assert ranged.status_code == 200, "rescued shell must ignore Range (full 200)"
+    assert "<title>Jentic One</title>" in ranged.text
+    # A wildly out-of-range request must not 416 the shell either.
+    huge = client.get(deep, headers={**HTML, "Range": "bytes=99999-100000"})
+    assert huge.status_code == 200
+    assert "<title>Jentic One</title>" in huge.text
+
+
+def test_combined_app_split_accept_header_still_boots_shell(ctx: Context, bundle: Path) -> None:
+    """Duplicate ``Accept`` header lines must be RFC 7230-combined, not overwritten.
+
+    A client/intermediary may split ``Accept`` across two header lines. If we
+    kept only the last, a ``text/html``-first navigation would lose its HTML
+    accept and 404 on a dotted deep-link (``require_explicit_html``). We combine
+    all ``accept`` lines, so a real navigation still boots the shell regardless of
+    line order.
+    """
+    app = create_combined_app(ctx, ["admin"])
+    client = _client(app)
+    deep = f"{SPA_MOUNT_PATH}/workspace/posthog-com/posthog-com-posthog-api/1.0"
+
+    # Raw split header lines (httpx sends each tuple as its own line).
+    for raw_headers in (
+        [("accept", "text/html"), ("accept", "application/json")],
+        [("accept", "application/json"), ("accept", "text/html")],
+    ):
+        r = client.get(deep, headers=raw_headers)
+        assert r.status_code == 200, f"split Accept {raw_headers} should boot the shell"
+        assert "<title>Jentic One</title>" in r.text
+
+
+def test_combined_app_rescued_shell_is_not_cacheable(ctx: Context, bundle: Path) -> None:
+    """The rescued shell must carry ``Cache-Control: no-store``.
+
+    The same dotted URL answers ``404`` (JSON accept) or the shell (HTML accept)
+    depending on the request, and the rescue path never honours conditional
+    revalidation — a shared cache keyed only on the URL could serve HTML to API
+    clients or a stale shell to browsers. ``no-store`` keeps caches out of the
+    rescue path entirely; the framework-served shell (``/app/``, extension-less
+    routes) keeps its own caching semantics.
+    """
+    app = create_combined_app(ctx, ["admin"])
+    client = _client(app)
+
+    deep = f"{SPA_MOUNT_PATH}/workspace/posthog-com/posthog-com-posthog-api/1.0"
+    rescued = client.get(deep, headers=HTML)
+    assert rescued.status_code == 200
+    assert rescued.headers.get("cache-control") == "no-store"
+
+    # The framework-served shell is NOT forced to no-store (framework semantics).
+    framework_shell = client.get(f"{SPA_MOUNT_PATH}/", headers=HTML)
+    assert framework_shell.status_code == 200
+    assert framework_shell.headers.get("cache-control") != "no-store"
+
+
+def test_combined_app_dot_segment_paths_are_never_rescued(ctx: Context, bundle: Path) -> None:
+    """Traversal-looking dotted ``/app`` paths must stay honest 404s, never the shell.
+
+    A dot-segment URL (``/app/../x.1``; the encoded ``%2e%2e`` form arrives at
+    the ASGI scope decoded) is never a legitimate SPA route. The framework mount
+    404s these dotted-final-segment shapes, and without a guard the shim would
+    "rescue" them — handing caches/scanners a 200 for a path the client router
+    can't resolve. Nothing could leak (the shell is a constant public file), but
+    the shim refuses dot-segment paths outright. (Extension-less traversal paths
+    like ``/app/../secret`` are answered by the framework's ``fallback="auto"``
+    mount itself — pre-existing behaviour this PR doesn't touch.)
+    """
+    app = create_combined_app(ctx, ["admin"])
+    client = _client(app)
+
+    for path in (
+        f"{SPA_MOUNT_PATH}/%2e%2e/secret.1",
+        f"{SPA_MOUNT_PATH}/a/%2e%2e/%2e%2e/etc/passwd.0",
+        f"{SPA_MOUNT_PATH}/%2e/x.1",
+    ):
+        r = client.get(path, headers=HTML)
+        assert r.status_code == 404, f"{path} must not be rescued"
+        assert "<title>" not in r.text
+
+
+def test_combined_app_missing_shell_mid_redeploy_404s(ctx: Context, bundle: Path) -> None:
+    """If ``index.html`` vanishes mid-redeploy the rescue degrades to a 404.
+
+    The bundle can be mid-swap when a deep-link navigation arrives; the shim
+    must answer a clean ``404`` (deploy error surfaced), never a ``500`` from an
+    unhandled ``FileNotFoundError``.
+    """
+    app = create_combined_app(ctx, ["admin"])
+    client = _client(app)
+    deep = f"{SPA_MOUNT_PATH}/workspace/posthog-com/posthog-com-posthog-api/1.0"
+
+    # Sanity: rescued while the bundle is intact.
+    assert client.get(deep, headers=HTML).status_code == 200
+
+    (bundle / "index.html").unlink()
+    degraded = client.get(deep, headers=HTML)
+    assert degraded.status_code == 404
+    assert "<title>" not in degraded.text
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a backend-only bug where browser navigations to a versioned API deep-link
(e.g. `/app/workspace/<vendor>/<name>/1.0`) returned raw `{"detail":"Not Found"}`
404 instead of booting the SPA. FastAPI's `app.frontend(fallback="auto")` treats
any `/app/*` path whose final segment has a file extension as a static-file
request, and API version segments contain dots (`1.0`, `2.1.3`), so the route was
mis-classified as a missing file. Bookmarks and shared/copied links to versioned
API pages broke for anyone opening them fresh. (The CLI-emitted `approve_url` is
an API-namespace path handled by the #813 login redirect, not this shim.)

## Related issue

Closes #647

## Changes

- Add `_SpaNavigationFallbackMiddleware`, an innermost ASGI shim that swaps a
  404 for the SPA shell (200 + `index.html`) **only** for a genuine GET/HEAD
  browser navigation under `/app/`; everything else passes through untouched so
  `app.frontend()` stays authoritative for real files (304/206/Range/symlinks).
- Decide asset-vs-route by MIME type (recognized static-file extension via
  `mimetypes`), not a hardcoded prefix list, so a missing/renamed asset anywhere
  in the bundle (`assets/…` or a mount-root file like `broker-openapi.json`)
  still 404s rather than silently booting the app.
- Register the shim as the innermost user middleware so the rescued shell flows
  back out through request-id/telemetry (carries `x-request-id`, logged as the
  real 200, not the inner 404).
- Harden: RFC 7230-combine split `Accept` header lines; strip `root_path` on a
  segment boundary; strip `Range`/`If-Range` from the rescued shell (full 200,
  never 206/416); clean 404 (not 500) if `index.html` is missing mid-redeploy;
  idempotent mount that raises `RuntimeError` if the middleware stack is
  already built.
- Review-board hardening (2026-07-31): rescued shell is
  `Cache-Control: no-store` (the same URL answers 404 to non-navigation
  clients and the rescue path never revalidates, so keep shared caches out);
  dot-segment `/app` paths (`/app/../x.1`, encoded `%2e%2e`) are refused —
  never rescued; packaging smoke now exercises the dotted deep-link and the
  no-store/404 split against the installed wheel.

## Testing

- `ruff check`, `ruff format --check`, `mypy` — clean.
- `uv run pytest tests/unit` → 2142 passed; `tests/arch` → 262 passed;
  `make test-integration-sqlite` → 541 passed.
- New tests: versioned deep-link boots the shell (`1.0`, `2.1.3`); missing
  asset (incl. root-level `.json`/`.svg`) still 404s; `Range` on the shell → full
  200; rescued shell carries `x-request-id`; split `Accept` still boots;
  rescued shell is `no-store` while the framework-served shell keeps framework
  caching; dot-segment paths 404; missing `index.html` mid-redeploy → 404.
- `make smoke-packaging` (build UI + wheel, install in clean venv): dotted
  deep-link `/app/workspace/stripe-com/stripe-com-api/1.0` serves the packaged
  shell with `no-store`, stays 404 for JSON clients, missing recognized assets
  404 — PASS.
- Red-team probes against the real combined app: 401/403 and API 404s pass
  through untouched (`/api/...` never rescued), `//app`, `%00`, backslash and
  non-`/app` paths never rescued, HEAD returns empty body with correct
  headers, websocket scopes ignored.

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] `make check` passes (lint, type check, secrets audit, arch tests)
- [x] Tests added/updated for the change
- [x] Docs updated where relevant (module docstrings; no separate plan doc)
- [x] No secrets, credentials, or internal-only references included