### PR TITLE
fix(broker/auth): typed token errors, fail-closed actor_type, refusal logging

### DIFF
--- a/src/jentic_one/broker/core/token_validation.py
+++ b/src/jentic_one/broker/core/token_validation.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
+from jentic_one.shared.auth.errors import TokenValidationError
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.broker.protocols import TokenResolverProtocol
 
@@ -50,7 +51,11 @@ class CachedTokenValidator:
             raise ValueError("max_entries must be >= 1")
 
     async def validate(self, token: str) -> Identity:
-        """Resolve and validate a token. Raises ValueError if inactive/expired/unknown."""
+        """Resolve and validate a token.
+
+        Raises ``TokenValidationError`` if the token is inactive, expired, or
+        unknown — the broker edge maps that to a uniform 401.
+        """
         cache_key = hashlib.sha256(token.encode()).hexdigest()
         now = time.monotonic()
 
@@ -73,11 +78,11 @@ class CachedTokenValidator:
 
     def _check_active(self, resolved: Identity | None) -> Identity:
         if resolved is None:
-            raise ValueError("unknown_token")
+            raise TokenValidationError("unknown_token")
         if not resolved.active:
-            raise ValueError("token_inactive")
+            raise TokenValidationError("token_inactive")
         if resolved.expires_at is not None and resolved.expires_at <= datetime.now(UTC):
-            raise ValueError("token_expired")
+            raise TokenValidationError("token_expired")
         return resolved
 
     def invalidate(self, token: str) -> None:

--- a/src/jentic_one/broker/services/auth/token_validation.py
+++ b/src/jentic_one/broker/services/auth/token_validation.py
@@ -12,6 +12,15 @@ dev HS256 :class:`JwtVerifier` (shared-secret) or the hardened asymmetric
 allowlist, RS↔HS confusion defence — ``shared/auth/jwt_verification``, §08 E1),
 selected by ``install_broker_auth`` from config. Opaque tokens go to the
 existing ``CachedTokenValidator`` (DB-backed, short-TTL cached).
+
+**Trust contract (self-contained JWT path).** A trusted issuer vouches for the
+claims it signs: the broker requires ``sub``, ``exp`` and ``actor_type`` and
+refuses (uniform 401) any token missing them — it never *infers* a missing
+claim (jentic-one#864). ``actor_type`` must be one of ``agent`` /
+``service_account`` (``_ALLOWED_ACTOR_TYPES``); ``toolkit`` and ``user``
+identities have DB-backed credential forms and cannot be asserted by a bare
+signed claim (jentic-one#868). Every refusal is logged server-side at WARNING
+with a static event name while the wire response stays uniform (jentic-one#874).
 """
 
 from __future__ import annotations
@@ -19,17 +28,27 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Protocol
+from typing import NoReturn, Protocol
 
 import jwt
+import structlog
 
 from jentic_one.broker.core.token_validation import CachedTokenValidator
+from jentic_one.shared.auth.errors import TokenValidationError
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.models import ActorType
+
+logger = structlog.get_logger(__name__)
 
 # Algorithms we accept for the self-contained-JWT path. HS256 only for the
 # minimal PR-A2 verifier; §08 widens/locks this down (and adds asymmetric/JWKS).
 _ALLOWED_ALGS: frozenset[str] = frozenset({"HS256"})
+
+# The self-contained-JWT path may only assert these actor types (jentic-one#868).
+# TOOLKIT and USER identities have DB-backed credential forms (toolkit keys,
+# opaque tokens) and must never enter the broker via a bare signed claim: a
+# trusted issuer vouches for AGENT/SERVICE_ACCOUNT, nothing else.
+_ALLOWED_ACTOR_TYPES: frozenset[ActorType] = frozenset({ActorType.AGENT, ActorType.SERVICE_ACCOUNT})
 
 
 class TokenVerifier(Protocol):
@@ -46,6 +65,7 @@ class TokenVerifier(Protocol):
 class Claim(StrEnum):
     """JWT claim keys the broker reads — no bare claim strings in the verifier."""
 
+    ISS = "iss"
     SUB = "sub"
     EXP = "exp"
     ACTOR_TYPE = "actor_type"
@@ -69,18 +89,18 @@ class JwtVerifier:
     secret: str
 
     def verify(self, token: str) -> dict[str, object]:
-        """Verify signature + expiry; raise ``ValueError`` on any failure."""
+        """Verify signature + expiry; raise ``TokenValidationError`` on failure."""
         # Pin the alg allowlist explicitly so an attacker can't downgrade to
         # ``alg:none``; PyJWT enforces ``exp`` when present by default.
         header = jwt.get_unverified_header(token)
         if header.get("alg") not in _ALLOWED_ALGS:
-            raise ValueError("jwt_alg_not_allowed")
+            raise TokenValidationError("jwt_alg_not_allowed")
         try:
             claims: dict[str, object] = jwt.decode(
                 token, self.secret, algorithms=list(_ALLOWED_ALGS)
             )
         except jwt.InvalidTokenError as exc:
-            raise ValueError(f"jwt_invalid: {exc}") from exc
+            raise TokenValidationError(f"jwt_invalid: {exc}") from exc
         return claims
 
 
@@ -90,20 +110,65 @@ class JwtTokenValidator:
 
     verifier: TokenVerifier
 
+    def _refuse(self, event: str, **fields: object) -> NoReturn:
+        """Log a refusal cause server-side, then raise the uniform typed error.
+
+        The wire response stays a uniform 401 (no oracle for forgers); the
+        static ``event`` name and structured ``fields`` are the *only* record
+        an operator gets of *why* a token was refused (jentic-one#874). Never
+        pass the raw token or a full claim set here — attacker-influenced
+        values are truncated by the caller.
+        """
+        logger.warning(event, **fields)
+        raise TokenValidationError(event)
+
     async def validate(self, token: str) -> Identity:
-        claims = self.verifier.verify(token)
+        try:
+            claims = self.verifier.verify(token)
+        except TokenValidationError as exc:
+            # The verifier already carries the specific reason; surface it
+            # centrally so both verifiers behind the protocol get refusal
+            # logging without each duplicating it.
+            logger.warning("jwt_refused", reason=str(exc)[:128])
+            raise
+
+        iss = claims.get(Claim.ISS)
         sub = claims.get(Claim.SUB)
         exp = claims.get(Claim.EXP)
         if not isinstance(sub, str) or not isinstance(exp, int | float):
-            raise ValueError("jwt_missing_required_claims")
+            self._refuse("jwt_missing_required_claims", iss=iss)
 
-        actor_type_raw = claims.get(Claim.ACTOR_TYPE, ActorType.AGENT.value)
+        # Fail closed on actor_type: a trusted issuer must *declare* it — we
+        # never default a missing claim to AGENT (jentic-one#864). Truncate the
+        # attacker-controlled value before logging.
+        actor_type_raw = claims.get(Claim.ACTOR_TYPE)
+        if actor_type_raw is None:
+            self._refuse("jwt_actor_type_missing", iss=iss, sub=sub)
+        try:
+            actor_type = ActorType(str(actor_type_raw))
+        except ValueError:
+            self._refuse(
+                "jwt_actor_type_unknown",
+                iss=iss,
+                sub=sub,
+                actor_type=str(actor_type_raw)[:64],
+            )
+        if actor_type not in _ALLOWED_ACTOR_TYPES:
+            # A signed claim can't mint a toolkit/user identity — those have
+            # DB-backed credential forms (jentic-one#868).
+            self._refuse(
+                "jwt_actor_type_not_allowed",
+                iss=iss,
+                sub=sub,
+                actor_type=actor_type.value,
+            )
+
         scopes_raw = claims.get(Claim.SCOPES, [])
         permissions = [str(s) for s in scopes_raw] if isinstance(scopes_raw, list) else []
 
         return Identity(
             sub=sub,
-            actor_type=ActorType(str(actor_type_raw)),
+            actor_type=actor_type,
             permissions=permissions,
             expires_at=datetime.fromtimestamp(float(exp), tz=UTC),
             active=True,

--- a/src/jentic_one/broker/services/auth/token_validation.py
+++ b/src/jentic_one/broker/services/auth/token_validation.py
@@ -116,6 +116,12 @@ class JwtVerifier:
             )
         except jwt.InvalidTokenError as exc:
             raise TokenValidationError(f"jwt_invalid: {exc}") from exc
+        except (OverflowError, ValueError) as exc:
+            # PyJWT validates ``exp``/``nbf``/``iat`` with ``int(payload[...])``,
+            # so a signed non-finite/absurd numeric claim (e.g. ``exp: inf``)
+            # raises OverflowError/ValueError *inside* decode — upstream of the
+            # downstream ``fromtimestamp`` guard — and is not an InvalidTokenError.
+            raise TokenValidationError(f"jwt_invalid: {exc}") from exc
         return claims
 
 

--- a/src/jentic_one/broker/services/auth/token_validation.py
+++ b/src/jentic_one/broker/services/auth/token_validation.py
@@ -19,8 +19,12 @@ refuses (uniform 401) any token missing them — it never *infers* a missing
 claim (jentic-one#864). ``actor_type`` must be one of ``agent`` /
 ``service_account`` (``_ALLOWED_ACTOR_TYPES``); ``toolkit`` and ``user``
 identities have DB-backed credential forms and cannot be asserted by a bare
-signed claim (jentic-one#868). Every refusal is logged server-side at WARNING
-with a static event name while the wire response stays uniform (jentic-one#874).
+signed claim (jentic-one#868). Every **JWT-path** refusal is logged
+server-side at WARNING under one event name (``jwt_refused``) with a ``reason``
+field, while the wire response stays uniform (jentic-one#874). The opaque
+path's ``unknown_token`` / ``token_inactive`` / ``token_expired`` refusals are
+**not** logged here (out of #874's scope — that lives with the opaque
+``CachedTokenValidator``).
 """
 
 from __future__ import annotations
@@ -49,6 +53,11 @@ _ALLOWED_ALGS: frozenset[str] = frozenset({"HS256"})
 # opaque tokens) and must never enter the broker via a bare signed claim: a
 # trusted issuer vouches for AGENT/SERVICE_ACCOUNT, nothing else.
 _ALLOWED_ACTOR_TYPES: frozenset[ActorType] = frozenset({ActorType.AGENT, ActorType.SERVICE_ACCOUNT})
+
+# Cap on attacker-influenced string fields written to the log stream, so a
+# secret-holder can't stuff arbitrarily large iss/sub/actor_type values into a
+# WARNING (jentic-one#874 review).
+_LOG_FIELD_MAXLEN = 64
 
 
 class TokenVerifier(Protocol):
@@ -91,8 +100,14 @@ class JwtVerifier:
     def verify(self, token: str) -> dict[str, object]:
         """Verify signature + expiry; raise ``TokenValidationError`` on failure."""
         # Pin the alg allowlist explicitly so an attacker can't downgrade to
-        # ``alg:none``; PyJWT enforces ``exp`` when present by default.
-        header = jwt.get_unverified_header(token)
+        # ``alg:none``; PyJWT enforces ``exp`` when present by default. Decode
+        # the header inside the guard — a JWT-shaped-but-undecodable token
+        # (``looks_like_jwt`` only checks the dot structure) would otherwise
+        # raise a bare ``jwt.DecodeError`` past the edge's typed catch → 500.
+        try:
+            header = jwt.get_unverified_header(token)
+        except jwt.InvalidTokenError as exc:
+            raise TokenValidationError(f"jwt_malformed: {exc}") from exc
         if header.get("alg") not in _ALLOWED_ALGS:
             raise TokenValidationError("jwt_alg_not_allowed")
         try:
@@ -110,27 +125,33 @@ class JwtTokenValidator:
 
     verifier: TokenVerifier
 
-    def _refuse(self, event: str, **fields: object) -> NoReturn:
-        """Log a refusal cause server-side, then raise the uniform typed error.
+    def _refuse(self, reason: str, **fields: object) -> NoReturn:
+        """Log a refusal cause server-side under one event name, then raise.
 
-        The wire response stays a uniform 401 (no oracle for forgers); the
-        static ``event`` name and structured ``fields`` are the *only* record
-        an operator gets of *why* a token was refused (jentic-one#874). Never
-        pass the raw token or a full claim set here — attacker-influenced
-        values are truncated by the caller.
+        The wire response stays a uniform 401 (no oracle for forgers). Every
+        JWT-path refusal — verifier-level and claim-level — logs the same
+        ``jwt_refused`` event with a ``reason`` field, so an operator alerts on
+        one event name and breaks down by reason (jentic-one#874). All
+        attacker-influenced string fields (``iss``/``sub``/``actor_type``) are
+        truncated to ``_LOG_FIELD_MAXLEN`` here so a secret-holder can't flood
+        the log stream with oversized claim values. The raised exception
+        message keeps the specific ``reason`` for callers that inspect it.
         """
-        logger.warning(event, **fields)
-        raise TokenValidationError(event)
+        safe = {
+            key: (value[:_LOG_FIELD_MAXLEN] if isinstance(value, str) else value)
+            for key, value in fields.items()
+        }
+        logger.warning("jwt_refused", reason=reason, **safe)
+        raise TokenValidationError(reason)
 
     async def validate(self, token: str) -> Identity:
         try:
             claims = self.verifier.verify(token)
         except TokenValidationError as exc:
-            # The verifier already carries the specific reason; surface it
-            # centrally so both verifiers behind the protocol get refusal
-            # logging without each duplicating it.
-            logger.warning("jwt_refused", reason=str(exc)[:128])
-            raise
+            # The verifier already carries the specific reason; funnel it through
+            # the same event/shape so both verifiers behind the protocol emit a
+            # single ``jwt_refused`` line without each duplicating logging.
+            self._refuse(str(exc)[:_LOG_FIELD_MAXLEN])
 
         iss = claims.get(Claim.ISS)
         sub = claims.get(Claim.SUB)
@@ -139,8 +160,7 @@ class JwtTokenValidator:
             self._refuse("jwt_missing_required_claims", iss=iss)
 
         # Fail closed on actor_type: a trusted issuer must *declare* it — we
-        # never default a missing claim to AGENT (jentic-one#864). Truncate the
-        # attacker-controlled value before logging.
+        # never default a missing claim to AGENT (jentic-one#864).
         actor_type_raw = claims.get(Claim.ACTOR_TYPE)
         if actor_type_raw is None:
             self._refuse("jwt_actor_type_missing", iss=iss, sub=sub)
@@ -151,7 +171,7 @@ class JwtTokenValidator:
                 "jwt_actor_type_unknown",
                 iss=iss,
                 sub=sub,
-                actor_type=str(actor_type_raw)[:64],
+                actor_type=str(actor_type_raw),
             )
         if actor_type not in _ALLOWED_ACTOR_TYPES:
             # A signed claim can't mint a toolkit/user identity — those have
@@ -163,6 +183,14 @@ class JwtTokenValidator:
                 actor_type=actor_type.value,
             )
 
+        # A hostile/buggy trusted issuer can sign an out-of-range ``exp``;
+        # ``fromtimestamp`` raises OverflowError/ValueError/OSError depending on
+        # magnitude and platform. Refuse rather than let it escape as a 500.
+        try:
+            expires_at = datetime.fromtimestamp(float(exp), tz=UTC)
+        except (OverflowError, ValueError, OSError):
+            self._refuse("jwt_exp_invalid", iss=iss, sub=sub)
+
         scopes_raw = claims.get(Claim.SCOPES, [])
         permissions = [str(s) for s in scopes_raw] if isinstance(scopes_raw, list) else []
 
@@ -170,7 +198,7 @@ class JwtTokenValidator:
             sub=sub,
             actor_type=actor_type,
             permissions=permissions,
-            expires_at=datetime.fromtimestamp(float(exp), tz=UTC),
+            expires_at=expires_at,
             active=True,
         )
 

--- a/src/jentic_one/broker/web/deps.py
+++ b/src/jentic_one/broker/web/deps.py
@@ -22,6 +22,7 @@ from jentic_one.broker.core.exceptions import RateLimitExceededError
 from jentic_one.broker.core.proxy_headers import reconstruct_upstream_url
 from jentic_one.broker.services.auth import CompositeTokenValidator
 from jentic_one.broker.services.idempotency import SharedStateIdempotencyStore
+from jentic_one.shared.auth.errors import TokenValidationError
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.broker.protocols import RuleEvaluatorProtocol, ToolkitDeriverProtocol
 from jentic_one.shared.context import Context
@@ -105,7 +106,7 @@ async def require_broker_identity(request: Request) -> Identity:
     validator: CompositeTokenValidator = request.app.state.broker_token_validator
     try:
         resolved = await validator.validate(credential)
-    except ValueError as exc:
+    except TokenValidationError as exc:
         raise Unauthorized(
             detail="Invalid or expired access token",
             instance=request.url.path,

--- a/src/jentic_one/shared/auth/__init__.py
+++ b/src/jentic_one/shared/auth/__init__.py
@@ -1,6 +1,7 @@
 """Shared identity/auth primitives: schemas, JWT helpers, token verification."""
 
 from jentic_one.shared.auth.api_key_resolver import ApiKeyResolver
+from jentic_one.shared.auth.errors import TokenValidationError
 from jentic_one.shared.auth.identity import (
     ChangePasswordPayload,
     Identity,
@@ -18,6 +19,7 @@ __all__ = [
     "Identity",
     "LoginPayload",
     "TokenBundle",
+    "TokenValidationError",
     "decode_jwt",
     "issue_jwt",
     "resolve_agent_key",

--- a/src/jentic_one/shared/auth/errors.py
+++ b/src/jentic_one/shared/auth/errors.py
@@ -1,0 +1,13 @@
+"""Typed errors for the shared auth edges."""
+
+from __future__ import annotations
+
+
+class TokenValidationError(Exception):
+    """A presented credential failed validation at an auth edge.
+
+    The message is a static snake_case reason (``unknown_token``,
+    ``jwt_actor_type_missing``, …) used for server-side logging only. Web
+    layers map this to a deliberately uniform 401 and MUST NOT echo the reason
+    to the client — a distinguishable response is an oracle for forgers.
+    """

--- a/src/jentic_one/shared/auth/jwt_verification.py
+++ b/src/jentic_one/shared/auth/jwt_verification.py
@@ -127,4 +127,11 @@ class TrustedIssuerVerifier:
             )
         except jwt.InvalidTokenError as exc:
             raise JwtVerificationError(f"jwt_invalid: {exc}") from exc
+        except (OverflowError, ValueError) as exc:
+            # PyJWT validates exp/nbf/iat via ``int(payload[...])``, so a signed
+            # non-finite/absurd numeric claim (e.g. ``exp: inf``) raises
+            # OverflowError/ValueError here rather than an InvalidTokenError.
+            # This is the only decode that validates those claims — the earlier
+            # unverified decode disables verification, so it can't hit this.
+            raise JwtVerificationError(f"jwt_invalid: {exc}") from exc
         return claims

--- a/src/jentic_one/shared/auth/jwt_verification.py
+++ b/src/jentic_one/shared/auth/jwt_verification.py
@@ -29,13 +29,19 @@ import jwt
 import structlog
 from jwt import PyJWKClient
 
+from jentic_one.shared.auth.errors import TokenValidationError
 from jentic_one.shared.config import JwtVerificationConfig, TrustedIssuerConfig
 
 logger = structlog.get_logger(__name__)
 
 
-class JwtVerificationError(ValueError):
-    """Raised when a JWT fails any hardened-verification check."""
+class JwtVerificationError(TokenValidationError):
+    """Raised when a JWT fails any hardened-verification check.
+
+    Subclasses the shared :class:`TokenValidationError` so the broker edge can
+    catch every token refusal with one typed clause and map it to a uniform
+    401 (jentic-one#866).
+    """
 
 
 @dataclass

--- a/tests/integration/broker/test_auth_e2e.py
+++ b/tests/integration/broker/test_auth_e2e.py
@@ -27,6 +27,7 @@ from jentic_one.admin.repos.refresh_token_repo import RefreshTokenRepository
 from jentic_one.broker.core.token_validation import CachedTokenValidator
 from jentic_one.broker.repos.token_resolver import InProcessTokenResolver
 from jentic_one.broker.services.auth import DualTokenValidator, JwtTokenValidator, JwtVerifier
+from jentic_one.shared.auth.errors import TokenValidationError
 from jentic_one.shared.db.session import DatabaseSession
 from jentic_one.shared.scopes import BROKER_EXECUTE_SCOPE
 
@@ -91,7 +92,12 @@ async def test_signed_jwt_validates_without_db_lookup(
     # No row seeded — a JWT must validate purely by signature.
     exp = int((datetime.now(UTC) + timedelta(minutes=2)).timestamp())
     token = jwt.encode(
-        {"sub": "agnt_jwt", "exp": exp, "scopes": [BROKER_EXECUTE_SCOPE]},
+        {
+            "sub": "agnt_jwt",
+            "exp": exp,
+            "actor_type": "agent",
+            "scopes": [BROKER_EXECUTE_SCOPE],
+        },
         _JWT_SECRET,
         algorithm="HS256",
     )
@@ -105,8 +111,34 @@ async def test_signed_jwt_validates_without_db_lookup(
 async def test_unknown_opaque_token_is_rejected(
     admin_db: DatabaseSession, clean_access_tokens: None
 ) -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(TokenValidationError):
         await _dual(admin_db).validate("at_does_not_exist")
+
+
+async def test_jwt_without_actor_type_fails_closed(
+    admin_db: DatabaseSession, clean_access_tokens: None
+) -> None:
+    """A validly-signed JWT missing ``actor_type`` is refused, not assumed AGENT (#864)."""
+    exp = int((datetime.now(UTC) + timedelta(minutes=2)).timestamp())
+    token = jwt.encode({"sub": "agnt_jwt", "exp": exp}, _JWT_SECRET, algorithm="HS256")
+
+    with pytest.raises(TokenValidationError, match="jwt_actor_type_missing"):
+        await _dual(admin_db).validate(token)
+
+
+async def test_jwt_claiming_toolkit_actor_type_is_rejected(
+    admin_db: DatabaseSession, clean_access_tokens: None
+) -> None:
+    """A signed JWT can't mint a toolkit identity with zero DB backing (#868)."""
+    exp = int((datetime.now(UTC) + timedelta(minutes=2)).timestamp())
+    token = jwt.encode(
+        {"sub": "tk_x", "exp": exp, "actor_type": "toolkit"},
+        _JWT_SECRET,
+        algorithm="HS256",
+    )
+
+    with pytest.raises(TokenValidationError, match="jwt_actor_type_not_allowed"):
+        await _dual(admin_db).validate(token)
 
 
 async def _seed_pair_and_grants(

--- a/tests/unit/broker/test_broker_deps.py
+++ b/tests/unit/broker/test_broker_deps.py
@@ -11,16 +11,19 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
+import jwt
 from fastapi import APIRouter, FastAPI, Request, Response
 from fastapi.testclient import TestClient
 from jentic.problem_details import ProblemDetailException, problem_detail_exception_handler
 
 from jentic_one.broker.core.token_validation import CachedTokenValidator
-from jentic_one.broker.services.auth import DualTokenValidator
+from jentic_one.broker.services.auth import DualTokenValidator, JwtTokenValidator, JwtVerifier
 from jentic_one.broker.web.deps import RequireToolkitAccess
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.models import ActorType
 from jentic_one.shared.scopes import BROKER_EXECUTE_SCOPE
+
+_JWT_SECRET = "broker-deps-test-secret-32-bytes-long!!"  # pragma: allowlist secret
 
 
 def _make_identity(
@@ -58,9 +61,10 @@ def _create_test_app(resolver_return: Identity | None | object = _SENTINEL) -> T
     mock_resolver = AsyncMock()
     mock_resolver.resolve_access_token = AsyncMock(return_value=effective_return)
     opaque = CachedTokenValidator(resolver=mock_resolver, cache_ttl_seconds=60.0)
-    app.state.broker_token_validator = DualTokenValidator(opaque=opaque, jwt=None)
+    jwt_validator = JwtTokenValidator(verifier=JwtVerifier(secret=_JWT_SECRET))
+    app.state.broker_token_validator = DualTokenValidator(opaque=opaque, jwt=jwt_validator)
 
-    return TestClient(app)
+    return TestClient(app, raise_server_exceptions=False)
 
 
 def test_returns_200_with_valid_token_and_scope() -> None:
@@ -92,3 +96,22 @@ def test_returns_403_with_insufficient_scope() -> None:
     resp = client.post("/execute", headers={"Authorization": "Bearer at_limited"})
     assert resp.status_code == 403
     assert resp.json()["type"] == "insufficient_scope"
+
+
+def test_malformed_jwt_shaped_token_returns_401_not_500() -> None:
+    """A JWT-shaped but undecodable token must not escape as a 500 (#880 review, finding #1)."""
+    client = _create_test_app()
+    resp = client.post("/execute", headers={"Authorization": "Bearer aaa.bbb.ccc"})
+    assert resp.status_code == 401
+
+
+def test_jwt_with_out_of_range_exp_returns_401_not_500() -> None:
+    """A validly-signed token with an absurd ``exp`` must be a 401, not a 500 (finding #2)."""
+    token = jwt.encode(
+        {"sub": "x", "exp": 10**20, "actor_type": "agent"},
+        _JWT_SECRET,
+        algorithm="HS256",
+    )
+    client = _create_test_app()
+    resp = client.post("/execute", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401

--- a/tests/unit/broker/test_broker_deps.py
+++ b/tests/unit/broker/test_broker_deps.py
@@ -115,3 +115,15 @@ def test_jwt_with_out_of_range_exp_returns_401_not_500() -> None:
     client = _create_test_app()
     resp = client.post("/execute", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 401
+
+
+def test_jwt_with_non_finite_exp_returns_401_not_500() -> None:
+    """A signed ``exp: inf`` (OverflowError inside PyJWT decode) must be a 401, not a 500."""
+    token = jwt.encode(
+        {"sub": "x", "exp": float("inf"), "actor_type": "agent"},
+        _JWT_SECRET,
+        algorithm="HS256",
+    )
+    client = _create_test_app()
+    resp = client.post("/execute", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401

--- a/tests/unit/broker/test_jwt_verification.py
+++ b/tests/unit/broker/test_jwt_verification.py
@@ -178,6 +178,20 @@ def test_expired_token_rejected() -> None:
         _verifier({"k1": key.public_key()}).verify(token)
 
 
+def test_non_finite_exp_rejected() -> None:
+    """A signed ``exp: inf`` raises OverflowError inside PyJWT's decode; the hardened
+    verifier must map it to the typed error, not let it escape as a 500 (#880 review)."""
+    key = _ec_key()
+    token = jwt.encode(
+        {"iss": _ISS, "sub": "user-1", "aud": _AUD, "exp": float("inf")},
+        key,
+        algorithm="ES256",
+        headers={"kid": "k1"},
+    )
+    with pytest.raises(JwtVerificationError, match="jwt_invalid"):
+        _verifier({"k1": key.public_key()}).verify(token)
+
+
 def test_expiry_within_leeway_accepted() -> None:
     key = _ec_key()
     # Expired 5s ago, but leeway is 10s.

--- a/tests/unit/broker/test_jwt_verification.py
+++ b/tests/unit/broker/test_jwt_verification.py
@@ -19,6 +19,7 @@ from pydantic import SecretStr
 
 from jentic_one.broker.core.setup import build_jwt_verifier
 from jentic_one.broker.services.auth import JwtVerifier
+from jentic_one.shared.auth.errors import TokenValidationError
 from jentic_one.shared.auth.jwt_verification import (
     JwtVerificationError,
     TrustedIssuerVerifier,
@@ -238,3 +239,8 @@ def test_build_verifier_falls_back_to_hs256_secret() -> None:
 
 def test_build_verifier_disabled_when_unconfigured() -> None:
     assert build_jwt_verifier(BrokerConfig(jwt_secret=None)) is None
+
+
+def test_jwt_verification_error_is_token_validation_error() -> None:
+    """The broker edge catches every refusal as one typed base (jentic-one#866)."""
+    assert issubclass(JwtVerificationError, TokenValidationError)

--- a/tests/unit/broker/test_token_cache_bound.py
+++ b/tests/unit/broker/test_token_cache_bound.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from jentic_one.broker.core.token_validation import CachedTokenValidator
+from jentic_one.shared.auth.errors import TokenValidationError
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.models import ActorType
 from jentic_one.shared.scopes import BROKER_EXECUTE_SCOPE
@@ -43,7 +44,7 @@ async def test_negative_cache_is_bounded_by_max_entries() -> None:
     validator = CachedTokenValidator(resolver=resolver, cache_ttl_seconds=300.0, max_entries=10)
 
     for i in range(100):
-        with pytest.raises(ValueError, match="unknown_token"):
+        with pytest.raises(TokenValidationError, match="unknown_token"):
             await validator.validate(f"garbage_{i}")
 
     assert len(validator._cache) == 10
@@ -57,16 +58,16 @@ async def test_lru_evicts_oldest_first() -> None:
     validator = CachedTokenValidator(resolver=resolver, cache_ttl_seconds=300.0, max_entries=3)
 
     for tok in ("a", "b", "c"):
-        with pytest.raises(ValueError):
+        with pytest.raises(TokenValidationError):
             await validator.validate(tok)
 
     # Touch "a" so it becomes most-recently-used (served from cache, no new call).
-    with pytest.raises(ValueError):
+    with pytest.raises(TokenValidationError):
         await validator.validate("a")
     assert resolver.calls == 3
 
     # Insert "d": should evict "b" (now the LRU), not "a".
-    with pytest.raises(ValueError):
+    with pytest.raises(TokenValidationError):
         await validator.validate("d")
 
     assert _key("b") not in validator._cache
@@ -82,7 +83,7 @@ async def test_cache_key_is_sha256_digest() -> None:
     validator = CachedTokenValidator(resolver=resolver, cache_ttl_seconds=300.0)
 
     raw = "at_some_secret_token"
-    with pytest.raises(ValueError):
+    with pytest.raises(TokenValidationError):
         await validator.validate(raw)
 
     assert _key(raw) in validator._cache
@@ -110,7 +111,7 @@ async def test_negative_caching_preserved() -> None:
     validator = CachedTokenValidator(resolver=resolver, cache_ttl_seconds=300.0)
 
     for _ in range(5):
-        with pytest.raises(ValueError, match="unknown_token"):
+        with pytest.raises(TokenValidationError, match="unknown_token"):
             await validator.validate("at_bad")
 
     assert resolver.calls == 1
@@ -122,10 +123,10 @@ async def test_ttl_expiry_still_works_under_bound() -> None:
     resolver = _CountingResolver(resolved=None)
     validator = CachedTokenValidator(resolver=resolver, cache_ttl_seconds=0.01, max_entries=10)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TokenValidationError):
         await validator.validate("at_x")
     time.sleep(0.02)
-    with pytest.raises(ValueError):
+    with pytest.raises(TokenValidationError):
         await validator.validate("at_x")
 
     assert resolver.calls == 2

--- a/tests/unit/broker/test_token_form_selection.py
+++ b/tests/unit/broker/test_token_form_selection.py
@@ -15,6 +15,7 @@ from jentic_one.broker.services.auth import (
     JwtVerifier,
     looks_like_jwt,
 )
+from jentic_one.broker.services.auth.token_validation import _LOG_FIELD_MAXLEN
 from jentic_one.shared.auth.errors import TokenValidationError
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.models import ActorType
@@ -191,8 +192,29 @@ async def test_allowed_actor_types_validate(actor_type: str, expected: ActorType
 
 
 @pytest.mark.asyncio
-async def test_refusal_is_logged_without_token_material() -> None:
-    """Each refusal emits one WARNING with structured context, never the raw token (#874)."""
+async def test_malformed_jwt_shaped_token_is_typed_401() -> None:
+    """A 3-segment but undecodable token is refused typed, not a bare DecodeError (#880 review)."""
+    # ``looks_like_jwt`` is True for this (three non-empty dot segments), so it
+    # routes to the JWT path; ``get_unverified_header`` would raise jwt.DecodeError.
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+
+    with pytest.raises(TokenValidationError, match="jwt_malformed"):
+        await validator.validate("aaa.bbb.ccc")
+
+
+@pytest.mark.asyncio
+async def test_out_of_range_exp_is_typed_401() -> None:
+    """A validly-signed token with an absurd ``exp`` is refused, not a 500 (#880 review)."""
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+    token = _sign({"sub": "x", "exp": 10**20, "actor_type": "agent"})
+
+    with pytest.raises(TokenValidationError, match="jwt_exp_invalid"):
+        await validator.validate(token)
+
+
+@pytest.mark.asyncio
+async def test_claim_refusal_logs_single_jwt_refused_event() -> None:
+    """Claim-level refusals log exactly one ``jwt_refused`` with a ``reason`` (#874)."""
     validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
     exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
     token = _sign({"sub": "agnt_jwt", "iss": "issuer-a", "exp": exp, "actor_type": "gibberish"})
@@ -206,11 +228,50 @@ async def test_refusal_is_logged_without_token_material() -> None:
     warnings = [e for e in logs if e["log_level"] == "warning"]
     assert len(warnings) == 1
     event = warnings[0]
-    assert event["event"] == "jwt_actor_type_unknown"
+    assert event["event"] == "jwt_refused"
+    assert event["reason"] == "jwt_actor_type_unknown"
     assert event["iss"] == "issuer-a"
     assert event["sub"] == "agnt_jwt"
     assert event["actor_type"] == "gibberish"
-    assert not any(token in str(v) for v in event.values())
+
+
+@pytest.mark.asyncio
+async def test_verifier_refusal_logs_single_jwt_refused_event() -> None:
+    """A verifier-level refusal (bad signature) uses the same event shape (#880 review)."""
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+    exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
+    token = _sign({"sub": "x", "exp": exp, "actor_type": "agent"}, secret="wrong-secret")
+
+    with (
+        structlog.testing.capture_logs() as logs,
+        pytest.raises(TokenValidationError),
+    ):
+        await validator.validate(token)
+
+    warnings = [e for e in logs if e["log_level"] == "warning"]
+    assert len(warnings) == 1
+    assert warnings[0]["event"] == "jwt_refused"
+    assert "reason" in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_oversized_claim_values_are_truncated_in_logs() -> None:
+    """Attacker-influenced iss/sub/actor_type are bounded before hitting the log stream (#874)."""
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+    exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
+    big = "z" * 500
+    token = _sign({"sub": big, "iss": big, "exp": exp, "actor_type": big})
+
+    with (
+        structlog.testing.capture_logs() as logs,
+        pytest.raises(TokenValidationError),
+    ):
+        await validator.validate(token)
+
+    event = next(e for e in logs if e["log_level"] == "warning")
+    assert len(event["iss"]) == _LOG_FIELD_MAXLEN
+    assert len(event["sub"]) == _LOG_FIELD_MAXLEN
+    assert len(event["actor_type"]) == _LOG_FIELD_MAXLEN
 
 
 @pytest.mark.asyncio

--- a/tests/unit/broker/test_token_form_selection.py
+++ b/tests/unit/broker/test_token_form_selection.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 
 import jwt
 import pytest
+import structlog
 
 from jentic_one.broker.core.token_validation import CachedTokenValidator
 from jentic_one.broker.services.auth import (
@@ -14,6 +15,7 @@ from jentic_one.broker.services.auth import (
     JwtVerifier,
     looks_like_jwt,
 )
+from jentic_one.shared.auth.errors import TokenValidationError
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.models import ActorType
 from jentic_one.shared.scopes import BROKER_EXECUTE_SCOPE
@@ -83,7 +85,14 @@ async def test_dispatcher_routes_jwt_to_verifier_without_lookup() -> None:
         jwt=JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET)),
     )
     exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
-    token = _sign({"sub": "agnt_jwt", "exp": exp, "scopes": [BROKER_EXECUTE_SCOPE]})
+    token = _sign(
+        {
+            "sub": "agnt_jwt",
+            "exp": exp,
+            "actor_type": ActorType.AGENT.value,
+            "scopes": [BROKER_EXECUTE_SCOPE],
+        }
+    )
 
     resolved = await dual.validate(token)
 
@@ -98,7 +107,7 @@ async def test_jwt_with_bad_signature_is_rejected() -> None:
     exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
     token = _sign({"sub": "agnt_jwt", "exp": exp}, secret="wrong-secret")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TokenValidationError):
         await validator.validate(token)
 
 
@@ -108,7 +117,7 @@ async def test_jwt_with_disallowed_alg_is_rejected() -> None:
     validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
     token = jwt.encode({"sub": "x", "exp": 9999999999}, key="", algorithm="none")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TokenValidationError):
         await validator.validate(token)
 
 
@@ -118,8 +127,90 @@ async def test_expired_jwt_is_rejected() -> None:
     exp = int((datetime.now(UTC) - timedelta(minutes=5)).timestamp())
     token = _sign({"sub": "agnt_jwt", "exp": exp})
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TokenValidationError):
         await validator.validate(token)
+
+
+@pytest.mark.asyncio
+async def test_missing_required_claims_rejected() -> None:
+    """A signed token without ``sub``/``exp`` is refused (not a 500)."""
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+    token = _sign({"exp": 9999999999})  # no sub
+
+    with pytest.raises(TokenValidationError, match="jwt_missing_required_claims"):
+        await validator.validate(token)
+
+
+@pytest.mark.asyncio
+async def test_missing_actor_type_fails_closed() -> None:
+    """A validly-signed token without ``actor_type`` is refused, not assumed AGENT (#864)."""
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+    exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
+    token = _sign({"sub": "agnt_jwt", "exp": exp})
+
+    with pytest.raises(TokenValidationError, match="jwt_actor_type_missing"):
+        await validator.validate(token)
+
+
+@pytest.mark.asyncio
+async def test_unknown_actor_type_is_typed_rejection() -> None:
+    """An unrecognised ``actor_type`` raises the typed error, never a bare enum ValueError."""
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+    exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
+    token = _sign({"sub": "agnt_jwt", "exp": exp, "actor_type": "gibberish"})
+
+    with pytest.raises(TokenValidationError, match="jwt_actor_type_unknown"):
+        await validator.validate(token)
+
+
+@pytest.mark.parametrize("actor_type", ["toolkit", "user"])
+@pytest.mark.asyncio
+async def test_disallowed_actor_type_rejected(actor_type: str) -> None:
+    """toolkit/user identities can't be minted by a bare signed claim (#868)."""
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+    exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
+    token = _sign({"sub": "x", "exp": exp, "actor_type": actor_type})
+
+    with pytest.raises(TokenValidationError, match="jwt_actor_type_not_allowed"):
+        await validator.validate(token)
+
+
+@pytest.mark.parametrize(
+    ("actor_type", "expected"),
+    [("agent", ActorType.AGENT), ("service_account", ActorType.SERVICE_ACCOUNT)],
+)
+@pytest.mark.asyncio
+async def test_allowed_actor_types_validate(actor_type: str, expected: ActorType) -> None:
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+    exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
+    token = _sign({"sub": "x", "exp": exp, "actor_type": actor_type})
+
+    resolved = await validator.validate(token)
+
+    assert resolved.actor_type is expected
+
+
+@pytest.mark.asyncio
+async def test_refusal_is_logged_without_token_material() -> None:
+    """Each refusal emits one WARNING with structured context, never the raw token (#874)."""
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+    exp = int((datetime.now(UTC) + timedelta(minutes=5)).timestamp())
+    token = _sign({"sub": "agnt_jwt", "iss": "issuer-a", "exp": exp, "actor_type": "gibberish"})
+
+    with (
+        structlog.testing.capture_logs() as logs,
+        pytest.raises(TokenValidationError),
+    ):
+        await validator.validate(token)
+
+    warnings = [e for e in logs if e["log_level"] == "warning"]
+    assert len(warnings) == 1
+    event = warnings[0]
+    assert event["event"] == "jwt_actor_type_unknown"
+    assert event["iss"] == "issuer-a"
+    assert event["sub"] == "agnt_jwt"
+    assert event["actor_type"] == "gibberish"
+    assert not any(token in str(v) for v in event.values())
 
 
 @pytest.mark.asyncio

--- a/tests/unit/broker/test_token_form_selection.py
+++ b/tests/unit/broker/test_token_form_selection.py
@@ -213,6 +213,21 @@ async def test_out_of_range_exp_is_typed_401() -> None:
 
 
 @pytest.mark.asyncio
+async def test_non_finite_exp_is_typed_401() -> None:
+    """A signed ``exp: inf`` raises OverflowError inside PyJWT's decode, not fromtimestamp.
+
+    PyJWT validates ``exp`` with ``int(payload["exp"])`` *before* our downstream
+    guard runs, so this must be caught at the verifier and mapped to the typed
+    error rather than escaping as a 500 (#880 review residual).
+    """
+    validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))
+    token = _sign({"sub": "x", "exp": float("inf"), "actor_type": "agent"})
+
+    with pytest.raises(TokenValidationError, match="jwt_invalid"):
+        await validator.validate(token)
+
+
+@pytest.mark.asyncio
 async def test_claim_refusal_logs_single_jwt_refused_event() -> None:
     """Claim-level refusals log exactly one ``jwt_refused`` with a ``reason`` (#874)."""
     validator = JwtTokenValidator(verifier=JwtVerifier(secret=_SECRET))

--- a/tests/unit/broker/test_token_validation.py
+++ b/tests/unit/broker/test_token_validation.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from jentic_one.broker.core.token_validation import CachedTokenValidator
+from jentic_one.shared.auth.errors import TokenValidationError
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.models import ActorType
 from jentic_one.shared.scopes import BROKER_EXECUTE_SCOPE
@@ -58,7 +59,7 @@ async def test_validate_raises_on_unknown_token(mock_resolver: AsyncMock) -> Non
     mock_resolver.resolve_access_token.return_value = None
     validator = CachedTokenValidator(resolver=mock_resolver)
 
-    with pytest.raises(ValueError, match="unknown_token"):
+    with pytest.raises(TokenValidationError, match="unknown_token"):
         await validator.validate("at_unknown")
 
 
@@ -67,7 +68,7 @@ async def test_validate_raises_on_inactive_token(mock_resolver: AsyncMock) -> No
     mock_resolver.resolve_access_token.return_value = _make_identity(active=False)
     validator = CachedTokenValidator(resolver=mock_resolver)
 
-    with pytest.raises(ValueError, match="token_inactive"):
+    with pytest.raises(TokenValidationError, match="token_inactive"):
         await validator.validate("at_inactive")
 
 
@@ -78,7 +79,7 @@ async def test_validate_raises_on_expired_token(mock_resolver: AsyncMock) -> Non
     )
     validator = CachedTokenValidator(resolver=mock_resolver)
 
-    with pytest.raises(ValueError, match="token_expired"):
+    with pytest.raises(TokenValidationError, match="token_expired"):
         await validator.validate("at_expired")
 
 
@@ -107,9 +108,9 @@ async def test_negative_cache_entry(mock_resolver: AsyncMock) -> None:
     mock_resolver.resolve_access_token.return_value = None
     validator = CachedTokenValidator(resolver=mock_resolver, cache_ttl_seconds=5.0)
 
-    with pytest.raises(ValueError, match="unknown_token"):
+    with pytest.raises(TokenValidationError, match="unknown_token"):
         await validator.validate("at_bad")
-    with pytest.raises(ValueError, match="unknown_token"):
+    with pytest.raises(TokenValidationError, match="unknown_token"):
         await validator.validate("at_bad")
 
     mock_resolver.resolve_access_token.assert_called_once()
@@ -123,7 +124,7 @@ async def test_expires_at_override_despite_active_flag(mock_resolver: AsyncMock)
     )
     validator = CachedTokenValidator(resolver=mock_resolver)
 
-    with pytest.raises(ValueError, match="token_expired"):
+    with pytest.raises(TokenValidationError, match="token_expired"):
         await validator.validate("at_edge_case")
 
 

--- a/tests/unit/broker/test_triple_token_validation.py
+++ b/tests/unit/broker/test_triple_token_validation.py
@@ -9,6 +9,7 @@ import pytest
 
 from jentic_one.broker.core.token_validation import CachedTokenValidator
 from jentic_one.broker.services.auth.token_validation import CompositeTokenValidator
+from jentic_one.shared.auth.errors import TokenValidationError
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.models import ActorType
 from jentic_one.shared.scopes import BROKER_EXECUTE_SCOPE
@@ -155,8 +156,8 @@ async def test_jwt_routes_to_jwt_path() -> None:
 
 
 @pytest.mark.asyncio
-async def test_unknown_api_key_raises_value_error(api_key_resolver: AsyncMock) -> None:
-    """An API key not found in the DB raises ValueError (mapped to 401)."""
+async def test_unknown_api_key_raises_typed_error(api_key_resolver: AsyncMock) -> None:
+    """An API key not found in the DB raises TokenValidationError (mapped to 401)."""
     api_key_resolver.resolve_access_token = AsyncMock(return_value=None)
     opaque_resolver = AsyncMock()
     opaque_resolver.resolve_access_token = AsyncMock()
@@ -170,5 +171,5 @@ async def test_unknown_api_key_raises_value_error(api_key_resolver: AsyncMock) -
         opaque=opaque_cached, api_key=api_key_cached, toolkit_key=toolkit_cached, jwt=None
     )
 
-    with pytest.raises(ValueError, match="unknown_token"):
+    with pytest.raises(TokenValidationError, match="unknown_token"):
         await triple.validate("jak_bad_key")


### PR DESCRIPTION
## Summary

Hardens the broker's self-contained-JWT validation path, which previously guessed claims and stayed silent on refusals. Four related issues, one PR (they touch the same ~60 lines and the same load-bearing `except` site):

- **#866** — every refusal raised a bare `ValueError`. Introduce a shared `TokenValidationError`, re-parent `JwtVerificationError` onto it, migrate every broker raise site (JWT **and** opaque paths), and narrow the `broker/web/deps.py` catch to the typed error so it can't mask unrelated bugs. Wire response stays a uniform 401.
- **#864** — a validly-signed JWT with no `actor_type` defaulted to `AGENT`. Now fails closed (typed rejection + WARNING), mirroring the shared `verify_token` gate.
- **#868** — any signed `actor_type` (incl. `toolkit`/`user`) was honoured with zero DB lookups. Restricted to an `{agent, service_account}` allowlist; those two identities have DB-backed credential forms and must not enter via a bare signed claim.
- **#874** — refusals were invisible server-side. Every JWT-path refusal now logs one WARNING under a single event name (`jwt_refused` + `reason` field); attacker-influenced claim values (`iss`/`sub`/`actor_type`) are truncated; the raw token is never logged.

## Review remediation (commit 2)

Follow-up addressing the PR review — two paths still escaped the edge's typed catch as 500s, and the logging claims didn't fully hold:

- **Malformed-header JWT → 500 (unauthenticated).** `jwt.get_unverified_header` sat outside the `try` in the dev HS256 `JwtVerifier`; a JWT-shaped-but-undecodable token (`looks_like_jwt` only checks dot structure) raised a bare `jwt.DecodeError` past the narrowed catch. Now mapped to `jwt_malformed`, matching the hardened `TrustedIssuerVerifier`.
- **Out-of-range `exp` → 500.** `datetime.fromtimestamp(float(exp))` raised `OverflowError`/`ValueError` for an absurd `exp` from a buggy/hostile signer. Now bounded and refused with `jwt_exp_invalid`.
- **Truncation now covers all three claim fields** (`iss`/`sub`/`actor_type`), centralised in `_refuse` so the invariant can't drift.
- **Unified log shape**: verifier- and claim-level refusals both emit `jwt_refused` + `reason`, so operators alert on one event name.
- Docstrings corrected to scope the logging claim to the JWT path (opaque-path refusals are not logged here).

## Breaking changes

1. **JWT `actor_type` now required.** Self-contained JWTs at the broker edge must embed `actor_type ∈ {agent, service_account}` (alongside `sub`/`exp`). **External trusted (JWKS) issuers must update their minting before upgrading** — a token without `actor_type`, previously treated as an agent, is now refused with a 401. No in-repo producer is affected (verified: nothing mints broker-consumable JWTs outside tests).
2. **`JwtVerificationError` re-parented** from `ValueError` to `Exception` (via the new `TokenValidationError`). Any external OSS consumer catching `ValueError` around it silently loses its handler. Verified **zero** in-repo and enterprise coupling (only the definition + the migrated `deps.py` catch), so it's safe here — flagged for downstream consumers.

## Known trade-off (#874)

The JWT path has no negative cache (unlike the opaque path), and every refusal writes a WARNING. Garbage-JWT spam is therefore one WARNING per request, unbounded — the deliberate cost of server-side refusal visibility. No sampling/rate-limiting in this PR; a follow-up could dedup or reuse the `_record_auth_failure` window already in `deps.py`.

## Test plan

- [x] `make lint` + `make typecheck` clean (mypy, 1059 files)
- [x] Broker + arch tests green (788), incl. claim-hardening cases and, from the review remediation: JWT-shaped-undecodable → typed 401 **and** 401-not-500 through the app; out-of-range `exp` → typed 401 **and** 401-not-500; verifier- and claim-level refusals each log exactly one `jwt_refused`; oversized `iss`/`sub`/`actor_type` truncated in the log stream
- [x] Broker auth e2e green on SQLite (7), incl. fail-closed (missing `actor_type`) and toolkit-claim-rejected cases
- [x] Re-parent pinned by a test asserting `JwtVerificationError` is a `TokenValidationError`

Plans: `issue-864-866-868-874-broker-jwt-hardening.md` (+ `_impl`) and `pr-880-review-remediation.md` in `jentic-one-rules`.

Closes #864
Closes #866
Closes #868
Closes #874