### PR TITLE
feat(access-requests): surface already-satisfied items and adopt existing artifacts in fulfilment wizard

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -371,7 +371,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 16314
+        "line_number": 16320
       }
     ],
     "release-please-config.json": [
@@ -1584,14 +1584,14 @@
         "filename": "ui/src/shared/credentials/lib/formBody.ts",
         "hashed_secret": "99234bc23431a0935499b2ff12e249fbde4bfa08",
         "is_verified": false,
-        "line_number": 199
+        "line_number": 200
       },
       {
         "type": "Secret Keyword",
         "filename": "ui/src/shared/credentials/lib/formBody.ts",
         "hashed_secret": "80792cd49faef85e000402528add5458c97b6b02",
         "is_verified": false,
-        "line_number": 203
+        "line_number": 204
       }
     ],
     "ui/src/shared/credentials/lib/schemes.ts": [
@@ -1618,5 +1618,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-30T13:10:09Z"
+  "generated_at": "2026-07-30T14:17:18Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -371,7 +371,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 16320
+        "line_number": 16326
       }
     ],
     "release-please-config.json": [
@@ -1618,5 +1618,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-30T14:17:18Z"
+  "generated_at": "2026-07-31T08:59:32Z"
 }

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -127,8 +127,14 @@ components:
           anyOf:
           - type: boolean
           - type: 'null'
-          description: Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, or an item whose target cannot be determined). Toolkit REFERENCES are resolved under the caller's visibility, mirroring decide-time resolution, so False can also mean 'satisfied by a toolkit this caller cannot see'; explicit-id targets are probed directly.
+          description: Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, an item whose target cannot be determined, an ambiguous toolkit reference — which approval would refuse as filed — or a credential:bind whose credential is not visible to the caller). Toolkit REFERENCES are resolved under the caller's visibility, mirroring decide-time resolution, so False can also mean 'satisfied by a toolkit this caller cannot see'; explicit-id targets are probed directly.
           title: Already Satisfied
+        already_satisfied_by:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: For a satisfied toolkit:bind, the id of the toolkit the agent is already bound to — names the exact object so consumers can point the operator at it. Null for other item types and whenever already_satisfied is not true.
+          title: Already Satisfied By
         applied_effects:
           anyOf:
           - additionalProperties: true

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -123,6 +123,12 @@ components:
         action:
           title: Action
           type: string
+        already_satisfied:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          description: Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, or an item whose target cannot be determined). Toolkit references are resolved under the caller's visibility, mirroring decide-time resolution.
+          title: Already Satisfied
         applied_effects:
           anyOf:
           - additionalProperties: true

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -127,7 +127,7 @@ components:
           anyOf:
           - type: boolean
           - type: 'null'
-          description: Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, or an item whose target cannot be determined). Toolkit references are resolved under the caller's visibility, mirroring decide-time resolution.
+          description: Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, or an item whose target cannot be determined). Toolkit REFERENCES are resolved under the caller's visibility, mirroring decide-time resolution, so False can also mean 'satisfied by a toolkit this caller cannot see'; explicit-id targets are probed directly.
           title: Already Satisfied
         applied_effects:
           anyOf:

--- a/src/jentic_one/control/repos/prerequisite_repo.py
+++ b/src/jentic_one/control/repos/prerequisite_repo.py
@@ -90,6 +90,48 @@ class PrerequisiteRepository:
         return result.scalar_one_or_none() is not None
 
     @staticmethod
+    async def agent_bound_to_any_toolkit(
+        session: AsyncSession, *, agent_id: str, toolkit_ids: list[str]
+    ) -> bool:
+        """Return True if the agent is bound to at least one of the given toolkits.
+
+        Batched variant of :meth:`agent_toolkit_binding_exists` for satisfaction
+        checks where a ``toolkit:bind`` reference resolves to several candidate
+        toolkits — being bound to any of them means the bind's outcome is
+        already in effect. Empty ``toolkit_ids`` short-circuits to False.
+        """
+        if not toolkit_ids:
+            return False
+        placeholders = ", ".join(f":tk_{i}" for i in range(len(toolkit_ids)))
+        params: dict[str, object] = {f"tk_{i}": tid for i, tid in enumerate(toolkit_ids)}
+        params["agent_id"] = agent_id
+        result = await session.execute(
+            text(
+                "SELECT 1 FROM agent_toolkit_bindings "
+                f"WHERE agent_id = :agent_id AND toolkit_id IN ({placeholders}) LIMIT 1"
+            ),
+            params,
+        )
+        return result.scalar_one_or_none() is not None
+
+    @staticmethod
+    async def actor_scope_grant_exists(session: AsyncSession, *, actor_id: str, scope: str) -> bool:
+        """Return True if the actor already holds this scope grant (admin DB).
+
+        Mirrors the uniqueness key of ``EffectsRepository.grant_scope_to_actor``'s
+        idempotent insert (``(actor_id, scope)``), so "exists" here is exactly
+        "the grant effect would be a no-op".
+        """
+        result = await session.execute(
+            text(
+                "SELECT 1 FROM actor_scope_grants "
+                "WHERE actor_id = :actor_id AND scope = :scope LIMIT 1"
+            ),
+            {"actor_id": actor_id, "scope": scope},
+        )
+        return result.scalar_one_or_none() is not None
+
+    @staticmethod
     async def list_toolkit_ids_for_agent(session: AsyncSession, *, agent_id: str) -> list[str]:
         """Return the ids of every toolkit the agent is actively bound to.
 

--- a/src/jentic_one/control/repos/prerequisite_repo.py
+++ b/src/jentic_one/control/repos/prerequisite_repo.py
@@ -95,10 +95,12 @@ class PrerequisiteRepository:
     ) -> bool:
         """Return True if the agent is bound to at least one of the given toolkits.
 
-        Batched variant of :meth:`agent_toolkit_binding_exists` for satisfaction
-        checks where a ``toolkit:bind`` reference resolves to several candidate
-        toolkits — being bound to any of them means the bind's outcome is
-        already in effect. Empty ``toolkit_ids`` short-circuits to False.
+        Batched variant of :meth:`agent_toolkit_binding_exists` for
+        satisfaction checks (issue #826). The current annotator only probes a
+        single resolved toolkit per item (ambiguous references are left
+        un-annotated), but the batched shape stays so future callers can check
+        several candidates in one query. Empty ``toolkit_ids`` short-circuits
+        to False.
         """
         if not toolkit_ids:
             return False

--- a/src/jentic_one/control/services/access_requests/schemas/access_requests.py
+++ b/src/jentic_one/control/services/access_requests/schemas/access_requests.py
@@ -42,6 +42,12 @@ class AccessRequestItemView(BaseModel):
     decided_by: str | None
     decided_at: dt.datetime | None
     decision_reason: str | None
+    # Tri-state satisfaction hint, stamped by ``AccessRequestService.get()`` only
+    # (single-request reads; list pages skip it): True when the item's outcome is
+    # already in effect (binding/grant exists), False when it determinately is
+    # not, None when not computed (decided items, indeterminate targets, list
+    # endpoints, fulfilment-only intents).
+    already_satisfied: bool | None = None
 
 
 class EvaluationCheck(BaseModel):

--- a/src/jentic_one/control/services/access_requests/schemas/access_requests.py
+++ b/src/jentic_one/control/services/access_requests/schemas/access_requests.py
@@ -45,9 +45,12 @@ class AccessRequestItemView(BaseModel):
     # Tri-state satisfaction hint, stamped by ``AccessRequestService.get()`` only
     # (single-request reads; list pages skip it): True when the item's outcome is
     # already in effect (binding/grant exists), False when it determinately is
-    # not, None when not computed (decided items, indeterminate targets, list
-    # endpoints, fulfilment-only intents).
+    # not, None when not computed (decided items, indeterminate or ambiguous
+    # targets, list endpoints, fulfilment-only intents).
     already_satisfied: bool | None = None
+    # For a satisfied toolkit:bind, the toolkit id that satisfies it — lets
+    # consumers point the operator at the exact object. None otherwise.
+    already_satisfied_by: str | None = None
 
 
 class EvaluationCheck(BaseModel):

--- a/src/jentic_one/control/services/access_requests/service.py
+++ b/src/jentic_one/control/services/access_requests/service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 from collections.abc import Sequence
+from dataclasses import dataclass, field
 from typing import Any
 
 import structlog
@@ -15,8 +16,9 @@ from jentic_one.control.repos.access_request_repo import AccessRequestRepository
 from jentic_one.control.repos.credential_repo import CredentialRepository
 from jentic_one.control.repos.effects_repo import EffectsRepository
 from jentic_one.control.repos.prerequisite_repo import PrerequisiteRepository
+from jentic_one.control.repos.toolkit_binding_repo import ToolkitBindingRepository
 from jentic_one.control.repos.toolkit_repo import ToolkitRepository
-from jentic_one.control.scoping.filters import build_access_filters
+from jentic_one.control.scoping.filters import build_access_filters, toolkit_owner_scope
 from jentic_one.control.services.access_requests.effects import (
     PLAN_INTENT_COMBINATIONS,
     UNGOVERNED_PLAN,
@@ -96,6 +98,24 @@ _SETTLED_STATUSES: frozenset[AccessRequestStatus] = frozenset(
         AccessRequestStatus.DENIED,
     }
 )
+
+
+@dataclass(slots=True)
+class _AdminSatisfactionProbes:
+    """Admin-DB satisfaction checks deferred until the control session closes.
+
+    ``get()`` computes control-DB satisfaction (credential bindings, toolkit
+    reference resolution) inside its control session, but the corresponding
+    admin-DB existence checks (agent↔toolkit bindings, scope grants) must not
+    run while the control session is open — one DB session at a time, mirroring
+    ``_resolve_filer_owners``. Each probe carries the item id to stamp plus the
+    already-resolved lookup key.
+    """
+
+    # (item_id, agent_id, candidate toolkit ids) — satisfied if bound to any.
+    toolkit_binds: list[tuple[str, str, list[str]]] = field(default_factory=list)
+    # (item_id, actor_id, scope) — satisfied if the grant row exists.
+    scope_grants: list[tuple[str, str, str]] = field(default_factory=list)
 
 
 class AccessRequestService:
@@ -439,6 +459,10 @@ class AccessRequestService:
             names = await self._resolve_names(session, [request])
             view = self._to_view(request, names=names)
             view.evaluation = self._compute_evaluation(request, identity)
+            admin_probes = await self._annotate_satisfaction_control(
+                view, request, identity=identity, session=session
+            )
+        await self._annotate_satisfaction_admin(view, admin_probes)
         await self._resolve_filer_owners([view])
         return view
 
@@ -518,6 +542,98 @@ class AccessRequestService:
                 email=row.email,
                 display_name=name or None,
             )
+
+    async def _annotate_satisfaction_control(
+        self,
+        view: AccessRequestView,
+        request: AccessRequest,
+        *,
+        identity: Identity,
+        session: Any,
+    ) -> _AdminSatisfactionProbes:
+        """Stamp control-DB ``already_satisfied`` hints; collect admin-DB probes.
+
+        Closes the manual-fulfilment gap (issue #826): an operator who set a
+        binding/grant up by hand (or adopted existing artifacts) sees which
+        pending items are already in effect and can approve them instead of
+        re-doing the work in the wizard. Labelling only — decide() re-validates
+        everything; this never authorizes.
+
+        Only PENDING effect items are annotated. Everything else stays ``None``
+        (not computed): decided items, fulfilment-only intents (their outcome is
+        the downstream binds'), and items whose target is indeterminate (a
+        target-less credential:bind, a vendor-less toolkit reference). A
+        reference that resolves to no toolkit visible to the caller is
+        determinately False — resolution runs under the caller's owner scope,
+        the same scope decide-time resolution would use.
+
+        Control-DB checks (credential bindings, reference resolution) run on the
+        caller's ``session``; admin-DB checks are returned as probes for
+        :meth:`_annotate_satisfaction_admin` to run after this session closes.
+        """
+        probes = _AdminSatisfactionProbes()
+        item_views_by_id = {iv.id: iv for iv in view.items}
+        for item in request.items:
+            if item.status != AccessRequestItemStatus.PENDING:
+                continue
+            item_view = item_views_by_id[item.id]
+            key = (item.resource_type, item.action)
+            if key == ("credential", "bind"):
+                if item.to_id and item.resource_id:
+                    binding = await ToolkitBindingRepository.get(
+                        session, item.to_id, item.resource_id
+                    )
+                    item_view.already_satisfied = binding is not None
+            elif key == ("toolkit", "bind"):
+                explicit_id = item.resource_id or item.to_id
+                if explicit_id:
+                    probes.toolkit_binds.append((item.id, item.actor_id, [explicit_id]))
+                    continue
+                reference = item.resource_reference or {}
+                vendor = reference.get("vendor")
+                if not vendor:
+                    continue
+                raw_name = reference.get("name")
+                candidates = await EffectsRepository.resolve_toolkits_for_api(
+                    session,
+                    vendor=slugify_api_field(str(vendor)),
+                    name=slugify_api_field(str(raw_name)) if raw_name else raw_name,
+                    version=reference.get("version"),
+                    owner_ids=toolkit_owner_scope(identity),
+                )
+                if not candidates:
+                    item_view.already_satisfied = False
+                else:
+                    probes.toolkit_binds.append((item.id, item.actor_id, candidates))
+            elif key == ("scope", "grant") and item.resource_id:
+                probes.scope_grants.append((item.id, item.actor_id, item.resource_id))
+        return probes
+
+    async def _annotate_satisfaction_admin(
+        self, view: AccessRequestView, probes: _AdminSatisfactionProbes
+    ) -> None:
+        """Resolve the deferred admin-DB satisfaction probes onto the view.
+
+        Runs in its own admin session after the control session has closed (see
+        :class:`_AdminSatisfactionProbes`). Each probe's lookup key was fully
+        resolved on the control side, so this is pure existence checking.
+        """
+        if not probes.toolkit_binds and not probes.scope_grants:
+            return
+        item_views_by_id = {iv.id: iv for iv in view.items}
+        async with self._ctx.admin_db.session() as session:
+            for item_id, agent_id, toolkit_ids in probes.toolkit_binds:
+                item_views_by_id[
+                    item_id
+                ].already_satisfied = await PrerequisiteRepository.agent_bound_to_any_toolkit(
+                    session, agent_id=agent_id, toolkit_ids=toolkit_ids
+                )
+            for item_id, actor_id, scope in probes.scope_grants:
+                item_views_by_id[
+                    item_id
+                ].already_satisfied = await PrerequisiteRepository.actor_scope_grant_exists(
+                    session, actor_id=actor_id, scope=scope
+                )
 
     async def decide(
         self,

--- a/src/jentic_one/control/services/access_requests/service.py
+++ b/src/jentic_one/control/services/access_requests/service.py
@@ -12,6 +12,7 @@ import structlog
 from jentic_one.control.core.errors import DuplicatePendingItemError
 from jentic_one.control.core.schema.access_request_items import RULE_BEARING_COMBINATIONS
 from jentic_one.control.core.schema.access_requests import AccessRequest
+from jentic_one.control.core.schema.credentials import Credential
 from jentic_one.control.repos.access_request_repo import AccessRequestRepository
 from jentic_one.control.repos.credential_repo import CredentialRepository
 from jentic_one.control.repos.effects_repo import EffectsRepository
@@ -112,8 +113,10 @@ class _AdminSatisfactionProbes:
     already-resolved lookup key.
     """
 
-    # (item_id, agent_id, candidate toolkit ids) — satisfied if bound to any.
-    toolkit_binds: list[tuple[str, str, list[str]]] = field(default_factory=list)
+    # (item_id, agent_id, toolkit_id) — satisfied if the agent is bound to it.
+    # Always a single resolved toolkit: explicit ids probe directly, and
+    # ambiguous references are left un-annotated (see the annotator).
+    toolkit_binds: list[tuple[str, str, str]] = field(default_factory=list)
     # (item_id, actor_id, scope) — satisfied if the grant row exists.
     scope_grants: list[tuple[str, str, str]] = field(default_factory=list)
 
@@ -549,6 +552,9 @@ class AccessRequestService:
         request: AccessRequest,
         *,
         identity: Identity,
+        # ``Any`` because the arch rule forbids sqlalchemy imports in control
+        # services (tests/arch/test_no_direct_db.py); the repos it's passed to
+        # type it as AsyncSession.
         session: Any,
     ) -> _AdminSatisfactionProbes:
         """Stamp control-DB ``already_satisfied`` hints; collect admin-DB probes.
@@ -561,11 +567,20 @@ class AccessRequestService:
 
         Only PENDING effect items are annotated. Everything else stays ``None``
         (not computed): decided items, fulfilment-only intents (their outcome is
-        the downstream binds'), and items whose target is indeterminate (a
-        target-less credential:bind, a vendor-less toolkit reference). A
-        reference that resolves to no toolkit visible to the caller is
-        determinately False — resolution runs under the caller's owner scope,
-        the same scope decide-time resolution would use.
+        the downstream binds'), items whose target is indeterminate (a
+        target-less credential:bind, a vendor-less toolkit reference), an
+        ambiguous toolkit reference (decide-time resolution would refuse it, so
+        a hint would advertise an approval that cannot succeed), and a
+        credential:bind whose credential the caller cannot see (mirrors
+        decide-time validation — and keeps the probe from acting as a
+        binding-existence oracle for amended-in foreign ids). A reference that
+        resolves to no toolkit visible to the caller is determinately False —
+        resolution runs under the caller's owner scope, the same scope
+        decide-time resolution would use.
+
+        When a ``toolkit:bind`` is satisfied, ``already_satisfied_by`` names the
+        toolkit that satisfies it so consumers can point the operator at the
+        exact object instead of a bare boolean.
 
         Control-DB checks (credential bindings, reference resolution) run on the
         caller's ``session``; admin-DB checks are returned as probes for
@@ -580,6 +595,18 @@ class AccessRequestService:
             key = (item.resource_type, item.action)
             if key == ("credential", "bind"):
                 if item.to_id and item.resource_id:
+                    # Same visibility gate as decide-time validation
+                    # (_validate_credential_bind_target): a credential the
+                    # caller can't see means approval would 422, and probing
+                    # past it would leak binding existence for arbitrary
+                    # amended-in ids.
+                    credential = await CredentialRepository.get_by_id(
+                        session,
+                        item.resource_id,
+                        filters=build_access_filters(identity, Credential),
+                    )
+                    if credential is None:
+                        continue
                     binding = await ToolkitBindingRepository.get(
                         session, item.to_id, item.resource_id
                     )
@@ -587,7 +614,7 @@ class AccessRequestService:
             elif key == ("toolkit", "bind"):
                 explicit_id = item.resource_id or item.to_id
                 if explicit_id:
-                    probes.toolkit_binds.append((item.id, item.actor_id, [explicit_id]))
+                    probes.toolkit_binds.append((item.id, item.actor_id, explicit_id))
                     continue
                 reference = item.resource_reference or {}
                 vendor = reference.get("vendor")
@@ -603,8 +630,12 @@ class AccessRequestService:
                 )
                 if not candidates:
                     item_view.already_satisfied = False
-                else:
-                    probes.toolkit_binds.append((item.id, item.actor_id, candidates))
+                elif len(candidates) == 1:
+                    probes.toolkit_binds.append((item.id, item.actor_id, candidates[0]))
+                # Several candidates: decide-time resolution would raise
+                # ToolkitReferenceAmbiguousError, so the item is not approvable
+                # as filed — leave the hint not-computed rather than advertise
+                # a satisfaction the operator can't act on.
             elif key == ("scope", "grant") and item.resource_id:
                 probes.scope_grants.append((item.id, item.actor_id, item.resource_id))
         return probes
@@ -622,16 +653,17 @@ class AccessRequestService:
             return
         item_views_by_id = {iv.id: iv for iv in view.items}
         async with self._ctx.admin_db.session() as session:
-            for item_id, agent_id, toolkit_ids in probes.toolkit_binds:
-                item_views_by_id[
-                    item_id
-                ].already_satisfied = await PrerequisiteRepository.agent_bound_to_any_toolkit(
-                    session, agent_id=agent_id, toolkit_ids=toolkit_ids
+            for item_id, agent_id, toolkit_id in probes.toolkit_binds:
+                item_view = item_views_by_id[item_id]
+                bound = await PrerequisiteRepository.agent_bound_to_any_toolkit(
+                    session, agent_id=agent_id, toolkit_ids=[toolkit_id]
                 )
+                item_view.already_satisfied = bound
+                if bound:
+                    item_view.already_satisfied_by = toolkit_id
             for item_id, actor_id, scope in probes.scope_grants:
-                item_views_by_id[
-                    item_id
-                ].already_satisfied = await PrerequisiteRepository.actor_scope_grant_exists(
+                item_view = item_views_by_id[item_id]
+                item_view.already_satisfied = await PrerequisiteRepository.actor_scope_grant_exists(
                     session, actor_id=actor_id, scope=scope
                 )
 

--- a/src/jentic_one/control/web/routers/access_requests.py
+++ b/src/jentic_one/control/web/routers/access_requests.py
@@ -46,6 +46,7 @@ def _to_item_response(item: AccessRequestItemView) -> AccessRequestItemResponse:
         decided_by=item.decided_by,
         decided_at=item.decided_at,
         decision_reason=item.decision_reason,
+        already_satisfied=item.already_satisfied,
     )
 
 

--- a/src/jentic_one/control/web/routers/access_requests.py
+++ b/src/jentic_one/control/web/routers/access_requests.py
@@ -47,6 +47,7 @@ def _to_item_response(item: AccessRequestItemView) -> AccessRequestItemResponse:
         decided_at=item.decided_at,
         decision_reason=item.decision_reason,
         already_satisfied=item.already_satisfied,
+        already_satisfied_by=item.already_satisfied_by,
     )
 
 

--- a/src/jentic_one/control/web/schemas/access_requests.py
+++ b/src/jentic_one/control/web/schemas/access_requests.py
@@ -147,11 +147,23 @@ class AccessRequestItemResponse(BaseModel):
             "manually-fulfilled work instead of re-doing it in the wizard. "
             "Populated on single-request GETs for pending credential:bind, "
             "toolkit:bind, and scope:grant items; null when not computed "
-            "(list endpoints, decided items, fulfilment-only intents, or an "
-            "item whose target cannot be determined). Toolkit REFERENCES are "
-            "resolved under the caller's visibility, mirroring decide-time "
-            "resolution, so False can also mean 'satisfied by a toolkit this "
-            "caller cannot see'; explicit-id targets are probed directly."
+            "(list endpoints, decided items, fulfilment-only intents, an item "
+            "whose target cannot be determined, an ambiguous toolkit "
+            "reference — which approval would refuse as filed — or a "
+            "credential:bind whose credential is not visible to the caller). "
+            "Toolkit REFERENCES are resolved under the caller's visibility, "
+            "mirroring decide-time resolution, so False can also mean "
+            "'satisfied by a toolkit this caller cannot see'; explicit-id "
+            "targets are probed directly."
+        ),
+    )
+    already_satisfied_by: str | None = Field(
+        default=None,
+        description=(
+            "For a satisfied toolkit:bind, the id of the toolkit the agent is "
+            "already bound to — names the exact object so consumers can point "
+            "the operator at it. Null for other item types and whenever "
+            "already_satisfied is not true."
         ),
     )
 

--- a/src/jentic_one/control/web/schemas/access_requests.py
+++ b/src/jentic_one/control/web/schemas/access_requests.py
@@ -148,9 +148,10 @@ class AccessRequestItemResponse(BaseModel):
             "Populated on single-request GETs for pending credential:bind, "
             "toolkit:bind, and scope:grant items; null when not computed "
             "(list endpoints, decided items, fulfilment-only intents, or an "
-            "item whose target cannot be determined). Toolkit references are "
+            "item whose target cannot be determined). Toolkit REFERENCES are "
             "resolved under the caller's visibility, mirroring decide-time "
-            "resolution."
+            "resolution, so False can also mean 'satisfied by a toolkit this "
+            "caller cannot see'; explicit-id targets are probed directly."
         ),
     )
 

--- a/src/jentic_one/control/web/schemas/access_requests.py
+++ b/src/jentic_one/control/web/schemas/access_requests.py
@@ -139,6 +139,20 @@ class AccessRequestItemResponse(BaseModel):
     decided_by: str | None = None
     decided_at: dt.datetime | None = None
     decision_reason: str | None = None
+    already_satisfied: bool | None = Field(
+        default=None,
+        description=(
+            "Whether this item's outcome is already in effect (the binding or "
+            "grant it asks for already exists), letting a reviewer approve "
+            "manually-fulfilled work instead of re-doing it in the wizard. "
+            "Populated on single-request GETs for pending credential:bind, "
+            "toolkit:bind, and scope:grant items; null when not computed "
+            "(list endpoints, decided items, fulfilment-only intents, or an "
+            "item whose target cannot be determined). Toolkit references are "
+            "resolved under the caller's visibility, mirroring decide-time "
+            "resolution."
+        ),
+    )
 
 
 class EvaluationCheckResponse(BaseModel):

--- a/tests/integration/control/test_prerequisite_satisfaction.py
+++ b/tests/integration/control/test_prerequisite_satisfaction.py
@@ -1,0 +1,106 @@
+"""Integration tests for the satisfaction predicates on ``PrerequisiteRepository``.
+
+These back the ``already_satisfied`` enrichment on single-request GETs (issue
+#826): ``agent_bound_to_any_toolkit`` answers "is this toolkit:bind's outcome
+already in effect for any candidate the reference resolved to?", and
+``actor_scope_grant_exists`` mirrors the uniqueness key of the idempotent
+scope-grant effect. Both run against a real admin DB.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy import text
+
+from jentic_one.control.repos.prerequisite_repo import PrerequisiteRepository
+from jentic_one.shared.db.session import DatabaseSession
+
+pytestmark = pytest.mark.integration
+
+_AGENT_ID = "agnt_satisfaction_test"
+_OWNER_ID = "usr_satisfaction_owner"
+
+
+@pytest.fixture()
+async def seed_admin_rows(admin_db: DatabaseSession) -> AsyncGenerator[None, None]:
+    """Seed an agent bound to one toolkit and holding one scope grant."""
+
+    async def _cleanup() -> None:
+        async with admin_db.session() as session:
+            await session.execute(
+                text("DELETE FROM actor_scope_grants WHERE actor_id = :aid"),
+                {"aid": _AGENT_ID},
+            )
+            await session.execute(
+                text("DELETE FROM agent_toolkit_bindings WHERE agent_id = :aid"),
+                {"aid": _AGENT_ID},
+            )
+            await session.execute(text("DELETE FROM agents WHERE id = :aid"), {"aid": _AGENT_ID})
+            await session.commit()
+
+    await _cleanup()
+    async with admin_db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO agents (id, name, registered_by, status) "
+                "VALUES (:id, 'satisfaction-test-agent', :owner, 'active')"
+            ),
+            {"id": _AGENT_ID, "owner": _OWNER_ID},
+        )
+        await session.execute(
+            text(
+                "INSERT INTO agent_toolkit_bindings (id, agent_id, toolkit_id) "
+                "VALUES ('atb_satisfaction_1', :aid, 'tk_satisfaction_bound')"
+            ),
+            {"aid": _AGENT_ID},
+        )
+        await session.execute(
+            text(
+                "INSERT INTO actor_scope_grants (id, actor_id, actor_type, scope, granted_by) "
+                "VALUES ('asg_satisfaction_1', :aid, 'agent', 'apis:write', :owner)"
+            ),
+            {"aid": _AGENT_ID, "owner": _OWNER_ID},
+        )
+        await session.commit()
+    yield
+    await _cleanup()
+
+
+async def test_agent_bound_to_any_toolkit(admin_db: DatabaseSession, seed_admin_rows: None) -> None:
+    """Bound to any candidate → True; disjoint candidates → False; empty → False."""
+    async with admin_db.session() as session:
+        assert await PrerequisiteRepository.agent_bound_to_any_toolkit(
+            session, agent_id=_AGENT_ID, toolkit_ids=["tk_satisfaction_bound"]
+        )
+        # A multi-candidate probe (an ambiguous reference) matches on any hit.
+        assert await PrerequisiteRepository.agent_bound_to_any_toolkit(
+            session,
+            agent_id=_AGENT_ID,
+            toolkit_ids=["tk_satisfaction_other", "tk_satisfaction_bound"],
+        )
+        assert not await PrerequisiteRepository.agent_bound_to_any_toolkit(
+            session, agent_id=_AGENT_ID, toolkit_ids=["tk_satisfaction_other"]
+        )
+        # Empty candidate list short-circuits without querying.
+        assert not await PrerequisiteRepository.agent_bound_to_any_toolkit(
+            session, agent_id=_AGENT_ID, toolkit_ids=[]
+        )
+        assert not await PrerequisiteRepository.agent_bound_to_any_toolkit(
+            session, agent_id="agnt_satisfaction_absent", toolkit_ids=["tk_satisfaction_bound"]
+        )
+
+
+async def test_actor_scope_grant_exists(admin_db: DatabaseSession, seed_admin_rows: None) -> None:
+    """Exists exactly when the (actor_id, scope) grant row does."""
+    async with admin_db.session() as session:
+        assert await PrerequisiteRepository.actor_scope_grant_exists(
+            session, actor_id=_AGENT_ID, scope="apis:write"
+        )
+        assert not await PrerequisiteRepository.actor_scope_grant_exists(
+            session, actor_id=_AGENT_ID, scope="capabilities:execute"
+        )
+        assert not await PrerequisiteRepository.actor_scope_grant_exists(
+            session, actor_id="agnt_satisfaction_absent", scope="apis:write"
+        )

--- a/tests/web/control/test_access_requests.py
+++ b/tests/web/control/test_access_requests.py
@@ -283,6 +283,162 @@ def test_get_not_found_returns_404(filer_client: TestClient) -> None:
     assert resp.json()["type"] == "access_request_not_found"
 
 
+# --- already_satisfied enrichment (issue #826) ---
+
+
+async def test_credential_bind_already_satisfied_flips_on_manual_binding(
+    filer_client: TestClient, web_context: Context
+) -> None:
+    """A pending credential:bind flips False → True once the binding exists.
+
+    The manual-fulfilment loop: an operator binds the credential by hand
+    (outside the wizard), and the request's GET now reports the item as
+    already in effect so the reviewer can approve instead of re-doing it.
+    List pages skip the enrichment (null) by design.
+    """
+    data = _file_request(filer_client)  # credential:bind cred_001 → tk_target
+    got = filer_client.get(f"/access-requests/{data['id']}").json()
+    assert got["items"][0]["already_satisfied"] is False
+
+    listed = filer_client.get("/access-requests").json()["data"][0]
+    assert listed["items"][0]["already_satisfied"] is None
+
+    async with web_context.control_db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO toolkit_credential_bindings (id, toolkit_id, credential_id) "
+                "VALUES ('tcb_webtest_sat', 'tk_target', 'cred_001') ON CONFLICT DO NOTHING"
+            )
+        )
+        await session.commit()
+    # seed_binding's teardown removes tk_target's bindings, so no local cleanup.
+    got = filer_client.get(f"/access-requests/{data['id']}").json()
+    assert got["items"][0]["already_satisfied"] is True
+
+
+def test_toolkit_bind_already_satisfied_and_null_once_decided(
+    filer_client: TestClient, owner_client: TestClient
+) -> None:
+    """A toolkit:bind whose agent↔toolkit binding already exists reports True;
+    once decided the hint is no longer computed (null)."""
+    # seed_binding already binds FILER_SUB to tk_target in the admin DB.
+    filed = filer_client.post(
+        "/access-requests",
+        json={
+            "items": [{"resource_type": "toolkit", "action": "bind", "resource_id": "tk_target"}]
+        },
+    )
+    assert filed.status_code == 202, filed.text
+    request_id = filed.json()["id"]
+    item_id = filed.json()["items"][0]["id"]
+
+    got = filer_client.get(f"/access-requests/{request_id}").json()
+    assert got["items"][0]["already_satisfied"] is True
+
+    decided = owner_client.post(
+        f"/access-requests/{request_id}:decide",
+        json={"items": [{"item_id": item_id, "decision": "approved"}]},
+    )
+    assert decided.status_code == 200, decided.text
+    got = filer_client.get(f"/access-requests/{request_id}").json()
+    assert got["items"][0]["status"] == "approved"
+    assert got["items"][0]["already_satisfied"] is None
+
+
+async def test_toolkit_bind_by_reference_already_satisfied(
+    filer_client: TestClient, owner_client: TestClient, web_context: Context
+) -> None:
+    """A reference-only toolkit:bind resolves under the viewer's scope and
+    reports True when the agent is already bound to a resolved toolkit."""
+    # Bind a canonical-vendor credential to tk_target so the reference resolves
+    # (seed_binding's cred_001 carries a raw, unslugged vendor on purpose).
+    async with web_context.control_db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO credentials (id, type, name, api_vendor, created_by) "
+                "VALUES ('cred_refsat', 'token_value', 'cred-refsat', 'webtest-refsat', :owner) "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"owner": OWNER_SUB},
+        )
+        await session.execute(
+            text(
+                "INSERT INTO toolkit_credential_bindings (id, toolkit_id, credential_id) "
+                "VALUES ('tcb_refsat', 'tk_target', 'cred_refsat') ON CONFLICT DO NOTHING"
+            )
+        )
+        await session.commit()
+    try:
+        filed = filer_client.post(
+            "/access-requests",
+            json={
+                "items": [
+                    {
+                        "resource_type": "toolkit",
+                        "action": "bind",
+                        "resource_reference": {"vendor": "webtest-refsat"},
+                    }
+                ]
+            },
+        )
+        assert filed.status_code == 202, filed.text
+        request_id = filed.json()["id"]
+
+        # The owner sees tk_target (they own it): the reference resolves to it
+        # and the agent is already bound → True.
+        got = owner_client.get(f"/access-requests/{request_id}").json()
+        assert got["items"][0]["already_satisfied"] is True
+
+        # The filer agent (no owner:toolkits:read delegation) can't see any
+        # toolkit serving the API — determinately unsatisfied under ITS scope.
+        got = filer_client.get(f"/access-requests/{request_id}").json()
+        assert got["items"][0]["already_satisfied"] is False
+    finally:
+        async with web_context.control_db.session() as session:
+            await session.execute(
+                text("DELETE FROM toolkit_credential_bindings WHERE id = 'tcb_refsat'")
+            )
+            await session.execute(text("DELETE FROM credentials WHERE id = 'cred_refsat'"))
+            await session.commit()
+
+
+async def test_scope_grant_already_satisfied_flips_on_manual_grant(
+    filer_client: TestClient, web_context: Context
+) -> None:
+    """A pending scope:grant flips False → True once the actor holds the scope."""
+    filed = filer_client.post(
+        "/access-requests",
+        json={
+            "items": [{"resource_type": "scope", "action": "grant", "resource_id": "apis:write"}]
+        },
+    )
+    assert filed.status_code == 202, filed.text
+    request_id = filed.json()["id"]
+
+    got = filer_client.get(f"/access-requests/{request_id}").json()
+    assert got["items"][0]["already_satisfied"] is False
+
+    try:
+        async with web_context.admin_db.session() as session:
+            await session.execute(
+                text(
+                    "INSERT INTO actor_scope_grants (id, actor_id, actor_type, scope, granted_by) "
+                    "VALUES ('asg_webtest_sat', :actor, 'agent', 'apis:write', :granted_by) "
+                    "ON CONFLICT DO NOTHING"
+                ),
+                {"actor": FILER_SUB, "granted_by": OWNER_SUB},
+            )
+            await session.commit()
+        got = filer_client.get(f"/access-requests/{request_id}").json()
+        assert got["items"][0]["already_satisfied"] is True
+    finally:
+        async with web_context.admin_db.session() as session:
+            await session.execute(
+                text("DELETE FROM actor_scope_grants WHERE id = 'asg_webtest_sat'")
+            )
+            await session.commit()
+
+
 # --- Decide ---
 
 

--- a/tests/web/control/test_access_requests.py
+++ b/tests/web/control/test_access_requests.py
@@ -287,20 +287,27 @@ def test_get_not_found_returns_404(filer_client: TestClient) -> None:
 
 
 async def test_credential_bind_already_satisfied_flips_on_manual_binding(
-    filer_client: TestClient, web_context: Context
+    filer_client: TestClient, owner_client: TestClient, web_context: Context
 ) -> None:
     """A pending credential:bind flips False → True once the binding exists.
 
     The manual-fulfilment loop: an operator binds the credential by hand
     (outside the wizard), and the request's GET now reports the item as
     already in effect so the reviewer can approve instead of re-doing it.
-    List pages skip the enrichment (null) by design.
+    List pages skip the enrichment (null) by design, and a viewer who cannot
+    see the credential gets no hint at all (null) — the probe mirrors
+    decide-time credential visibility so it can't be used as a
+    binding-existence oracle for amended-in foreign ids.
     """
     data = _file_request(filer_client)  # credential:bind cred_001 → tk_target
-    got = filer_client.get(f"/access-requests/{data['id']}").json()
+    got = owner_client.get(f"/access-requests/{data['id']}").json()
     assert got["items"][0]["already_satisfied"] is False
 
-    listed = filer_client.get("/access-requests").json()["data"][0]
+    # The filer agent doesn't own cred_001 → hint not computed for it.
+    got = filer_client.get(f"/access-requests/{data['id']}").json()
+    assert got["items"][0]["already_satisfied"] is None
+
+    listed = owner_client.get("/access-requests").json()["data"][0]
     assert listed["items"][0]["already_satisfied"] is None
 
     async with web_context.control_db.session() as session:
@@ -312,7 +319,7 @@ async def test_credential_bind_already_satisfied_flips_on_manual_binding(
         )
         await session.commit()
     # seed_binding's teardown removes tk_target's bindings, so no local cleanup.
-    got = filer_client.get(f"/access-requests/{data['id']}").json()
+    got = owner_client.get(f"/access-requests/{data['id']}").json()
     assert got["items"][0]["already_satisfied"] is True
 
 
@@ -334,6 +341,8 @@ def test_toolkit_bind_already_satisfied_and_null_once_decided(
 
     got = filer_client.get(f"/access-requests/{request_id}").json()
     assert got["items"][0]["already_satisfied"] is True
+    # The satisfying toolkit is named so consumers can point at the object.
+    assert got["items"][0]["already_satisfied_by"] == "tk_target"
 
     decided = owner_client.post(
         f"/access-requests/{request_id}:decide",
@@ -343,6 +352,7 @@ def test_toolkit_bind_already_satisfied_and_null_once_decided(
     got = filer_client.get(f"/access-requests/{request_id}").json()
     assert got["items"][0]["status"] == "approved"
     assert got["items"][0]["already_satisfied"] is None
+    assert got["items"][0]["already_satisfied_by"] is None
 
 
 async def test_toolkit_bind_by_reference_already_satisfied(
@@ -385,20 +395,130 @@ async def test_toolkit_bind_by_reference_already_satisfied(
         request_id = filed.json()["id"]
 
         # The owner sees tk_target (they own it): the reference resolves to it
-        # and the agent is already bound → True.
+        # and the agent is already bound → True, naming the toolkit.
         got = owner_client.get(f"/access-requests/{request_id}").json()
         assert got["items"][0]["already_satisfied"] is True
+        assert got["items"][0]["already_satisfied_by"] == "tk_target"
 
         # The filer agent (no owner:toolkits:read delegation) can't see any
         # toolkit serving the API — determinately unsatisfied under ITS scope.
         got = filer_client.get(f"/access-requests/{request_id}").json()
         assert got["items"][0]["already_satisfied"] is False
+        assert got["items"][0]["already_satisfied_by"] is None
     finally:
         async with web_context.control_db.session() as session:
             await session.execute(
                 text("DELETE FROM toolkit_credential_bindings WHERE id = 'tcb_refsat'")
             )
             await session.execute(text("DELETE FROM credentials WHERE id = 'cred_refsat'"))
+            await session.commit()
+
+
+async def test_toolkit_bind_raw_vendor_reference_is_slugified(
+    filer_client: TestClient, owner_client: TestClient, web_context: Context
+) -> None:
+    """A reference filed with a raw vendor still resolves: the annotator
+    slugifies it before matching the canonical (slugified-on-write) rows."""
+    async with web_context.control_db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO credentials (id, type, name, api_vendor, created_by) "
+                "VALUES ('cred_rawsat', 'token_value', 'cred-rawsat', 'webtest-rawsat', :owner) "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"owner": OWNER_SUB},
+        )
+        await session.execute(
+            text(
+                "INSERT INTO toolkit_credential_bindings (id, toolkit_id, credential_id) "
+                "VALUES ('tcb_rawsat', 'tk_target', 'cred_rawsat') ON CONFLICT DO NOTHING"
+            )
+        )
+        await session.commit()
+    try:
+        filed = filer_client.post(
+            "/access-requests",
+            json={
+                "items": [
+                    {
+                        "resource_type": "toolkit",
+                        "action": "bind",
+                        # Raw, unslugged — as agents actually file them.
+                        "resource_reference": {"vendor": "Webtest.Rawsat"},
+                    }
+                ]
+            },
+        )
+        assert filed.status_code == 202, filed.text
+        got = owner_client.get(f"/access-requests/{filed.json()['id']}").json()
+        assert got["items"][0]["already_satisfied"] is True
+        assert got["items"][0]["already_satisfied_by"] == "tk_target"
+    finally:
+        async with web_context.control_db.session() as session:
+            await session.execute(
+                text("DELETE FROM toolkit_credential_bindings WHERE id = 'tcb_rawsat'")
+            )
+            await session.execute(text("DELETE FROM credentials WHERE id = 'cred_rawsat'"))
+            await session.commit()
+
+
+async def test_toolkit_bind_ambiguous_reference_not_annotated(
+    filer_client: TestClient, owner_client: TestClient, web_context: Context
+) -> None:
+    """A reference resolving to several toolkits stays null: decide-time
+    resolution would refuse it (ToolkitReferenceAmbiguousError), so a hint
+    would advertise an approval that cannot succeed as filed."""
+    async with web_context.control_db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO credentials (id, type, name, api_vendor, created_by) "
+                "VALUES ('cred_ambsat', 'token_value', 'cred-ambsat', 'webtest-ambsat', :owner) "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"owner": OWNER_SUB},
+        )
+        await session.execute(
+            text(
+                "INSERT INTO toolkits (id, name, created_by) "
+                "VALUES ('tk_ambsat_2', 'ambsat-second', :owner) ON CONFLICT DO NOTHING"
+            ),
+            {"owner": OWNER_SUB},
+        )
+        await session.execute(
+            text(
+                "INSERT INTO toolkit_credential_bindings (id, toolkit_id, credential_id) VALUES "
+                "('tcb_ambsat_1', 'tk_target', 'cred_ambsat'), "
+                "('tcb_ambsat_2', 'tk_ambsat_2', 'cred_ambsat') ON CONFLICT DO NOTHING"
+            )
+        )
+        await session.commit()
+    try:
+        filed = filer_client.post(
+            "/access-requests",
+            json={
+                "items": [
+                    {
+                        "resource_type": "toolkit",
+                        "action": "bind",
+                        "resource_reference": {"vendor": "webtest-ambsat"},
+                    }
+                ]
+            },
+        )
+        assert filed.status_code == 202, filed.text
+        got = owner_client.get(f"/access-requests/{filed.json()['id']}").json()
+        assert got["items"][0]["already_satisfied"] is None
+        assert got["items"][0]["already_satisfied_by"] is None
+    finally:
+        async with web_context.control_db.session() as session:
+            await session.execute(
+                text(
+                    "DELETE FROM toolkit_credential_bindings "
+                    "WHERE id IN ('tcb_ambsat_1', 'tcb_ambsat_2')"
+                )
+            )
+            await session.execute(text("DELETE FROM toolkits WHERE id = 'tk_ambsat_2'"))
+            await session.execute(text("DELETE FROM credentials WHERE id = 'cred_ambsat'"))
             await session.commit()
 
 

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -175,6 +175,18 @@
             "title": "Action",
             "type": "string"
           },
+          "already_satisfied": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, or an item whose target cannot be determined). Toolkit references are resolved under the caller's visibility, mirroring decide-time resolution.",
+            "title": "Already Satisfied"
+          },
           "applied_effects": {
             "anyOf": [
               {

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -184,8 +184,20 @@
                 "type": "null"
               }
             ],
-            "description": "Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, or an item whose target cannot be determined). Toolkit REFERENCES are resolved under the caller's visibility, mirroring decide-time resolution, so False can also mean 'satisfied by a toolkit this caller cannot see'; explicit-id targets are probed directly.",
+            "description": "Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, an item whose target cannot be determined, an ambiguous toolkit reference — which approval would refuse as filed — or a credential:bind whose credential is not visible to the caller). Toolkit REFERENCES are resolved under the caller's visibility, mirroring decide-time resolution, so False can also mean 'satisfied by a toolkit this caller cannot see'; explicit-id targets are probed directly.",
             "title": "Already Satisfied"
+          },
+          "already_satisfied_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "For a satisfied toolkit:bind, the id of the toolkit the agent is already bound to — names the exact object so consumers can point the operator at it. Null for other item types and whenever already_satisfied is not true.",
+            "title": "Already Satisfied By"
           },
           "applied_effects": {
             "anyOf": [

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -184,7 +184,7 @@
                 "type": "null"
               }
             ],
-            "description": "Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, or an item whose target cannot be determined). Toolkit references are resolved under the caller's visibility, mirroring decide-time resolution.",
+            "description": "Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, or an item whose target cannot be determined). Toolkit REFERENCES are resolved under the caller's visibility, mirroring decide-time resolution, so False can also mean 'satisfied by a toolkit this caller cannot see'; explicit-id targets are probed directly.",
             "title": "Already Satisfied"
           },
           "applied_effects": {

--- a/ui/src/modules/toolkits/components/ToolkitDetailBody.tsx
+++ b/ui/src/modules/toolkits/components/ToolkitDetailBody.tsx
@@ -8,9 +8,10 @@ import {
 	Settings,
 	ShieldCheck,
 	ShieldOff,
+	Unplug,
 } from 'lucide-react';
 import { Button, EmptyState, TabNav } from '@/shared/ui';
-import { useToolkit } from '@/modules/toolkits/api';
+import { useToolkit, useToolkitAgents } from '@/modules/toolkits/api';
 import { OverviewTab } from '@/modules/toolkits/components/detail/OverviewTab';
 import { ActivityTab } from '@/modules/toolkits/components/detail/ActivityTab';
 import { AccessTab } from '@/modules/toolkits/components/detail/AccessTab';
@@ -63,6 +64,9 @@ export interface ToolkitDetailBodyProps {
 
 export function ToolkitDetailBody({ toolkitId, onRequestClose }: ToolkitDetailBodyProps) {
 	const { data: toolkit, isLoading } = useToolkit(toolkitId);
+	// Shares the Overview tab's query cache (same key), so this costs nothing
+	// extra when Overview is the active tab.
+	const { data: boundAgents } = useToolkitAgents(toolkitId);
 
 	const [searchParams, setSearchParams] = useSearchParams();
 	const tabParam = searchParams.get('tab');
@@ -109,6 +113,16 @@ export function ToolkitDetailBody({ toolkitId, onRequestClose }: ToolkitDetailBo
 		);
 
 	const suspended = !toolkit.active;
+	// A toolkit with credentials but NO bound agent serves nothing: this is the
+	// classic manual-setup dead end (issue #826) — the operator created the
+	// toolkit and bound a credential but never linked the agent, so every call
+	// still fails. Surface it inline rather than letting them discover it via
+	// an agent's 403. Suppressed while suspended (the danger banner owns that
+	// state) and until the agents query resolves (no flash on load).
+	const unservedCredentials =
+		!suspended && toolkit.credential_count > 0 && boundAgents !== undefined
+			? boundAgents.length === 0
+			: false;
 
 	const tabOptions = [
 		{
@@ -157,6 +171,42 @@ export function ToolkitDetailBody({ toolkitId, onRequestClose }: ToolkitDetailBo
 									callers. Restore access with the kill switch above.
 								</p>
 							</div>
+						</div>
+					</motion.div>
+				)}
+			</AnimatePresence>
+
+			<AnimatePresence initial={false}>
+				{unservedCredentials && (
+					<motion.div key="no-agents-banner" {...panelMotion} className="overflow-hidden">
+						<div
+							className="border-warning/40 bg-warning/5 flex items-start gap-3 rounded-xl border p-4"
+							role="status"
+							data-testid="toolkit-no-agents-banner"
+						>
+							<div className="bg-warning/15 text-warning flex h-9 w-9 shrink-0 items-center justify-center rounded-lg">
+								<Unplug className="h-5 w-5" />
+							</div>
+							<div className="min-w-0 flex-1">
+								<p className="text-warning font-heading text-sm font-semibold">
+									No agent is linked to this toolkit
+								</p>
+								<p className="text-muted-foreground mt-0.5 text-sm">
+									Its bound credential
+									{toolkit.credential_count === 1 ? ' is' : 's are'} not reachable
+									by any agent yet — link an agent from the Overview tab to put{' '}
+									{toolkit.credential_count === 1 ? 'it' : 'them'} to use.
+								</p>
+							</div>
+							{activeTab !== 'overview' && (
+								<Button
+									variant="secondary"
+									size="sm"
+									onClick={() => setTab('overview')}
+								>
+									Go to Overview
+								</Button>
+							)}
 						</div>
 					</motion.div>
 				)}

--- a/ui/src/modules/toolkits/components/ToolkitDetailBody.tsx
+++ b/ui/src/modules/toolkits/components/ToolkitDetailBody.tsx
@@ -118,11 +118,15 @@ export function ToolkitDetailBody({ toolkitId, onRequestClose }: ToolkitDetailBo
 	// toolkit and bound a credential but never linked the agent, so every call
 	// still fails. Surface it inline rather than letting them discover it via
 	// an agent's 403. Suppressed while suspended (the danger banner owns that
-	// state) and until the agents query resolves (no flash on load).
-	const unservedCredentials =
-		!suspended && toolkit.credential_count > 0 && boundAgents !== undefined
-			? boundAgents.length === 0
-			: false;
+	// state), until the agents query resolves (no flash on load), and when the
+	// toolkit has API keys — key callers reach the credentials fine, so
+	// "serves nothing" would be false.
+	const hasUnservedCredentials =
+		!suspended &&
+		toolkit.credential_count > 0 &&
+		toolkit.key_count === 0 &&
+		boundAgents !== undefined &&
+		boundAgents.length === 0;
 
 	const tabOptions = [
 		{
@@ -177,7 +181,7 @@ export function ToolkitDetailBody({ toolkitId, onRequestClose }: ToolkitDetailBo
 			</AnimatePresence>
 
 			<AnimatePresence initial={false}>
-				{unservedCredentials && (
+				{hasUnservedCredentials && (
 					<motion.div key="no-agents-banner" {...panelMotion} className="overflow-hidden">
 						<div
 							className="border-warning/40 bg-warning/5 flex items-start gap-3 rounded-xl border p-4"
@@ -194,8 +198,9 @@ export function ToolkitDetailBody({ toolkitId, onRequestClose }: ToolkitDetailBo
 								<p className="text-muted-foreground mt-0.5 text-sm">
 									Its bound credential
 									{toolkit.credential_count === 1 ? ' is' : 's are'} not reachable
-									by any agent yet — link an agent from the Overview tab to put{' '}
-									{toolkit.credential_count === 1 ? 'it' : 'them'} to use.
+									by any agent yet — link an agent{' '}
+									{activeTab === 'overview' ? 'below' : 'from the Overview tab'}{' '}
+									to put {toolkit.credential_count === 1 ? 'it' : 'them'} to use.
 								</p>
 							</div>
 							{activeTab !== 'overview' && (

--- a/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
+++ b/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
@@ -847,8 +847,28 @@ describe('ToolkitDetailPage', () => {
 });
 
 describe('ToolkitDetailPage — no-linked-agents banner', () => {
+	/** The default tk_demo_github handler carries key_count: 1 — override to a
+	 *  keys-less toolkit so the credential-dead-end condition can fire. */
+	function stubKeylessToolkit(credentialCount = 1) {
+		worker.use(
+			http.get('/toolkits/:toolkitId', () =>
+				HttpResponse.json({
+					toolkit_id: 'tk_demo_github',
+					name: 'GitHub Tools',
+					description: null,
+					active: true,
+					created_by: 'admin@local',
+					created_at: '2026-05-01T10:00:00Z',
+					updated_at: null,
+					credential_count: credentialCount,
+					key_count: 0,
+				}),
+			),
+		);
+	}
+
 	it('warns when credentials are bound but no agent is linked', async () => {
-		// tk_demo_github carries credential_count: 1; strip its bound agents.
+		stubKeylessToolkit();
 		seedAgents({ bound: [], workspace: [] });
 		const { container } = renderWithProviders(<ToolkitDetailPage />, {
 			route: ROUTE,
@@ -862,6 +882,7 @@ describe('ToolkitDetailPage — no-linked-agents banner', () => {
 	});
 
 	it('shows no banner when an agent is bound', async () => {
+		stubKeylessToolkit();
 		// Default handlers bind Support Bot to tk_demo_github.
 		renderWithProviders(<ToolkitDetailPage />, { route: ROUTE, path: PATH });
 		await screen.findByRole('heading', { name: 'GitHub Tools' });
@@ -872,29 +893,30 @@ describe('ToolkitDetailPage — no-linked-agents banner', () => {
 		expect(screen.queryByTestId('toolkit-no-agents-banner')).not.toBeInTheDocument();
 	});
 
-	it('shows no banner when the toolkit has no credentials to serve', async () => {
-		worker.use(
-			http.get('/toolkits/:toolkitId', () =>
-				HttpResponse.json({
-					toolkit_id: 'tk_demo_github',
-					name: 'GitHub Tools',
-					description: null,
-					active: true,
-					created_by: 'admin@local',
-					created_at: '2026-05-01T10:00:00Z',
-					updated_at: null,
-					credential_count: 0,
-					key_count: 0,
-				}),
-			),
-		);
+	it('shows no banner when the toolkit has API keys to serve the credentials', async () => {
+		// Default handler: credential_count 1, key_count 1 — key callers reach
+		// the credentials fine, so there is no dead end to warn about.
 		seedAgents({ bound: [], workspace: [] });
 		renderWithProviders(<ToolkitDetailPage />, { route: ROUTE, path: PATH });
 		await screen.findByRole('heading', { name: 'GitHub Tools' });
 
-		// An unbound, credential-less toolkit is just new — nothing to warn about.
-		await waitFor(() =>
-			expect(screen.queryByTestId('toolkit-no-agents-banner')).not.toBeInTheDocument(),
-		);
+		// Settle the agents query first so the absence can't be a false pass
+		// on the not-yet-loaded suppression.
+		await screen.findByText(/no agents linked/i);
+		expect(screen.queryByTestId('toolkit-no-agents-banner')).not.toBeInTheDocument();
+	});
+
+	it('shows no banner when the toolkit has no credentials to serve', async () => {
+		stubKeylessToolkit(0);
+		seedAgents({ bound: [], workspace: [] });
+		renderWithProviders(<ToolkitDetailPage />, { route: ROUTE, path: PATH });
+		await screen.findByRole('heading', { name: 'GitHub Tools' });
+
+		// An unbound, credential-less toolkit is just new — nothing to warn
+		// about. Settle the agents query first: the banner is suppressed until
+		// it resolves, so asserting immediately would pass even if the logic
+		// regressed.
+		await screen.findByText(/no agents linked/i);
+		expect(screen.queryByTestId('toolkit-no-agents-banner')).not.toBeInTheDocument();
 	});
 });

--- a/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
+++ b/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
@@ -845,3 +845,56 @@ describe('ToolkitDetailPage', () => {
 		expect(screen.queryByRole('dialog', { name: /delete toolkit/i })).toBeInTheDocument();
 	});
 });
+
+describe('ToolkitDetailPage — no-linked-agents banner', () => {
+	it('warns when credentials are bound but no agent is linked', async () => {
+		// tk_demo_github carries credential_count: 1; strip its bound agents.
+		seedAgents({ bound: [], workspace: [] });
+		const { container } = renderWithProviders(<ToolkitDetailPage />, {
+			route: ROUTE,
+			path: PATH,
+		});
+		await screen.findByRole('heading', { name: 'GitHub Tools' });
+
+		const banner = await screen.findByTestId('toolkit-no-agents-banner');
+		expect(banner).toHaveTextContent(/no agent is linked to this toolkit/i);
+		await checkA11y(container);
+	});
+
+	it('shows no banner when an agent is bound', async () => {
+		// Default handlers bind Support Bot to tk_demo_github.
+		renderWithProviders(<ToolkitDetailPage />, { route: ROUTE, path: PATH });
+		await screen.findByRole('heading', { name: 'GitHub Tools' });
+
+		// Wait for the bound-agents query to resolve (Overview lists the agent)
+		// so the assertion isn't a false pass on the not-yet-loaded state.
+		await screen.findByText('Support Bot');
+		expect(screen.queryByTestId('toolkit-no-agents-banner')).not.toBeInTheDocument();
+	});
+
+	it('shows no banner when the toolkit has no credentials to serve', async () => {
+		worker.use(
+			http.get('/toolkits/:toolkitId', () =>
+				HttpResponse.json({
+					toolkit_id: 'tk_demo_github',
+					name: 'GitHub Tools',
+					description: null,
+					active: true,
+					created_by: 'admin@local',
+					created_at: '2026-05-01T10:00:00Z',
+					updated_at: null,
+					credential_count: 0,
+					key_count: 0,
+				}),
+			),
+		);
+		seedAgents({ bound: [], workspace: [] });
+		renderWithProviders(<ToolkitDetailPage />, { route: ROUTE, path: PATH });
+		await screen.findByRole('heading', { name: 'GitHub Tools' });
+
+		// An unbound, credential-less toolkit is just new — nothing to warn about.
+		await waitFor(() =>
+			expect(screen.queryByTestId('toolkit-no-agents-banner')).not.toBeInTheDocument(),
+		);
+	});
+});

--- a/ui/src/shared/api/generated/models/AccessRequestItemResponse.ts
+++ b/ui/src/shared/api/generated/models/AccessRequestItemResponse.ts
@@ -7,6 +7,10 @@
  */
 export type AccessRequestItemResponse = {
     action: string;
+    /**
+     * Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, or an item whose target cannot be determined). Toolkit references are resolved under the caller's visibility, mirroring decide-time resolution.
+     */
+    already_satisfied?: (boolean | null);
     applied_effects?: (Record<string, any> | null);
     credential_name?: (string | null);
     decided_at?: (string | null);

--- a/ui/src/shared/api/generated/models/AccessRequestItemResponse.ts
+++ b/ui/src/shared/api/generated/models/AccessRequestItemResponse.ts
@@ -8,9 +8,13 @@
 export type AccessRequestItemResponse = {
     action: string;
     /**
-     * Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, or an item whose target cannot be determined). Toolkit REFERENCES are resolved under the caller's visibility, mirroring decide-time resolution, so False can also mean 'satisfied by a toolkit this caller cannot see'; explicit-id targets are probed directly.
+     * Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, an item whose target cannot be determined, an ambiguous toolkit reference — which approval would refuse as filed — or a credential:bind whose credential is not visible to the caller). Toolkit REFERENCES are resolved under the caller's visibility, mirroring decide-time resolution, so False can also mean 'satisfied by a toolkit this caller cannot see'; explicit-id targets are probed directly.
      */
     already_satisfied?: (boolean | null);
+    /**
+     * For a satisfied toolkit:bind, the id of the toolkit the agent is already bound to — names the exact object so consumers can point the operator at it. Null for other item types and whenever already_satisfied is not true.
+     */
+    already_satisfied_by?: (string | null);
     applied_effects?: (Record<string, any> | null);
     credential_name?: (string | null);
     decided_at?: (string | null);

--- a/ui/src/shared/api/generated/models/AccessRequestItemResponse.ts
+++ b/ui/src/shared/api/generated/models/AccessRequestItemResponse.ts
@@ -8,7 +8,7 @@
 export type AccessRequestItemResponse = {
     action: string;
     /**
-     * Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, or an item whose target cannot be determined). Toolkit references are resolved under the caller's visibility, mirroring decide-time resolution.
+     * Whether this item's outcome is already in effect (the binding or grant it asks for already exists), letting a reviewer approve manually-fulfilled work instead of re-doing it in the wizard. Populated on single-request GETs for pending credential:bind, toolkit:bind, and scope:grant items; null when not computed (list endpoints, decided items, fulfilment-only intents, or an item whose target cannot be determined). Toolkit REFERENCES are resolved under the caller's visibility, mirroring decide-time resolution, so False can also mean 'satisfied by a toolkit this caller cannot see'; explicit-id targets are probed directly.
      */
     already_satisfied?: (boolean | null);
     applied_effects?: (Record<string, any> | null);

--- a/ui/src/shared/app/rail/ProvisioningRequestDialog.tsx
+++ b/ui/src/shared/app/rail/ProvisioningRequestDialog.tsx
@@ -72,6 +72,7 @@ import {
 	isPlanGranted,
 	planChains,
 	planDenialReason,
+	slugifyApiField,
 	type PlanApiReference,
 	type PlanChain,
 } from '@/shared/lib/provisioningPlan';
@@ -533,15 +534,17 @@ export function ProvisioningRequestDialog({
 
 	// The operator's existing toolkits, fetched lazily the first time a toolkit
 	// step is shown — they feed the "use an existing toolkit" picker so manual
-	// setups can be adopted instead of duplicated (issue #826). One page is
-	// plenty for a picker; empty (or failed) collapses the section entirely.
+	// setups can be adopted instead of duplicated (issue #826). Suspended
+	// toolkits are excluded (adopting one would wire the agent to a dead end).
+	// One page is plenty for a picker; empty (or failed) collapses the section
+	// entirely.
 	const [existingToolkits, setExistingToolkits] = useState<ToolkitResponse[] | null>(null);
 	useEffect(() => {
 		if (!open || step !== 'toolkit' || existingToolkits !== null) return;
 		let cancelled = false;
 		void ToolkitsService.listToolkits({ limit: 100 })
 			.then((res) => {
-				if (!cancelled) setExistingToolkits(res.data);
+				if (!cancelled) setExistingToolkits(res.data.filter((tk) => tk.active));
 			})
 			.catch(() => {
 				if (!cancelled) setExistingToolkits([]);
@@ -553,8 +556,10 @@ export function ProvisioningRequestDialog({
 
 	// Existing credentials for the CURRENT chain's API vendor, cached per
 	// vendor. Vendor-filtered server-side so the picker only offers
-	// credentials that can actually serve this chain.
-	const chainVendor = chain?.apiRef.vendor;
+	// credentials that can actually serve this chain — the filter is an exact
+	// match against slugified rows, so the raw filed vendor must be slugified
+	// first (issue #656's mismatch). Disabled credentials are excluded.
+	const chainVendor = chain ? slugifyApiField(chain.apiRef.vendor) : undefined;
 	const [existingCredentials, setExistingCredentials] = useState<
 		Record<string, CredentialRedactedResponse[]>
 	>({});
@@ -565,7 +570,10 @@ export function ProvisioningRequestDialog({
 		void CredentialsService.listCredentials({ vendor: chainVendor, limit: 100 })
 			.then((res) => {
 				if (!cancelled) {
-					setExistingCredentials((prev) => ({ ...prev, [chainVendor]: res.data }));
+					setExistingCredentials((prev) => ({
+						...prev,
+						[chainVendor]: res.data.filter((c) => c.active),
+					}));
 				}
 			})
 			.catch(() => {
@@ -610,7 +618,13 @@ export function ProvisioningRequestDialog({
 		});
 	}, [chain, chains, agentName, updateChain]);
 
-	/** Adopt an existing credential — already connected, so no connect flow. */
+	/**
+	 * Adopt an existing credential — reused as-is, no connect flow. The picker
+	 * only offers active credentials; whether an OAuth credential actually
+	 * completed its sign-in is not observable from the redacted listing, so
+	 * adoption trusts the operator's choice (a broken pick fails at execute
+	 * time, same as it would for the manual setup being adopted).
+	 */
 	const handleAdoptCredential = useCallback(
 		(credentialId: string) => {
 			const cred = chainCredentialOptions?.find((c) => c.credential_id === credentialId);
@@ -1274,11 +1288,13 @@ export function ProvisioningRequestDialog({
 												// #826: the agent is ALREADY bound to a toolkit
 												// serving this API — the operator most likely set
 												// it up manually. Nudge towards adopting it
-												// instead of minting a duplicate.
+												// instead of minting a duplicate. Don't promise
+												// the picker: it only renders once the toolkit
+												// list has loaded non-empty.
 												<div className="border-warning/40 bg-warning/5 mb-3 rounded-lg border p-3 text-sm">
 													This agent is already wired to a toolkit serving{' '}
-													{chainLabel} — pick that existing toolkit below
-													instead of creating another one.
+													{chainLabel} — prefer adopting that existing
+													toolkit over creating another one.
 												</div>
 											)}
 										<Label htmlFor="pw-toolkit-name">Toolkit name</Label>
@@ -1379,7 +1395,7 @@ export function ProvisioningRequestDialog({
 														credentialLabel ??
 														'credential'}
 												</span>{' '}
-												— no sign-in needed.
+												— reused as-is.
 											</span>
 										</div>
 										<Button
@@ -1407,10 +1423,10 @@ export function ProvisioningRequestDialog({
 										</Button>
 										{chainCredentialOptions !== null &&
 											chainCredentialOptions.length > 0 && (
-												// Adopt-existing path (#826): a credential the
-												// operator already provisioned for this vendor
-												// can be reused as-is — no connect flow (it is
-												// already usable) and no orphan discard.
+												// Adopt-existing path (#826): an active credential
+												// the operator already provisioned for this vendor
+												// can be reused as-is — no connect flow and no
+												// orphan discard.
 												<div className="space-y-1.5 pt-2">
 													<Label htmlFor="pw-existing-credential">
 														Or use an existing credential for{' '}
@@ -1576,13 +1592,15 @@ export function ProvisioningRequestDialog({
 															{summarizeRules(cs?.rules ?? [])}
 														</SummaryRow>
 														{chainAlreadyWired(c) && (
+															// Honest per-path copy: adoption reuses the
+															// detected setup; creating anyway wires the
+															// NEW toolkit alongside it.
 															<SummaryRow label="Note">
 																<span className="text-muted-foreground">
-																	Parts of this API are already
-																	wired for this agent (an
-																	existing binding was detected) —
-																	approving records the grant
-																	without duplicating anything.
+																	{cs?.toolkitAdopted ||
+																	cs?.credentialAdopted
+																		? 'Parts of this API are already wired for this agent — approving records the grant against the existing setup without duplicating anything.'
+																		: 'This agent already has a toolkit wired for this API — approving will bind the new objects created here alongside that existing setup.'}
 																</span>
 															</SummaryRow>
 														)}

--- a/ui/src/shared/app/rail/ProvisioningRequestDialog.tsx
+++ b/ui/src/shared/app/rail/ProvisioningRequestDialog.tsx
@@ -34,6 +34,7 @@ import { Dialog } from '@/shared/ui/Dialog';
 import { Button } from '@/shared/ui/Button';
 import { Input } from '@/shared/ui/Input';
 import { Label } from '@/shared/ui/Label';
+import { Select } from '@/shared/ui/Select';
 import { Badge } from '@/shared/ui/Badge';
 import { ActorLabel } from '@/shared/ui/ActorLabel';
 import { AgentBadge } from '@/shared/ui/AgentBadge';
@@ -43,7 +44,16 @@ import { useActorDirectory } from '@/shared/hooks';
 import { CreateCredentialDialog } from '@/shared/credentials/components/CreateCredentialDialog';
 import type { CreatedCredentialInfo } from '@/shared/credentials/components/CreateCredentialDialog';
 import { CREDENTIAL_TYPE_LABELS, runConnectFlow } from '@/shared/credentials/api';
-import { CredentialType, AgentsService, getToken, subscribeToken } from '@/shared/api';
+import {
+	CredentialType,
+	AgentsService,
+	CredentialsService,
+	ToolkitsService,
+	getToken,
+	subscribeToken,
+	type CredentialRedactedResponse,
+	type ToolkitResponse,
+} from '@/shared/api';
 import {
 	amendAccessRequest,
 	decideAccessRequest,
@@ -83,8 +93,16 @@ interface ChainProgress {
 	toolkitId: string | null;
 	toolkitName: string;
 	toolkitNameEdited: boolean;
+	/** The toolkit was ADOPTED from the operator's existing toolkits (picker),
+	 * not created this session — excluded from orphan discard on cancel. */
+	toolkitAdopted: boolean;
 	credentialId: string | null;
 	credentialType: string | null;
+	/** Display name of an adopted credential (created ones show their type). */
+	credentialName: string | null;
+	/** The credential was adopted from existing credentials — no connect flow,
+	 * excluded from orphan discard on cancel. */
+	credentialAdopted: boolean;
 	rules: PermissionRuleInput[];
 	/** Operator chose not to set this API up now; its items are denied at submit. */
 	skipped: boolean;
@@ -231,8 +249,11 @@ function seedChainProgress(chains: PlanChain[], agentName: string | undefined): 
 		toolkitId: null,
 		toolkitName: suggestChainToolkitName(chain, agentName, chains),
 		toolkitNameEdited: false,
+		toolkitAdopted: false,
 		credentialId: null,
 		credentialType: null,
+		credentialName: null,
+		credentialAdopted: false,
 		rules: proposedChainRules(chain),
 		skipped: chainUnfulfillable(chain),
 	}));
@@ -329,7 +350,17 @@ export function ProvisioningRequestDialog({
 		for (const chain of chains) {
 			const cs = byKey.get(chain.key);
 			if (!cs) return undefined;
-			aligned.push(cs);
+			// Backfill fields older drafts predate (adopt-existing support):
+			// their objects were all wizard-created, so `adopted: false` is the
+			// historically-accurate default, keeping them discardable. The
+			// stored JSON may genuinely lack these keys even though the type
+			// declares them, hence the runtime defaults.
+			aligned.push({
+				...cs,
+				toolkitAdopted: cs.toolkitAdopted ?? false,
+				credentialName: cs.credentialName ?? null,
+				credentialAdopted: cs.credentialAdopted ?? false,
+			});
 		}
 		return { ...draft, chains: aligned };
 	};
@@ -349,13 +380,15 @@ export function ProvisioningRequestDialog({
 	// cancelling a partially-fulfilled wizard (replaces a browser confirm()).
 	const [confirmDiscard, setConfirmDiscard] = useState(false);
 	const [discarding, setDiscarding] = useState(false);
-	// The request's status re-fetched on open. Callers pass a possibly-stale
-	// snapshot from the list query; before showing the LIVE create/approve
-	// controls we confirm the request is still pending, so an operator can't
-	// re-fulfil a request that was decided/expired since the list was fetched
-	// (which would strand a real toolkit/credential then fail at decide). Null
-	// until the fetch resolves; the terminal gate falls back to the snapshot.
-	const [freshStatus, setFreshStatus] = useState<string | null>(null);
+	// The request re-fetched on open. Callers pass a possibly-stale snapshot
+	// from the list query; before showing the LIVE create/approve controls we
+	// confirm the request is still pending, so an operator can't re-fulfil a
+	// request that was decided/expired since the list was fetched (which would
+	// strand a real toolkit/credential then fail at decide). The fresh copy
+	// also carries the single-GET `already_satisfied` enrichment feeding the
+	// "already in place" hints. Null until the fetch resolves; the terminal
+	// gate falls back to the snapshot.
+	const [freshRequest, setFreshRequest] = useState<AccessRequest | null>(null);
 
 	// Transient flags reset on every (re)open; the draft (created ids, rules)
 	// persists between dismissals so a peek doesn't discard fulfilment progress.
@@ -381,7 +414,7 @@ export function ProvisioningRequestDialog({
 		let cancelled = false;
 		void getAccessRequest(request.id)
 			.then((fresh) => {
-				if (!cancelled) setFreshStatus(fresh.status);
+				if (!cancelled) setFreshRequest(fresh);
 			})
 			.catch(() => {
 				// Best-effort: on a fetch failure keep the snapshot status; the
@@ -404,7 +437,7 @@ export function ProvisioningRequestDialog({
 		setChainStates(draft?.chains ?? seedChainProgress(chains, agentName));
 		setTouched(draft !== undefined);
 		setOutcome(null);
-		setFreshStatus(null);
+		setFreshRequest(null);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [request.id]);
 
@@ -415,7 +448,7 @@ export function ProvisioningRequestDialog({
 	// (nothing created, nothing edited, still on step 1) is not worth
 	// resuming — store nothing, so merely peeking at plans doesn't
 	// accumulate map entries for the rest of the session.
-	const effectiveStatus = freshStatus ?? request.status;
+	const effectiveStatus = freshRequest?.status ?? request.status;
 	useEffect(() => {
 		if (outcome !== null || effectiveStatus !== 'pending') return;
 		if (!touched) {
@@ -479,6 +512,129 @@ export function ProvisioningRequestDialog({
 		[chainIndex],
 	);
 
+	// Per-item "already in effect" hints from the fresh single-request GET
+	// (issue #826): true when the binding/grant an item asks for already
+	// exists — e.g. the operator set things up manually outside the wizard.
+	// Absent entries mean "not computed" (never "no").
+	const satisfiedItemIds = useMemo(() => {
+		const ids = new Set<string>();
+		for (const it of freshRequest?.items ?? []) {
+			if (it.already_satisfied === true) ids.add(it.id);
+		}
+		return ids;
+	}, [freshRequest]);
+	const chainAlreadyWired = useCallback(
+		(c: PlanChain): boolean =>
+			[c.credentialBind, c.toolkitBind].some(
+				(it) => it !== undefined && satisfiedItemIds.has(it.id),
+			),
+		[satisfiedItemIds],
+	);
+
+	// The operator's existing toolkits, fetched lazily the first time a toolkit
+	// step is shown — they feed the "use an existing toolkit" picker so manual
+	// setups can be adopted instead of duplicated (issue #826). One page is
+	// plenty for a picker; empty (or failed) collapses the section entirely.
+	const [existingToolkits, setExistingToolkits] = useState<ToolkitResponse[] | null>(null);
+	useEffect(() => {
+		if (!open || step !== 'toolkit' || existingToolkits !== null) return;
+		let cancelled = false;
+		void ToolkitsService.listToolkits({ limit: 100 })
+			.then((res) => {
+				if (!cancelled) setExistingToolkits(res.data);
+			})
+			.catch(() => {
+				if (!cancelled) setExistingToolkits([]);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [open, step, existingToolkits]);
+
+	// Existing credentials for the CURRENT chain's API vendor, cached per
+	// vendor. Vendor-filtered server-side so the picker only offers
+	// credentials that can actually serve this chain.
+	const chainVendor = chain?.apiRef.vendor;
+	const [existingCredentials, setExistingCredentials] = useState<
+		Record<string, CredentialRedactedResponse[]>
+	>({});
+	useEffect(() => {
+		if (!open || step !== 'credential' || !chainVendor) return;
+		if (existingCredentials[chainVendor] !== undefined) return;
+		let cancelled = false;
+		void CredentialsService.listCredentials({ vendor: chainVendor, limit: 100 })
+			.then((res) => {
+				if (!cancelled) {
+					setExistingCredentials((prev) => ({ ...prev, [chainVendor]: res.data }));
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setExistingCredentials((prev) => ({ ...prev, [chainVendor]: [] }));
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [open, step, chainVendor, existingCredentials]);
+	const chainCredentialOptions = chainVendor ? (existingCredentials[chainVendor] ?? null) : null;
+
+	/** Adopt an existing toolkit for the current chain (selection is commit). */
+	const handleAdoptToolkit = useCallback(
+		(toolkitId: string) => {
+			const tk = existingToolkits?.find((t) => t.toolkit_id === toolkitId);
+			if (!tk) return;
+			// Adopting commits to this chain, same as creating (clears a skip).
+			// `toolkitNameEdited` stops the async suggested-name upgrade from
+			// clobbering the adopted name.
+			updateChain({
+				toolkitId: tk.toolkit_id,
+				toolkitName: tk.name,
+				toolkitNameEdited: true,
+				toolkitAdopted: true,
+				skipped: false,
+			});
+			setStep(noAuth ? 'rules' : 'credential');
+		},
+		[existingToolkits, noAuth, updateChain],
+	);
+
+	/** Un-adopt: back to the create form (adopted objects are never deleted). */
+	const handleClearAdoptedToolkit = useCallback(() => {
+		if (!chain) return;
+		updateChain({
+			toolkitId: null,
+			toolkitName: suggestChainToolkitName(chain, agentName, chains),
+			toolkitNameEdited: false,
+			toolkitAdopted: false,
+		});
+	}, [chain, chains, agentName, updateChain]);
+
+	/** Adopt an existing credential — already connected, so no connect flow. */
+	const handleAdoptCredential = useCallback(
+		(credentialId: string) => {
+			const cred = chainCredentialOptions?.find((c) => c.credential_id === credentialId);
+			if (!cred) return;
+			updateChain({
+				credentialId: cred.credential_id,
+				credentialType: cred.type,
+				credentialName: cred.name,
+				credentialAdopted: true,
+			});
+			setStep('rules');
+		},
+		[chainCredentialOptions, updateChain],
+	);
+
+	const handleClearAdoptedCredential = useCallback(() => {
+		updateChain({
+			credentialId: null,
+			credentialType: null,
+			credentialName: null,
+			credentialAdopted: false,
+		});
+	}, [updateChain]);
+
 	/** Advance past the current chain: next chain's first step, or review. */
 	const advanceChain = useCallback(() => {
 		if (chainIndex + 1 < chains.length) {
@@ -517,6 +673,7 @@ export function ProvisioningRequestDialog({
 			updateChain({
 				toolkitId: created.toolkitId,
 				toolkitName: created.name,
+				toolkitAdopted: false,
 				skipped: false,
 			});
 			setStep(noAuth ? 'rules' : 'credential');
@@ -530,7 +687,12 @@ export function ProvisioningRequestDialog({
 	const handleCredentialCreated = useCallback(
 		async (info: CreatedCredentialInfo) => {
 			setCredentialDialogOpen(false);
-			updateChain({ credentialId: info.credentialId, credentialType: info.type });
+			updateChain({
+				credentialId: info.credentialId,
+				credentialType: info.type,
+				credentialName: null,
+				credentialAdopted: false,
+			});
 			// An OAuth2 credential that needs a browser sign-in (authorization-code
 			// with an authorize URL) has NO token until the connect flow completes —
 			// binding it as-is makes the broker fail at execute with "No refresh
@@ -574,10 +736,14 @@ export function ProvisioningRequestDialog({
 		[updateChain],
 	);
 
-	// Everything the wizard created this session, for orphan control on cancel.
-	const createdToolkitIds = chainStates.filter((cs) => cs.toolkitId).map((cs) => cs.toolkitId!);
+	// Everything the wizard CREATED this session, for orphan control on cancel.
+	// Adopted (pre-existing) objects are deliberately excluded — discarding
+	// them would delete infrastructure the operator set up outside the wizard.
+	const createdToolkitIds = chainStates
+		.filter((cs) => cs.toolkitId && !cs.toolkitAdopted)
+		.map((cs) => cs.toolkitId!);
 	const createdCredentialIds = chainStates
-		.filter((cs) => cs.credentialId)
+		.filter((cs) => cs.credentialId && !cs.credentialAdopted)
 		.map((cs) => cs.credentialId!);
 
 	const handleCancel = useCallback(() => {
@@ -1040,7 +1206,7 @@ export function ProvisioningRequestDialog({
 								blurb={
 									chainSkipped
 										? 'This API is not part of the grant.'
-										: `A toolkit is the container that will serve ${chainLabel} to this agent. Give it a name — the default is fine.`
+										: `A toolkit is the container that will serve ${chainLabel} to this agent. Give it a name — the default is fine — or pick one of your existing toolkits.`
 								}
 							>
 								{chainSkipped ? (
@@ -1084,8 +1250,37 @@ export function ProvisioningRequestDialog({
 											)}
 										</span>
 									</div>
+								) : progress?.toolkitId != null && progress.toolkitAdopted ? (
+									<div className="max-w-md space-y-3">
+										<div className="border-success/30 bg-success/5 flex items-center gap-2.5 rounded-lg border p-4 text-sm">
+											<CheckCircle2 className="text-success h-5 w-5 shrink-0" />
+											<span>
+												Using existing toolkit{' '}
+												<span className="font-medium">
+													{progress.toolkitName}
+												</span>{' '}
+												— continue to the next step.
+											</span>
+										</div>
+										<Button variant="ghost" onClick={handleClearAdoptedToolkit}>
+											Use a different toolkit
+										</Button>
+									</div>
 								) : (
 									<div className="max-w-md space-y-1.5">
+										{chain?.toolkitBind !== undefined &&
+											satisfiedItemIds.has(chain.toolkitBind.id) &&
+											progress?.toolkitId == null && (
+												// #826: the agent is ALREADY bound to a toolkit
+												// serving this API — the operator most likely set
+												// it up manually. Nudge towards adopting it
+												// instead of minting a duplicate.
+												<div className="border-warning/40 bg-warning/5 mb-3 rounded-lg border p-3 text-sm">
+													This agent is already wired to a toolkit serving{' '}
+													{chainLabel} — pick that existing toolkit below
+													instead of creating another one.
+												</div>
+											)}
 										<Label htmlFor="pw-toolkit-name">Toolkit name</Label>
 										<Input
 											id="pw-toolkit-name"
@@ -1112,6 +1307,40 @@ export function ProvisioningRequestDialog({
 												</span>
 											</div>
 										)}
+										{progress?.toolkitId == null &&
+											existingToolkits !== null &&
+											existingToolkits.length > 0 && (
+												// Adopt-existing path (#826): a manual setup can
+												// be pointed at instead of duplicated. Selection
+												// is commit (pure picker) — it advances the step.
+												<div className="space-y-1.5 pt-4">
+													<Label htmlFor="pw-existing-toolkit">
+														Or use an existing toolkit
+													</Label>
+													<Select
+														id="pw-existing-toolkit"
+														value=""
+														onChange={(e) => {
+															if (e.target.value) {
+																handleAdoptToolkit(e.target.value);
+															}
+														}}
+														disabled={busy}
+													>
+														<option value="">
+															Choose an existing toolkit…
+														</option>
+														{existingToolkits.map((tk) => (
+															<option
+																key={tk.toolkit_id}
+																value={tk.toolkit_id}
+															>
+																{tk.name}
+															</option>
+														))}
+													</Select>
+												</div>
+											)}
 									</div>
 								)}
 							</StepBody>
@@ -1139,7 +1368,28 @@ export function ProvisioningRequestDialog({
 									</>
 								}
 							>
-								{progress?.credentialId ? (
+								{progress?.credentialId && progress.credentialAdopted ? (
+									<div className="max-w-md space-y-3">
+										<div className="border-success/30 bg-success/5 flex items-center gap-2.5 rounded-lg border p-4 text-sm">
+											<CheckCircle2 className="text-success h-5 w-5 shrink-0" />
+											<span>
+												Using existing credential{' '}
+												<span className="font-medium">
+													{progress.credentialName ??
+														credentialLabel ??
+														'credential'}
+												</span>{' '}
+												— no sign-in needed.
+											</span>
+										</div>
+										<Button
+											variant="ghost"
+											onClick={handleClearAdoptedCredential}
+										>
+											Use a different credential
+										</Button>
+									</div>
+								) : progress?.credentialId ? (
 									<div className="border-success/30 bg-success/5 flex max-w-md items-center gap-2.5 rounded-lg border p-4 text-sm">
 										<CheckCircle2 className="text-success h-5 w-5 shrink-0" />
 										<span>
@@ -1147,13 +1397,55 @@ export function ProvisioningRequestDialog({
 										</span>
 									</div>
 								) : (
-									<Button
-										variant="primary"
-										size="lg"
-										onClick={() => setCredentialDialogOpen(true)}
-									>
-										<KeyRound className="h-4 w-4" /> Connect credential
-									</Button>
+									<div className="max-w-md space-y-4">
+										<Button
+											variant="primary"
+											size="lg"
+											onClick={() => setCredentialDialogOpen(true)}
+										>
+											<KeyRound className="h-4 w-4" /> Connect credential
+										</Button>
+										{chainCredentialOptions !== null &&
+											chainCredentialOptions.length > 0 && (
+												// Adopt-existing path (#826): a credential the
+												// operator already provisioned for this vendor
+												// can be reused as-is — no connect flow (it is
+												// already usable) and no orphan discard.
+												<div className="space-y-1.5 pt-2">
+													<Label htmlFor="pw-existing-credential">
+														Or use an existing credential for{' '}
+														{chainLabel}
+													</Label>
+													<Select
+														id="pw-existing-credential"
+														value=""
+														onChange={(e) => {
+															if (e.target.value) {
+																handleAdoptCredential(
+																	e.target.value,
+																);
+															}
+														}}
+														disabled={busy}
+													>
+														<option value="">
+															Choose an existing credential…
+														</option>
+														{chainCredentialOptions.map((cred) => (
+															<option
+																key={cred.credential_id}
+																value={cred.credential_id}
+															>
+																{cred.name} (
+																{credentialTypeLabel(cred.type) ??
+																	cred.type}
+																)
+															</option>
+														))}
+													</Select>
+												</div>
+											)}
+									</div>
 								)}
 							</StepBody>
 						)}
@@ -1252,12 +1544,28 @@ export function ProvisioningRequestDialog({
 													<>
 														<SummaryRow label="Toolkit">
 															{cs?.toolkitName}
+															{cs?.toolkitAdopted && (
+																<span className="text-muted-foreground ml-2">
+																	(existing)
+																</span>
+															)}
 														</SummaryRow>
 														<SummaryRow label="Credential">
 															{chainIsNoAuth(c) ? (
 																<span className="text-muted-foreground">
 																	none — this API needs no auth
 																</span>
+															) : cs?.credentialAdopted ? (
+																<>
+																	{cs.credentialName ??
+																		credentialTypeLabel(
+																			cs.credentialType,
+																		) ??
+																		'connected'}
+																	<span className="text-muted-foreground ml-2">
+																		(existing)
+																	</span>
+																</>
 															) : (
 																(credentialTypeLabel(
 																	cs?.credentialType,
@@ -1267,6 +1575,17 @@ export function ProvisioningRequestDialog({
 														<SummaryRow label="Agent can">
 															{summarizeRules(cs?.rules ?? [])}
 														</SummaryRow>
+														{chainAlreadyWired(c) && (
+															<SummaryRow label="Note">
+																<span className="text-muted-foreground">
+																	Parts of this API are already
+																	wired for this agent (an
+																	existing binding was detected) —
+																	approving records the grant
+																	without duplicating anything.
+																</span>
+															</SummaryRow>
+														)}
 													</>
 												)}
 											</dl>
@@ -1277,6 +1596,11 @@ export function ProvisioningRequestDialog({
 											{shape.extras.map((it) => (
 												<SummaryRow key={it.id} label="Also approves">
 													{extraItemLabel(it)}
+													{satisfiedItemIds.has(it.id) && (
+														<span className="text-success ml-2">
+															already in place — approving records it
+														</span>
+													)}
 												</SummaryRow>
 											))}
 										</dl>

--- a/ui/src/shared/app/rail/ProvisioningRequestDialog.tsx
+++ b/ui/src/shared/app/rail/ProvisioningRequestDialog.tsx
@@ -516,13 +516,24 @@ export function ProvisioningRequestDialog({
 	// Per-item "already in effect" hints from the fresh single-request GET
 	// (issue #826): true when the binding/grant an item asks for already
 	// exists — e.g. the operator set things up manually outside the wizard.
-	// Absent entries mean "not computed" (never "no").
+	// Absent entries mean "not computed" (never "no"). `satisfiedByItemId`
+	// carries the satisfying toolkit id for toolkit:bind items so the nudge
+	// can name the exact object instead of waving at a bare boolean.
 	const satisfiedItemIds = useMemo(() => {
 		const ids = new Set<string>();
 		for (const it of freshRequest?.items ?? []) {
 			if (it.already_satisfied === true) ids.add(it.id);
 		}
 		return ids;
+	}, [freshRequest]);
+	const satisfiedByItemId = useMemo(() => {
+		const map = new Map<string, string>();
+		for (const it of freshRequest?.items ?? []) {
+			if (it.already_satisfied === true && it.already_satisfied_by) {
+				map.set(it.id, it.already_satisfied_by);
+			}
+		}
+		return map;
 	}, [freshRequest]);
 	const chainAlreadyWired = useCallback(
 		(c: PlanChain): boolean =>
@@ -536,9 +547,12 @@ export function ProvisioningRequestDialog({
 	// step is shown — they feed the "use an existing toolkit" picker so manual
 	// setups can be adopted instead of duplicated (issue #826). Suspended
 	// toolkits are excluded (adopting one would wire the agent to a dead end).
-	// One page is plenty for a picker; empty (or failed) collapses the section
-	// entirely.
-	const [existingToolkits, setExistingToolkits] = useState<ToolkitResponse[] | null>(null);
+	// One page is plenty for a picker; a genuinely empty list collapses the
+	// section, but a FAILED fetch shows a retry line instead — silently
+	// collapsing while the nudge says "adopt" would strand the operator.
+	const [existingToolkits, setExistingToolkits] = useState<ToolkitResponse[] | null | 'error'>(
+		null,
+	);
 	useEffect(() => {
 		if (!open || step !== 'toolkit' || existingToolkits !== null) return;
 		let cancelled = false;
@@ -547,7 +561,7 @@ export function ProvisioningRequestDialog({
 				if (!cancelled) setExistingToolkits(res.data.filter((tk) => tk.active));
 			})
 			.catch(() => {
-				if (!cancelled) setExistingToolkits([]);
+				if (!cancelled) setExistingToolkits('error');
 			});
 		return () => {
 			cancelled = true;
@@ -558,10 +572,11 @@ export function ProvisioningRequestDialog({
 	// vendor. Vendor-filtered server-side so the picker only offers
 	// credentials that can actually serve this chain — the filter is an exact
 	// match against slugified rows, so the raw filed vendor must be slugified
-	// first (issue #656's mismatch). Disabled credentials are excluded.
+	// first (issue #656's mismatch). Disabled credentials are excluded; a
+	// failed fetch is kept distinct from empty so the UI can offer a retry.
 	const chainVendor = chain ? slugifyApiField(chain.apiRef.vendor) : undefined;
 	const [existingCredentials, setExistingCredentials] = useState<
-		Record<string, CredentialRedactedResponse[]>
+		Record<string, CredentialRedactedResponse[] | 'error'>
 	>({});
 	useEffect(() => {
 		if (!open || step !== 'credential' || !chainVendor) return;
@@ -578,7 +593,7 @@ export function ProvisioningRequestDialog({
 			})
 			.catch(() => {
 				if (!cancelled) {
-					setExistingCredentials((prev) => ({ ...prev, [chainVendor]: [] }));
+					setExistingCredentials((prev) => ({ ...prev, [chainVendor]: 'error' }));
 				}
 			});
 		return () => {
@@ -587,10 +602,24 @@ export function ProvisioningRequestDialog({
 	}, [open, step, chainVendor, existingCredentials]);
 	const chainCredentialOptions = chainVendor ? (existingCredentials[chainVendor] ?? null) : null;
 
-	/** Adopt an existing toolkit for the current chain (selection is commit). */
+	// Picker selections are staged locally and committed by an explicit
+	// button: committing on <select> change is a keyboard trap (arrowing
+	// through options on a closed native select fires change per keystroke —
+	// WCAG 3.2.2). Reset whenever the step or chain changes.
+	const [pendingToolkitChoice, setPendingToolkitChoice] = useState('');
+	const [pendingCredentialChoice, setPendingCredentialChoice] = useState('');
+	useEffect(() => {
+		setPendingToolkitChoice('');
+		setPendingCredentialChoice('');
+	}, [step, chainIndex]);
+
+	/** Adopt an existing toolkit for the current chain. */
 	const handleAdoptToolkit = useCallback(
 		(toolkitId: string) => {
-			const tk = existingToolkits?.find((t) => t.toolkit_id === toolkitId);
+			const tk =
+				existingToolkits === 'error'
+					? undefined
+					: existingToolkits?.find((t) => t.toolkit_id === toolkitId);
 			if (!tk) return;
 			// Adopting commits to this chain, same as creating (clears a skip).
 			// `toolkitNameEdited` stops the async suggested-name upgrade from
@@ -627,7 +656,10 @@ export function ProvisioningRequestDialog({
 	 */
 	const handleAdoptCredential = useCallback(
 		(credentialId: string) => {
-			const cred = chainCredentialOptions?.find((c) => c.credential_id === credentialId);
+			const cred =
+				chainCredentialOptions === 'error'
+					? undefined
+					: chainCredentialOptions?.find((c) => c.credential_id === credentialId);
 			if (!cred) return;
 			updateChain({
 				credentialId: cred.credential_id,
@@ -987,6 +1019,26 @@ export function ProvisioningRequestDialog({
 		: null;
 	const multiChain = chains.length > 1;
 	const chainLabel = apiLabel(chain?.apiRef ?? null);
+
+	// The toolkit that already satisfies this chain's toolkit:bind (from the
+	// backend hint), if any — named in the nudge and floated to the top of the
+	// picker so the operator can find THE wired toolkit among up to 100
+	// name-only options. Plain derivation (no hook): we're past the early
+	// returns, and the list caps at one page.
+	const wiredToolkitId = chain?.toolkitBind
+		? satisfiedByItemId.get(chain.toolkitBind.id)
+		: undefined;
+	const toolkitPickerOptions =
+		existingToolkits === 'error' || existingToolkits === null || !wiredToolkitId
+			? existingToolkits
+			: [
+					...existingToolkits.filter((tk) => tk.toolkit_id === wiredToolkitId),
+					...existingToolkits.filter((tk) => tk.toolkit_id !== wiredToolkitId),
+				];
+	const wiredToolkitName =
+		wiredToolkitId && existingToolkits !== 'error'
+			? existingToolkits?.find((tk) => tk.toolkit_id === wiredToolkitId)?.name
+			: undefined;
 	const chainSkipped = progress?.skipped === true;
 	// Skipping is only offered on a composite: skipping the ONLY chain would
 	// leave nothing to approve, which is a deny — the rail already has a
@@ -1288,13 +1340,26 @@ export function ProvisioningRequestDialog({
 												// #826: the agent is ALREADY bound to a toolkit
 												// serving this API — the operator most likely set
 												// it up manually. Nudge towards adopting it
-												// instead of minting a duplicate. Don't promise
-												// the picker: it only renders once the toolkit
-												// list has loaded non-empty.
+												// instead of minting a duplicate, naming the
+												// toolkit when the picker has resolved it.
 												<div className="border-warning/40 bg-warning/5 mb-3 rounded-lg border p-3 text-sm">
-													This agent is already wired to a toolkit serving{' '}
-													{chainLabel} — prefer adopting that existing
-													toolkit over creating another one.
+													{wiredToolkitName ? (
+														<>
+															This agent is already wired to{' '}
+															<span className="font-medium">
+																{wiredToolkitName}
+															</span>{' '}
+															for {chainLabel} — adopt it below
+															instead of creating another one.
+														</>
+													) : (
+														<>
+															This agent is already wired to a toolkit
+															serving {chainLabel} — prefer adopting
+															that existing toolkit over creating
+															another one.
+														</>
+													)}
 												</div>
 											)}
 										<Label htmlFor="pw-toolkit-name">Toolkit name</Label>
@@ -1324,37 +1389,74 @@ export function ProvisioningRequestDialog({
 											</div>
 										)}
 										{progress?.toolkitId == null &&
-											existingToolkits !== null &&
-											existingToolkits.length > 0 && (
+											toolkitPickerOptions === 'error' && (
+												// Failure ≠ empty: the nudge above may be telling
+												// the operator to adopt — never strand them with
+												// a silent collapse (issue #826 review).
+												<div className="text-muted-foreground flex items-center gap-2 pt-4 text-sm">
+													<span>
+														Couldn’t load your existing toolkits — you
+														can still create a new one, or retry.
+													</span>
+													<Button
+														variant="secondary"
+														size="sm"
+														onClick={() => setExistingToolkits(null)}
+													>
+														Retry
+													</Button>
+												</div>
+											)}
+										{progress?.toolkitId == null &&
+											toolkitPickerOptions !== 'error' &&
+											toolkitPickerOptions !== null &&
+											toolkitPickerOptions.length > 0 && (
 												// Adopt-existing path (#826): a manual setup can
 												// be pointed at instead of duplicated. Selection
-												// is commit (pure picker) — it advances the step.
+												// is staged; the button commits (a change-commit
+												// select is a keyboard trap). The already-wired
+												// toolkit, when known, is floated to the top.
 												<div className="space-y-1.5 pt-4">
 													<Label htmlFor="pw-existing-toolkit">
-														Or use an existing toolkit
+														Or use an existing toolkit (the credential
+														you connect next is added to it)
 													</Label>
 													<Select
 														id="pw-existing-toolkit"
-														value=""
-														onChange={(e) => {
-															if (e.target.value) {
-																handleAdoptToolkit(e.target.value);
-															}
-														}}
+														value={pendingToolkitChoice}
+														onChange={(e) =>
+															setPendingToolkitChoice(e.target.value)
+														}
 														disabled={busy}
 													>
 														<option value="">
 															Choose an existing toolkit…
 														</option>
-														{existingToolkits.map((tk) => (
+														{toolkitPickerOptions.map((tk) => (
 															<option
 																key={tk.toolkit_id}
 																value={tk.toolkit_id}
 															>
 																{tk.name}
+																{tk.toolkit_id === wiredToolkitId
+																	? ' — already linked to this agent'
+																	: ''}
 															</option>
 														))}
 													</Select>
+													{pendingToolkitChoice && (
+														<Button
+															variant="secondary"
+															onClick={() =>
+																handleAdoptToolkit(
+																	pendingToolkitChoice,
+																)
+															}
+															disabled={busy}
+														>
+															Use this toolkit
+														</Button>
+													)}
 												</div>
 											)}
 									</div>
@@ -1395,7 +1497,9 @@ export function ProvisioningRequestDialog({
 														credentialLabel ??
 														'credential'}
 												</span>{' '}
-												— reused as-is.
+												— reused as-is. Its sign-in isn’t re-verified; if it
+												has stopped working, calls will fail until you
+												reconnect it.
 											</span>
 										</div>
 										<Button
@@ -1421,12 +1525,39 @@ export function ProvisioningRequestDialog({
 										>
 											<KeyRound className="h-4 w-4" /> Connect credential
 										</Button>
-										{chainCredentialOptions !== null &&
+										{chainCredentialOptions === 'error' && (
+											// Failure ≠ empty — offer a retry instead of a
+											// silent collapse.
+											<div className="text-muted-foreground flex items-center gap-2 pt-2 text-sm">
+												<span>
+													Couldn’t load your existing credentials — you
+													can still connect a new one, or retry.
+												</span>
+												<Button
+													variant="secondary"
+													size="sm"
+													onClick={() =>
+														setExistingCredentials((prev) => {
+															const next = { ...prev };
+															if (chainVendor) {
+																delete next[chainVendor];
+															}
+															return next;
+														})
+													}
+												>
+													Retry
+												</Button>
+											</div>
+										)}
+										{chainCredentialOptions !== 'error' &&
+											chainCredentialOptions !== null &&
 											chainCredentialOptions.length > 0 && (
 												// Adopt-existing path (#826): an active credential
 												// the operator already provisioned for this vendor
 												// can be reused as-is — no connect flow and no
-												// orphan discard.
+												// orphan discard. Staged selection + explicit
+												// commit (see the toolkit picker).
 												<div className="space-y-1.5 pt-2">
 													<Label htmlFor="pw-existing-credential">
 														Or use an existing credential for{' '}
@@ -1434,14 +1565,12 @@ export function ProvisioningRequestDialog({
 													</Label>
 													<Select
 														id="pw-existing-credential"
-														value=""
-														onChange={(e) => {
-															if (e.target.value) {
-																handleAdoptCredential(
-																	e.target.value,
-																);
-															}
-														}}
+														value={pendingCredentialChoice}
+														onChange={(e) =>
+															setPendingCredentialChoice(
+																e.target.value,
+															)
+														}
 														disabled={busy}
 													>
 														<option value="">
@@ -1459,6 +1588,19 @@ export function ProvisioningRequestDialog({
 															</option>
 														))}
 													</Select>
+													{pendingCredentialChoice && (
+														<Button
+															variant="secondary"
+															onClick={() =>
+																handleAdoptCredential(
+																	pendingCredentialChoice,
+																)
+															}
+															disabled={busy}
+														>
+															Use this credential
+														</Button>
+													)}
 												</div>
 											)}
 									</div>
@@ -1592,14 +1734,18 @@ export function ProvisioningRequestDialog({
 															{summarizeRules(cs?.rules ?? [])}
 														</SummaryRow>
 														{chainAlreadyWired(c) && (
-															// Honest per-path copy: adoption reuses the
-															// detected setup; creating anyway wires the
-															// NEW toolkit alongside it.
+															// Honest per-path copy: adoption reuses
+															// the detected setup (but the approve
+															// still REPLACES the binding's
+															// permission rules with the ones
+															// confirmed here — say so); creating
+															// anyway wires the NEW toolkit
+															// alongside it.
 															<SummaryRow label="Note">
 																<span className="text-muted-foreground">
 																	{cs?.toolkitAdopted ||
 																	cs?.credentialAdopted
-																		? 'Parts of this API are already wired for this agent — approving records the grant against the existing setup without duplicating anything.'
+																		? 'Parts of this API are already wired for this agent — approving reuses that setup and updates its permission rules to the ones you confirmed here. Nothing is duplicated.'
 																		: 'This agent already has a toolkit wired for this API — approving will bind the new objects created here alongside that existing setup.'}
 																</span>
 															</SummaryRow>

--- a/ui/src/shared/app/rail/__tests__/ProvisioningRequestDialog.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/ProvisioningRequestDialog.test.tsx
@@ -573,3 +573,290 @@ describe('ProvisioningRequestDialog — multi-chain composite', () => {
 		expect(draft.chains[0].key).toContain('open-meteo-com');
 	});
 });
+
+/** A single-chain plan whose credential must be operator-provided (api_key). */
+function authPlanRequest(): AccessRequest {
+	const base = planRequest();
+	return {
+		...base,
+		id: 'arq_plan_auth',
+		approve_url: 'https://app.example.test/access-requests/arq_plan_auth',
+		items: base.items.map((it) =>
+			it.action === 'provision'
+				? {
+						...it,
+						resource_reference: {
+							...it.resource_reference,
+							security_scheme: 'api_key',
+						},
+					}
+				: it,
+		),
+	};
+}
+
+describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
+	beforeEach(() => {
+		setToken('test-token');
+		resetProvisioningWizardDrafts();
+	});
+	afterEach(() => clearToken());
+
+	/** Stub the pickers' list endpoints + the amend/decide submit path. */
+	function stubAdoption(
+		request: AccessRequest,
+		opts?: { onAmend?: (body: unknown) => void; onDecide?: (body: unknown) => void },
+	) {
+		stubDirectoryAndRequest(request);
+		worker.use(
+			http.get('/toolkits', () =>
+				HttpResponse.json({
+					data: [
+						{
+							toolkit_id: 'tk_existing',
+							name: 'Ops toolkit',
+							description: null,
+							active: true,
+							created_by: 'usr_admin',
+							created_at: '2026-01-01T00:00:00Z',
+							updated_at: null,
+							credential_count: 1,
+							key_count: 0,
+						},
+					],
+					has_more: false,
+					next_cursor: null,
+				}),
+			),
+			http.get('/credentials', () =>
+				HttpResponse.json({
+					data: [
+						{
+							credential_id: 'cred_exist',
+							name: 'Weather key',
+							type: 'api_key',
+							provider: 'manual',
+							active: true,
+							api: { vendor: 'open-meteo-com', name: 'forecast', version: null },
+							created_at: '2026-01-01T00:00:00Z',
+							updated_at: null,
+						},
+					],
+					has_more: false,
+					next_cursor: null,
+				}),
+			),
+			http.post('/credentials', () =>
+				HttpResponse.json({ credential: { credential_id: 'cred_noauth_1' } }),
+			),
+			http.post('/access-requests/*', async ({ request: httpReq }) => {
+				const url = new URL(httpReq.url);
+				const body = await httpReq.json();
+				if (url.pathname.endsWith(':amend')) {
+					opts?.onAmend?.(body);
+					return HttpResponse.json(request);
+				}
+				if (url.pathname.endsWith(':decide')) {
+					opts?.onDecide?.(body);
+					const decisions = (body as { items: { item_id: string; decision: string }[] })
+						.items;
+					const byId = new Map(decisions.map((d) => [d.item_id, d.decision]));
+					return HttpResponse.json({
+						...request,
+						status: 'approved',
+						items: request.items.map((it) => ({
+							...it,
+							status: byId.get(it.id) ?? it.status,
+						})),
+					});
+				}
+				return new HttpResponse(null, { status: 404 });
+			}),
+		);
+	}
+
+	it('adopting an existing toolkit skips the create call and amends its id', async () => {
+		let amendBody: unknown;
+		let createCalls = 0;
+		const request = planRequest();
+		stubAdoption(request, { onAmend: (b) => (amendBody = b) });
+		worker.use(
+			http.post('/toolkits', () => {
+				createCalls += 1;
+				return HttpResponse.json(
+					{ toolkit: { toolkit_id: 'tk_new', name: 'nope' }, api_key: 'k' },
+					{ status: 201 },
+				);
+			}),
+		);
+		renderWithProviders(
+			<ProvisioningRequestDialog open request={request} onClose={() => {}} />,
+		);
+		const user = userEvent.setup();
+
+		// Pick the existing toolkit instead of creating one — selection is
+		// commit, so the wizard advances (no-auth plan: straight to rules).
+		const picker = await screen.findByLabelText(/use an existing toolkit/i);
+		await user.selectOptions(picker, 'tk_existing');
+		await user.click(await screen.findByRole('button', { name: /^Review/ }));
+
+		// Review names the adopted toolkit and marks it as pre-existing.
+		expect(await screen.findByText('Ops toolkit')).toBeInTheDocument();
+		expect(screen.getByText('(existing)')).toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: /Approve & grant access/ }));
+		expect(await screen.findByText('Access granted')).toBeInTheDocument();
+
+		// The binds were amended to the ADOPTED id; nothing was created.
+		const amendments = (
+			amendBody as { items: { item_id: string; to_id?: string; resource_id?: string }[] }
+		).items;
+		const byItem = new Map(amendments.map((a) => [a.item_id, a]));
+		expect(byItem.get('i3')?.to_id).toBe('tk_existing');
+		expect(byItem.get('i4')?.resource_id).toBe('tk_existing');
+		expect(createCalls).toBe(0);
+	});
+
+	it('never offers to discard adopted objects on cancel', async () => {
+		const request = planRequest();
+		stubAdoption(request);
+		let closed = false;
+		let deleteCalls = 0;
+		worker.use(
+			http.delete('/toolkits/:id', () => {
+				deleteCalls += 1;
+				return new HttpResponse(null, { status: 204 });
+			}),
+		);
+		renderWithProviders(
+			<ProvisioningRequestDialog
+				open
+				request={request}
+				onClose={() => {
+					closed = true;
+				}}
+			/>,
+		);
+		const user = userEvent.setup();
+
+		const picker = await screen.findByLabelText(/use an existing toolkit/i);
+		await user.selectOptions(picker, 'tk_existing');
+		await screen.findByRole('button', { name: /^Review/ });
+
+		// Cancel: the wizard created NOTHING this session (the toolkit was
+		// adopted), so there are no orphans — close directly, never offering
+		// to delete infrastructure the operator set up outside the wizard.
+		await user.click(screen.getByRole('button', { name: 'Close' }));
+		await waitFor(() => expect(closed).toBe(true));
+		// The confirm <dialog> stays mounted while closed, so assert on
+		// visibility rather than presence.
+		expect(screen.getByText('Keep this setup for later?')).not.toBeVisible();
+		expect(deleteCalls).toBe(0);
+	});
+
+	it('adopting an existing credential skips the connect flow and amends its id', async () => {
+		let amendBody: unknown;
+		const request = authPlanRequest();
+		stubAdoption(request, { onAmend: (b) => (amendBody = b) });
+		worker.use(
+			http.post('/toolkits', () =>
+				HttpResponse.json({
+					toolkit: { toolkit_id: 'tk_auth', name: 'Weather Agent toolkit' },
+					api_key: 'k',
+				}),
+			),
+		);
+		renderWithProviders(
+			<ProvisioningRequestDialog open request={request} onClose={() => {}} />,
+		);
+		const user = userEvent.setup();
+
+		await screen.findByLabelText('Toolkit name');
+		await user.click(screen.getByRole('button', { name: /Create toolkit/i }));
+
+		// The credential step offers the vendor-scoped existing credentials;
+		// adopting one advances straight to rules — no create form, no
+		// connect flow (an existing credential is already usable).
+		const picker = await screen.findByLabelText(/use an existing credential/i);
+		await user.selectOptions(picker, 'cred_exist');
+		await user.click(await screen.findByRole('button', { name: /^Review/ }));
+
+		expect(await screen.findByText('Weather key')).toBeInTheDocument();
+		expect(screen.getByText('(existing)')).toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: /Approve & grant access/ }));
+		expect(await screen.findByText('Access granted')).toBeInTheDocument();
+
+		const amendments = (amendBody as { items: { item_id: string; resource_id?: string }[] })
+			.items;
+		const byItem = new Map(amendments.map((a) => [a.item_id, a]));
+		expect(byItem.get('i3')?.resource_id).toBe('cred_exist');
+	});
+});
+
+describe('ProvisioningRequestDialog — already-in-place hints (#826)', () => {
+	beforeEach(() => {
+		setToken('test-token');
+		resetProvisioningWizardDrafts();
+	});
+	afterEach(() => clearToken());
+
+	/** A composite whose chain-1 toolkit:bind and scope extra are already satisfied. */
+	function satisfiedComposite(): AccessRequest {
+		const request = compositeRequest();
+		return {
+			...request,
+			items: request.items.map((it) => {
+				if (it.id === 'a4' || it.id === 's1') return { ...it, already_satisfied: true };
+				return it;
+			}),
+		};
+	}
+
+	it('nudges towards adopting when the agent is already wired to the API', async () => {
+		stubDirectoryAndRequest(satisfiedComposite());
+		renderWithProviders(
+			<ProvisioningRequestDialog open request={satisfiedComposite()} onClose={() => {}} />,
+		);
+
+		// The fresh GET carries `already_satisfied` on chain 1's toolkit:bind:
+		// the toolkit step points at the existing wiring before the operator
+		// mints a duplicate toolkit.
+		expect(await screen.findByText(/already wired to a toolkit serving/i)).toBeInTheDocument();
+	});
+
+	it('marks satisfied chains and extras on the review step', async () => {
+		const request = satisfiedComposite();
+		stubDirectoryAndRequest(request);
+		let created = 0;
+		worker.use(
+			http.post('/toolkits', () => {
+				created += 1;
+				return HttpResponse.json({
+					toolkit: {
+						toolkit_id: `tk_chain_${created}`,
+						name: `Chain toolkit ${created}`,
+					},
+					api_key: 'k',
+				});
+			}),
+		);
+		renderWithProviders(
+			<ProvisioningRequestDialog open request={request} onClose={() => {}} />,
+		);
+		const user = userEvent.setup();
+
+		// Walk both no-auth chains to reach review.
+		await screen.findByLabelText('Toolkit name');
+		await user.click(screen.getByRole('button', { name: /Create toolkit/i }));
+		await user.click(await screen.findByRole('button', { name: /Next API/ }));
+		await screen.findByLabelText('Toolkit name');
+		await user.click(screen.getByRole('button', { name: /Create toolkit/i }));
+		await user.click(await screen.findByRole('button', { name: /^Review/ }));
+
+		// Chain 1 carries the existing-binding note; the satisfied scope grant
+		// is labelled as already in place.
+		expect(await screen.findByText(/already wired for this agent/i)).toBeInTheDocument();
+		expect(screen.getByText(/already in place — approving records it/i)).toBeInTheDocument();
+	});
+});

--- a/ui/src/shared/app/rail/__tests__/ProvisioningRequestDialog.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/ProvisioningRequestDialog.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { renderWithProviders, screen, waitFor, userEvent } from '@/__tests__/test-utils';
+import { renderWithProviders, screen, waitFor, within, userEvent } from '@/__tests__/test-utils';
 import { worker } from '@/mocks/browser';
 import { clearToken, setToken } from '@/shared/api';
 import {
@@ -605,7 +605,11 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 	/** Stub the pickers' list endpoints + the amend/decide submit path. */
 	function stubAdoption(
 		request: AccessRequest,
-		opts?: { onAmend?: (body: unknown) => void; onDecide?: (body: unknown) => void },
+		opts?: {
+			onAmend?: (body: unknown) => void;
+			onDecide?: (body: unknown) => void;
+			onCredentialQuery?: (vendor: string | null) => void;
+		},
 	) {
 		stubDirectoryAndRequest(request);
 		worker.use(
@@ -623,13 +627,26 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 							credential_count: 1,
 							key_count: 0,
 						},
+						{
+							// Suspended — must never be offered for adoption.
+							toolkit_id: 'tk_suspended',
+							name: 'Suspended toolkit',
+							description: null,
+							active: false,
+							created_by: 'usr_admin',
+							created_at: '2026-01-01T00:00:00Z',
+							updated_at: null,
+							credential_count: 0,
+							key_count: 0,
+						},
 					],
 					has_more: false,
 					next_cursor: null,
 				}),
 			),
-			http.get('/credentials', () =>
-				HttpResponse.json({
+			http.get('/credentials', ({ request: httpReq }) => {
+				opts?.onCredentialQuery?.(new URL(httpReq.url).searchParams.get('vendor'));
+				return HttpResponse.json({
 					data: [
 						{
 							credential_id: 'cred_exist',
@@ -641,11 +658,22 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 							created_at: '2026-01-01T00:00:00Z',
 							updated_at: null,
 						},
+						{
+							// Disabled for injection — must never be offered.
+							credential_id: 'cred_disabled',
+							name: 'Old disabled key',
+							type: 'api_key',
+							provider: 'manual',
+							active: false,
+							api: { vendor: 'open-meteo-com', name: 'forecast', version: null },
+							created_at: '2026-01-01T00:00:00Z',
+							updated_at: null,
+						},
 					],
 					has_more: false,
 					next_cursor: null,
-				}),
-			),
+				});
+			}),
 			http.post('/credentials', () =>
 				HttpResponse.json({ credential: { credential_id: 'cred_noauth_1' } }),
 			),
@@ -792,6 +820,53 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 		const byItem = new Map(amendments.map((a) => [a.item_id, a]));
 		expect(byItem.get('i3')?.resource_id).toBe('cred_exist');
 	});
+
+	it('slugifies the raw filed vendor and hides inactive artifacts in the pickers', async () => {
+		// Agents file references with raw domains ('Open-Meteo.com'); stored
+		// rows carry the slug ('open-meteo-com') and the credential list's
+		// vendor filter is an exact match — an unslugged query would silently
+		// collapse the picker (issue #656's mismatch).
+		let queriedVendor: string | null | undefined;
+		const base = authPlanRequest();
+		const rawRef = { vendor: 'Open-Meteo.com', name: 'forecast' };
+		const request = {
+			...base,
+			items: base.items.map((it) => ({
+				...it,
+				resource_reference: { ...it.resource_reference, ...rawRef },
+			})),
+		};
+		stubAdoption(request, { onCredentialQuery: (v) => (queriedVendor = v) });
+		worker.use(
+			http.post('/toolkits', () =>
+				HttpResponse.json({
+					toolkit: { toolkit_id: 'tk_auth', name: 'Weather Agent toolkit' },
+					api_key: 'k',
+				}),
+			),
+		);
+		renderWithProviders(
+			<ProvisioningRequestDialog open request={request} onClose={() => {}} />,
+		);
+		const user = userEvent.setup();
+
+		// Toolkit picker: the suspended toolkit is never offered.
+		const toolkitPicker = await screen.findByLabelText(/use an existing toolkit/i);
+		expect(within(toolkitPicker).getByRole('option', { name: 'Ops toolkit' })).toBeVisible();
+		expect(
+			within(toolkitPicker).queryByRole('option', { name: 'Suspended toolkit' }),
+		).not.toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: /Create toolkit/i }));
+
+		// Credential picker: queried with the slug, disabled rows filtered out.
+		const credPicker = await screen.findByLabelText(/use an existing credential/i);
+		expect(queriedVendor).toBe('open-meteo-com');
+		expect(within(credPicker).getByRole('option', { name: /Weather key/ })).toBeVisible();
+		expect(
+			within(credPicker).queryByRole('option', { name: /Old disabled key/ }),
+		).not.toBeInTheDocument();
+	});
 });
 
 describe('ProvisioningRequestDialog — already-in-place hints (#826)', () => {
@@ -854,9 +929,14 @@ describe('ProvisioningRequestDialog — already-in-place hints (#826)', () => {
 		await user.click(screen.getByRole('button', { name: /Create toolkit/i }));
 		await user.click(await screen.findByRole('button', { name: /^Review/ }));
 
-		// Chain 1 carries the existing-binding note; the satisfied scope grant
+		// Chain 1 carries the existing-binding note — the operator created a
+		// NEW toolkit despite the detected wiring, so the note is honest about
+		// binding it alongside the existing setup. The satisfied scope grant
 		// is labelled as already in place.
-		expect(await screen.findByText(/already wired for this agent/i)).toBeInTheDocument();
+		expect(
+			await screen.findByText(/already has a toolkit wired for this API/i),
+		).toBeInTheDocument();
+		expect(screen.getByText(/alongside that existing setup/i)).toBeInTheDocument();
 		expect(screen.getByText(/already in place — approving records it/i)).toBeInTheDocument();
 	});
 });

--- a/ui/src/shared/app/rail/__tests__/ProvisioningRequestDialog.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/ProvisioningRequestDialog.test.tsx
@@ -723,9 +723,12 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 		const user = userEvent.setup();
 
 		// Pick the existing toolkit instead of creating one — selection is
-		// commit, so the wizard advances (no-auth plan: straight to rules).
+		// staged, the button commits (no-auth plan: straight to rules).
 		const picker = await screen.findByLabelText(/use an existing toolkit/i);
+		// No satisfaction hint on this request — the nudge must not render.
+		expect(screen.queryByText(/already wired/i)).not.toBeInTheDocument();
 		await user.selectOptions(picker, 'tk_existing');
+		await user.click(screen.getByRole('button', { name: 'Use this toolkit' }));
 		await user.click(await screen.findByRole('button', { name: /^Review/ }));
 
 		// Review names the adopted toolkit and marks it as pre-existing.
@@ -769,6 +772,7 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 
 		const picker = await screen.findByLabelText(/use an existing toolkit/i);
 		await user.selectOptions(picker, 'tk_existing');
+		await user.click(screen.getByRole('button', { name: 'Use this toolkit' }));
 		await screen.findByRole('button', { name: /^Review/ });
 
 		// Cancel: the wizard created NOTHING this session (the toolkit was
@@ -803,10 +807,11 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 		await user.click(screen.getByRole('button', { name: /Create toolkit/i }));
 
 		// The credential step offers the vendor-scoped existing credentials;
-		// adopting one advances straight to rules — no create form, no
-		// connect flow (an existing credential is already usable).
+		// staging one and committing advances straight to rules — no create
+		// form, no connect flow.
 		const picker = await screen.findByLabelText(/use an existing credential/i);
 		await user.selectOptions(picker, 'cred_exist');
+		await user.click(screen.getByRole('button', { name: 'Use this credential' }));
 		await user.click(await screen.findByRole('button', { name: /^Review/ }));
 
 		expect(await screen.findByText('Weather key')).toBeInTheDocument();
@@ -866,6 +871,84 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 		expect(
 			within(credPicker).queryByRole('option', { name: /Old disabled key/ }),
 		).not.toBeInTheDocument();
+	});
+
+	it('names the wired toolkit, floats it in the picker, and reviews honestly on adopt', async () => {
+		// The backend hint carries WHICH toolkit satisfies the bind
+		// (already_satisfied_by) — the nudge names it and the picker floats it
+		// so the operator isn't left hunting through name-only options.
+		const base = planRequest();
+		const request = {
+			...base,
+			items: base.items.map((it) =>
+				it.id === 'i4'
+					? { ...it, already_satisfied: true, already_satisfied_by: 'tk_existing' }
+					: it,
+			),
+		};
+		stubAdoption(request);
+		renderWithProviders(
+			<ProvisioningRequestDialog open request={request} onClose={() => {}} />,
+		);
+		const user = userEvent.setup();
+
+		const nudge = await screen.findByText(/already wired to/i);
+		expect(nudge).toHaveTextContent('Ops toolkit');
+
+		const picker = await screen.findByLabelText(/use an existing toolkit/i);
+		const options = within(picker).getAllByRole('option');
+		expect(options[1]).toHaveTextContent(/Ops toolkit — already linked to this agent/);
+
+		// Adopt it and reach review: the note is the adopted variant, honest
+		// about the rules being updated (an approve REPLACES binding rules —
+		// never "nothing changes").
+		await user.selectOptions(picker, 'tk_existing');
+		await user.click(screen.getByRole('button', { name: 'Use this toolkit' }));
+		await user.click(await screen.findByRole('button', { name: /^Review/ }));
+		expect(
+			await screen.findByText(/reuses that setup and updates its permission rules/i),
+		).toBeInTheDocument();
+	});
+
+	it('offers a retry instead of silently collapsing when the toolkit list fails', async () => {
+		// The nudge may be telling the operator to adopt — a failed fetch must
+		// say so and offer a way out, not silently hide the picker.
+		const request = planRequest();
+		stubDirectoryAndRequest(request);
+		let failures = 0;
+		worker.use(
+			http.get('/toolkits', () => {
+				failures += 1;
+				if (failures === 1) return new HttpResponse(null, { status: 500 });
+				return HttpResponse.json({
+					data: [
+						{
+							toolkit_id: 'tk_existing',
+							name: 'Ops toolkit',
+							description: null,
+							active: true,
+							created_by: 'usr_admin',
+							created_at: '2026-01-01T00:00:00Z',
+							updated_at: null,
+							credential_count: 1,
+							key_count: 0,
+						},
+					],
+					has_more: false,
+					next_cursor: null,
+				});
+			}),
+		);
+		renderWithProviders(
+			<ProvisioningRequestDialog open request={request} onClose={() => {}} />,
+		);
+		const user = userEvent.setup();
+
+		expect(
+			await screen.findByText(/couldn.t load your existing toolkits/i),
+		).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Retry' }));
+		expect(await screen.findByLabelText(/use an existing toolkit/i)).toBeInTheDocument();
 	});
 });
 

--- a/ui/src/shared/lib/__tests__/provisioningPlan.test.ts
+++ b/ui/src/shared/lib/__tests__/provisioningPlan.test.ts
@@ -14,6 +14,7 @@ import {
 	planDenialReason,
 	planIsNoAuth,
 	planSteps,
+	slugifyApiField,
 } from '@/shared/lib/provisioningPlan';
 import type { AccessRequest, AccessRequestItem } from '@/shared/lib/accessRequests';
 
@@ -307,6 +308,29 @@ describe('provisioningPlan', () => {
 			const shape = planChains(req);
 			expect(shape.chains).toEqual([]);
 			expect(shape.extras).toHaveLength(1);
+		});
+	});
+
+	describe('slugifyApiField', () => {
+		// Must mirror the backend's slugify_api_field exactly: stored rows are
+		// slugified on write and server-side filters are exact matches.
+		it('lowercases, trims, and collapses runs of non [a-z0-9-] to one hyphen', () => {
+			expect(slugifyApiField('  Open-Meteo.com  ')).toBe('open-meteo-com');
+			expect(slugifyApiField('httpbin.org')).toBe('httpbin-org');
+			expect(slugifyApiField('A__B  C!!d')).toBe('a-b-c-d');
+		});
+
+		it('trims leading/trailing hyphens produced by the collapse', () => {
+			expect(slugifyApiField('.leading and trailing.')).toBe('leading-and-trailing');
+			expect(slugifyApiField('---')).toBe('');
+		});
+
+		it('collapses non-ascii like the backend regex does', () => {
+			expect(slugifyApiField('météo.fr')).toBe('m-t-o-fr');
+		});
+
+		it('truncates to the backend API_FIELD_MAX_LENGTH of 100', () => {
+			expect(slugifyApiField(`${'a'.repeat(150)}.com`)).toBe('a'.repeat(100));
 		});
 	});
 });

--- a/ui/src/shared/lib/accessRequests.ts
+++ b/ui/src/shared/lib/accessRequests.ts
@@ -60,9 +60,16 @@ export interface AccessRequestItem {
 	 * item's outcome is already in effect (the binding/grant exists — e.g. an
 	 * operator set it up manually outside the wizard), `false` when it
 	 * determinately is not, absent/null when not computed (list pages,
-	 * decided items, fulfilment-only intents, indeterminate targets).
+	 * decided items, fulfilment-only intents, indeterminate or ambiguous
+	 * targets).
 	 */
 	already_satisfied?: boolean | null;
+	/**
+	 * For a satisfied toolkit:bind, the id of the toolkit the agent is already
+	 * bound to — lets the wizard name the exact object instead of a bare
+	 * boolean. Absent/null otherwise.
+	 */
+	already_satisfied_by?: string | null;
 }
 
 /** Permission-rule effect — `require-approval` exists in the schema but is rarely shown. */

--- a/ui/src/shared/lib/accessRequests.ts
+++ b/ui/src/shared/lib/accessRequests.ts
@@ -55,6 +55,14 @@ export interface AccessRequestItem {
 	decided_by?: string | null;
 	decided_at?: string | null;
 	decision_reason?: string | null;
+	/**
+	 * Tri-state satisfaction hint from single-request GETs: `true` when the
+	 * item's outcome is already in effect (the binding/grant exists — e.g. an
+	 * operator set it up manually outside the wizard), `false` when it
+	 * determinately is not, absent/null when not computed (list pages,
+	 * decided items, fulfilment-only intents, indeterminate targets).
+	 */
+	already_satisfied?: boolean | null;
 }
 
 /** Permission-rule effect — `require-approval` exists in the schema but is rarely shown. */

--- a/ui/src/shared/lib/provisioningPlan.ts
+++ b/ui/src/shared/lib/provisioningPlan.ts
@@ -56,6 +56,25 @@ export interface PlanApiReference {
 }
 
 /**
+ * Normalize an API vendor/name field to its canonical slug form.
+ *
+ * Mirror of the backend's `slugify_api_field`: lowercase, strip, collapse
+ * runs of non-`[a-z0-9-]` to a single hyphen, trim hyphens, truncate.
+ * Plan items carry the reference as the agent filed it (raw domains like
+ * `httpbin.org`), while stored rows are slugified on write — any exact-match
+ * server-side filter (e.g. the credential list's `vendor` param) needs the
+ * slug, not the raw value.
+ */
+export function slugifyApiField(value: string): string {
+	return value
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9-]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+		.slice(0, 100);
+}
+
+/**
  * Extract the API reference the plan is about, preferring the toolkit:create
  * item (always present) and falling back to any item carrying a reference.
  */


### PR DESCRIPTION
## What this does

Closes #826.

Until now, if an operator set up a toolkit, credential, or scope grant **by hand** (outside the wizard), the access request had no idea. The reviewer saw a plain pending request, and the provisioning wizard would cheerfully walk them through creating a *second* toolkit and a *second* credential right next to the ones that already existed.

This PR teaches both sides about manual work:

### The request now knows what's already done

`GET /access-requests/{id}` annotates each pending item with a new `already_satisfied` field (plus `already_satisfied_by` naming the satisfying toolkit for binds):

| Item | "Already satisfied" means… |
|---|---|
| `toolkit:bind` | the agent is already bound to a toolkit serving that API (`already_satisfied_by` says which) |
| `credential:bind` | the credential ↔ toolkit binding already exists (the agent leg is the separate `toolkit:bind` item) |
| `scope:grant` | the actor already holds that scope |

It's a hint, not an authorization — approving still re-validates everything. List endpoints are untouched, so there's no extra query load where nobody reads the field. Probes mirror decide-time visibility: an ambiguous toolkit reference (which approval would refuse as filed) and a credential the caller can't see are left un-annotated rather than leaking or misleading.

### The wizard can adopt instead of duplicate

- Each chain's toolkit and credential steps now offer a **"use an existing toolkit / credential"** picker. Adopting skips the create and connect flows and simply points the plan at the existing object. Selection is staged and committed with an explicit button (no change-fires-commit keyboard trap), and a failed fetch shows a retry line instead of silently collapsing the picker.
- Adopted objects are **never** offered for deletion on cancel — the wizard only cleans up things it created itself.
- If the agent is already wired for an API, the wizard nudges the operator towards adopting — naming the wired toolkit and floating it to the top of the picker when the hint identifies it. The review step honestly says what approval will do (reuse the setup **and update its permission rules** vs. bind new objects alongside it).
- Pickers only offer usable things: inactive toolkits/credentials are hidden, and the vendor filter is slugified so raw filed domains (`httpbin.org`) still match stored rows (`httpbin-org`).

### One dead end got a signpost

A toolkit with bound credentials but **no linked agent** is the most common leftover of manual setup — nothing can ever use those credentials. The toolkit detail page now shows a warning banner with a shortcut to link an agent. Suppressed when the toolkit has API keys (key callers reach the credentials fine).

## Review notes

- Cross-DB discipline: control-DB checks run inside the request's session; admin-DB probes are collected and run after it closes — no session ever spans both databases.
- Two review rounds: three subagents (bugbot, security, architecture) on the initial cut, then a full 8-lens board (feasibility, product fit, security, architecture, code quality, operator UX, cold-eyes fact check, bugbot). All must-fixes landed:
  - **Security (medium)**: the `credential:bind` probe was an unscoped binding-existence oracle reachable via file → amend → GET; it now gates on decide-time credential visibility.
  - **Feasibility**: an ambiguous reference could report `True` yet be unapprovable as filed; ambiguity is now left un-annotated.
  - **Operator UX**: named nudge + floated picker option, staged picker commit (WCAG 3.2.2), fetch-failure retry, honest rules-replacement copy, API-key banner suppression.
  - **Code quality**: a false-pass `waitFor` race in the banner tests, the untested adopted-note branch, raw-vendor + `slugifyApiField` coverage, commit-type convention.

## Follow-ups (not this PR)

- Surface `already_satisfied` in the plain approve/deny dialog and at list level for reviewer triage.
- Badge/rank picker toolkits by the API they serve (the canonical #826 state — toolkit + credential exist, agent unbound — has no satisfied item to nudge from).
- Expose OAuth connect state in the redacted credential listing so the picker can warn on unconnected credentials.
- Prompt "link an agent?" after binding a credential via the manual Toolkits path (#826 option a).

## Test plan

- [x] `make check` — ruff, mypy, secrets, arch
- [x] `make test-fast` — 2370 passed
- [x] Control integration + web tests (Postgres) — 192 passed, incl. new `test_prerequisite_satisfaction.py`; full Postgres integration suite green in CI
- [x] New web tests: `already_satisfied` for all three item types, flip-on-manual-fulfilment, null-once-decided, ambiguity → null, visibility-gated probe, raw-vendor slugification
- [x] UI: tsc, eslint, prettier, vitest — 851 passed (+10 lint-project); new suites for adopt-existing, discard-safety, slugified vendor + inactive filtering, already-in-place hints, named nudge + honest review note, picker retry, no-agents banner (incl. API-key suppression), `slugifyApiField` unit tests
- [x] Enterprise `oss-tests-fast` — 2370 passed with enterprise seams registered
