### PR TITLE
feat(catalog): notify when a registered API's upstream spec changes (Flow 3 MVP)

### DIFF
--- a/src/jentic_one/migrations/registry/versions/d3e4f5a6b7c8_add_catalog_update_checks_table.py
+++ b/src/jentic_one/migrations/registry/versions/d3e4f5a6b7c8_add_catalog_update_checks_table.py
@@ -1,0 +1,56 @@
+"""add catalog_update_checks table
+
+Revision ID: d3e4f5a6b7c8
+Revises: c2d3e4f5a6b7
+Create Date: 2026-07-31
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from jentic_one.shared.db.types import GUID
+
+revision: str = "d3e4f5a6b7c8"
+down_revision: str | None = "c2d3e4f5a6b7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pg = op.get_bind().dialect.name == "postgresql"
+    op.create_table(
+        "catalog_update_checks",
+        sa.Column(
+            "id",
+            sa.String(length=30),
+            server_default=sa.text("generate_ksuid('cuc')") if pg else None,
+            nullable=False,
+        ),
+        sa.Column("local_api_id", GUID(), nullable=False),
+        sa.Column("spec_url", sa.String(length=2048), nullable=False),
+        sa.Column("last_seen_etag", sa.Text(), nullable=True),
+        sa.Column("last_seen_digest", sa.String(length=64), nullable=True),
+        sa.Column("last_notified_digest", sa.String(length=64), nullable=True),
+        sa.Column("last_checked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_catalog_update_checks_local_api_id",
+        "catalog_update_checks",
+        ["local_api_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_catalog_update_checks_local_api_id", table_name="catalog_update_checks")
+    op.drop_table("catalog_update_checks")

--- a/src/jentic_one/registry/core/schema/__init__.py
+++ b/src/jentic_one/registry/core/schema/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from jentic_one.registry.core.schema.api_revisions import ApiRevision
 from jentic_one.registry.core.schema.apis import Api
 from jentic_one.registry.core.schema.catalog_snapshots import CatalogSnapshot
+from jentic_one.registry.core.schema.catalog_update_checks import CatalogUpdateCheck
 from jentic_one.registry.core.schema.notes import Note
 from jentic_one.registry.core.schema.operation_url_index import OperationURLIndex
 from jentic_one.registry.core.schema.operations import Operation
@@ -18,6 +19,7 @@ __all__ = [
     "Api",
     "ApiRevision",
     "CatalogSnapshot",
+    "CatalogUpdateCheck",
     "Note",
     "Operation",
     "OperationURLIndex",

--- a/src/jentic_one/registry/core/schema/catalog_update_checks.py
+++ b/src/jentic_one/registry/core/schema/catalog_update_checks.py
@@ -1,0 +1,61 @@
+"""CatalogUpdateCheck ORM model — per-API upstream-change bookkeeping (Flow 3).
+
+One row per **local** registered API (``local_api_id``, unique — never the
+upstream manifest id, per D-005a) recording what the update-notify sweep last
+observed for that API's upstream spec URL:
+
+- ``last_seen_etag`` — the validator sent back as ``If-None-Match`` on the next
+  sweep so an unchanged spec answers ``304`` and transfers no body.
+- ``last_seen_digest`` — ``sha256`` of the last fetched spec bytes. Recorded for
+  observability / future weak-ETag handling; the current MVP dedupes on
+  ``last_notified_digest`` and compares against the registered revision's
+  ``spec_digest``, so this column is written but not yet read.
+- ``last_notified_digest`` — the digest that last produced a
+  ``catalog.update_available`` event, so a persistently-changed spec notifies
+  **once** rather than every sweep.
+- ``last_checked_at`` — when the sweep last probed this API.
+
+The table is deliberately narrow and relationship-free: it is sweep scratch
+state, not part of the API aggregate, so it does not widen ``apis``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Index, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from jentic_one.shared.db.base import RegistryBase
+from jentic_one.shared.db.ids import generate_ksuid
+from jentic_one.shared.db.types import GUID, UTCDateTime
+from jentic_one.shared.db.utils import utcnow
+
+
+class CatalogUpdateCheck(RegistryBase):
+    """Per-API record of the last upstream-spec observation for update notify."""
+
+    __tablename__ = "catalog_update_checks"
+    __table_args__ = (Index("ix_catalog_update_checks_local_api_id", "local_api_id", unique=True),)
+
+    id: Mapped[str] = mapped_column(
+        String(30),
+        primary_key=True,
+        default=lambda: generate_ksuid("cuc"),
+        server_default=func.generate_ksuid("cuc"),
+    )
+    #: The local registry API this row tracks (``apis.id``). No FK constraint:
+    #: the row is cheap scratch state and a dropped API is reconciled by the
+    #: sweep (a check with no matching registered spec url is simply ignored).
+    local_api_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False)
+    #: The upstream spec URL probed (the API's revision ``source_url``).
+    spec_url: Mapped[str] = mapped_column(String(2048), nullable=False)
+    last_seen_etag: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_seen_digest: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    last_notified_digest: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    last_checked_at: Mapped[datetime | None] = mapped_column(UTCDateTime(), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        UTCDateTime(), nullable=False, default=utcnow, server_default=func.now()
+    )

--- a/src/jentic_one/registry/repos/catalog_update_check_repo.py
+++ b/src/jentic_one/registry/repos/catalog_update_check_repo.py
@@ -1,0 +1,78 @@
+"""Repository for ``catalog_update_checks`` — per-API update-notify bookkeeping.
+
+Flush-only, never commits (the caller owns the transaction), matching the rest
+of the registry repositories. Rows are keyed by ``local_api_id`` (unique), so
+reads/writes go through :meth:`get` / :meth:`upsert` on that key.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from jentic_one.registry.core.schema.catalog_update_checks import CatalogUpdateCheck
+
+
+class CatalogUpdateCheckRepository:
+    """Data access for the update-notify check rows — flush-only, never commits."""
+
+    @staticmethod
+    async def get(session: AsyncSession, local_api_id: uuid.UUID) -> CatalogUpdateCheck | None:
+        """Return the check row for a local API, or ``None`` when never probed."""
+        result = await session.execute(
+            select(CatalogUpdateCheck).where(CatalogUpdateCheck.local_api_id == local_api_id)
+        )
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def upsert(
+        session: AsyncSession,
+        *,
+        local_api_id: uuid.UUID,
+        spec_url: str,
+        etag: str | None,
+        digest: str | None,
+        checked_at: datetime,
+        notified_digest: str | None = None,
+    ) -> CatalogUpdateCheck:
+        """Insert or update the observation for ``local_api_id`` and return the row.
+
+        ``notified_digest`` is only written when non-``None`` — a probe that
+        observes no change (or a ``304``) must not clear the digest that last
+        produced an event, or the dedupe would re-fire on the next real change.
+
+        Read-then-insert (no ``ON CONFLICT``) is acceptable because the
+        update-notify sweep is triggered only from the (rare, max-age-gated) lazy
+        manifest refresh and probes each API at most once per interval, so a true
+        concurrent write to the same ``local_api_id`` is unlikely. If two refreshes
+        do race, the unique ``local_api_id`` index turns the losing INSERT into an
+        ``IntegrityError`` (no duplicate row) — the worst case is one duplicate
+        ``catalog.update_available`` event, which the next sweep dedupes. Promote to
+        ``INSERT … ON CONFLICT`` if the sweep is ever hoisted onto a shared lock or
+        run concurrently.
+        """
+        row = await CatalogUpdateCheckRepository.get(session, local_api_id)
+        if row is None:
+            row = CatalogUpdateCheck(
+                local_api_id=local_api_id,
+                spec_url=spec_url,
+                last_seen_etag=etag,
+                last_seen_digest=digest,
+                last_notified_digest=notified_digest,
+                last_checked_at=checked_at,
+            )
+            session.add(row)
+        else:
+            row.spec_url = spec_url
+            if etag is not None:
+                row.last_seen_etag = etag
+            if digest is not None:
+                row.last_seen_digest = digest
+            if notified_digest is not None:
+                row.last_notified_digest = notified_digest
+            row.last_checked_at = checked_at
+        await session.flush()
+        return row

--- a/src/jentic_one/registry/repos/revision_repo.py
+++ b/src/jentic_one/registry/repos/revision_repo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, cast
 
@@ -12,7 +13,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from jentic_one.registry.core.schema.api_revisions import ApiRevision
+from jentic_one.registry.core.schema.apis import Api
 from jentic_one.shared.models import ApiRevisionSourceType, ApiRevisionState
+
+
+@dataclass(frozen=True)
+class RegisteredSpec:
+    """A sweep candidate: a registered API's spec URL + its current identity/digest."""
+
+    api_id: uuid.UUID
+    source_url: str
+    spec_digest: str | None
+    vendor: str
+    name: str
+    version: str
 
 
 class ApiRevisionRepository:
@@ -253,3 +267,46 @@ class ApiRevisionRepository:
         )
         await session.flush()
         return result.rowcount
+
+    @staticmethod
+    async def registered_specs_for_notify(
+        session: AsyncSession,
+    ) -> list[RegisteredSpec]:
+        """Non-archived revisions that carry a ``source_url`` — the sweep candidates.
+
+        Joins each candidate revision to its API's identity + current spec digest so
+        the update-notify sweep can build an event payload and dedupe without a
+        second query. One row per ``(api_id, source_url)``; an API with multiple
+        non-archived revisions from the same URL is de-duplicated by the caller via
+        the unique ``local_api_id`` check row.
+        """
+        result = await session.execute(
+            select(
+                ApiRevision.api_id,
+                ApiRevision.source_url,
+                ApiRevision.spec_digest,
+                Api.vendor,
+                Api.name,
+                Api.version,
+            )
+            .join(Api, Api.id == ApiRevision.api_id)
+            .where(ApiRevision.source_url.is_not(None))
+            .where(ApiRevision.state != ApiRevisionState.ARCHIVED)
+        )
+        seen: set[uuid.UUID] = set()
+        specs: list[RegisteredSpec] = []
+        for api_id, source_url, spec_digest, vendor, name, version in result.all():
+            if api_id in seen:
+                continue
+            seen.add(api_id)
+            specs.append(
+                RegisteredSpec(
+                    api_id=api_id,
+                    source_url=source_url,
+                    spec_digest=spec_digest,
+                    vendor=vendor,
+                    name=name,
+                    version=version,
+                )
+            )
+        return specs

--- a/src/jentic_one/registry/repos/revision_repo.py
+++ b/src/jentic_one/registry/repos/revision_repo.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, cast
 
-from sqlalchemy import and_, delete, or_, select, update
+from sqlalchemy import and_, case, delete, or_, select, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -276,10 +276,19 @@ class ApiRevisionRepository:
 
         Joins each candidate revision to its API's identity + current spec digest so
         the update-notify sweep can build an event payload and dedupe without a
-        second query. One row per ``(api_id, source_url)``; an API with multiple
-        non-archived revisions from the same URL is de-duplicated by the caller via
-        the unique ``local_api_id`` check row.
+        second query. Exactly one row per ``api_id``: an API commonly has multiple
+        non-archived revisions (imports create drafts that are never auto-promoted),
+        so we must pick a **deterministic** one or the sweep would compare upstream
+        against a row-order-dependent digest/``source_url`` and fire spurious
+        notifications. Selection order: the API's ``current_revision_id`` if set,
+        then newest ``created_at``, then ``id`` as a final tiebreak (matching the
+        ``ix_api_revisions_api_id_created_at_id`` index).
         """
+        # 0 for the API's current revision, 1 otherwise — sorts current first.
+        current_first = case(
+            (ApiRevision.id == Api.current_revision_id, 0),
+            else_=1,
+        )
         result = await session.execute(
             select(
                 ApiRevision.api_id,
@@ -292,6 +301,12 @@ class ApiRevisionRepository:
             .join(Api, Api.id == ApiRevision.api_id)
             .where(ApiRevision.source_url.is_not(None))
             .where(ApiRevision.state != ApiRevisionState.ARCHIVED)
+            .order_by(
+                ApiRevision.api_id,
+                current_first,
+                ApiRevision.created_at.desc(),
+                ApiRevision.id,
+            )
         )
         seen: set[uuid.UUID] = set()
         specs: list[RegisteredSpec] = []

--- a/src/jentic_one/registry/services/catalog/fetch.py
+++ b/src/jentic_one/registry/services/catalog/fetch.py
@@ -58,7 +58,7 @@ async def fetch_json(url: str, *, config: IngestConfig) -> dict[str, Any]:
     caps) but returns a plain decoded JSON object instead of an IngestSpecification.
     """
     try:
-        validated_url = validate_upstream_url(url)
+        validated_url = validate_upstream_url(url, config.egress)
     except ValueError as exc:
         raise CatalogFetchError(f"unsafe URL rejected: {exc}") from exc
 
@@ -76,7 +76,9 @@ async def fetch_json(url: str, *, config: IngestConfig) -> dict[str, Any]:
                 if not location:
                     break
                 try:
-                    validated_url = validate_upstream_url(urljoin(validated_url, location))
+                    validated_url = validate_upstream_url(
+                        urljoin(validated_url, location), config.egress
+                    )
                 except ValueError as exc:
                     raise CatalogFetchError(f"unsafe URL rejected: {exc}") from exc
                 resp = await client.get(validated_url, headers={"user-agent": _USER_AGENT})
@@ -125,7 +127,7 @@ async def fetch_bytes_conditional(
     stable digest) means the upstream spec is byte-identical to what we last saw.
     """
     try:
-        validated_url = validate_upstream_url(url)
+        validated_url = validate_upstream_url(url, config.egress)
     except ValueError as exc:
         raise CatalogFetchError(f"unsafe URL rejected: {exc}") from exc
 
@@ -147,7 +149,9 @@ async def fetch_bytes_conditional(
                 if not location:
                     break
                 try:
-                    validated_url = validate_upstream_url(urljoin(validated_url, location))
+                    validated_url = validate_upstream_url(
+                        urljoin(validated_url, location), config.egress
+                    )
                 except ValueError as exc:
                     raise CatalogFetchError(f"unsafe URL rejected: {exc}") from exc
                 resp = await client.get(validated_url, headers=headers)

--- a/src/jentic_one/registry/services/catalog/fetch.py
+++ b/src/jentic_one/registry/services/catalog/fetch.py
@@ -9,7 +9,9 @@ hardening and without coupling to the ingest pipeline's spec-shaped return type.
 
 from __future__ import annotations
 
+import hashlib
 import json
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urljoin
 
@@ -21,6 +23,23 @@ from jentic_one.shared.url_validation import validate_upstream_url
 
 class CatalogFetchError(Exception):
     """Raised when an upstream catalog document cannot be fetched or parsed."""
+
+
+@dataclass(frozen=True)
+class ConditionalFetch:
+    """Result of a conditional (``If-None-Match``) byte fetch.
+
+    ``not_modified`` is ``True`` when the server answered ``304`` to our
+    ``If-None-Match`` — ``content``/``digest`` are then ``None`` (nothing was
+    transferred). Otherwise ``content`` holds the raw body, ``digest`` its
+    ``sha256`` hex, and ``etag`` the response's validator (``None`` when the
+    upstream sends none).
+    """
+
+    not_modified: bool
+    etag: str | None
+    content: bytes | None
+    digest: str | None
 
 
 async def fetch_json(url: str, *, config: IngestConfig) -> dict[str, Any]:
@@ -78,3 +97,75 @@ async def fetch_json(url: str, *, config: IngestConfig) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         raise CatalogFetchError("expected a JSON object")
     return parsed
+
+
+async def fetch_bytes_conditional(
+    url: str, *, config: IngestConfig, etag: str | None = None
+) -> ConditionalFetch:
+    """Conditionally GET a URL's raw bytes, with the same SSRF/redirect/size guards.
+
+    A cheap upstream-change probe for the update-notify sweep: when ``etag`` is
+    provided it is sent as ``If-None-Match`` so an unchanged resource answers
+    ``304 Not Modified`` with no body transferred (``ConditionalFetch.not_modified``
+    is then ``True``). Otherwise the body is returned with its ``sha256`` digest
+    and the response ``ETag``. Redirects are followed manually with per-hop URL
+    revalidation and the same content-length + body-size caps as ``fetch_json``;
+    the conditional header is re-sent on each hop.
+
+    raw.githubusercontent.com serves content-derived ETags, so a stable ETag (or
+    stable digest) means the upstream spec is byte-identical to what we last saw.
+    """
+    try:
+        validated_url = validate_upstream_url(url)
+    except ValueError as exc:
+        raise CatalogFetchError(f"unsafe URL rejected: {exc}") from exc
+
+    headers = {"If-None-Match": etag} if etag else None
+    max_bytes = config.max_spec_bytes
+    limit_mb = max_bytes / (1024 * 1024)
+    try:
+        async with httpx.AsyncClient(
+            timeout=config.fetch_timeout_s, follow_redirects=False
+        ) as client:
+            resp = await client.get(validated_url, headers=headers)
+            for _ in range(config.max_redirects):
+                if resp.status_code < 300 or resp.status_code >= 400:
+                    break
+                location = resp.headers.get("location")
+                if not location:
+                    break
+                try:
+                    validated_url = validate_upstream_url(urljoin(validated_url, location))
+                except ValueError as exc:
+                    raise CatalogFetchError(f"unsafe URL rejected: {exc}") from exc
+                resp = await client.get(validated_url, headers=headers)
+            else:
+                if 300 <= resp.status_code < 400:
+                    raise CatalogFetchError("too many redirects")
+    except CatalogFetchError:
+        raise
+    except httpx.HTTPError as exc:
+        raise CatalogFetchError(f"failed to fetch {url}: {exc}") from exc
+
+    if resp.status_code == 304:
+        return ConditionalFetch(
+            not_modified=True, etag=resp.headers.get("etag") or etag, content=None, digest=None
+        )
+
+    if resp.status_code < 200 or resp.status_code >= 300:
+        raise CatalogFetchError(f"non-success status {resp.status_code} fetching {url}")
+
+    content_length = resp.headers.get("content-length")
+    if content_length and content_length.isdigit() and int(content_length) > max_bytes:
+        raise CatalogFetchError(f"response exceeds size limit ({limit_mb:.0f} MB)")
+
+    body = resp.content
+    if len(body) > max_bytes:
+        raise CatalogFetchError(f"response exceeds size limit ({limit_mb:.0f} MB)")
+
+    return ConditionalFetch(
+        not_modified=False,
+        etag=resp.headers.get("etag"),
+        content=body,
+        digest=hashlib.sha256(body).hexdigest(),
+    )

--- a/src/jentic_one/registry/services/catalog/fetch.py
+++ b/src/jentic_one/registry/services/catalog/fetch.py
@@ -25,6 +25,14 @@ class CatalogFetchError(Exception):
     """Raised when an upstream catalog document cannot be fetched or parsed."""
 
 
+#: Identify the catalog fetcher/update-notify poller to upstream hosts. Server-
+#: initiated recurring third-party fetches should announce themselves so operators
+#: can attribute traffic and hosts can apply sane rate limits (unidentified bots
+#: are throttled first). See the raw.githubusercontent poll path in the catalog
+#: update-notify sweep.
+_USER_AGENT = "jentic-one-catalog/1 (+https://github.com/jentic/jentic-one)"
+
+
 @dataclass(frozen=True)
 class ConditionalFetch:
     """Result of a conditional (``If-None-Match``) byte fetch.
@@ -57,9 +65,10 @@ async def fetch_json(url: str, *, config: IngestConfig) -> dict[str, Any]:
     max_bytes = config.max_spec_bytes
     try:
         async with httpx.AsyncClient(
-            timeout=config.fetch_timeout_s, follow_redirects=False
+            timeout=config.fetch_timeout_s,
+            follow_redirects=False,
         ) as client:
-            resp = await client.get(validated_url)
+            resp = await client.get(validated_url, headers={"user-agent": _USER_AGENT})
             for _ in range(config.max_redirects):
                 if resp.status_code < 300 or resp.status_code >= 400:
                     break
@@ -70,7 +79,7 @@ async def fetch_json(url: str, *, config: IngestConfig) -> dict[str, Any]:
                     validated_url = validate_upstream_url(urljoin(validated_url, location))
                 except ValueError as exc:
                     raise CatalogFetchError(f"unsafe URL rejected: {exc}") from exc
-                resp = await client.get(validated_url)
+                resp = await client.get(validated_url, headers={"user-agent": _USER_AGENT})
             else:
                 if 300 <= resp.status_code < 400:
                     raise CatalogFetchError("too many redirects")
@@ -120,12 +129,15 @@ async def fetch_bytes_conditional(
     except ValueError as exc:
         raise CatalogFetchError(f"unsafe URL rejected: {exc}") from exc
 
-    headers = {"If-None-Match": etag} if etag else None
+    headers = {"user-agent": _USER_AGENT}
+    if etag:
+        headers["If-None-Match"] = etag
     max_bytes = config.max_spec_bytes
     limit_mb = max_bytes / (1024 * 1024)
     try:
         async with httpx.AsyncClient(
-            timeout=config.fetch_timeout_s, follow_redirects=False
+            timeout=config.fetch_timeout_s,
+            follow_redirects=False,
         ) as client:
             resp = await client.get(validated_url, headers=headers)
             for _ in range(config.max_redirects):

--- a/src/jentic_one/registry/services/catalog/service.py
+++ b/src/jentic_one/registry/services/catalog/service.py
@@ -153,22 +153,33 @@ class CatalogService:
             await self.refresh()
         except CatalogUnavailableError:
             return
-        self._spawn_update_notify_sweep()
+        self.trigger_update_notify_sweep()
 
-    def _spawn_update_notify_sweep(self) -> None:
+    def trigger_update_notify_sweep(self) -> None:
         """Fire-and-forget the update-notify sweep off the triggering read path.
+
+        Public entry point for both the lazy refresh-on-read (``_safe_refresh``) and
+        the explicit operator ``POST /catalog:refresh`` — an intentional "check
+        upstream now" should sweep too.
 
         The sweep issues up to N conditional GETs, so awaiting it inline would make
         an unlucky user's (max-age-gated) catalog read block on the whole batch. We
         detach it into a background task instead; failures are logged, never raised
         back to the reader. The task is parked in ``_SWEEP_TASKS`` so it isn't GC'd
         before it finishes (this service instance is per-request and short-lived).
+
+        No-ops when the sweep is disabled (kill switch) so a disabled install never
+        spawns a throwaway task per refresh.
         """
+        if self._cfg.update_check_interval_seconds <= 0:
+            return
         try:
             task = asyncio.create_task(self._run_update_notify_sweep())
         except RuntimeError:
-            # No running loop (e.g. a sync test harness): run inline as a fallback.
-            logger.debug("catalog_update_sweep_no_loop_running_inline")
+            # No running event loop (only reachable from a sync caller, which the
+            # async refresh path never is). Skip rather than block; there is no
+            # safe inline fallback without a loop.
+            logger.debug("catalog_update_sweep_skipped_no_running_loop")
             return
         _SWEEP_TASKS.add(task)
 

--- a/src/jentic_one/registry/services/catalog/service.py
+++ b/src/jentic_one/registry/services/catalog/service.py
@@ -21,9 +21,17 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
+import structlog
+
 from jentic_one.registry.repos.catalog_repo import CatalogRepository
+from jentic_one.registry.repos.catalog_update_check_repo import CatalogUpdateCheckRepository
+from jentic_one.registry.repos.revision_repo import ApiRevisionRepository, RegisteredSpec
 from jentic_one.registry.services.catalog import manifest_builder as mb
-from jentic_one.registry.services.catalog.fetch import CatalogFetchError, fetch_json
+from jentic_one.registry.services.catalog.fetch import (
+    CatalogFetchError,
+    fetch_bytes_conditional,
+    fetch_json,
+)
 from jentic_one.registry.services.errors import (
     CatalogEntryNotFoundError,
     CatalogUnavailableError,
@@ -31,9 +39,13 @@ from jentic_one.registry.services.errors import (
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.context import Context
 from jentic_one.shared.db.utils import utcnow
+from jentic_one.shared.events import emit_event_best_effort
 from jentic_one.shared.jobs.enqueue import enqueue_job
+from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.models.jobs import JobKind
 from jentic_one.shared.pagination import decode_catalog_cursor, encode_catalog_cursor
+
+logger = structlog.get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -132,6 +144,117 @@ class CatalogService:
             await self.refresh()
         except CatalogUnavailableError:
             return
+        await self._run_update_notify_sweep()
+
+    async def _run_update_notify_sweep(self) -> None:
+        """Probe registered specs for upstream changes; emit an event on change.
+
+        Piggybacks on the (rare, max-age-gated) manifest refresh. For each
+        registered API with a spec URL, sends a conditional ``GET``
+        (``If-None-Match`` with the last-seen ETag) at most once per
+        ``update_check_interval_seconds``; a ``304`` or an unchanged digest is a
+        no-op, a changed digest emits ``catalog.update_available`` once (deduped on
+        ``last_notified_digest``). Upstream/DB failures are swallowed per API so a
+        flaky host never breaks the refresh or the rest of the batch. A ``0``
+        interval disables the sweep entirely (air-gapped kill switch).
+
+        Note the refresh's advisory lock is transaction-scoped (it guards only the
+        staleness check), so this sweep is **not** globally single-flight: a rare
+        concurrent double-refresh could emit a duplicate event for the same change.
+        That is deliberately tolerated — the event is idempotent for operators and
+        the next sweep dedupes on the persisted digest. Probes run serially (one
+        network round-trip each); fine at MVP catalog scale — a future fan-out would
+        need a ``Semaphore`` bounded below the DB pool size.
+        """
+        interval = self._cfg.update_check_interval_seconds
+        if interval <= 0:
+            return
+
+        async with self._ctx.registry_db.session() as session:
+            candidates = await ApiRevisionRepository.registered_specs_for_notify(session)
+        if not candidates:
+            return
+
+        now = utcnow()
+        for spec in candidates:
+            try:
+                await self._probe_one(spec, now=now, interval=interval)
+            except Exception:  # best-effort per API, never break the sweep
+                logger.warning(
+                    "catalog_update_probe_failed",
+                    api_id=str(spec.api_id),
+                    spec_url=spec.source_url,
+                    exc_info=True,
+                )
+
+    async def _probe_one(self, spec: RegisteredSpec, *, now: datetime, interval: int) -> None:
+        """Conditionally fetch one registered spec and emit on a fresh change."""
+        async with self._ctx.registry_db.session() as session:
+            check = await CatalogUpdateCheckRepository.get(session, spec.api_id)
+
+        if check is not None and check.last_checked_at is not None:
+            age = (now - check.last_checked_at).total_seconds()
+            if age < interval:
+                return
+
+        prior_etag = check.last_seen_etag if check is not None else None
+        result = await fetch_bytes_conditional(
+            spec.source_url, config=self._ingest_cfg, etag=prior_etag
+        )
+
+        if result.not_modified or result.digest is None:
+            async with self._ctx.registry_db.transaction() as session:
+                await CatalogUpdateCheckRepository.upsert(
+                    session,
+                    local_api_id=spec.api_id,
+                    spec_url=spec.source_url,
+                    etag=result.etag,
+                    digest=None,
+                    checked_at=now,
+                )
+            return
+
+        upstream_digest = result.digest
+        last_notified = check.last_notified_digest if check is not None else None
+        # A change worth notifying: the upstream bytes differ from what backs the
+        # registered revision, and we have not already notified for this exact
+        # upstream digest. Comparing against spec_digest (not just last_seen)
+        # means a spec that reverts to the registered content stops notifying.
+        changed = upstream_digest != spec.spec_digest and upstream_digest != last_notified
+
+        notified_digest = upstream_digest if changed else None
+        async with self._ctx.registry_db.transaction() as session:
+            await CatalogUpdateCheckRepository.upsert(
+                session,
+                local_api_id=spec.api_id,
+                spec_url=spec.source_url,
+                etag=result.etag,
+                digest=upstream_digest,
+                checked_at=now,
+                notified_digest=notified_digest,
+            )
+
+        if not changed:
+            return
+
+        async with self._ctx.admin_db.transaction() as session:
+            await emit_event_best_effort(
+                session,
+                type=EventType.CATALOG_UPDATE_AVAILABLE,
+                severity=EventSeverity.INFO,
+                summary=(f"Upstream spec updated for {spec.vendor}/{spec.name} ({spec.version})"),
+                requires_action=True,
+                created_by=None,
+                data={
+                    "api_id": str(spec.api_id),
+                    "vendor": spec.vendor,
+                    "name": spec.name,
+                    "version": spec.version,
+                    "current_digest": spec.spec_digest,
+                    "upstream_digest": upstream_digest,
+                    "spec_url": spec.source_url,
+                },
+            )
 
     async def _refresh_if_stale(self) -> None:
         """Lazy refresh-on-read seam for the single-entry reads (``get``)."""

--- a/src/jentic_one/registry/services/catalog/service.py
+++ b/src/jentic_one/registry/services/catalog/service.py
@@ -17,6 +17,7 @@ Boundaries kept from D-005a:
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -46,6 +47,14 @@ from jentic_one.shared.models.jobs import JobKind
 from jentic_one.shared.pagination import decode_catalog_cursor, encode_catalog_cursor
 
 logger = structlog.get_logger(__name__)
+
+#: Strong references to in-flight fire-and-forget sweep tasks. ``CatalogService``
+#: is constructed per-request and GC'd when the request returns, so a task held
+#: only on ``self`` could be collected mid-flight (asyncio keeps only weak refs to
+#: tasks). Parking them here until they finish keeps them alive; the done-callback
+#: discards on completion. Bounded in practice by the max-age + advisory-lock gates
+#: on the refresh that spawns them.
+_SWEEP_TASKS: set[asyncio.Task[None]] = set()
 
 
 @dataclass(frozen=True)
@@ -144,7 +153,31 @@ class CatalogService:
             await self.refresh()
         except CatalogUnavailableError:
             return
-        await self._run_update_notify_sweep()
+        self._spawn_update_notify_sweep()
+
+    def _spawn_update_notify_sweep(self) -> None:
+        """Fire-and-forget the update-notify sweep off the triggering read path.
+
+        The sweep issues up to N conditional GETs, so awaiting it inline would make
+        an unlucky user's (max-age-gated) catalog read block on the whole batch. We
+        detach it into a background task instead; failures are logged, never raised
+        back to the reader. The task is parked in ``_SWEEP_TASKS`` so it isn't GC'd
+        before it finishes (this service instance is per-request and short-lived).
+        """
+        try:
+            task = asyncio.create_task(self._run_update_notify_sweep())
+        except RuntimeError:
+            # No running loop (e.g. a sync test harness): run inline as a fallback.
+            logger.debug("catalog_update_sweep_no_loop_running_inline")
+            return
+        _SWEEP_TASKS.add(task)
+
+        def _done(t: asyncio.Task[None]) -> None:
+            _SWEEP_TASKS.discard(t)
+            if not t.cancelled() and (exc := t.exception()) is not None:
+                logger.warning("catalog_update_sweep_task_failed", exc_info=exc)
+
+        task.add_done_callback(_done)
 
     async def _run_update_notify_sweep(self) -> None:
         """Probe registered specs for upstream changes; emit an event on change.
@@ -162,9 +195,10 @@ class CatalogService:
         staleness check), so this sweep is **not** globally single-flight: a rare
         concurrent double-refresh could emit a duplicate event for the same change.
         That is deliberately tolerated — the event is idempotent for operators and
-        the next sweep dedupes on the persisted digest. Probes run serially (one
-        network round-trip each); fine at MVP catalog scale — a future fan-out would
-        need a ``Semaphore`` bounded below the DB pool size.
+        the next sweep dedupes on the persisted digest. Probes fan out with bounded
+        concurrency (``update_sweep_max_concurrency``, kept below the DB pool) under
+        a wall-clock budget (``update_sweep_deadline_seconds``) so a large or hostile
+        candidate set can't turn one refresh into an unbounded stall.
         """
         interval = self._cfg.update_check_interval_seconds
         if interval <= 0:
@@ -176,16 +210,42 @@ class CatalogService:
             return
 
         now = utcnow()
-        for spec in candidates:
-            try:
-                await self._probe_one(spec, now=now, interval=interval)
-            except Exception:  # best-effort per API, never break the sweep
-                logger.warning(
-                    "catalog_update_probe_failed",
-                    api_id=str(spec.api_id),
-                    spec_url=spec.source_url,
-                    exc_info=True,
-                )
+        sem = asyncio.Semaphore(max(1, self._cfg.update_sweep_max_concurrency))
+        stats = {"probed": 0, "failed": 0}
+
+        async def _guarded(spec: RegisteredSpec) -> None:
+            async with sem:
+                try:
+                    await self._probe_one(spec, now=now, interval=interval)
+                    stats["probed"] += 1
+                except Exception:  # best-effort per API, never break the sweep
+                    stats["failed"] += 1
+                    logger.warning(
+                        "catalog_update_probe_failed",
+                        api_id=str(spec.api_id),
+                        spec_url=spec.source_url,
+                        exc_info=True,
+                    )
+
+        started = asyncio.get_running_loop().time()
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*(_guarded(spec) for spec in candidates)),
+                timeout=self._cfg.update_sweep_deadline_seconds,
+            )
+        except TimeoutError:
+            logger.warning(
+                "catalog_update_sweep_deadline_hit",
+                candidates=len(candidates),
+                probed=stats["probed"],
+            )
+        logger.info(
+            "catalog_update_sweep_complete",
+            candidates=len(candidates),
+            probed=stats["probed"],
+            failed=stats["failed"],
+            duration_ms=int((asyncio.get_running_loop().time() - started) * 1000),
+        )
 
     async def _probe_one(self, spec: RegisteredSpec, *, now: datetime, interval: int) -> None:
         """Conditionally fetch one registered spec and emit on a fresh change."""
@@ -243,7 +303,12 @@ class CatalogService:
                 type=EventType.CATALOG_UPDATE_AVAILABLE,
                 severity=EventSeverity.INFO,
                 summary=(f"Upstream spec updated for {spec.vendor}/{spec.name} ({spec.version})"),
-                requires_action=True,
+                # Informational until Flow-3 ships a resolve path (one-click re-import
+                # / dismiss-snooze per (api_id, digest) — Phase 4). Marking it
+                # requires_action now would pile unresolvable items into the action
+                # inbox (nothing the operator can do clears them), so it surfaces in
+                # the events feed only. Flip to True alongside the re-import affordance.
+                requires_action=False,
                 created_by=None,
                 data={
                     "api_id": str(spec.api_id),

--- a/src/jentic_one/registry/web/routers/catalog.py
+++ b/src/jentic_one/registry/web/routers/catalog.py
@@ -187,6 +187,10 @@ async def refresh_catalog(
 ) -> JSONResponse:
     """Force a refresh of the catalog cache from the upstream manifest (org:admin)."""
     result = await svc.refresh()
+    # An explicit operator "refresh now" is the strongest "check upstream" signal,
+    # so trigger the update-notify sweep too (the lazy read path already does this
+    # via _safe_refresh). Fire-and-forget: never block the refresh response on it.
+    svc.trigger_update_notify_sweep()
     resp = CatalogRefreshResponse(count=result.count)
     return JSONResponse(content=resp.model_dump(mode="json", by_alias=True))
 

--- a/src/jentic_one/shared/config.py
+++ b/src/jentic_one/shared/config.py
@@ -764,6 +764,13 @@ class CatalogConfig(BaseModel):
     # API is re-probed at most once per this interval. Zero disables the sweep
     # entirely (kill switch for air-gapped installs — no event spam, no egress).
     update_check_interval_seconds: int = 86400
+    # Aggregate guardrails for one update-notify sweep. The sweep is offloaded off
+    # the triggering read (fire-and-forget), but it still probes N registered specs
+    # over the network, so bound the batch: stop after this many wall-clock seconds
+    # and run at most this many probes concurrently. Concurrency is kept below the
+    # registry DB pool so the sweep never starves live request traffic.
+    update_sweep_deadline_seconds: int = 300
+    update_sweep_max_concurrency: int = 4
 
 
 class ServerConfig(BaseModel):

--- a/src/jentic_one/shared/config.py
+++ b/src/jentic_one/shared/config.py
@@ -758,6 +758,12 @@ class CatalogConfig(BaseModel):
     # Lazy refresh-on-read: a manifest older than this is refreshed on the next
     # list()/get(). Zero disables auto-refresh (manual :refresh only).
     manifest_max_age_seconds: int = 86400
+    # Update-notify (Flow 3): after a manifest refresh, conditionally re-fetch the
+    # spec URLs of registered APIs (If-None-Match) and emit a
+    # ``catalog.update_available`` event when the upstream spec changed. A given
+    # API is re-probed at most once per this interval. Zero disables the sweep
+    # entirely (kill switch for air-gapped installs — no event spam, no egress).
+    update_check_interval_seconds: int = 86400
 
 
 class ServerConfig(BaseModel):

--- a/src/jentic_one/shared/models/events.py
+++ b/src/jentic_one/shared/models/events.py
@@ -31,8 +31,10 @@ class EventType:
     JOB_FAILED_PERMANENTLY = "job.failed_permanently"
     UNAUTHORIZED_ACCESS_ATTEMPT = "security.unauthorized_access_attempt"
     # A registered catalog/imported API's upstream spec changed (detected by the
-    # update-notify sweep). Emitted with requires_action=True and deduped on the
-    # observed spec digest so it fires once per real change, not every sweep.
+    # update-notify sweep). Emitted with requires_action=False (informational
+    # until Flow-3 ships a resolve path — one-click re-import / dismiss — in a
+    # later phase) and deduped on the observed spec digest so it fires once per
+    # real change, not every sweep.
     CATALOG_UPDATE_AVAILABLE = "catalog.update_available"
 
     # --- Product-telemetry event types (issue #446) ----------------------

--- a/src/jentic_one/shared/models/events.py
+++ b/src/jentic_one/shared/models/events.py
@@ -30,6 +30,10 @@ class EventType:
     UPSTREAM_CIRCUIT_OPEN = "upstream.circuit_open"
     JOB_FAILED_PERMANENTLY = "job.failed_permanently"
     UNAUTHORIZED_ACCESS_ATTEMPT = "security.unauthorized_access_attempt"
+    # A registered catalog/imported API's upstream spec changed (detected by the
+    # update-notify sweep). Emitted with requires_action=True and deduped on the
+    # observed spec digest so it fires once per real change, not every sweep.
+    CATALOG_UPDATE_AVAILABLE = "catalog.update_available"
 
     # --- Product-telemetry event types (issue #446) ----------------------
     # These flow through emit_event (the single entry point) like any other
@@ -84,6 +88,7 @@ class EventType:
             UPSTREAM_CIRCUIT_OPEN,
             JOB_FAILED_PERMANENTLY,
             UNAUTHORIZED_ACCESS_ATTEMPT,
+            CATALOG_UPDATE_AVAILABLE,
             INSTANCE_INITIALIZED,
             INSTANCE_BOOTED,
             CREDENTIAL_STORED,

--- a/tests/integration/registry/repos/conftest.py
+++ b/tests/integration/registry/repos/conftest.py
@@ -10,6 +10,7 @@ from sqlalchemy import delete, update
 
 from jentic_one.registry.core.schema.api_revisions import ApiRevision
 from jentic_one.registry.core.schema.apis import Api
+from jentic_one.registry.core.schema.catalog_update_checks import CatalogUpdateCheck
 from jentic_one.registry.core.schema.notes import Note
 from jentic_one.registry.core.schema.operation_url_index import OperationURLIndex
 from jentic_one.registry.core.schema.operations import Operation
@@ -29,6 +30,7 @@ async def clean_registry(registry_db: DatabaseSession) -> AsyncGenerator[None, N
     async def _truncate() -> None:
         async with registry_db.session() as session:
             await session.execute(delete(Note))
+            await session.execute(delete(CatalogUpdateCheck))
             await session.execute(delete(OperationURLIndex))
             await session.execute(delete(SecuritySchemeFlow))
             await session.execute(delete(SecurityScheme))

--- a/tests/integration/registry/repos/test_catalog_update_check_repo.py
+++ b/tests/integration/registry/repos/test_catalog_update_check_repo.py
@@ -1,0 +1,126 @@
+"""Integration tests for CatalogUpdateCheckRepository + the notify join query.
+
+Verifies the ``catalog_update_checks`` model round-trips against real PostgreSQL
+(KSUID id, unique ``local_api_id``, selective ``notified_digest`` write) and that
+``ApiRevisionRepository.registered_specs_for_notify`` joins revisions to their API
+identity, excludes archived revisions, and de-duplicates per API.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from jentic_one.registry.core.schema.api_revisions import ApiRevision
+from jentic_one.registry.core.schema.apis import Api
+from jentic_one.registry.repos.catalog_update_check_repo import CatalogUpdateCheckRepository
+from jentic_one.registry.repos.revision_repo import ApiRevisionRepository
+from jentic_one.shared.db.session import DatabaseSession
+
+pytestmark = pytest.mark.integration
+
+
+async def test_upsert_inserts_then_updates(registry_db: DatabaseSession, sample_api: Api) -> None:
+    """First upsert inserts a KSUID-id row; the second updates it in place."""
+    now = datetime.now(UTC)
+    async with registry_db.session() as session:
+        row = await CatalogUpdateCheckRepository.upsert(
+            session,
+            local_api_id=sample_api.id,
+            spec_url="https://example.com/openapi.json",
+            etag='"v1"',
+            digest="digest-1",
+            checked_at=now,
+        )
+        await session.commit()
+        row_id = row.id
+
+    assert row_id.startswith("cuc_")
+
+    async with registry_db.session() as session:
+        again = await CatalogUpdateCheckRepository.upsert(
+            session,
+            local_api_id=sample_api.id,
+            spec_url="https://example.com/openapi.json",
+            etag='"v2"',
+            digest="digest-2",
+            checked_at=now,
+            notified_digest="digest-2",
+        )
+        await session.commit()
+
+    assert again.id == row_id  # same row, updated in place
+    assert again.last_seen_etag == '"v2"'
+    assert again.last_seen_digest == "digest-2"
+    assert again.last_notified_digest == "digest-2"
+
+
+async def test_upsert_does_not_clear_notified_digest_on_none(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """A later probe with notified_digest=None keeps the previously-notified value."""
+    now = datetime.now(UTC)
+    async with registry_db.session() as session:
+        await CatalogUpdateCheckRepository.upsert(
+            session,
+            local_api_id=sample_api.id,
+            spec_url="https://example.com/openapi.json",
+            etag='"v1"',
+            digest="digest-1",
+            checked_at=now,
+            notified_digest="digest-1",
+        )
+        await session.commit()
+
+    async with registry_db.session() as session:
+        row = await CatalogUpdateCheckRepository.upsert(
+            session,
+            local_api_id=sample_api.id,
+            spec_url="https://example.com/openapi.json",
+            etag='"v1"',
+            digest=None,
+            checked_at=now,
+        )
+        await session.commit()
+
+    assert row.last_notified_digest == "digest-1"
+
+
+async def test_registered_specs_for_notify_joins_identity_and_excludes_archived(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """The notify query returns identity+digest for non-archived, source_url'd revisions."""
+    async with registry_db.session() as session:
+        session.add(
+            ApiRevision(
+                api_id=sample_api.id,
+                state="published",
+                spec_digest="sha256:live",
+                source_type="url",
+                source_url="https://example.com/openapi.json",
+            )
+        )
+        # An archived revision from a different URL must be excluded.
+        session.add(
+            ApiRevision(
+                api_id=sample_api.id,
+                state="archived",
+                spec_digest="sha256:old",
+                source_type="url",
+                source_url="https://example.com/old.json",
+            )
+        )
+        await session.commit()
+
+    async with registry_db.session() as session:
+        specs = await ApiRevisionRepository.registered_specs_for_notify(session)
+
+    mine = [s for s in specs if s.api_id == sample_api.id]
+    assert len(mine) == 1
+    spec = mine[0]
+    assert spec.source_url == "https://example.com/openapi.json"
+    assert spec.spec_digest == "sha256:live"
+    assert spec.vendor == sample_api.vendor
+    assert spec.name == sample_api.name
+    assert spec.version == sample_api.version

--- a/tests/integration/registry/repos/test_catalog_update_check_repo.py
+++ b/tests/integration/registry/repos/test_catalog_update_check_repo.py
@@ -124,3 +124,54 @@ async def test_registered_specs_for_notify_joins_identity_and_excludes_archived(
     assert spec.vendor == sample_api.vendor
     assert spec.name == sample_api.name
     assert spec.version == sample_api.version
+
+
+async def test_registered_specs_for_notify_picks_deterministic_revision(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """With >1 live revision, selection is deterministic: current_revision_id wins,
+    else newest created_at — never DB-row-order-dependent (would cause spurious
+    notifies against a stale digest/source_url)."""
+    older = ApiRevision(
+        api_id=sample_api.id,
+        state="published",
+        spec_digest="sha256:older",
+        source_type="url",
+        source_url="https://example.com/older.json",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    newer = ApiRevision(
+        api_id=sample_api.id,
+        state="draft",
+        spec_digest="sha256:newer",
+        source_type="url",
+        source_url="https://example.com/newer.json",
+        created_at=datetime(2026, 6, 1, tzinfo=UTC),
+    )
+    async with registry_db.session() as session:
+        session.add_all([older, newer])
+        await session.commit()
+        newer_id, older_id = newer.id, older.id
+
+    # No current_revision_id → newest created_at wins.
+    async with registry_db.session() as session:
+        specs = await ApiRevisionRepository.registered_specs_for_notify(session)
+    mine = [s for s in specs if s.api_id == sample_api.id]
+    assert len(mine) == 1
+    assert mine[0].spec_digest == "sha256:newer"
+    assert mine[0].source_url == "https://example.com/newer.json"
+
+    # current_revision_id set to the OLDER revision → it overrides recency.
+    async with registry_db.session() as session:
+        api = await session.get(Api, sample_api.id)
+        assert api is not None
+        api.current_revision_id = older_id
+        await session.commit()
+
+    async with registry_db.session() as session:
+        specs = await ApiRevisionRepository.registered_specs_for_notify(session)
+    mine = [s for s in specs if s.api_id == sample_api.id]
+    assert len(mine) == 1
+    assert mine[0].spec_digest == "sha256:older"
+    assert mine[0].source_url == "https://example.com/older.json"
+    assert newer_id != older_id  # sanity: two distinct revisions existed

--- a/tests/integration/registry/services/test_catalog_update_notify_sweep.py
+++ b/tests/integration/registry/services/test_catalog_update_notify_sweep.py
@@ -10,6 +10,7 @@ digest-based dedupe against persisted state — the parts unit mocks can't catch
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
@@ -97,7 +98,7 @@ async def test_sweep_emits_event_and_records_check(
     events = await _events(integration_context)
     assert len(events) == 1
     evt = events[0]
-    assert evt.requires_action is True
+    assert evt.requires_action is False
     assert evt.data["api_id"] == str(registered_api.id)
     assert evt.data["upstream_digest"] == "sha256:upstream-new"
     assert evt.data["current_digest"] == "sha256:registered"
@@ -147,3 +148,45 @@ async def test_sweep_no_event_when_upstream_matches_registered(
         check = await CatalogUpdateCheckRepository.get(session, registered_api.id)
     assert check is not None
     assert check.last_notified_digest is None  # recorded the check, but never notified
+
+
+async def test_sweep_no_event_with_real_bare_hex_digest(
+    integration_context: Context, registry_db: DatabaseSession, clean_state: None
+) -> None:
+    """Guards the digest *format* contract: ingest stores a bare sha256 hex
+    (``hashlib.sha256(body).hexdigest()``, no ``sha256:`` prefix), and the probe
+    computes the same bare hex over the same body — so an unchanged upstream must
+    compare equal and emit nothing. The other tests hand-feed opaque ``sha256:*``
+    markers on both sides, which would pass even if the two sides framed digests
+    differently; this one exercises the real convention end-to-end.
+    """
+    body = b'{"openapi": "3.0.0", "info": {"title": "widgets", "version": "1"}}'
+    real_digest = hashlib.sha256(body).hexdigest()
+    assert ":" not in real_digest  # bare hex, matching the ingest convention
+
+    api = Api(vendor="notify-test.com", name="widgets", version="v1")
+    async with registry_db.session() as session:
+        session.add(api)
+        await session.flush()
+        session.add(
+            ApiRevision(
+                api_id=api.id,
+                state="published",
+                spec_digest=real_digest,
+                source_type="url",
+                source_url=_SPEC_URL,
+            )
+        )
+        await session.commit()
+
+    integration_context.config.catalog.update_check_interval_seconds = 86400
+    same = ConditionalFetch(not_modified=False, etag='"v1"', content=body, digest=real_digest)
+    svc = CatalogService(integration_context)
+    with patch(f"{_SWEEP}.fetch_bytes_conditional", new_callable=AsyncMock, return_value=same):
+        await svc._run_update_notify_sweep()
+
+    assert await _events(integration_context) == []
+    async with integration_context.registry_db.session() as session:
+        check = await CatalogUpdateCheckRepository.get(session, api.id)
+    assert check is not None
+    assert check.last_notified_digest is None

--- a/tests/integration/registry/services/test_catalog_update_notify_sweep.py
+++ b/tests/integration/registry/services/test_catalog_update_notify_sweep.py
@@ -1,0 +1,149 @@
+"""Integration tests for the catalog update-notify sweep against real Postgres.
+
+Unlike the unit tests (which mock every repo + session), these drive
+``CatalogService._run_update_notify_sweep`` / ``_probe_one`` end-to-end against
+the real ``registry_db`` + ``admin_db``, stubbing **only** the out-of-process HTTP
+boundary (``fetch_bytes_conditional``). This exercises the multi-session
+orchestration (read check → fetch → upsert txn → admin emit txn) and the
+digest-based dedupe against persisted state — the parts unit mocks can't catch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import delete, select
+
+from jentic_one.admin.core.schema.events import Event
+from jentic_one.registry.core.schema.api_revisions import ApiRevision
+from jentic_one.registry.core.schema.apis import Api
+from jentic_one.registry.core.schema.catalog_update_checks import CatalogUpdateCheck
+from jentic_one.registry.repos.catalog_update_check_repo import CatalogUpdateCheckRepository
+from jentic_one.registry.services.catalog.fetch import ConditionalFetch
+from jentic_one.registry.services.catalog.service import CatalogService
+from jentic_one.shared.context import Context
+from jentic_one.shared.db.session import DatabaseSession
+from jentic_one.shared.models.events import EventType
+
+pytestmark = pytest.mark.integration
+
+_SWEEP = "jentic_one.registry.services.catalog.service"
+_SPEC_URL = "https://raw.githubusercontent.com/jentic/x/main/openapi.json"
+
+
+@pytest.fixture()
+async def clean_state(
+    registry_db: DatabaseSession, integration_context: Context
+) -> AsyncGenerator[None, None]:
+    async def _wipe() -> None:
+        async with registry_db.session() as session:
+            await session.execute(delete(CatalogUpdateCheck))
+            await session.execute(delete(ApiRevision).where(ApiRevision.source_url == _SPEC_URL))
+            await session.execute(delete(Api).where(Api.vendor == "notify-test.com"))
+            await session.commit()
+        async with integration_context.admin_db.session() as session:
+            await session.execute(
+                delete(Event).where(Event.type == EventType.CATALOG_UPDATE_AVAILABLE)
+            )
+            await session.commit()
+
+    await _wipe()
+    yield
+    await _wipe()
+
+
+@pytest.fixture()
+async def registered_api(registry_db: DatabaseSession, clean_state: None) -> Api:
+    """A registered API with a published revision carrying a source_url + digest."""
+    api = Api(vendor="notify-test.com", name="widgets", version="v1")
+    async with registry_db.session() as session:
+        session.add(api)
+        await session.flush()
+        session.add(
+            ApiRevision(
+                api_id=api.id,
+                state="published",
+                spec_digest="sha256:registered",
+                source_type="url",
+                source_url=_SPEC_URL,
+            )
+        )
+        await session.commit()
+    return api
+
+
+async def _events(ctx: Context) -> list[Event]:
+    async with ctx.admin_db.session() as session:
+        result = await session.execute(
+            select(Event).where(Event.type == EventType.CATALOG_UPDATE_AVAILABLE)
+        )
+        return list(result.scalars().all())
+
+
+async def test_sweep_emits_event_and_records_check(
+    integration_context: Context, registered_api: Api
+) -> None:
+    """A changed upstream digest emits one event and persists the notify state."""
+    integration_context.config.catalog.update_check_interval_seconds = 86400
+    changed = ConditionalFetch(
+        not_modified=False, etag='"v2"', content=b"{}", digest="sha256:upstream-new"
+    )
+    svc = CatalogService(integration_context)
+    with patch(f"{_SWEEP}.fetch_bytes_conditional", new_callable=AsyncMock, return_value=changed):
+        await svc._run_update_notify_sweep()
+
+    events = await _events(integration_context)
+    assert len(events) == 1
+    evt = events[0]
+    assert evt.requires_action is True
+    assert evt.data["api_id"] == str(registered_api.id)
+    assert evt.data["upstream_digest"] == "sha256:upstream-new"
+    assert evt.data["current_digest"] == "sha256:registered"
+    assert evt.data["spec_url"] == _SPEC_URL
+
+    async with integration_context.registry_db.session() as session:
+        check = await CatalogUpdateCheckRepository.get(session, registered_api.id)
+    assert check is not None
+    assert check.last_notified_digest == "sha256:upstream-new"
+    assert check.last_seen_etag == '"v2"'
+
+
+async def test_sweep_dedupes_across_runs(integration_context: Context, registered_api: Api) -> None:
+    """A second sweep observing the same upstream digest does not re-emit."""
+    integration_context.config.catalog.update_check_interval_seconds = 1
+    changed = ConditionalFetch(
+        not_modified=False, etag='"v2"', content=b"{}", digest="sha256:upstream-new"
+    )
+    svc = CatalogService(integration_context)
+    with patch(f"{_SWEEP}.fetch_bytes_conditional", new_callable=AsyncMock, return_value=changed):
+        await svc._run_update_notify_sweep()
+        # Force the per-API interval gate open by clearing last_checked_at.
+        async with integration_context.registry_db.transaction() as session:
+            check = await CatalogUpdateCheckRepository.get(session, registered_api.id)
+            assert check is not None
+            check.last_checked_at = None
+        await svc._run_update_notify_sweep()
+
+    events = await _events(integration_context)
+    assert len(events) == 1  # deduped on the persisted last_notified_digest
+
+
+async def test_sweep_no_event_when_upstream_matches_registered(
+    integration_context: Context, registered_api: Api
+) -> None:
+    """Upstream digest equal to the registered revision's digest → no event."""
+    integration_context.config.catalog.update_check_interval_seconds = 86400
+    same = ConditionalFetch(
+        not_modified=False, etag='"v1"', content=b"{}", digest="sha256:registered"
+    )
+    svc = CatalogService(integration_context)
+    with patch(f"{_SWEEP}.fetch_bytes_conditional", new_callable=AsyncMock, return_value=same):
+        await svc._run_update_notify_sweep()
+
+    assert await _events(integration_context) == []
+    async with integration_context.registry_db.session() as session:
+        check = await CatalogUpdateCheckRepository.get(session, registered_api.id)
+    assert check is not None
+    assert check.last_notified_digest is None  # recorded the check, but never notified

--- a/tests/unit/registry/services/test_catalog_fetch.py
+++ b/tests/unit/registry/services/test_catalog_fetch.py
@@ -251,3 +251,35 @@ async def test_conditional_too_many_redirects_raises() -> None:
         await fetch_bytes_conditional(
             "https://example.com/openapi.json", config=IngestConfig(max_redirects=2)
         )
+
+
+@pytest.mark.asyncio
+async def test_conditional_sends_user_agent() -> None:
+    """The poller identifies itself with a descriptive User-Agent (politeness)."""
+    seen: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("user-agent"))
+        return httpx.Response(status_code=200, content=b"{}", headers={"etag": '"v1"'})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    with _patched(client):
+        await fetch_bytes_conditional("https://example.com/openapi.json", config=IngestConfig())
+    assert seen and seen[0] is not None
+    assert "jentic-one-catalog" in seen[0]
+
+
+@pytest.mark.asyncio
+async def test_conditional_304_propagates_refreshed_etag() -> None:
+    """A 304 that returns a *new* validator surfaces it so the next probe re-sends it."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=304, headers={"etag": '"v1-refreshed"'})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    with _patched(client):
+        result = await fetch_bytes_conditional(
+            "https://example.com/openapi.json", config=IngestConfig(), etag='"v1"'
+        )
+    assert result.not_modified is True
+    assert result.etag == '"v1-refreshed"'

--- a/tests/unit/registry/services/test_catalog_fetch.py
+++ b/tests/unit/registry/services/test_catalog_fetch.py
@@ -6,6 +6,7 @@ specs un-previewable with ``catalog spec unavailable: response exceeds size
 limit``; these tests pin the configured limit and the labelled error message.
 """
 
+import hashlib
 import json
 from typing import Any
 from unittest.mock import patch
@@ -13,7 +14,11 @@ from unittest.mock import patch
 import httpx
 import pytest
 
-from jentic_one.registry.services.catalog.fetch import CatalogFetchError, fetch_json
+from jentic_one.registry.services.catalog.fetch import (
+    CatalogFetchError,
+    fetch_bytes_conditional,
+    fetch_json,
+)
 from jentic_one.shared.config import IngestConfig
 
 _SPEC: dict[str, Any] = {"openapi": "3.1.0", "info": {"title": "Big API", "version": "1.0.0"}}
@@ -79,4 +84,170 @@ async def test_custom_cap_is_respected() -> None:
         await fetch_json(
             "https://example.com/openapi.json",
             config=IngestConfig(max_spec_bytes=1024),
+        )
+
+
+# ── fetch_bytes_conditional (update-notify probe) ───────────────────────────
+
+
+def _mock_conditional_client(
+    *, body: bytes = _SPEC_BYTES, etag: str | None = '"v1"'
+) -> httpx.AsyncClient:
+    """A transport that honours ``If-None-Match``: matching etag → 304, else 200."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        inm = request.headers.get("if-none-match")
+        if etag is not None and inm == etag:
+            return httpx.Response(status_code=304, headers={"etag": etag})
+        headers = {"content-type": "application/json"}
+        if etag is not None:
+            headers["etag"] = etag
+        return httpx.Response(status_code=200, content=body, headers=headers)
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_conditional_first_fetch_returns_bytes_etag_and_digest() -> None:
+    """No prior etag → full body, its sha256 digest, and the response etag."""
+    client = _mock_conditional_client()
+    with _patched(client):
+        result = await fetch_bytes_conditional(
+            "https://example.com/openapi.json", config=IngestConfig()
+        )
+    assert result.not_modified is False
+    assert result.content == _SPEC_BYTES
+    assert result.digest == hashlib.sha256(_SPEC_BYTES).hexdigest()
+    assert result.etag == '"v1"'
+
+
+@pytest.mark.asyncio
+async def test_conditional_matching_etag_yields_not_modified() -> None:
+    """A stored etag matching upstream → 304, no body/digest transferred."""
+    client = _mock_conditional_client()
+    with _patched(client):
+        result = await fetch_bytes_conditional(
+            "https://example.com/openapi.json", config=IngestConfig(), etag='"v1"'
+        )
+    assert result.not_modified is True
+    assert result.content is None
+    assert result.digest is None
+    assert result.etag == '"v1"'
+
+
+@pytest.mark.asyncio
+async def test_conditional_stale_etag_returns_new_bytes() -> None:
+    """A stored etag that no longer matches → fresh 200 with new body + etag."""
+    client = _mock_conditional_client(etag='"v2"')
+    with _patched(client):
+        result = await fetch_bytes_conditional(
+            "https://example.com/openapi.json", config=IngestConfig(), etag='"v1"'
+        )
+    assert result.not_modified is False
+    assert result.content == _SPEC_BYTES
+    assert result.etag == '"v2"'
+
+
+@pytest.mark.asyncio
+async def test_conditional_no_etag_from_upstream_still_returns_digest() -> None:
+    """When upstream sends no ETag, the digest still drives change detection."""
+    client = _mock_conditional_client(etag=None)
+    with _patched(client):
+        result = await fetch_bytes_conditional(
+            "https://example.com/openapi.json", config=IngestConfig()
+        )
+    assert result.not_modified is False
+    assert result.etag is None
+    assert result.digest is not None
+
+
+@pytest.mark.asyncio
+async def test_conditional_oversized_body_raises() -> None:
+    client = _mock_conditional_client(body=b"x" * (26 * 1024 * 1024), etag=None)
+    with _patched(client), pytest.raises(CatalogFetchError, match="size limit"):
+        await fetch_bytes_conditional("https://example.com/openapi.json", config=IngestConfig())
+
+
+@pytest.mark.asyncio
+async def test_conditional_rejects_unsafe_url() -> None:
+    with pytest.raises(CatalogFetchError, match="unsafe URL"):
+        await fetch_bytes_conditional("http://169.254.169.254/latest", config=IngestConfig())
+
+
+@pytest.mark.asyncio
+async def test_conditional_oversized_content_length_raises() -> None:
+    """The pre-body content-length guard also gates the conditional path."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status_code=200,
+            content=b"small",
+            headers={"content-length": "40000000", "content-type": "application/json"},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    with _patched(client), pytest.raises(CatalogFetchError, match=r"size limit \(25 MB\)"):
+        await fetch_bytes_conditional("https://example.com/openapi.json", config=IngestConfig())
+
+
+@pytest.mark.asyncio
+async def test_conditional_revalidates_redirect_target_against_ssrf() -> None:
+    """A redirect to a private/link-local address is rejected mid-hop (SSRF-via-redirect).
+
+    This pins the per-hop ``validate_upstream_url`` in the redirect loop: dropping
+    it would turn an innocuous first URL into an SSRF against cloud metadata.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "example.com":
+            return httpx.Response(
+                status_code=302, headers={"location": "http://169.254.169.254/latest/meta-data/"}
+            )
+        # Should never be reached — the guard must reject the redirect target first.
+        return httpx.Response(status_code=200, content=b"{}")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    with _patched(client), pytest.raises(CatalogFetchError, match="unsafe URL"):
+        await fetch_bytes_conditional("https://example.com/openapi.json", config=IngestConfig())
+
+
+@pytest.mark.asyncio
+async def test_conditional_resends_if_none_match_across_redirects() -> None:
+    """The conditional header is re-sent on the redirected hop, so a 304 still works."""
+    seen_headers: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_headers.append(request.headers.get("if-none-match"))
+        if request.url.path == "/openapi.json":
+            return httpx.Response(
+                status_code=302, headers={"location": "https://example.com/moved.json"}
+            )
+        # Redirected hop: honour If-None-Match → 304.
+        if request.headers.get("if-none-match") == '"v1"':
+            return httpx.Response(status_code=304, headers={"etag": '"v1"'})
+        return httpx.Response(status_code=200, content=_SPEC_BYTES, headers={"etag": '"v1"'})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    with _patched(client):
+        result = await fetch_bytes_conditional(
+            "https://example.com/openapi.json", config=IngestConfig(), etag='"v1"'
+        )
+    assert result.not_modified is True
+    # Both the initial request and the redirected hop carried the conditional header.
+    assert seen_headers == ['"v1"', '"v1"']
+
+
+@pytest.mark.asyncio
+async def test_conditional_too_many_redirects_raises() -> None:
+    """A redirect chain longer than the budget is refused, not followed forever."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Always redirect to a safe-but-different URL to exhaust the budget.
+        nxt = f"https://example.com/hop-{request.url.path}"
+        return httpx.Response(status_code=302, headers={"location": nxt})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    with _patched(client), pytest.raises(CatalogFetchError, match="too many redirects"):
+        await fetch_bytes_conditional(
+            "https://example.com/openapi.json", config=IngestConfig(max_redirects=2)
         )

--- a/tests/unit/registry/services/test_catalog_refresh_lock.py
+++ b/tests/unit/registry/services/test_catalog_refresh_lock.py
@@ -14,6 +14,8 @@ def _make_ctx(*, max_age: int = 300) -> MagicMock:
     ctx = MagicMock()
     ctx.config.catalog.manifest_max_age_seconds = max_age
     ctx.config.catalog.manifest_url = "https://example.com/apis.json"
+    # Disable the update-notify sweep for these lock-focused tests.
+    ctx.config.catalog.update_check_interval_seconds = 0
     ctx.config.ingest = MagicMock()
     mock_session = AsyncMock()
     ctx.registry_db.transaction.return_value.__aenter__ = AsyncMock(return_value=mock_session)

--- a/tests/unit/registry/services/test_catalog_update_notify.py
+++ b/tests/unit/registry/services/test_catalog_update_notify.py
@@ -296,7 +296,7 @@ async def test_safe_refresh_runs_sweep_after_successful_refresh() -> None:
         ),
         patch(f"{_SWEEP}.CatalogRepository.fetched_at", new_callable=AsyncMock, return_value=None),
         patch.object(svc, "refresh", new_callable=AsyncMock),
-        patch.object(svc, "_spawn_update_notify_sweep") as spawn,
+        patch.object(svc, "trigger_update_notify_sweep") as spawn,
     ):
         await svc._safe_refresh()
         spawn.assert_called_once()
@@ -316,7 +316,7 @@ async def test_safe_refresh_skips_sweep_when_refresh_fails() -> None:
         patch.object(
             svc, "refresh", new_callable=AsyncMock, side_effect=CatalogUnavailableError("x")
         ),
-        patch.object(svc, "_spawn_update_notify_sweep") as spawn,
+        patch.object(svc, "trigger_update_notify_sweep") as spawn,
     ):
         await svc._safe_refresh()
         spawn.assert_not_called()
@@ -332,9 +332,19 @@ async def test_spawn_sweep_detaches_and_runs_task() -> None:
         ran.set()
 
     with patch.object(svc, "_run_update_notify_sweep", side_effect=_fake_sweep):
-        svc._spawn_update_notify_sweep()
+        svc.trigger_update_notify_sweep()
         # Not yet awaited — the coroutine only runs once we yield to the loop.
         await asyncio.wait_for(ran.wait(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_spawn_sweep_noops_when_disabled() -> None:
+    """The kill switch (interval<=0) means no task is ever spawned."""
+    svc = CatalogService(_make_ctx(interval=0))
+    with patch.object(svc, "_run_update_notify_sweep", new_callable=AsyncMock) as run:
+        svc.trigger_update_notify_sweep()
+        await asyncio.sleep(0)  # give any (wrongly) spawned task a chance to run
+        run.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/registry/services/test_catalog_update_notify.py
+++ b/tests/unit/registry/services/test_catalog_update_notify.py
@@ -7,6 +7,7 @@ dedupe, the no-change no-op, and the per-API best-effort isolation.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -27,6 +28,8 @@ def _make_ctx(*, interval: int = 86400) -> MagicMock:
     ctx.config.catalog.update_check_interval_seconds = interval
     ctx.config.catalog.manifest_max_age_seconds = 300
     ctx.config.catalog.manifest_url = "https://example.com/apis.json"
+    ctx.config.catalog.update_sweep_deadline_seconds = 300
+    ctx.config.catalog.update_sweep_max_concurrency = 4
     ctx.config.ingest = MagicMock()
     session = AsyncMock()
     for db in (ctx.registry_db, ctx.admin_db):
@@ -160,7 +163,7 @@ async def test_probe_change_emits_event_once() -> None:
         emit.assert_awaited_once()
         emit_kwargs = emit.await_args.kwargs if emit.await_args else {}
         assert emit_kwargs["type"] == EventType.CATALOG_UPDATE_AVAILABLE
-        assert emit_kwargs["requires_action"] is True
+        assert emit_kwargs["requires_action"] is False
         assert emit_kwargs["data"]["upstream_digest"] == "upstream-new"
         upsert_kwargs = upsert.await_args.kwargs if upsert.await_args else {}
         assert upsert_kwargs["notified_digest"] == "upstream-new"
@@ -283,7 +286,7 @@ async def test_sweep_swallows_emit_failure_per_api() -> None:
 
 @pytest.mark.asyncio
 async def test_safe_refresh_runs_sweep_after_successful_refresh() -> None:
-    """_safe_refresh triggers the update-notify sweep once the refresh succeeds."""
+    """_safe_refresh spawns the update-notify sweep once the refresh succeeds."""
     svc = CatalogService(_make_ctx(interval=86400))
     with (
         patch(
@@ -293,10 +296,10 @@ async def test_safe_refresh_runs_sweep_after_successful_refresh() -> None:
         ),
         patch(f"{_SWEEP}.CatalogRepository.fetched_at", new_callable=AsyncMock, return_value=None),
         patch.object(svc, "refresh", new_callable=AsyncMock),
-        patch.object(svc, "_run_update_notify_sweep", new_callable=AsyncMock) as sweep,
+        patch.object(svc, "_spawn_update_notify_sweep") as spawn,
     ):
         await svc._safe_refresh()
-        sweep.assert_awaited_once()
+        spawn.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -313,7 +316,84 @@ async def test_safe_refresh_skips_sweep_when_refresh_fails() -> None:
         patch.object(
             svc, "refresh", new_callable=AsyncMock, side_effect=CatalogUnavailableError("x")
         ),
-        patch.object(svc, "_run_update_notify_sweep", new_callable=AsyncMock) as sweep,
+        patch.object(svc, "_spawn_update_notify_sweep") as spawn,
     ):
         await svc._safe_refresh()
-        sweep.assert_not_called()
+        spawn.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_spawn_sweep_detaches_and_runs_task() -> None:
+    """The spawn seam runs the sweep as a background task (not awaited inline)."""
+    svc = CatalogService(_make_ctx(interval=86400))
+    ran = asyncio.Event()
+
+    async def _fake_sweep() -> None:
+        ran.set()
+
+    with patch.object(svc, "_run_update_notify_sweep", side_effect=_fake_sweep):
+        svc._spawn_update_notify_sweep()
+        # Not yet awaited — the coroutine only runs once we yield to the loop.
+        await asyncio.wait_for(ran.wait(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_sweep_deadline_hit_is_swallowed() -> None:
+    """A sweep exceeding the wall-clock budget logs and returns, never raises."""
+    ctx = _make_ctx(interval=86400)
+    ctx.config.catalog.update_sweep_deadline_seconds = 0  # trip the deadline immediately
+    svc = CatalogService(ctx)
+
+    async def _slow(_spec_arg: object, *, now: object, interval: int) -> None:
+        await asyncio.sleep(0.2)
+
+    with (
+        patch(
+            f"{_SWEEP}.ApiRevisionRepository.registered_specs_for_notify",
+            new_callable=AsyncMock,
+            return_value=[_spec()],
+        ),
+        patch.object(svc, "_probe_one", side_effect=_slow),
+    ):
+        # Must not raise despite the probe outrunning the deadline.
+        await svc._run_update_notify_sweep()
+
+
+@pytest.mark.asyncio
+async def test_sweep_bounds_concurrency() -> None:
+    """No more than update_sweep_max_concurrency probes run at once."""
+    ctx = _make_ctx(interval=86400)
+    ctx.config.catalog.update_sweep_max_concurrency = 2
+    svc = CatalogService(ctx)
+    specs = [
+        RegisteredSpec(
+            api_id=uuid.uuid4(),
+            source_url=f"https://raw.githubusercontent.com/x/y/main/{i}.json",
+            spec_digest="d",
+            vendor="acme",
+            name="widgets",
+            version="1.0.0",
+        )
+        for i in range(6)
+    ]
+    in_flight = 0
+    peak = 0
+
+    async def _probe(_spec_arg: object, *, now: object, interval: int) -> None:
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        await asyncio.sleep(0.02)
+        in_flight -= 1
+
+    with (
+        patch(
+            f"{_SWEEP}.ApiRevisionRepository.registered_specs_for_notify",
+            new_callable=AsyncMock,
+            return_value=specs,
+        ),
+        patch.object(svc, "_probe_one", side_effect=_probe),
+    ):
+        await svc._run_update_notify_sweep()
+
+    assert peak <= 2

--- a/tests/unit/registry/services/test_catalog_update_notify.py
+++ b/tests/unit/registry/services/test_catalog_update_notify.py
@@ -1,0 +1,319 @@
+"""Unit tests for the catalog update-notify sweep (Flow 3 MVP).
+
+Covers ``CatalogService._run_update_notify_sweep`` / ``_probe_one`` behaviour with
+mocked fetch + repos: the interval gate, the 304 no-op, the change-emits-once
+dedupe, the no-change no-op, and the per-API best-effort isolation.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from jentic_one.registry.repos.revision_repo import RegisteredSpec
+from jentic_one.registry.services.catalog.fetch import ConditionalFetch
+from jentic_one.registry.services.catalog.service import CatalogService
+from jentic_one.registry.services.errors import CatalogUnavailableError
+from jentic_one.shared.models.events import EventType
+
+_API_ID = uuid.uuid4()
+
+
+def _make_ctx(*, interval: int = 86400) -> MagicMock:
+    ctx = MagicMock()
+    ctx.config.catalog.update_check_interval_seconds = interval
+    ctx.config.catalog.manifest_max_age_seconds = 300
+    ctx.config.catalog.manifest_url = "https://example.com/apis.json"
+    ctx.config.ingest = MagicMock()
+    session = AsyncMock()
+    for db in (ctx.registry_db, ctx.admin_db):
+        db.transaction.return_value.__aenter__ = AsyncMock(return_value=session)
+        db.transaction.return_value.__aexit__ = AsyncMock(return_value=False)
+        db.session.return_value.__aenter__ = AsyncMock(return_value=session)
+        db.session.return_value.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+def _spec(digest: str | None = "local-digest") -> RegisteredSpec:
+    return RegisteredSpec(
+        api_id=_API_ID,
+        source_url="https://raw.githubusercontent.com/x/y/main/openapi.json",
+        spec_digest=digest,
+        vendor="acme",
+        name="widgets",
+        version="1.0.0",
+    )
+
+
+def _check(
+    *, last_checked_at: datetime | None, etag: str | None, notified: str | None
+) -> MagicMock:
+    row = MagicMock()
+    row.last_checked_at = last_checked_at
+    row.last_seen_etag = etag
+    row.last_notified_digest = notified
+    return row
+
+
+_SWEEP = "jentic_one.registry.services.catalog.service"
+
+
+@pytest.mark.asyncio
+async def test_sweep_disabled_when_interval_zero() -> None:
+    svc = CatalogService(_make_ctx(interval=0))
+    with patch(f"{_SWEEP}.ApiRevisionRepository.registered_specs_for_notify") as specs:
+        await svc._run_update_notify_sweep()
+        specs.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_probe_skips_within_interval() -> None:
+    """A recently-checked API is not re-probed until the interval elapses."""
+    svc = CatalogService(_make_ctx(interval=86400))
+    recent = datetime.now(UTC) - timedelta(seconds=10)
+    with (
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.get",
+            new_callable=AsyncMock,
+            return_value=_check(last_checked_at=recent, etag='"v1"', notified=None),
+        ),
+        patch(f"{_SWEEP}.fetch_bytes_conditional", new_callable=AsyncMock) as fetch,
+        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+    ):
+        await svc._probe_one(_spec(), now=datetime.now(UTC), interval=86400)
+        fetch.assert_not_called()
+        emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_probe_at_interval_boundary_re_probes() -> None:
+    """At exactly the interval boundary the API is re-probed (strict age < interval)."""
+    svc = CatalogService(_make_ctx(interval=100))
+    now = datetime.now(UTC)
+    checked = now - timedelta(seconds=100)  # age == interval → not < interval → probe
+    with (
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.get",
+            new_callable=AsyncMock,
+            return_value=_check(last_checked_at=checked, etag='"v1"', notified=None),
+        ),
+        patch(
+            f"{_SWEEP}.fetch_bytes_conditional",
+            new_callable=AsyncMock,
+            return_value=ConditionalFetch(
+                not_modified=True, etag='"v1"', content=None, digest=None
+            ),
+        ) as fetch,
+        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
+        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock),
+    ):
+        await svc._probe_one(_spec(), now=now, interval=100)
+        fetch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_probe_304_is_noop_but_records_check() -> None:
+    svc = CatalogService(_make_ctx())
+    with (
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.get", new_callable=AsyncMock, return_value=None
+        ),
+        patch(
+            f"{_SWEEP}.fetch_bytes_conditional",
+            new_callable=AsyncMock,
+            return_value=ConditionalFetch(
+                not_modified=True, etag='"v1"', content=None, digest=None
+            ),
+        ),
+        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock) as upsert,
+        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+    ):
+        await svc._probe_one(_spec(), now=datetime.now(UTC), interval=86400)
+        emit.assert_not_called()
+        upsert.assert_awaited_once()
+        upsert_kwargs = upsert.await_args.kwargs if upsert.await_args else {}
+        assert upsert_kwargs.get("notified_digest") is None
+
+
+@pytest.mark.asyncio
+async def test_probe_change_emits_event_once() -> None:
+    """A digest differing from both the registered and last-notified emits + records it."""
+    svc = CatalogService(_make_ctx())
+    with (
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.get", new_callable=AsyncMock, return_value=None
+        ),
+        patch(
+            f"{_SWEEP}.fetch_bytes_conditional",
+            new_callable=AsyncMock,
+            return_value=ConditionalFetch(
+                not_modified=False, etag='"v2"', content=b"{}", digest="upstream-new"
+            ),
+        ),
+        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock) as upsert,
+        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+    ):
+        await svc._probe_one(_spec(digest="local-digest"), now=datetime.now(UTC), interval=86400)
+        emit.assert_awaited_once()
+        emit_kwargs = emit.await_args.kwargs if emit.await_args else {}
+        assert emit_kwargs["type"] == EventType.CATALOG_UPDATE_AVAILABLE
+        assert emit_kwargs["requires_action"] is True
+        assert emit_kwargs["data"]["upstream_digest"] == "upstream-new"
+        upsert_kwargs = upsert.await_args.kwargs if upsert.await_args else {}
+        assert upsert_kwargs["notified_digest"] == "upstream-new"
+
+
+@pytest.mark.asyncio
+async def test_probe_already_notified_digest_does_not_re_emit() -> None:
+    """Dedupe: the same upstream digest we already notified for stays silent."""
+    svc = CatalogService(_make_ctx())
+    with (
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.get",
+            new_callable=AsyncMock,
+            return_value=_check(last_checked_at=None, etag=None, notified="upstream-new"),
+        ),
+        patch(
+            f"{_SWEEP}.fetch_bytes_conditional",
+            new_callable=AsyncMock,
+            return_value=ConditionalFetch(
+                not_modified=False, etag='"v2"', content=b"{}", digest="upstream-new"
+            ),
+        ),
+        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
+        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+    ):
+        await svc._probe_one(_spec(digest="local-digest"), now=datetime.now(UTC), interval=86400)
+        emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_probe_upstream_matches_registered_is_noop() -> None:
+    """Upstream digest equal to the registered revision's digest → no event."""
+    svc = CatalogService(_make_ctx())
+    with (
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.get", new_callable=AsyncMock, return_value=None
+        ),
+        patch(
+            f"{_SWEEP}.fetch_bytes_conditional",
+            new_callable=AsyncMock,
+            return_value=ConditionalFetch(
+                not_modified=False, etag='"v1"', content=b"{}", digest="local-digest"
+            ),
+        ),
+        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
+        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+    ):
+        await svc._probe_one(_spec(digest="local-digest"), now=datetime.now(UTC), interval=86400)
+        emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sweep_isolates_per_api_failures() -> None:
+    """A probe that raises for one API does not abort the rest of the sweep."""
+    svc = CatalogService(_make_ctx())
+    specs = [_spec(), _spec(digest="other")]
+    with (
+        patch(
+            f"{_SWEEP}.ApiRevisionRepository.registered_specs_for_notify",
+            new_callable=AsyncMock,
+            return_value=specs,
+        ),
+        patch.object(svc, "_probe_one", new_callable=AsyncMock) as probe,
+    ):
+        probe.side_effect = [RuntimeError("boom"), None]
+        await svc._run_update_notify_sweep()
+        assert probe.await_count == 2
+
+
+def test_catalog_update_event_in_all_frozenset() -> None:
+    assert EventType.CATALOG_UPDATE_AVAILABLE in EventType.ALL
+
+
+@pytest.mark.asyncio
+async def test_sweep_no_candidates_is_noop() -> None:
+    """Empty registered-spec set → no fetch, no emit, clean early return."""
+    svc = CatalogService(_make_ctx())
+    with (
+        patch(
+            f"{_SWEEP}.ApiRevisionRepository.registered_specs_for_notify",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(f"{_SWEEP}.fetch_bytes_conditional", new_callable=AsyncMock) as fetch,
+    ):
+        await svc._run_update_notify_sweep()
+        fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sweep_swallows_emit_failure_per_api() -> None:
+    """A hard failure in a probe's emit path is isolated by the sweep, not propagated."""
+    svc = CatalogService(_make_ctx())
+    with (
+        patch(
+            f"{_SWEEP}.ApiRevisionRepository.registered_specs_for_notify",
+            new_callable=AsyncMock,
+            return_value=[_spec(digest="local-digest")],
+        ),
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.get", new_callable=AsyncMock, return_value=None
+        ),
+        patch(
+            f"{_SWEEP}.fetch_bytes_conditional",
+            new_callable=AsyncMock,
+            return_value=ConditionalFetch(
+                not_modified=False, etag='"v2"', content=b"{}", digest="upstream-new"
+            ),
+        ),
+        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
+        patch(
+            f"{_SWEEP}.emit_event_best_effort",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("emit boom"),
+        ),
+    ):
+        # Must complete without raising — the sweep-level guard isolates the failure.
+        await svc._run_update_notify_sweep()
+
+
+@pytest.mark.asyncio
+async def test_safe_refresh_runs_sweep_after_successful_refresh() -> None:
+    """_safe_refresh triggers the update-notify sweep once the refresh succeeds."""
+    svc = CatalogService(_make_ctx(interval=86400))
+    with (
+        patch(
+            f"{_SWEEP}.CatalogRepository.try_acquire_refresh_lock",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(f"{_SWEEP}.CatalogRepository.fetched_at", new_callable=AsyncMock, return_value=None),
+        patch.object(svc, "refresh", new_callable=AsyncMock),
+        patch.object(svc, "_run_update_notify_sweep", new_callable=AsyncMock) as sweep,
+    ):
+        await svc._safe_refresh()
+        sweep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_safe_refresh_skips_sweep_when_refresh_fails() -> None:
+    """A CatalogUnavailableError short-circuits before the sweep runs."""
+    svc = CatalogService(_make_ctx(interval=86400))
+    with (
+        patch(
+            f"{_SWEEP}.CatalogRepository.try_acquire_refresh_lock",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(f"{_SWEEP}.CatalogRepository.fetched_at", new_callable=AsyncMock, return_value=None),
+        patch.object(
+            svc, "refresh", new_callable=AsyncMock, side_effect=CatalogUnavailableError("x")
+        ),
+        patch.object(svc, "_run_update_notify_sweep", new_callable=AsyncMock) as sweep,
+    ):
+        await svc._safe_refresh()
+        sweep.assert_not_called()


### PR DESCRIPTION
## Summary

Phase-2 MVP of **Flow 3** (upstream API spec changes → we detect it and notify),
from `docs/plans/spec-flywheel-and-catalog-update-notify.md`. Closes #883.

When someone browses the catalog and the cached manifest is stale, we already
refresh it. This PR piggybacks on that refresh: right after it, we conditionally
re-fetch the spec URLs of **registered** APIs using `If-None-Match`, hash the
body, and emit a `catalog.update_available` event when the bytes actually
changed. No new background loop, no UI/CLI surfaces yet — those are later phases.

---

## For humans

### What you get
- If you imported an API from the catalog and its upstream OpenAPI spec later
  changes, an event shows up in the **events feed** (`catalog.update_available`)
  with a friendly summary: *"Upstream spec updated for {vendor}/{name}
  ({version})"*.
- It fires **once per real change** (deduped on the content hash), and a spec
  that reverts back to what you have registered goes quiet again.
- **Kill switch:** set `catalog.update_check_interval_seconds = 0` (air-gapped
  installs get zero egress, zero events).

### How it behaves (and what it deliberately does *not* do yet)
- Detection is **piggybacked on catalog reads**, not a scheduler — an instance
  nobody browses won't notice changes until someone opens the catalog and the
  24h manifest cache is stale. A dedicated scanner is Phase 4.
- The event is **informational** (`requires_action=False`) for now: there is no
  one-click re-import or dismiss yet (Phase 4), so we don't want unresolvable
  items piling up in the action inbox. It still shows in the feed.
- The sweep runs **off** the user's request (fire-and-forget) and is bounded by a
  wall-clock deadline + limited concurrency, so a slow/hostile upstream can never
  stall a catalog page load.

### The flow, end to end

```mermaid
sequenceDiagram
    actor User
    participant Catalog as CatalogService
    participant Refresh as manifest refresh
    participant Sweep as update-notify sweep (background task)
    participant Up as upstream spec host
    participant RDB as registry DB
    participant ADB as admin DB (events)

    User->>Catalog: GET /catalog (authenticated)
    Catalog->>Refresh: _safe_refresh() (advisory-lock, max-age gated)
    Refresh-->>Catalog: manifest refreshed
    Catalog-)Sweep: spawn (fire-and-forget) — request returns now
    Note over User,Catalog: user response is NOT blocked on the sweep

    loop each registered spec (bounded concurrency, under a deadline)
        Sweep->>RDB: read last check row (etag/digest)
        Sweep->>Up: GET spec  (If-None-Match: last etag)
        alt 304 Not Modified
            Up-->>Sweep: 304
            Sweep->>RDB: touch last_checked_at (+ refreshed etag)
        else 200 changed bytes
            Up-->>Sweep: 200 + body
            Note over Sweep: sha256(body) vs registered digest & last-notified
            Sweep->>RDB: upsert etag/digest/notified_digest
            Sweep->>ADB: emit catalog.update_available (once)
        end
    end
```

---

## For agents / maintainers

### Change map
| Area | File | What |
| --- | --- | --- |
| fetch | `registry/services/catalog/fetch.py` | `fetch_bytes_conditional()` beside `fetch_json` — same SSRF/redirect/size guards (per-hop `validate_upstream_url`, now threading `config.egress`), sends `If-None-Match`, returns a 304 signal **or** raw bytes + `sha256` hex + response ETag. Both fetchers send a descriptive `User-Agent`. |
| schema | `registry/core/schema/catalog_update_checks.py` + migration `d3e4f5a6b7c8` | `catalog_update_checks` table (KSUID id, **unique `local_api_id`** = local `apis.id`, never the manifest id per D-005a). |
| repo | `registry/repos/catalog_update_check_repo.py` | `get()` / `upsert()`, flush-only-never-commit; `upsert` won't clear `notified_digest` on a no-change probe. |
| candidates | `registry/repos/revision_repo.py` | `registered_specs_for_notify()` → non-archived revisions with a `source_url`, joined to identity + current digest. |
| orchestration | `registry/services/catalog/service.py` | `_spawn_update_notify_sweep()` (offload) → `_run_update_notify_sweep()` (deadline + `Semaphore` + summary log) → `_probe_one()` (fetch, compare, upsert, emit). |
| events | `shared/models/events.py` | `EventType.CATALOG_UPDATE_AVAILABLE` added to constants **and** `ALL`. |
| config | `shared/config.py` | `update_check_interval_seconds` (default 86400, `0` = kill switch), `update_sweep_deadline_seconds` (300), `update_sweep_max_concurrency` (4, below the DB pool). |

### The change signal is the body hash, not the ETag
`sha256(body)` is the source of truth. The ETag is used **only** as a `304`
optimization (`If-None-Match`), never trusted for equality (weak ETags don't
promise byte-identity). A change notifies iff the upstream hash differs from
**both** the registered revision's digest **and** the last-notified digest —
so a revert-to-registered stops notifying, and each distinct change fires once.

```mermaid
flowchart TD
    A[conditional GET spec] --> B{304?}
    B -- yes --> T[touch last_checked_at + etag]
    B -- no --> C[sha256 body = upstream_digest]
    C --> D{upstream_digest != registered digest<br/>AND != last_notified_digest?}
    D -- no --> U[upsert etag/digest only]
    D -- yes --> E[upsert + set last_notified_digest]
    E --> F[emit catalog.update_available once]
```

### Data model

```mermaid
erDiagram
    apis ||--o| catalog_update_checks : "local_api_id (unique, no FK)"
    apis ||--o{ api_revisions : "api_id"
    catalog_update_checks {
        string id PK "KSUID cuc_*"
        uuid local_api_id UK "= apis.id"
        string spec_url
        text last_seen_etag
        string last_seen_digest
        string last_notified_digest "dedupe key"
        datetime last_checked_at
        datetime created_at
    }
```
No FK on `local_api_id` by design: the row is cheap scratch state; a dropped API
is simply ignored by the next sweep (no matching registered spec).

### Concurrency / correctness notes (honesty)
- The refresh advisory lock is **transaction-scoped**, so the sweep is **not**
  globally single-flight. A rare concurrent double-refresh can emit a duplicate
  event; the next sweep dedupes on the persisted digest. Deliberately tolerated
  (idempotent for operators), documented in code.
- Digest convention is **bare sha256 hex** on both sides (ingest computes
  `hashlib.sha256(resp.content).hexdigest()`; the probe hashes the fetched body
  the same way). An integration test exercises the real hex end-to-end so a
  future framing drift can't silently make every probe look "changed".

---

## Review board (two rounds)

**Round 1 — 6 lenses** (security, ORM/migration, correctness, architecture/rules,
testing, plan-fidelity): unanimous **APPROVE-WITH-NITS**; nits applied
(SSRF-via-redirect test, corrected "single-flight" claim).

**Round 2 — 6 lenses** (feasibility/operability, deep security, code-quality,
product-fit, best-practices research, + regression sweep). Two REQUEST-CHANGES
blockers raised and **both fixed in this PR**:

| Finding | Lens | Resolution |
| --- | --- | --- |
| Sweep awaited inline on the user read path; no aggregate bound | feasibility (MUST), security (SHOULD) | Offloaded to a fire-and-forget task; added wall-clock deadline + bounded concurrency + summary log (`d492e8e`) |
| `requires_action=True` with no resolve path → inbox fatigue | product-fit (High) | Downgraded to `requires_action=False` until Phase-4 re-import lands (`d492e8e`) |
| Digest-prefix mismatch could cause spurious notifies | code-quality (gate) | **Verified non-bug** (both sides bare hex); added a real-hex integration test that had been masked (`d492e8e`) |
| Anonymous GETs to upstream | research (MUST) | Descriptive `User-Agent` on both fetchers (`0179f0f`) |
| Egress-config parity gap (fail-closed) | security (SHOULD) | Threaded `config.egress` into catalog SSRF validation (`d492e8e`) |

## Deferred follow-ups (non-blocking, tracked)
- **DNS-rebind TOCTOU:** wire `DnsPinningTransport` into catalog + ingest fetchers
  (pre-existing across the fetch layer).
- **Backoff / `Retry-After`** on `429/503` (needs a `next_retry_at` column →
  Phase-4 scanner), honor `X-Poll-Interval`/`Cache-Control`.
- **Fairness:** order candidates by oldest `last_checked_at` + `max_probes_per_sweep`.
- **Extract** the shared SSRF/redirect/size guard out of the two fetchers.
- **Semantic diff** (oasdiff) after the hash gate to kill whitespace false-positives;
  **distinct "spec removed"** signal on 404; **coalescing** by vendor.
- **Dedicated scheduler** over lazy-read piggyback (this is the Phase-4
  `catalog_update_scanner`).

## Test plan
- [x] `make lint` (ruff + mypy) clean
- [x] Unit — fetch: 200/304/stale-etag/no-etag/oversize(body+content-length)/
      unsafe-url + SSRF-via-redirect + per-hop `If-None-Match` + too-many-redirects
      + `User-Agent` + 304-refreshed-ETag
- [x] Unit — sweep: interval/boundary/change-once/dedupe/no-change/empty/per-API
      isolation + offload spawn + deadline-swallow + concurrency-bound +
      `_safe_refresh`→spawn wiring + `ALL` membership
- [x] Integration (real Postgres, HTTP boundary stubbed only): sweep emits+records,
      dedupes across runs, no-event-when-matching (opaque + **real bare-hex**),
      repo round-trip + notify join
- [x] ORM arch conventions + registry unit suite

Made with [Cursor](https://cursor.com)
