### PR TITLE
docs(skill): drop obsolete import-workflow injection guards

### DIFF
--- a/skills/import-new-api/SKILL.md
+++ b/skills/import-new-api/SKILL.md
@@ -193,7 +193,8 @@ value on the same line after the colon.
 - `import_oas_url` — the **raw** link verified in step 4 (`raw.githubusercontent.com/...`), never
   a `github.com/.../blob/...` page URL.
 - `vendor_name` — validated against a safe charset (letters, digits, `.`, `-`, `_`, and a single
-  optional `/` for `<domain>/<api_name>`); anything else is rejected with a comment on the issue.
+  optional `/` for `<domain>/<api_name>`, each segment starting with a letter or digit); anything
+  else is rejected with a comment on the issue.
   It still isn't checked for *correctness*, so get it right: the bare domain from step 2 for a
   single-API vendor (`firecrawl.dev` → `vendor=firecrawl.dev; api_name=main`), or
   `<domain>/<api_name>` when the vendor ships several distinct APIs

--- a/skills/import-new-api/SKILL.md
+++ b/skills/import-new-api/SKILL.md
@@ -194,9 +194,9 @@ value on the same line after the colon.
   a `github.com/.../blob/...` page URL.
 - `vendor_name` — validated against a safe charset (letters, digits, `.`, `-`, `_`, and a single
   optional `/` for `<domain>/<api_name>`, each segment starting with a letter or digit); anything
-  else is rejected with a comment on the issue.
-  It still isn't checked for *correctness*, so get it right: the bare domain from step 2 for a
-  single-API vendor (`firecrawl.dev` → `vendor=firecrawl.dev; api_name=main`), or
+  else is rejected with a comment on the issue. It is **not** checked for *correctness*, though, so
+  get it right: the bare domain from step 2 for a single-API vendor
+  (`firecrawl.dev` → `vendor=firecrawl.dev; api_name=main`), or
   `<domain>/<api_name>` when the vendor ships several distinct APIs
   (`firecrawl.dev/scrape` → `vendor=firecrawl.dev; api_name=scrape`). A slug or misspelt domain
   is accepted silently and mis-catalogues the API.

--- a/skills/import-new-api/SKILL.md
+++ b/skills/import-new-api/SKILL.md
@@ -184,12 +184,6 @@ done; echo "raw link: $code"
 
 ### 5. Open the import issue on jentic-public-apis
 
-> ⚠️ **Injection hazard — keep the body free of shell metacharacters.** The import workflow
-> interpolates the raw issue body directly into a shell script (`BODY="${{ github.event.issue.body }}"`),
-> inside **double quotes**. So backticks, `$(...)`, `${...}`, **double quotes (`"`)** and
-> **backslashes (`\`)** in the body are all live injection/breakage vectors. Write the body
-> plainly — no code spans, no JSON snippets — and run the guard below before submitting.
-
 The workflow triggers on any opened/reopened issue whose body contains `import_oas_url:` — the
 `[AUTO]` title and `enhancement` label are template conventions (keep them for humans; the parser
 ignores them). It extracts `import_oas_url` and `vendor_name` with a line-anchored grep after
@@ -198,8 +192,10 @@ value on the same line after the colon.
 
 - `import_oas_url` — the **raw** link verified in step 4 (`raw.githubusercontent.com/...`), never
   a `github.com/.../blob/...` page URL.
-- `vendor_name` — passed to the importer **unvalidated**, so get it right: the bare domain from
-  step 2 for a single-API vendor (`firecrawl.dev` → `vendor=firecrawl.dev; api_name=main`), or
+- `vendor_name` — validated against a safe charset (letters, digits, `.`, `-`, `_`, and a single
+  optional `/` for `<domain>/<api_name>`); anything else is rejected with a comment on the issue.
+  It still isn't checked for *correctness*, so get it right: the bare domain from step 2 for a
+  single-API vendor (`firecrawl.dev` → `vendor=firecrawl.dev; api_name=main`), or
   `<domain>/<api_name>` when the vendor ships several distinct APIs
   (`firecrawl.dev/scrape` → `vendor=firecrawl.dev; api_name=scrape`). A slug or misspelt domain
   is accepted silently and mis-catalogues the API.
@@ -216,14 +212,9 @@ vendor_name: <VENDOR_NAME>
 
 ## Additional Information
 
-<one or two plain sentences: what the API does, path count, auth scheme, source. No backticks, no code, no quotes.>
+<one or two plain sentences: what the API does, path count, auth scheme, source.>
 EOF
 )
-
-# Guard: the import workflow shell-evals the body inside double quotes
-if printf '%s' "$BODY" | grep -qE '[`$"\\]'; then
-  echo "Unsafe issue body (contains one of \` \$ \" \\)"; exit 1
-fi
 
 gh issue create --repo jentic/jentic-public-apis \
   --title "[AUTO] Import OpenAPI to Jentic Public APIs: <VENDOR_NAME>" \
@@ -267,4 +258,4 @@ Give the user:
   exist; every import adds a new `{vendor}/{slug}/{version}/` subtree. Don't create a fresh repo
   per API.
 - **You act under the user's GitHub identity.** Show them the issue body and file list before
-  submission; keep the body free of `` ` `` `$` `"` `\`.
+  submission.


### PR DESCRIPTION
## Summary
- The jentic-public-apis import workflow no longer shell-interpolates the raw issue body — untrusted values now flow through `env:` and `import_oas_url`/`vendor_name` are validated against allowlists (rejected with an issue comment). Fixed in the merged [jentic-public-apis#21955](https://github.com/jentic/jentic-public-apis/pull/21955).
- This removes the now-obsolete client-side guards from `skills/import-new-api/SKILL.md`: the "Injection hazard" callout (its premise is no longer true), the pre-submit `grep` metacharacter guard around `gh issue create`, and the "no backticks/quotes" prose.
- Corrects the `vendor_name` note from "unvalidated" to "validated against a safe charset (each segment starting with a letter/digit), rejected on failure; still not correctness-checked".
- All consent/identity/existence/official-spec guardrails are left intact.

## Review board (mandatory gate)
- Security: **APPROVE** — verified against the actual workflow (`env:` indirection at `import-openapi.yaml:102-114`, validation at `:131`/`:153`); no residual exploitable risk, the removed guard was belt-and-braces in a doc.
- Skill-fidelity: **APPROVE-WITH-NITS** — Step 5 heredoc→`gh issue create` flow reads cleanly, no dangling references, `vendor_name` text matches the merged regex; segment-start nit applied.

## Test plan
- [x] Grep confirms no residual `injection`/`guard`/`unvalidated`/metacharacter references in the skill.
- [x] Docs-only change; no code paths, tests, or synced skill copies affected (drift test covers `jentic.md` only).

Made with [Cursor](https://cursor.com)