### PR TITLE
refactor(ui): share the detail-console grammar across toolkit, agent, and SA consoles

### DIFF
--- a/ui/e2e/agents.spec.ts
+++ b/ui/e2e/agents.spec.ts
@@ -92,7 +92,11 @@ test('the Activity tab feeds per-agent executions and deep-links to Monitor', as
 	await expect(page.getByText('github.create_issue')).toBeVisible();
 
 	// The Monitor deep-link carries the actor filter (Monitor's URL contract).
-	const href = await page.getByRole('link', { name: /Open in Monitor/ }).getAttribute('href');
+	// Two links match (back row + feed card) — both share the same href.
+	const href = await page
+		.getByRole('link', { name: /Open Monitor/ })
+		.first()
+		.getAttribute('href');
 	expect(href).toContain('tab=executions');
 	expect(href).toContain('actor_id=agnt_active_1');
 	expect(href).toContain('actor_type=agent');

--- a/ui/e2e/docker/agents.spec.ts
+++ b/ui/e2e/docker/agents.spec.ts
@@ -86,7 +86,8 @@ test('a DCR-registered agent gets the identity console and can be renamed', asyn
 	// pre-filtered Monitor deep-link) still renders for an admin viewer —
 	// asserted unconditionally so a regression can't silently skip this check.
 	await page.getByRole('tab', { name: 'Activity' }).click();
-	const monitorLink = page.getByRole('link', { name: /Open in Monitor/ });
+	// Two links match (back row + feed card) — both share the same href.
+	const monitorLink = page.getByRole('link', { name: /Open Monitor/ }).first();
 	await expect(monitorLink).toBeVisible();
 	expect(await monitorLink.getAttribute('href')).toContain(`actor_id=${agent.clientId}`);
 

--- a/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
@@ -247,7 +247,7 @@ describe('AgentDetailPage', () => {
 		// The feed lists this agent's executions only (agents-module fixture).
 		expect(await screen.findByText('github.create_issue')).toBeInTheDocument();
 		expect(screen.getByText(/pbac_denied/)).toBeInTheDocument();
-		expect(screen.getByText('Execution volume (7d)')).toBeInTheDocument();
+		expect(screen.getByText('Execution volume · 7d')).toBeInTheDocument();
 
 		// The deep-link carries the actor filter into Monitor's URL contract.
 		const link = screen.getByRole('link', { name: /Open in Monitor/ });

--- a/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
@@ -249,11 +249,15 @@ describe('AgentDetailPage', () => {
 		expect(screen.getByText(/pbac_denied/)).toBeInTheDocument();
 		expect(screen.getByText('Execution volume · 7d')).toBeInTheDocument();
 
-		// The deep-link carries the actor filter into Monitor's URL contract.
-		const link = screen.getByRole('link', { name: /Open in Monitor/ });
-		expect(link.getAttribute('href')).toContain('tab=executions');
-		expect(link.getAttribute('href')).toContain('actor_id=agnt_active_1');
-		expect(link.getAttribute('href')).toContain('actor_type=agent');
+		// The deep-links (page header + feed card) carry the actor filter into
+		// Monitor's URL contract.
+		const links = screen.getAllByRole('link', { name: /Open Monitor/ });
+		expect(links.length).toBeGreaterThan(0);
+		for (const link of links) {
+			expect(link.getAttribute('href')).toContain('tab=executions');
+			expect(link.getAttribute('href')).toContain('actor_id=agnt_active_1');
+			expect(link.getAttribute('href')).toContain('actor_type=agent');
+		}
 	});
 
 	it('shows a quiet permission note on the Activity tab for non-admins (403)', async () => {

--- a/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
@@ -249,10 +249,10 @@ describe('AgentDetailPage', () => {
 		expect(screen.getByText(/pbac_denied/)).toBeInTheDocument();
 		expect(screen.getByText('Execution volume · 7d')).toBeInTheDocument();
 
-		// The deep-links (page header + feed card) carry the actor filter into
-		// Monitor's URL contract.
+		// The deep-links carry the actor filter into Monitor's URL contract —
+		// exactly two: the back-row link and the feed-card link.
 		const links = screen.getAllByRole('link', { name: /Open Monitor/ });
-		expect(links.length).toBeGreaterThan(0);
+		expect(links).toHaveLength(2);
 		for (const link of links) {
 			expect(link.getAttribute('href')).toContain('tab=executions');
 			expect(link.getAttribute('href')).toContain('actor_id=agnt_active_1');
@@ -337,7 +337,8 @@ describe('AgentDetailPage', () => {
 		).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Deny inbox-triage-bot' })).toBeInTheDocument();
 		// Destructive actions (Archive / Disable) moved to the Settings tab's
-		// danger zone (phase 4) — the header only offers constructive ones.
+		// danger zone / header kill switch — a pending agent's header only
+		// offers constructive verbs.
 		expect(
 			screen.queryByRole('button', { name: 'Archive inbox-triage-bot' }),
 		).not.toBeInTheDocument();
@@ -457,23 +458,23 @@ describe('AgentDetailPage', () => {
 		expect(screen.queryByLabelText('Owner')).not.toBeInTheDocument();
 	});
 
-	it('disables an active agent through the danger-zone confirm flow', async () => {
+	it('disables an active agent through the header kill switch and offers restore', async () => {
 		const user = userEvent.setup();
 		renderDetail('agnt_active_1');
 		await screen.findByRole('heading', { name: 'support-agent' });
 
-		await user.click(screen.getByRole('tab', { name: 'Settings' }));
-		await user.click(await screen.findByRole('button', { name: 'Disable support-agent' }));
+		// The pill mirrors the live status and arms an inline confirm — no
+		// mutation on the first click.
+		const pill = screen.getByRole('button', { name: 'Disable support-agent (kill switch)' });
+		expect(pill).toHaveTextContent('Active');
+		await user.click(pill);
+		expect(screen.getByText('Block this agent?')).toBeInTheDocument();
 
-		// The danger zone never mutates directly — it routes through the
-		// page-level confirm dialog first.
-		const dialog = await screen.findByRole('dialog');
-		expect(within(dialog).getByText(/Disable support-agent/)).toBeInTheDocument();
-		await user.click(within(dialog).getByRole('button', { name: 'Disable' }));
-
+		await user.click(screen.getByRole('button', { name: 'Disable' }));
 		expect(await screen.findByText('Agent disabled')).toBeInTheDocument();
-		// Detail cache invalidates → the header badge flips and the header now
-		// offers the constructive Enable action.
+
+		// Detail cache invalidates → the pill flips to the danger state and
+		// now offers the restore flow.
 		await waitFor(() => {
 			expect(screen.getByTestId('detail-status-badge')).toHaveTextContent('Disabled');
 		});
@@ -500,12 +501,13 @@ describe('AgentDetailPage', () => {
 		expect(nameInput).toHaveValue('renamed-agent');
 	});
 
-	it('hosts Disable and Archive in the Settings danger zone for an active agent', async () => {
+	it('hosts only the terminal Archive in the Settings danger zone for an active agent', async () => {
 		const user = userEvent.setup();
 		renderDetail('agnt_active_1');
 		await screen.findByRole('heading', { name: 'support-agent' });
 
-		// Header carries no destructive lifecycle buttons any more.
+		// The reversible Disable lives in the header kill switch, not the
+		// danger zone — no plain "Disable support-agent" button anywhere.
 		expect(
 			screen.queryByRole('button', { name: 'Disable support-agent' }),
 		).not.toBeInTheDocument();
@@ -515,7 +517,9 @@ describe('AgentDetailPage', () => {
 
 		await user.click(screen.getByRole('tab', { name: 'Settings' }));
 		expect(await screen.findByText('Danger zone')).toBeInTheDocument();
-		expect(screen.getByRole('button', { name: 'Disable support-agent' })).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: 'Disable support-agent' }),
+		).not.toBeInTheDocument();
 
 		// Archive routes through the cascade-delete confirmation dialog.
 		await user.click(screen.getByRole('button', { name: 'Archive support-agent' }));

--- a/ui/src/modules/agents/__tests__/ServiceAccountDetailPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/ServiceAccountDetailPage.test.tsx
@@ -130,8 +130,9 @@ describe('ServiceAccountDetailPage', () => {
 		await user.click(screen.getByRole('tab', { name: 'Activity' }));
 		expect(await screen.findByText(/Recent executions/)).toBeInTheDocument();
 
+		// Exactly two deep-links: the back-row link and the feed-card link.
 		const links = await screen.findAllByRole('link', { name: /Open Monitor/ });
-		expect(links.length).toBeGreaterThan(0);
+		expect(links).toHaveLength(2);
 		for (const link of links) {
 			expect(link.getAttribute('href')).toContain('actor_id=sva_active_1');
 			expect(link.getAttribute('href')).toContain('actor_type=service_account');
@@ -165,7 +166,7 @@ describe('ServiceAccountDetailPage', () => {
 		expect(within(dialog).getByText('API key generated')).toBeInTheDocument();
 	});
 
-	it('hosts Disable and Archive in the Settings danger zone with the PATCH gap documented', async () => {
+	it('hosts only the terminal Archive in the danger zone with the PATCH gap documented', async () => {
 		const user = userEvent.setup();
 		renderDetail('sva_active_1');
 		await screen.findByRole('heading', { name: 'metrics-exporter' });
@@ -174,9 +175,10 @@ describe('ServiceAccountDetailPage', () => {
 		// No metadata form: jentic-one has no PATCH /service-accounts.
 		expect(await screen.findByText(/no PATCH \/service-accounts/)).toBeInTheDocument();
 		expect(screen.getByText('Danger zone')).toBeInTheDocument();
+		// The reversible Disable lives in the header kill switch, not here.
 		expect(
-			screen.getByRole('button', { name: 'Disable metrics-exporter' }),
-		).toBeInTheDocument();
+			screen.queryByRole('button', { name: 'Disable metrics-exporter' }),
+		).not.toBeInTheDocument();
 
 		// Archive routes through the cascade-delete confirmation dialog.
 		await user.click(screen.getByRole('button', { name: 'Archive metrics-exporter' }));

--- a/ui/src/modules/agents/__tests__/ServiceAccountDetailPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/ServiceAccountDetailPage.test.tsx
@@ -130,9 +130,12 @@ describe('ServiceAccountDetailPage', () => {
 		await user.click(screen.getByRole('tab', { name: 'Activity' }));
 		expect(await screen.findByText(/Recent executions/)).toBeInTheDocument();
 
-		const link = await screen.findByRole('link', { name: /Open in Monitor/ });
-		expect(link.getAttribute('href')).toContain('actor_id=sva_active_1');
-		expect(link.getAttribute('href')).toContain('actor_type=service_account');
+		const links = await screen.findAllByRole('link', { name: /Open Monitor/ });
+		expect(links.length).toBeGreaterThan(0);
+		for (const link of links) {
+			expect(link.getAttribute('href')).toContain('actor_id=sva_active_1');
+			expect(link.getAttribute('href')).toContain('actor_type=service_account');
+		}
 	});
 
 	it('generates an API key from the Keys tab and shows it once', async () => {

--- a/ui/src/modules/agents/components/ActorAccessRequestsCard.tsx
+++ b/ui/src/modules/agents/components/ActorAccessRequestsCard.tsx
@@ -21,10 +21,7 @@ import { useState } from 'react';
 import { ShieldQuestion, CheckCircle2 } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
-	Card,
-	CardHeader,
-	CardBody,
-	CardTitle,
+	DetailSection,
 	Badge,
 	EmptyState,
 	ErrorAlert,
@@ -66,101 +63,93 @@ export function ActorAccessRequestsCard({
 
 	return (
 		<>
-			<Card>
-				<CardHeader className="flex flex-row items-center justify-between gap-2">
-					<CardTitle as="h2" className="flex items-center gap-2">
-						<ShieldQuestion
-							className="text-warning h-4 w-4 shrink-0"
-							aria-hidden="true"
-						/>
-						Access requests
-					</CardTitle>
-					{data && data.length > 0 && (
+			<DetailSection
+				title="Access requests"
+				icon={<ShieldQuestion className="h-4 w-4" />}
+				titleExtra={
+					data && data.length > 0 ? (
 						<Badge variant={ACCESS_REQUEST_STATUS_VARIANT[status] ?? 'default'}>
 							{data.length}
 						</Badge>
-					)}
-				</CardHeader>
-				<CardBody className="space-y-3">
-					<SegmentedToggle options={STATUS_OPTIONS} value={status} onChange={setStatus} />
+					) : null
+				}
+				bodyClassName="space-y-3"
+			>
+				<SegmentedToggle options={STATUS_OPTIONS} value={status} onChange={setStatus} />
 
-					{isPending ? (
-						<LoadingState size="sm" />
-					) : isError ? (
-						<ErrorAlert
-							message={
-								error instanceof Error
-									? error.message
-									: "Failed to load this actor's access requests."
-							}
-						/>
-					) : !data || data.length === 0 ? (
-						<EmptyState
-							icon={<CheckCircle2 className="h-8 w-8" aria-hidden="true" />}
-							title={
-								status === 'pending'
-									? 'No pending access requests'
-									: 'No access requests'
-							}
-							description={
-								status === 'pending'
-									? `${actorName} has no access requests awaiting a decision.`
-									: `${actorName} has no access requests matching this filter.`
-							}
-						/>
-					) : (
-						<ul className="divide-border divide-y">
-							{data.map((request) => (
-								<li key={request.id}>
-									<button
-										type="button"
-										onClick={() => setActive(request)}
-										className="hover:bg-muted/40 flex w-full items-center justify-between gap-3 rounded-md py-2.5 text-left transition-colors"
-									>
-										<div className="min-w-0">
-											<p className="text-foreground truncate font-medium">
-												{summarizeAccessRequest(request)}
+				{isPending ? (
+					<LoadingState size="sm" />
+				) : isError ? (
+					<ErrorAlert
+						message={
+							error instanceof Error
+								? error.message
+								: "Failed to load this actor's access requests."
+						}
+					/>
+				) : !data || data.length === 0 ? (
+					<EmptyState
+						icon={<CheckCircle2 className="h-8 w-8" aria-hidden="true" />}
+						title={
+							status === 'pending'
+								? 'No pending access requests'
+								: 'No access requests'
+						}
+						description={
+							status === 'pending'
+								? `${actorName} has no access requests awaiting a decision.`
+								: `${actorName} has no access requests matching this filter.`
+						}
+					/>
+				) : (
+					<ul className="divide-border divide-y">
+						{data.map((request) => (
+							<li key={request.id}>
+								<button
+									type="button"
+									onClick={() => setActive(request)}
+									className="hover:bg-muted/40 flex w-full items-center justify-between gap-3 rounded-md py-2.5 text-left transition-colors"
+								>
+									<div className="min-w-0">
+										<p className="text-foreground truncate font-medium">
+											{summarizeAccessRequest(request)}
+										</p>
+										{request.reason && (
+											<p className="text-muted-foreground truncate text-xs">
+												{request.reason}
 											</p>
-											{request.reason && (
-												<p className="text-muted-foreground truncate text-xs">
-													{request.reason}
-												</p>
-											)}
-										</div>
-										<div className="flex shrink-0 items-center gap-3">
-											{request.filed_at && (
-												<time
-													dateTime={request.filed_at}
-													title={new Date(
-														request.filed_at,
-													).toLocaleString()}
-													className="text-muted-foreground hidden text-xs whitespace-nowrap tabular-nums sm:inline"
-												>
-													{timeAgo(request.filed_at)}
-												</time>
-											)}
-											{status === 'all' && (
-												<Badge
-													variant={
-														ACCESS_REQUEST_STATUS_VARIANT[
-															request.status
-														] ?? 'default'
-													}
-												>
-													{request.status}
-												</Badge>
-											)}
-											<span className="text-accent-teal text-sm font-medium">
-												{request.status === 'pending' ? 'Review' : 'View'}
-											</span>
-										</div>
-									</button>
-								</li>
-							))}
-						</ul>
-					)}
-				</CardBody>
-			</Card>
+										)}
+									</div>
+									<div className="flex shrink-0 items-center gap-3">
+										{request.filed_at && (
+											<time
+												dateTime={request.filed_at}
+												title={new Date(request.filed_at).toLocaleString()}
+												className="text-muted-foreground hidden text-xs whitespace-nowrap tabular-nums sm:inline"
+											>
+												{timeAgo(request.filed_at)}
+											</time>
+										)}
+										{status === 'all' && (
+											<Badge
+												variant={
+													ACCESS_REQUEST_STATUS_VARIANT[request.status] ??
+													'default'
+												}
+											>
+												{request.status}
+											</Badge>
+										)}
+										<span className="text-accent-teal text-sm font-medium">
+											{request.status === 'pending' ? 'Review' : 'View'}
+										</span>
+									</div>
+								</button>
+							</li>
+						))}
+					</ul>
+				)}
+			</DetailSection>
 
 			<AccessRequestDecisionDialog
 				request={active}

--- a/ui/src/modules/agents/components/ScopesCard.tsx
+++ b/ui/src/modules/agents/components/ScopesCard.tsx
@@ -17,11 +17,9 @@ import { ShieldCheck } from 'lucide-react';
 import {
 	Badge,
 	Button,
-	Card,
-	CardBody,
-	CardHeader,
-	CardTitle,
+	DetailSection,
 	Dialog,
+	EmptyRow,
 	ErrorAlert,
 	LoadingState,
 	ScopePicker,
@@ -93,34 +91,33 @@ export function ScopesCard({ actorKind, actorId, actorName, canEdit = true }: Sc
 	const granted = scopesQuery.data ?? [];
 
 	return (
-		<Card>
-			<CardHeader className="flex flex-row items-center justify-between gap-2">
-				<div className="flex items-center gap-2">
-					<ShieldCheck className="text-primary h-4 w-4" />
-					<CardTitle>Scopes</CardTitle>
-				</div>
-				{canEdit && !scopesQuery.isPending && !scopesQuery.error && (
-					<Button
-						size="sm"
-						variant="outline"
-						onClick={() => setEditing(true)}
-						aria-label={`Edit scopes for ${actorName}`}
-					>
-						Edit scopes
-					</Button>
-				)}
-			</CardHeader>
-			<CardBody className="space-y-2">
+		<>
+			<DetailSection
+				title="Scopes"
+				icon={<ShieldCheck className="h-4 w-4" />}
+				trailing={
+					canEdit && !scopesQuery.isPending && !scopesQuery.error ? (
+						<Button
+							size="sm"
+							variant="outline"
+							onClick={() => setEditing(true)}
+							aria-label={`Edit scopes for ${actorName}`}
+						>
+							Edit scopes
+						</Button>
+					) : null
+				}
+			>
 				{scopesQuery.isPending ? (
 					<LoadingState size="sm" />
 				) : scopesQuery.error ? (
 					<ErrorAlert message={scopesQuery.error as Error} />
 				) : granted.length === 0 ? (
-					<div className="text-muted-foreground border-border/60 rounded-lg border border-dashed p-4 text-center text-sm">
+					<EmptyRow icon={<ShieldCheck />}>
 						No scopes granted.
 						{canEdit &&
 							' This actor can’t perform privileged operations until you grant some.'}
-					</div>
+					</EmptyRow>
 				) : (
 					<ul className="flex flex-wrap gap-2" aria-label="Granted scopes">
 						{[...granted]
@@ -134,7 +131,7 @@ export function ScopesCard({ actorKind, actorId, actorName, canEdit = true }: Sc
 							))}
 					</ul>
 				)}
-			</CardBody>
+			</DetailSection>
 
 			{editing && (
 				<EditScopesDialog
@@ -161,7 +158,7 @@ export function ScopesCard({ actorKind, actorId, actorName, canEdit = true }: Sc
 					}}
 				/>
 			)}
-		</Card>
+		</>
 	);
 }
 

--- a/ui/src/modules/agents/components/detail/ActivityPanel.tsx
+++ b/ui/src/modules/agents/components/detail/ActivityPanel.tsx
@@ -1,58 +1,19 @@
 /**
  * ActivityPanel — the detail page's Activity tab: the shared console chart
  * pair (stacked execution volume + total-call trend, `ExecutionVolumeCharts`)
- * plus a most-recent-executions feed, both scoped by `actor_id`. Monitor
- * owns the full history (cursor paging, trace sheets,
- * filters), so the panel ends in a pre-filtered "Open in Monitor" deep-link
- * rather than re-implementing any of that here.
+ * plus the shared recent-executions feed (`RecentExecutionsCard`), both
+ * scoped by `actor_id`. Monitor owns the full history (cursor paging, trace
+ * sheets, filters), so the panel deep-links there rather than
+ * re-implementing any of that here.
  *
  * Both sources are permission-gated (usage behind `org:admin`, executions
  * behind `executions:read`): a 403 resolves to `null` (not an error) and the
  * panel renders one quiet permission note instead of charts.
  */
-import { Activity, ArrowRight, ListOrdered } from 'lucide-react';
-import {
-	AppLink,
-	DataTable,
-	DetailSection,
-	EmptyState,
-	ExecutionVolumeCharts,
-	LoadingState,
-	StatusBadge,
-	type Column,
-} from '@/shared/ui';
+import { Activity } from 'lucide-react';
+import { EmptyState, ExecutionVolumeCharts, LoadingState, RecentExecutionsCard } from '@/shared/ui';
 import { ROUTE_PATHS } from '@/shared/app';
-import { formatTimestamp, timeAgo } from '@/shared/lib/utils';
-import {
-	useActorExecutions,
-	useActorUsageDetail,
-	type ActorExecutionEntity,
-} from '@/modules/agents/api';
-
-/** "412ms" / "1.2s", or an em-dash for executions without a duration. */
-function formatDuration(ms: number | null): string {
-	if (ms == null) return '—';
-	if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
-	return `${Math.round(ms)}ms`;
-}
-
-/** The operation cell: "toolkit.operation" with the error inlined for failures. */
-function OperationCell({ row }: { row: ActorExecutionEntity }) {
-	const toolkit = row.toolkitName ?? row.toolkitId;
-	return (
-		<div className="min-w-0">
-			<code className="text-foreground/90 block truncate font-mono text-xs">
-				{toolkit}
-				{row.operationId ? `.${row.operationId}` : ''}
-			</code>
-			{row.error && (
-				<span className="text-danger block truncate text-[11px]" title={row.error}>
-					{row.error}
-				</span>
-			)}
-		</div>
-	);
-}
+import { useActorExecutions, useActorUsageDetail } from '@/modules/agents/api';
 
 interface ActivityPanelProps {
 	actorId: string;
@@ -95,50 +56,7 @@ export function ActivityPanel({ actorId, actorType }: ActivityPanelProps) {
 	}
 
 	const buckets = usage.data?.buckets ?? [];
-
 	const items = executions.data?.items ?? [];
-	const columns: Column<ActorExecutionEntity>[] = [
-		{
-			key: 'status',
-			header: 'Status',
-			className: 'w-20',
-			render: (row) =>
-				row.httpStatus != null ? (
-					<StatusBadge status={row.httpStatus} />
-				) : (
-					<span className="text-muted-foreground text-xs">{row.status}</span>
-				),
-		},
-		{
-			key: 'operation',
-			header: 'Operation',
-			className: 'max-w-[360px]',
-			render: (row) => <OperationCell row={row} />,
-		},
-		{
-			key: 'duration',
-			header: 'Duration',
-			className: 'w-24 text-right',
-			render: (row) => (
-				<span className="text-muted-foreground font-mono text-xs tabular-nums">
-					{formatDuration(row.durationMs)}
-				</span>
-			),
-		},
-		{
-			key: 'time',
-			header: 'Time',
-			className: 'w-28 text-right',
-			render: (row) => (
-				<span
-					className="text-muted-foreground text-xs"
-					title={formatTimestamp(row.startedAt)}
-				>
-					{timeAgo(row.startedAt)}
-				</span>
-			),
-		},
-	];
 
 	return (
 		<div className="space-y-4">
@@ -151,56 +69,22 @@ export function ActivityPanel({ actorId, actorType }: ActivityPanelProps) {
 			)}
 
 			{executions.data != null && (
-				<DetailSection
-					title="Recent executions"
-					icon={<ListOrdered className="h-4 w-4" />}
-					trailing={
-						<AppLink
-							href={monitorLink}
-							className="text-muted-foreground hover:text-primary inline-flex items-center gap-1 text-xs font-medium transition-colors"
-						>
-							Open in Monitor <ArrowRight className="h-3.5 w-3.5" />
-						</AppLink>
-					}
-					bodyClassName="px-0 py-0 space-y-0"
-				>
-					<DataTable<ActorExecutionEntity>
-						columns={columns}
-						data={items}
-						getRowKey={(row) => row.id}
-						emptyMessage="No executions recorded for this actor yet."
-						ariaLabel="Recent executions"
-						renderCard={(row) => (
-							<div className="space-y-1.5">
-								<div className="flex items-center justify-between gap-2">
-									{row.httpStatus != null ? (
-										<StatusBadge status={row.httpStatus} />
-									) : (
-										<span className="text-muted-foreground text-xs">
-											{row.status}
-										</span>
-									)}
-									<span
-										className="text-muted-foreground text-[11px]"
-										title={formatTimestamp(row.startedAt)}
-									>
-										{timeAgo(row.startedAt)}
-									</span>
-								</div>
-								<OperationCell row={row} />
-							</div>
-						)}
-					/>
-					{executions.data.hasMore && (
-						<p className="text-muted-foreground border-border/60 border-t px-4 py-2.5 text-xs">
-							Showing the {items.length} most recent —{' '}
-							<AppLink href={monitorLink} className="text-primary font-medium">
-								see the full history in Monitor
-							</AppLink>
-							.
-						</p>
-					)}
-				</DetailSection>
+				<RecentExecutionsCard
+					monitorHref={monitorLink}
+					emptyMessage="No executions recorded for this actor yet."
+					hasMore={executions.data.hasMore}
+					items={items.map((row) => ({
+						id: row.id,
+						status: row.status,
+						httpStatus: row.httpStatus,
+						label: `${row.toolkitName ?? row.toolkitId}${
+							row.operationId ? `.${row.operationId}` : ''
+						}`,
+						error: row.error,
+						durationMs: row.durationMs,
+						startedAt: row.startedAt,
+					}))}
+				/>
 			)}
 		</div>
 	);

--- a/ui/src/modules/agents/components/detail/ActivityPanel.tsx
+++ b/ui/src/modules/agents/components/detail/ActivityPanel.tsx
@@ -1,7 +1,8 @@
 /**
- * ActivityPanel — the detail page's Activity tab: this actor's execution
- * volume (7-day stacked bars) plus a most-recent-executions feed, both scoped
- * by `actor_id`. Monitor owns the full history (cursor paging, trace sheets,
+ * ActivityPanel — the detail page's Activity tab: the shared console chart
+ * pair (stacked execution volume + total-call trend, `ExecutionVolumeCharts`)
+ * plus a most-recent-executions feed, both scoped by `actor_id`. Monitor
+ * owns the full history (cursor paging, trace sheets,
  * filters), so the panel ends in a pre-filtered "Open in Monitor" deep-link
  * rather than re-implementing any of that here.
  *
@@ -9,17 +10,16 @@
  * behind `executions:read`): a 403 resolves to `null` (not an error) and the
  * panel renders one quiet permission note instead of charts.
  */
-import { Activity, ArrowRight, ListOrdered, TrendingUp } from 'lucide-react';
+import { Activity, ArrowRight, ListOrdered } from 'lucide-react';
 import {
 	AppLink,
 	DataTable,
 	DetailSection,
 	EmptyState,
+	ExecutionVolumeCharts,
 	LoadingState,
-	StackedBarChart,
 	StatusBadge,
 	type Column,
-	type StackedBarDatum,
 } from '@/shared/ui';
 import { ROUTE_PATHS } from '@/shared/app';
 import { formatTimestamp, timeAgo } from '@/shared/lib/utils';
@@ -34,18 +34,6 @@ function formatDuration(ms: number | null): string {
 	if (ms == null) return '—';
 	if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
 	return `${Math.round(ms)}ms`;
-}
-
-/**
- * Label a bucket timestamp for the x-axis: clock time for sub-day buckets,
- * month + day otherwise (mirrors the dashboard's bucket-label convention).
- */
-function bucketLabel(ts: number, bucketSeconds: number): string {
-	const date = new Date(ts * 1000);
-	if (bucketSeconds < 86_400) {
-		return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-	}
-	return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
 /** The operation cell: "toolkit.operation" with the error inlined for failures. */
@@ -107,24 +95,6 @@ export function ActivityPanel({ actorId, actorType }: ActivityPanelProps) {
 	}
 
 	const buckets = usage.data?.buckets ?? [];
-	const bars: StackedBarDatum[] = buckets.map((b) => ({
-		key: String(b.ts),
-		label: bucketLabel(b.ts, usage.data?.bucketSeconds ?? 86_400),
-		segments: [
-			{
-				key: 'success',
-				label: 'succeeded',
-				value: b.success,
-				colorClassName: 'bg-accent-green/80',
-			},
-			{
-				key: 'failed',
-				label: 'failed',
-				value: b.failed,
-				colorClassName: 'bg-danger/70',
-			},
-		],
-	}));
 
 	const items = executions.data?.items ?? [];
 	const columns: Column<ActorExecutionEntity>[] = [
@@ -173,22 +143,11 @@ export function ActivityPanel({ actorId, actorType }: ActivityPanelProps) {
 	return (
 		<div className="space-y-4">
 			{usage.data != null && (
-				<DetailSection
-					title="Execution volume · 7d"
-					icon={<TrendingUp className="h-4 w-4" />}
-				>
-					{buckets.length === 0 ? (
-						<p className="text-muted-foreground py-6 text-center text-sm">
-							No executions in the last 7 days.
-						</p>
-					) : (
-						<StackedBarChart
-							bars={bars}
-							height={120}
-							ariaLabel={`Execution volume over the last 7 days: ${usage.data.total} total, ${usage.data.failed} failed.`}
-						/>
-					)}
-				</DetailSection>
+				<ExecutionVolumeCharts
+					buckets={buckets}
+					bucketSeconds={usage.data.bucketSeconds}
+					emptyMessage="No executions in the last 7 days. Volume appears here once this actor starts making calls."
+				/>
 			)}
 
 			{executions.data != null && (

--- a/ui/src/modules/agents/components/detail/ActivityPanel.tsx
+++ b/ui/src/modules/agents/components/detail/ActivityPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * ActivityPanel — the detail page's Activity tab: the shared console chart
- * pair (stacked execution volume + total-call trend, `ExecutionVolumeCharts`)
+ * pair (stacked execution volume + success-rate trend, `ExecutionVolumeCharts`)
  * plus the shared recent-executions feed (`RecentExecutionsCard`), both
  * scoped by `actor_id`. Monitor owns the full history (cursor paging, trace
  * sheets, filters), so the panel deep-links there rather than

--- a/ui/src/modules/agents/components/detail/ActivityPanel.tsx
+++ b/ui/src/modules/agents/components/detail/ActivityPanel.tsx
@@ -9,14 +9,11 @@
  * behind `executions:read`): a 403 resolves to `null` (not an error) and the
  * panel renders one quiet permission note instead of charts.
  */
-import { Activity, ArrowRight } from 'lucide-react';
+import { Activity, ArrowRight, ListOrdered, TrendingUp } from 'lucide-react';
 import {
 	AppLink,
-	Card,
-	CardBody,
-	CardHeader,
-	CardTitle,
 	DataTable,
+	DetailSection,
 	EmptyState,
 	LoadingState,
 	StackedBarChart,
@@ -176,76 +173,75 @@ export function ActivityPanel({ actorId, actorType }: ActivityPanelProps) {
 	return (
 		<div className="space-y-4">
 			{usage.data != null && (
-				<Card>
-					<CardHeader>
-						<CardTitle>Execution volume (7d)</CardTitle>
-					</CardHeader>
-					<CardBody>
-						{buckets.length === 0 ? (
-							<p className="text-muted-foreground py-6 text-center text-sm">
-								No executions in the last 7 days.
-							</p>
-						) : (
-							<StackedBarChart
-								bars={bars}
-								height={120}
-								ariaLabel={`Execution volume over the last 7 days: ${usage.data.total} total, ${usage.data.failed} failed.`}
-							/>
-						)}
-					</CardBody>
-				</Card>
+				<DetailSection
+					title="Execution volume · 7d"
+					icon={<TrendingUp className="h-4 w-4" />}
+				>
+					{buckets.length === 0 ? (
+						<p className="text-muted-foreground py-6 text-center text-sm">
+							No executions in the last 7 days.
+						</p>
+					) : (
+						<StackedBarChart
+							bars={bars}
+							height={120}
+							ariaLabel={`Execution volume over the last 7 days: ${usage.data.total} total, ${usage.data.failed} failed.`}
+						/>
+					)}
+				</DetailSection>
 			)}
 
 			{executions.data != null && (
-				<Card>
-					<CardHeader className="flex flex-row items-center justify-between gap-2">
-						<CardTitle>Recent executions</CardTitle>
+				<DetailSection
+					title="Recent executions"
+					icon={<ListOrdered className="h-4 w-4" />}
+					trailing={
 						<AppLink
 							href={monitorLink}
 							className="text-muted-foreground hover:text-primary inline-flex items-center gap-1 text-xs font-medium transition-colors"
 						>
 							Open in Monitor <ArrowRight className="h-3.5 w-3.5" />
 						</AppLink>
-					</CardHeader>
-					<CardBody className="px-0 py-0">
-						<DataTable<ActorExecutionEntity>
-							columns={columns}
-							data={items}
-							getRowKey={(row) => row.id}
-							emptyMessage="No executions recorded for this actor yet."
-							ariaLabel="Recent executions"
-							renderCard={(row) => (
-								<div className="space-y-1.5">
-									<div className="flex items-center justify-between gap-2">
-										{row.httpStatus != null ? (
-											<StatusBadge status={row.httpStatus} />
-										) : (
-											<span className="text-muted-foreground text-xs">
-												{row.status}
-											</span>
-										)}
-										<span
-											className="text-muted-foreground text-[11px]"
-											title={formatTimestamp(row.startedAt)}
-										>
-											{timeAgo(row.startedAt)}
+					}
+					bodyClassName="px-0 py-0 space-y-0"
+				>
+					<DataTable<ActorExecutionEntity>
+						columns={columns}
+						data={items}
+						getRowKey={(row) => row.id}
+						emptyMessage="No executions recorded for this actor yet."
+						ariaLabel="Recent executions"
+						renderCard={(row) => (
+							<div className="space-y-1.5">
+								<div className="flex items-center justify-between gap-2">
+									{row.httpStatus != null ? (
+										<StatusBadge status={row.httpStatus} />
+									) : (
+										<span className="text-muted-foreground text-xs">
+											{row.status}
 										</span>
-									</div>
-									<OperationCell row={row} />
+									)}
+									<span
+										className="text-muted-foreground text-[11px]"
+										title={formatTimestamp(row.startedAt)}
+									>
+										{timeAgo(row.startedAt)}
+									</span>
 								</div>
-							)}
-						/>
-						{executions.data.hasMore && (
-							<p className="text-muted-foreground border-border/60 border-t px-4 py-2.5 text-xs">
-								Showing the {items.length} most recent —{' '}
-								<AppLink href={monitorLink} className="text-primary font-medium">
-									see the full history in Monitor
-								</AppLink>
-								.
-							</p>
+								<OperationCell row={row} />
+							</div>
 						)}
-					</CardBody>
-				</Card>
+					/>
+					{executions.data.hasMore && (
+						<p className="text-muted-foreground border-border/60 border-t px-4 py-2.5 text-xs">
+							Showing the {items.length} most recent —{' '}
+							<AppLink href={monitorLink} className="text-primary font-medium">
+								see the full history in Monitor
+							</AppLink>
+							.
+						</p>
+					)}
+				</DetailSection>
 			)}
 		</div>
 	);

--- a/ui/src/modules/agents/components/detail/ActorAuditPanel.tsx
+++ b/ui/src/modules/agents/components/detail/ActorAuditPanel.tsx
@@ -1,46 +1,16 @@
 /**
  * ActorAuditPanel — the "Recent changes" card on the agent / service-account
- * detail Overview tab. A read-only, actor-scoped slice of the org-wide audit
- * log: the lifecycle trail recorded against this actor as the TARGET
- * (register, approve/deny, disable/enable, key rotation, toolkit grant/
- * revoke). Deliberately the same visual grammar as the toolkit console's
- * `ToolkitAuditPanel` so "Recent changes" reads identically across consoles.
+ * detail Overview tab: a thin, actor-scoped wrapper over the shared
+ * {@link AuditTrailCard} (the same card the toolkit console renders, so
+ * "Recent changes" reads identically across consoles). Surfaces the lifecycle
+ * trail recorded against this actor as the TARGET (register, approve/deny,
+ * disable/enable, key rotation, toolkit grant/revoke).
  *
  * Requires `org:admin` — the repository maps 401/403 to an empty list, so
  * non-admins see the graceful "no entries" state rather than an error.
  */
-import { AnimatePresence, motion } from 'framer-motion';
-import { History, ScrollText } from 'lucide-react';
-import { ActorLabel, Badge, ErrorAlert } from '@/shared/ui';
-import { formatTimestamp, timeAgo } from '@/shared/lib/utils';
-import { useActorAudit, type ActorAuditEntry } from '@/modules/agents/api';
-
-const rowMotion = {
-	initial: { opacity: 0, y: -4 },
-	animate: { opacity: 1, y: 0 },
-	exit: { opacity: 0, y: -4 },
-	transition: { duration: 0.16, ease: 'easeOut' as const },
-};
-
-function actionVariant(action: string): 'default' | 'success' | 'danger' {
-	const a = action.toLowerCase();
-	if (
-		a.includes('delete') ||
-		a.includes('deny') ||
-		a.includes('disable') ||
-		a.includes('archive') ||
-		a.includes('revoke')
-	) {
-		return 'danger';
-	}
-	if (a.includes('create') || a.includes('register') || a.includes('approve')) return 'success';
-	return 'default';
-}
-
-/** Fallback display when an entry has no resolvable actor id (system events). */
-function fallbackActor(entry: ActorAuditEntry): string {
-	return entry.actor_type ?? 'system';
-}
+import { AuditTrailCard } from '@/shared/ui';
+import { useActorAudit } from '@/modules/agents/api';
 
 export interface ActorAuditPanelProps {
 	actorKind: 'agent' | 'service-account';
@@ -51,78 +21,22 @@ export function ActorAuditPanel({ actorKind, actorId }: ActorAuditPanelProps) {
 	const { data: entries = [], isLoading, isError } = useActorAudit(actorKind, actorId);
 
 	return (
-		<div className="bg-card border-border overflow-hidden rounded-xl border">
-			<div className="border-border flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3.5 sm:px-5 sm:py-4">
-				<h3 className="font-heading text-foreground flex items-center gap-2.5 font-semibold">
-					<span
-						aria-hidden="true"
-						className="bg-muted text-muted-foreground ring-border flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ring-1"
-					>
-						<History className="h-4 w-4" />
-					</span>
-					Recent changes
-				</h3>
-				<span className="text-muted-foreground text-xs">Lifecycle events · admin only</span>
-			</div>
-			<div className="space-y-2 px-4 py-3.5 sm:px-5 sm:py-4">
-				{isError && <ErrorAlert message="Failed to load the audit log." />}
-				{!isError && isLoading && (
-					<>
-						<div className="bg-muted h-10 animate-pulse rounded-lg" />
-						<div className="bg-muted h-10 animate-pulse rounded-lg" />
-					</>
-				)}
-				{!isError && !isLoading && entries.length === 0 && (
-					<div className="border-border/50 rounded-lg border border-dashed px-5 py-6 text-center">
-						<ScrollText className="text-muted-foreground/50 mx-auto h-6 w-6" />
-						<p className="text-muted-foreground mt-2 text-sm">
-							No recorded changes for this{' '}
-							{actorKind === 'agent' ? 'agent' : 'service account'} yet. The full
-							audit trail lives in Monitor → Audit.
-						</p>
-					</div>
-				)}
-				<AnimatePresence initial={false}>
-					{entries.map((entry) => {
-						const occurred = Date.parse(entry.occurred_at);
-						return (
-							<motion.div
-								key={entry.id}
-								{...rowMotion}
-								className="bg-muted/30 border-border/60 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border px-3 py-2"
-							>
-								<Badge variant={actionVariant(entry.action)}>{entry.action}</Badge>
-								<span className="text-foreground min-w-0 flex-1 truncate text-sm">
-									{entry.actor_id ? (
-										<ActorLabel
-											actorId={entry.actor_id}
-											actorType={entry.actor_type ?? undefined}
-										/>
-									) : (
-										fallbackActor(entry)
-									)}
-									{entry.reason ? (
-										<span className="text-muted-foreground">
-											{' '}
-											— {entry.reason}
-										</span>
-									) : null}
-								</span>
-								<span
-									className="text-muted-foreground shrink-0 text-xs"
-									title={
-										Number.isFinite(occurred)
-											? formatTimestamp(entry.occurred_at)
-											: entry.occurred_at
-									}
-								>
-									{Number.isFinite(occurred) ? timeAgo(entry.occurred_at) : ''}
-								</span>
-							</motion.div>
-						);
-					})}
-				</AnimatePresence>
-			</div>
-		</div>
+		<AuditTrailCard
+			entries={entries.map((entry) => ({
+				id: entry.id,
+				action: entry.action,
+				actorId: entry.actor_id,
+				actorType: entry.actor_type,
+				reason: entry.reason,
+				occurredAt: entry.occurred_at,
+			}))}
+			isLoading={isLoading}
+			isError={isError}
+			caption="Lifecycle events · admin only"
+			errorMessage="Failed to load the audit log."
+			emptyMessage={`No recorded changes for this ${
+				actorKind === 'agent' ? 'agent' : 'service account'
+			} yet. The full audit trail lives in Monitor → Audit.`}
+		/>
 	);
 }

--- a/ui/src/modules/agents/components/detail/AgentKeysPanel.tsx
+++ b/ui/src/modules/agents/components/detail/AgentKeysPanel.tsx
@@ -10,16 +10,7 @@
  */
 import { useState } from 'react';
 import { Ban, History, KeyRound } from 'lucide-react';
-import {
-	ActorLabel,
-	Badge,
-	Button,
-	Card,
-	CardBody,
-	CardHeader,
-	CardTitle,
-	LoadingState,
-} from '@/shared/ui';
+import { ActorLabel, Badge, Button, DetailSection, LoadingState } from '@/shared/ui';
 import { formatTimestamp, timeAgo } from '@/shared/lib/utils';
 import {
 	useAgentApiKeyInfo,
@@ -63,122 +54,112 @@ export function AgentKeysPanel({ agent }: { agent: AgentEntity }) {
 
 	return (
 		<div className="space-y-4">
-			<Card>
-				<CardHeader className="flex flex-row items-center justify-between gap-2">
-					<div className="flex items-center gap-2">
-						<KeyRound className="text-primary h-4 w-4" />
-						<CardTitle>API Key</CardTitle>
-					</div>
-					{info && (
+			<DetailSection
+				title="API key"
+				icon={<KeyRound className="h-4 w-4" />}
+				titleExtra={
+					info && (
 						<Badge variant={info.status === 'active' ? 'success' : 'danger'}>
 							{info.status}
 						</Badge>
-					)}
-				</CardHeader>
-				<CardBody className="space-y-4">
-					{info ? (
-						<dl className="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3">
-							<MetaItem label="Key ID" value={info.id} />
-							<MetaItem label="Created" value={formatTimestamp(info.createdAt)} />
-							{info.rotatedAt && (
-								<MetaItem
-									label="Last rotated"
-									value={formatTimestamp(info.rotatedAt)}
-								/>
-							)}
-							{info.createdBy && (
-								<MetaItem
-									label="Created by"
-									value={<ActorLabel actorId={info.createdBy} />}
-								/>
-							)}
-						</dl>
-					) : (
-						<p className="text-muted-foreground text-sm">
-							No API key has been issued for this agent yet.
-						</p>
-					)}
+					)
+				}
+				bodyClassName="space-y-4"
+			>
+				{info ? (
+					<dl className="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3">
+						<MetaItem label="Key ID" value={info.id} />
+						<MetaItem label="Created" value={formatTimestamp(info.createdAt)} />
+						{info.rotatedAt && (
+							<MetaItem
+								label="Last rotated"
+								value={formatTimestamp(info.rotatedAt)}
+							/>
+						)}
+						{info.createdBy && (
+							<MetaItem
+								label="Created by"
+								value={<ActorLabel actorId={info.createdBy} />}
+							/>
+						)}
+					</dl>
+				) : (
+					<p className="text-muted-foreground text-sm">
+						No API key has been issued for this agent yet.
+					</p>
+				)}
 
-					{agent.status === 'active' ? (
-						<div className="flex flex-wrap justify-end gap-2">
-							{agent.hasApiKey && (
-								<Button
-									size="sm"
-									variant="danger"
-									disabled={mutating}
-									loading={revokeApiKey.isPending}
-									onClick={() => setConfirmRevoke(true)}
-									aria-label={`Revoke API key for ${agent.name}`}
-								>
-									<Ban className="h-3.5 w-3.5" />
-									Revoke API Key
-								</Button>
-							)}
+				{agent.status === 'active' ? (
+					<div className="flex flex-wrap justify-end gap-2">
+						{agent.hasApiKey && (
 							<Button
 								size="sm"
-								variant="outline"
+								variant="danger"
 								disabled={mutating}
-								loading={!confirmRegenerate && generateApiKey.isPending}
-								onClick={() => {
-									// Regenerating rotates the credential — the current key
-									// stops working the moment the new one is issued, so it
-									// confirms first. A first issue destroys nothing and
-									// generates directly.
-									if (agent.hasApiKey) setConfirmRegenerate(true);
-									else void generate();
-								}}
-								aria-label={`${agent.hasApiKey ? 'Regenerate' : 'Generate'} API key for ${agent.name}`}
+								loading={revokeApiKey.isPending}
+								onClick={() => setConfirmRevoke(true)}
+								aria-label={`Revoke API key for ${agent.name}`}
 							>
-								<KeyRound className="h-3.5 w-3.5" />
-								{agent.hasApiKey ? 'Regenerate API Key' : 'Generate API Key'}
+								<Ban className="h-3.5 w-3.5" />
+								Revoke API Key
 							</Button>
-						</div>
-					) : (
-						<p className="text-muted-foreground text-xs">
-							Keys can only be issued while the agent is active.
-						</p>
-					)}
-				</CardBody>
-			</Card>
+						)}
+						<Button
+							size="sm"
+							variant="outline"
+							disabled={mutating}
+							loading={!confirmRegenerate && generateApiKey.isPending}
+							onClick={() => {
+								// Regenerating rotates the credential — the current key
+								// stops working the moment the new one is issued, so it
+								// confirms first. A first issue destroys nothing and
+								// generates directly.
+								if (agent.hasApiKey) setConfirmRegenerate(true);
+								else void generate();
+							}}
+							aria-label={`${agent.hasApiKey ? 'Regenerate' : 'Generate'} API key for ${agent.name}`}
+						>
+							<KeyRound className="h-3.5 w-3.5" />
+							{agent.hasApiKey ? 'Regenerate API Key' : 'Generate API Key'}
+						</Button>
+					</div>
+				) : (
+					<p className="text-muted-foreground text-xs">
+						Keys can only be issued while the agent is active.
+					</p>
+				)}
+			</DetailSection>
 
 			{history.length > 0 && (
-				<Card>
-					<CardHeader className="flex flex-row items-center gap-2">
-						<History className="text-primary h-4 w-4" />
-						<CardTitle>API Key History</CardTitle>
-					</CardHeader>
-					<CardBody className="space-y-2">
-						{history.map((entry) => (
-							<div
-								key={entry.id}
-								className="border-border/60 flex items-center justify-between rounded-lg border px-3 py-2"
-							>
-								<div className="flex items-center gap-2">
-									<Badge
-										variant={
-											entry.reason === 'api_key_revoked'
-												? 'danger'
-												: 'default'
-										}
-									>
-										{entry.reason === 'api_key_revoked' ? 'Revoked' : 'Rotated'}
-									</Badge>
-									{entry.actorId && (
-										<span className="text-muted-foreground truncate text-xs">
-											by <ActorLabel actorId={entry.actorId} />
-										</span>
-									)}
-								</div>
-								<span
-									className="text-muted-foreground/70 shrink-0 text-[11px]"
-									title={formatTimestamp(entry.occurredAt)}
+				<DetailSection title="API key history" icon={<History className="h-4 w-4" />}>
+					{history.map((entry) => (
+						<div
+							key={entry.id}
+							className="border-border/60 flex items-center justify-between rounded-lg border px-3 py-2"
+						>
+							<div className="flex items-center gap-2">
+								<Badge
+									variant={
+										entry.reason === 'api_key_revoked' ? 'danger' : 'default'
+									}
 								>
-									{timeAgo(entry.occurredAt)}
-								</span>
+									{entry.reason === 'api_key_revoked' ? 'Revoked' : 'Rotated'}
+								</Badge>
+								{entry.actorId && (
+									<span className="text-muted-foreground truncate text-xs">
+										by <ActorLabel actorId={entry.actorId} />
+									</span>
+								)}
 							</div>
-						))}
-					</CardBody>
-				</Card>
+							<span
+								className="text-muted-foreground/70 shrink-0 text-[11px]"
+								title={formatTimestamp(entry.occurredAt)}
+							>
+								{timeAgo(entry.occurredAt)}
+							</span>
+						</div>
+					))}
+				</DetailSection>
 			)}
 
 			<ConfirmDialog

--- a/ui/src/modules/agents/components/detail/AgentSettingsPanel.tsx
+++ b/ui/src/modules/agents/components/detail/AgentSettingsPanel.tsx
@@ -7,11 +7,11 @@
  *     are sent (real PATCH semantics). Ownership is intentionally NOT
  *     editable here — reassigning an agent's accountable human is an
  *     administrative act, not routine metadata upkeep.
- *   - {@link DangerZone} → the destructive lifecycle actions (Disable /
- *     Archive), moved out of the identity header so it only ever offers
- *     constructive actions. Both buttons defer to the page-level
- *     {@link LifecycleDialogs} via `onLifecycle` — this panel never mutates
- *     lifecycle state itself.
+ *   - {@link DangerZone} → the terminal Archive action. Suspension is NOT
+ *     here: the reversible Disable/Enable flip lives in the page header's
+ *     kill switch, exactly like the toolkit console. The button defers to
+ *     the page-level {@link LifecycleDialogs} via `onLifecycle` — this panel
+ *     never mutates lifecycle state itself.
  */
 import { DangerZone, IdentitySettingsCard, type DangerZoneAction } from '@/shared/ui';
 import {
@@ -24,7 +24,7 @@ import {
 interface AgentSettingsPanelProps {
 	agent: AgentEntity;
 	/** Ask the page to run a destructive lifecycle action (opens its dialog). */
-	onLifecycle: (action: 'disable' | 'archive') => void;
+	onLifecycle: (action: 'archive') => void;
 	/** True while any page-level lifecycle mutation is in flight. */
 	lifecyclePending: boolean;
 }
@@ -37,33 +37,18 @@ export function AgentSettingsPanel({
 	const update = useUpdateAgent();
 
 	const actions = ACTIONS_FOR_STATUS[agent.status];
-	const dangerActions: DangerZoneAction[] = [
-		...(actions.includes('disable')
-			? [
-					{
-						key: 'disable',
-						title: 'Disable agent',
-						description:
-							'Immediately revokes this agent’s ability to authenticate. Reversible — you can re-enable it later.',
-						buttonLabel: 'Disable',
-						ariaLabel: `Disable ${agent.name}`,
-						emphasis: 'outline' as const,
-					},
-				]
-			: []),
-		...(actions.includes('archive')
-			? [
-					{
-						key: 'archive',
-						title: 'Archive agent',
-						description:
-							'Removes this agent from the fleet and cascades to its bindings. This cannot be undone.',
-						buttonLabel: 'Archive',
-						ariaLabel: `Archive ${agent.name}`,
-					},
-				]
-			: []),
-	];
+	const dangerActions: DangerZoneAction[] = actions.includes('archive')
+		? [
+				{
+					key: 'archive',
+					title: 'Archive agent',
+					description:
+						'Removes this agent from the fleet and cascades to its bindings. This cannot be undone.',
+					buttonLabel: 'Archive',
+					ariaLabel: `Archive ${agent.name}`,
+				},
+			]
+		: [];
 
 	return (
 		<div className="space-y-4">
@@ -91,7 +76,7 @@ export function AgentSettingsPanel({
 			<DangerZone
 				actions={dangerActions}
 				pending={lifecyclePending}
-				onAction={(key) => onLifecycle(key as 'disable' | 'archive')}
+				onAction={() => onLifecycle('archive')}
 			/>
 		</div>
 	);

--- a/ui/src/modules/agents/components/detail/AgentSettingsPanel.tsx
+++ b/ui/src/modules/agents/components/detail/AgentSettingsPanel.tsx
@@ -1,42 +1,25 @@
 /**
- * AgentSettingsPanel — the "Settings" tab of the agent detail console.
- *
- * Three concerns, deliberately separated (same grammar as the toolkit
- * console's Settings tab):
- *   - Identity → the immutable, copyable agent id. It lives here (not in the
- *     page chrome) so the header stays clean — exactly where the toolkit
- *     console keeps its toolkit id.
- *   - Editable metadata → name / description via PATCH /agents/{id}. Only
- *     dirty fields are sent (real PATCH semantics), and Save stays disabled
- *     until something actually changed. Ownership is intentionally NOT
+ * AgentSettingsPanel — the "Settings" tab of the agent detail console, built
+ * from the shared console cards so it reads identically to the toolkit and
+ * service-account Settings tabs:
+ *   - {@link IdentitySettingsCard} → the immutable, copyable agent id plus
+ *     editable name / description via PATCH /agents/{id}. Only dirty fields
+ *     are sent (real PATCH semantics). Ownership is intentionally NOT
  *     editable here — reassigning an agent's accountable human is an
  *     administrative act, not routine metadata upkeep.
- *   - Danger zone → the destructive lifecycle actions (Disable / Archive)
- *     move here from the identity header, so the header only ever offers
- *     constructive actions (Approve / Deny / Enable). Both destructive
- *     buttons defer to the page-level {@link LifecycleDialogs} via
- *     `onLifecycle` — this panel never mutates lifecycle state itself.
+ *   - {@link DangerZone} → the destructive lifecycle actions (Disable /
+ *     Archive), moved out of the identity header so it only ever offers
+ *     constructive actions. Both buttons defer to the page-level
+ *     {@link LifecycleDialogs} via `onLifecycle` — this panel never mutates
+ *     lifecycle state itself.
  */
-import { useEffect, useRef, useState } from 'react';
-import { Fingerprint } from 'lucide-react';
-import {
-	Button,
-	Card,
-	CardBody,
-	CardHeader,
-	CardTitle,
-	CopyButton,
-	Input,
-	Label,
-	Textarea,
-} from '@/shared/ui';
+import { DangerZone, IdentitySettingsCard, type DangerZoneAction } from '@/shared/ui';
 import {
 	useUpdateAgent,
 	ACTIONS_FOR_STATUS,
 	type AgentEntity,
 	type AgentPatch,
 } from '@/modules/agents/api';
-import { DangerZone, type DangerZoneItem } from '@/modules/agents/components/detail/shared';
 
 interface AgentSettingsPanelProps {
 	agent: AgentEntity;
@@ -53,70 +36,29 @@ export function AgentSettingsPanel({
 }: AgentSettingsPanelProps) {
 	const update = useUpdateAgent();
 
-	const [name, setName] = useState(agent.name);
-	const [description, setDescription] = useState(agent.description ?? '');
-	const [nameError, setNameError] = useState<string | null>(null);
-
-	// Seed-from-props syncs only when the entity itself changed — never on
-	// re-renders of the same agent, or a background refetch would clobber the
-	// user's draft. Without this, a warm detail cache could carry agent A's
-	// draft onto agent B and PATCH the wrong row.
-	const seededIdRef = useRef(agent.id);
-	useEffect(() => {
-		if (seededIdRef.current === agent.id) return;
-		seededIdRef.current = agent.id;
-		setName(agent.name);
-		setDescription(agent.description ?? '');
-		setNameError(null);
-	}, [agent.id, agent.name, agent.description]);
-
-	const trimmedName = name.trim();
-	const dirty = trimmedName !== agent.name || description.trim() !== (agent.description ?? '');
-
-	async function handleSave() {
-		if (!trimmedName) {
-			setNameError('A name is required.');
-			return;
-		}
-		setNameError(null);
-		// PATCH semantics: only ship the fields that changed; empty string on a
-		// nullable field means "clear it".
-		const patch: AgentPatch = {};
-		if (trimmedName !== agent.name) patch.name = trimmedName;
-		if (description.trim() !== (agent.description ?? '')) {
-			patch.description = description.trim() || null;
-		}
-		try {
-			const next = await update.mutateAsync({ id: agent.id, patch });
-			// Re-seed the drafts from the server's canonical row so the form
-			// goes back to a clean (non-dirty) state.
-			setName(next.name);
-			setDescription(next.description ?? '');
-		} catch {
-			// The hook toasts the failure; keep the draft so the user can retry.
-		}
-	}
-
 	const actions = ACTIONS_FOR_STATUS[agent.status];
-	const dangerItems: DangerZoneItem[] = [
+	const dangerActions: DangerZoneAction[] = [
 		...(actions.includes('disable')
 			? [
 					{
-						action: 'disable' as const,
+						key: 'disable',
 						title: 'Disable agent',
 						description:
 							'Immediately revokes this agent’s ability to authenticate. Reversible — you can re-enable it later.',
+						buttonLabel: 'Disable',
 						ariaLabel: `Disable ${agent.name}`,
+						emphasis: 'outline' as const,
 					},
 				]
 			: []),
 		...(actions.includes('archive')
 			? [
 					{
-						action: 'archive' as const,
+						key: 'archive',
 						title: 'Archive agent',
 						description:
 							'Removes this agent from the fleet and cascades to its bindings. This cannot be undone.',
+						buttonLabel: 'Archive',
 						ariaLabel: `Archive ${agent.name}`,
 					},
 				]
@@ -125,59 +67,32 @@ export function AgentSettingsPanel({
 
 	return (
 		<div className="space-y-4">
-			<Card>
-				<CardHeader>
-					<CardTitle>General</CardTitle>
-				</CardHeader>
-				<CardBody className="space-y-4">
-					{/* The immutable agent id — what API calls and audit rows
-					    reference. Lives here (not in the page chrome), same as the
-					    toolkit console's Toolkit ID. */}
-					<div className="flex flex-wrap items-center justify-between gap-2">
-						<span className="text-muted-foreground flex items-center gap-1.5 text-xs">
-							<Fingerprint className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-							Agent ID
-						</span>
-						<span className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 font-mono text-xs">
-							{agent.id}
-							<CopyButton value={agent.id} size="icon" variant="ghost" />
-						</span>
-					</div>
-					<div className="space-y-1.5">
-						<Label htmlFor="agent-settings-name">Name</Label>
-						<Input
-							id="agent-settings-name"
-							value={name}
-							onChange={(e) => setName(e.target.value)}
-							error={nameError ?? undefined}
-							maxLength={255}
-						/>
-					</div>
-					<div className="space-y-1.5">
-						<Label htmlFor="agent-settings-description">Description</Label>
-						<Textarea
-							id="agent-settings-description"
-							value={description}
-							onChange={(e) => setDescription(e.target.value)}
-							placeholder="What does this agent do?"
-							rows={3}
-							maxLength={1024}
-						/>
-					</div>
-					<div className="flex justify-end">
-						<Button
-							size="sm"
-							onClick={handleSave}
-							loading={update.isPending}
-							disabled={!dirty || update.isPending}
-						>
-							Save changes
-						</Button>
-					</div>
-				</CardBody>
-			</Card>
+			<IdentitySettingsCard
+				idLabel="Agent ID"
+				idValue={agent.id}
+				name={agent.name}
+				description={agent.description ?? null}
+				saving={update.isPending}
+				descriptionPlaceholder="What does this agent do?"
+				onSave={async (draft) => {
+					// PATCH semantics: only ship the fields that changed; empty
+					// string on the nullable description means "clear it".
+					const patch: AgentPatch = {};
+					if (draft.name !== agent.name) patch.name = draft.name;
+					if (draft.description !== (agent.description ?? '')) {
+						patch.description = draft.description || null;
+					}
+					// The hook toasts failures; a rejection keeps the draft in the
+					// card so the user can retry.
+					await update.mutateAsync({ id: agent.id, patch });
+				}}
+			/>
 
-			<DangerZone items={dangerItems} pending={lifecyclePending} onAction={onLifecycle} />
+			<DangerZone
+				actions={dangerActions}
+				pending={lifecyclePending}
+				onAction={(key) => onLifecycle(key as 'disable' | 'archive')}
+			/>
 		</div>
 	);
 }

--- a/ui/src/modules/agents/components/detail/BoundToolkitsCard.tsx
+++ b/ui/src/modules/agents/components/detail/BoundToolkitsCard.tsx
@@ -16,11 +16,9 @@ import { ArrowRight, Link as LinkIcon, Shield, Unlink } from 'lucide-react';
 import {
 	AppLink,
 	Button,
-	Card,
-	CardBody,
-	CardHeader,
-	CardTitle,
+	DetailSection,
 	Dialog,
+	EmptyRow,
 	ErrorAlert,
 	LoadingState,
 	ToolkitGlyph,
@@ -169,58 +167,56 @@ export function BoundToolkitsCard({
 
 	return (
 		<>
-			<Card>
-				<CardHeader className="flex flex-row items-center justify-between gap-2">
-					<div className="flex items-center gap-2">
-						<Shield className="text-primary h-4 w-4" />
-						<CardTitle>Bound toolkits</CardTitle>
-					</div>
-					{canBind && (
-						<Button
-							variant="secondary"
-							size="sm"
-							onClick={() => setBindToolkitOpen(true)}
-						>
-							<LinkIcon className="h-4 w-4" /> Bind toolkit
-						</Button>
-					)}
-				</CardHeader>
-				<CardBody className="space-y-2">
-					{toolkits.isPending ? (
-						<LoadingState size="sm" />
-					) : toolkits.error ? (
-						<ErrorAlert message={toolkits.error as Error} />
-					) : !toolkits.data || toolkits.data.length === 0 ? (
-						<div className="text-muted-foreground border-border/60 rounded-lg border border-dashed p-4 text-center text-sm">
-							{canBind
-								? 'No toolkits bound to this agent. Bind one to let this agent call its APIs.'
-								: agentStatus === 'pending'
-									? 'No toolkits bound. Approve this agent first — toolkits can only be bound to active agents.'
-									: 'No toolkits bound. Toolkits can only be bound to active agents.'}
-						</div>
-					) : (
-						toolkits.data.map((t) => (
-							<BoundToolkitRow
-								key={t.id}
-								toolkit={t}
-								confirming={unlinkToolkitId === t.toolkitId}
-								unbindPending={unbindToolkit.isPending}
-								onStartUnbind={() => setUnlinkToolkitId(t.toolkitId)}
-								onCancelUnbind={() => setUnlinkToolkitId(null)}
-								onConfirmUnbind={async () => {
-									try {
-										await unbindToolkit.mutateAsync(t.toolkitId);
-										setUnlinkToolkitId(null);
-									} catch {
-										// onError toasts; keep the row in the confirming
-										// state so the user can retry.
-									}
-								}}
-							/>
-						))
-					)}
-				</CardBody>
-			</Card>
+			<DetailSection
+				title="Bound toolkits"
+				icon={<Shield className="h-4 w-4" />}
+				action={
+					canBind
+						? {
+								label: (
+									<>
+										<LinkIcon className="h-4 w-4" /> Bind toolkit
+									</>
+								),
+								onClick: () => setBindToolkitOpen(true),
+							}
+						: undefined
+				}
+			>
+				{toolkits.isPending ? (
+					<LoadingState size="sm" />
+				) : toolkits.error ? (
+					<ErrorAlert message={toolkits.error as Error} />
+				) : !toolkits.data || toolkits.data.length === 0 ? (
+					<EmptyRow icon={<Shield />}>
+						{canBind
+							? 'No toolkits bound to this agent. Bind one to let this agent call its APIs.'
+							: agentStatus === 'pending'
+								? 'No toolkits bound. Approve this agent first — toolkits can only be bound to active agents.'
+								: 'No toolkits bound. Toolkits can only be bound to active agents.'}
+					</EmptyRow>
+				) : (
+					toolkits.data.map((t) => (
+						<BoundToolkitRow
+							key={t.id}
+							toolkit={t}
+							confirming={unlinkToolkitId === t.toolkitId}
+							unbindPending={unbindToolkit.isPending}
+							onStartUnbind={() => setUnlinkToolkitId(t.toolkitId)}
+							onCancelUnbind={() => setUnlinkToolkitId(null)}
+							onConfirmUnbind={async () => {
+								try {
+									await unbindToolkit.mutateAsync(t.toolkitId);
+									setUnlinkToolkitId(null);
+								} catch {
+									// onError toasts; keep the row in the confirming
+									// state so the user can retry.
+								}
+							}}
+						/>
+					))
+				)}
+			</DetailSection>
 
 			{/* Bind toolkit — agent-side picker mirroring the toolkit page's
 			 *  "Link agent" (#607). */}

--- a/ui/src/modules/agents/components/detail/shared.tsx
+++ b/ui/src/modules/agents/components/detail/shared.tsx
@@ -1,12 +1,10 @@
 /**
  * Shared scaffolding for the agent / service-account detail consoles — the
- * pieces both pages (and their tab panels) would otherwise copy. Mirrors the
- * toolkit console's `components/detail/shared.tsx` precedent so the two
- * console families stay structurally alike.
+ * pieces both pages (and their tab panels) would otherwise copy. The card
+ * shells themselves (`DetailSection`, `DangerZone`, `IdentitySettingsCard`,
+ * `AuditTrailCard`) are shared product-wide from `@/shared/ui`.
  */
 import type { ReactNode } from 'react';
-import { TriangleAlert } from 'lucide-react';
-import { Button, Card, CardBody, CardHeader, CardTitle } from '@/shared/ui';
 
 /** A compact label/value pair used in the attribution / key meta grids. */
 export function MetaItem({ label, value }: { label: string; value: ReactNode }) {
@@ -24,74 +22,4 @@ export function MetaItem({ label, value }: { label: string; value: ReactNode }) 
 export function successShare(success: number, total: number): string {
 	if (total === 0) return '—';
 	return `${((success / total) * 100).toFixed(1).replace(/\.0$/, '')}%`;
-}
-
-export interface DangerZoneItem {
-	action: 'disable' | 'archive';
-	title: string;
-	description: string;
-	/** Accessible label carrying the actor name (e.g. "Disable support-agent"). */
-	ariaLabel: string;
-}
-
-interface DangerZoneProps {
-	items: DangerZoneItem[];
-	/** True while any page-level lifecycle mutation is in flight. */
-	pending: boolean;
-	/** Ask the page to run the action (opens its confirm dialog). */
-	onAction: (action: 'disable' | 'archive') => void;
-}
-
-/** Button label for each danger-zone verb (matches the kebab vocabulary). */
-const DANGER_LABEL: Record<DangerZoneItem['action'], string> = {
-	disable: 'Disable',
-	archive: 'Archive',
-};
-
-/**
- * The Settings tab's destructive-actions card, shared by both consoles.
- * Renders nothing when no destructive verb applies to the actor's status.
- * Disable (reversible) reads as an outline; Archive (terminal) as solid
- * danger. Actions always defer to the page-level confirm dialogs — this
- * component never mutates lifecycle state itself.
- */
-export function DangerZone({ items, pending, onAction }: DangerZoneProps) {
-	if (items.length === 0) return null;
-	return (
-		<Card className="border-danger/30">
-			<CardHeader>
-				<CardTitle className="text-danger flex items-center gap-2">
-					<TriangleAlert className="h-4 w-4" aria-hidden />
-					Danger zone
-				</CardTitle>
-			</CardHeader>
-			<CardBody className="divide-border/60 divide-y">
-				{items.map((item) => (
-					<div
-						key={item.action}
-						className="flex flex-wrap items-center justify-between gap-3 py-3 first:pt-0 last:pb-0"
-					>
-						<div className="min-w-0">
-							<p className="text-foreground text-sm font-medium">{item.title}</p>
-							<p className="text-muted-foreground text-xs">{item.description}</p>
-						</div>
-						<Button
-							size="sm"
-							variant={item.action === 'archive' ? 'danger' : 'outline'}
-							className={
-								item.action === 'archive'
-									? 'shrink-0'
-									: 'border-danger/40 text-danger hover:bg-danger/10 shrink-0'
-							}
-							disabled={pending}
-							onClick={() => onAction(item.action)}
-							aria-label={item.ariaLabel}
-						>
-							{DANGER_LABEL[item.action]}
-						</Button>
-					</div>
-				))}
-			</CardBody>
-		</Card>
-	);
 }

--- a/ui/src/modules/agents/pages/AgentDetailPage.tsx
+++ b/ui/src/modules/agents/pages/AgentDetailPage.tsx
@@ -4,18 +4,17 @@
  *
  * Layout mirrors the toolkit console exactly: a shared `PageHeader` band (the
  * agent's badge as icon, its name as title, its own description as subtitle,
- * and the constructive lifecycle actions — Approve / Deny / Enable — in the
- * header action slot), a back row, a denial banner when rejected, the KPI
- * strip, then five tab panels:
+ * with the kill switch for the reversible active/disabled flip plus the
+ * constructive Approve / Deny actions in the header action slot), a back row,
+ * a denial banner when rejected, the KPI strip, then five tab panels:
  *   - Overview  → attribution meta + bound toolkits + audit slice
  *   - Activity  → this agent's execution volume + recent executions
  *                 (GET /monitoring/usage?agent_id=…, GET /executions?actor_id=…)
- *                 with a pre-filtered "Open in Monitor" deep-link
+ *                 with a pre-filtered "Open Monitor" deep-link
  *   - Access    → platform scopes (#615) + filed access requests (#619)
  *   - Keys      → API-key metadata, generate/regenerate/revoke, rotation history
  *   - Settings  → the copyable agent id + editable metadata (PATCH
- *                 /agents/{id}) + danger zone hosting the destructive
- *                 lifecycle actions (Disable / Archive)
+ *                 /agents/{id}) + danger zone hosting the terminal Archive
  *
  * The active tab lives in `?tab=` (like Monitor's lenses) so every view is
  * shareable and back-button friendly. Activity/KPI sources are admin-gated:
@@ -177,11 +176,12 @@ export default function AgentDetailPage() {
 	const agent = agentQuery.data;
 	// The identity header offers the kill switch for the reversible
 	// active/disabled flip (same control as the toolkit console) plus the
-	// constructive actions (Approve / Deny); destructive-irreversible ones
-	// (Archive) live in the Settings tab's danger zone.
+	// constructive actions (Approve / Deny); the terminal Archive lives in
+	// the Settings tab's danger zone. `enable`/`disable` never render as
+	// header buttons — the kill switch owns that verb pair.
 	const killSwitchStatus = agent.status === 'active' || agent.status === 'disabled';
 	const headerActions = ACTIONS_FOR_STATUS[agent.status].filter(
-		(a) => a !== 'disable' && a !== 'archive' && (!killSwitchStatus || a !== 'enable'),
+		(a) => a !== 'disable' && a !== 'archive' && a !== 'enable',
 	);
 	const actionPending =
 		approve.isPending ||
@@ -192,34 +192,23 @@ export default function AgentDetailPage() {
 
 	/**
 	 * Which specific header action is in flight (drives the per-button
-	 * spinner). Only constructive verbs render in the header — disable /
-	 * archive run behind the Settings danger zone's confirm dialogs, which
-	 * own their own pending state.
+	 * spinner). Only Approve / Deny render as header buttons — the
+	 * enable/disable pair runs through the kill switch (its own spinner) and
+	 * Archive behind the Settings danger zone's confirm dialog.
 	 */
 	const pendingAction: AgentAction | null = approve.isPending
 		? 'approve'
 		: deny.isPending
 			? 'deny'
-			: enable.isPending
-				? 'enable'
-				: null;
+			: null;
 
 	function handleAction(action: AgentAction) {
 		switch (action) {
 			case 'approve':
 				approve.mutate(agent.id);
 				break;
-			case 'enable':
-				enable.mutate(agent.id);
-				break;
 			case 'deny':
 				setConfirm({ kind: 'deny', id: agent.id, name: agent.name });
-				break;
-			case 'disable':
-				setConfirm({ kind: 'disable', id: agent.id, name: agent.name });
-				break;
-			case 'archive':
-				setConfirm({ kind: 'archive', id: agent.id, name: agent.name });
 				break;
 		}
 	}

--- a/ui/src/modules/agents/pages/AgentDetailPage.tsx
+++ b/ui/src/modules/agents/pages/AgentDetailPage.tsx
@@ -25,6 +25,7 @@ import { useState } from 'react';
 import { useParams, useSearchParams } from 'react-router';
 import {
 	Activity as ActivityIcon,
+	Fingerprint,
 	Key,
 	LayoutDashboard,
 	Settings,
@@ -37,8 +38,7 @@ import {
 	AppLink,
 	BackButton,
 	Button,
-	Card,
-	CardBody,
+	DetailSection,
 	LoadingState,
 	PageHeader,
 	PageShell,
@@ -325,54 +325,51 @@ export default function AgentDetailPage() {
 			>
 				{activeTab === 'overview' && (
 					<>
-						<Card>
-							<CardBody>
-								<dl className="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
+						<DetailSection
+							title="Attribution"
+							icon={<Fingerprint className="h-4 w-4" />}
+						>
+							<dl className="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
+								<MetaItem
+									label="Registered"
+									value={formatTimestamp(agent.createdAt)}
+								/>
+								{agent.attribution.registeredBy ? (
 									<MetaItem
-										label="Registered"
-										value={formatTimestamp(agent.createdAt)}
+										label="Registered by"
+										value={
+											<ActorLabel actorId={agent.attribution.registeredBy} />
+										}
 									/>
-									{agent.attribution.registeredBy ? (
-										<MetaItem
-											label="Registered by"
-											value={
-												<ActorLabel
-													actorId={agent.attribution.registeredBy}
-												/>
-											}
-										/>
-									) : null}
-									{agent.approvedAt ? (
-										<MetaItem
-											label="Approved"
-											value={formatTimestamp(agent.approvedAt)}
-										/>
-									) : null}
-									{agent.attribution.approvedBy ? (
-										<MetaItem
-											label="Approved by"
-											value={
-												<ActorLabel
-													actorId={agent.attribution.approvedBy}
-												/>
-											}
-										/>
-									) : null}
-									{agent.ownerId ? (
-										<MetaItem
-											label="Owner"
-											value={<ActorLabel actorId={agent.ownerId} />}
-										/>
-									) : null}
-									{agent.parentAgentId ? (
-										<MetaItem
-											label="Parent agent"
-											value={<ActorLabel actorId={agent.parentAgentId} />}
-										/>
-									) : null}
-								</dl>
-							</CardBody>
-						</Card>
+								) : null}
+								{agent.approvedAt ? (
+									<MetaItem
+										label="Approved"
+										value={formatTimestamp(agent.approvedAt)}
+									/>
+								) : null}
+								{agent.attribution.approvedBy ? (
+									<MetaItem
+										label="Approved by"
+										value={
+											<ActorLabel actorId={agent.attribution.approvedBy} />
+										}
+									/>
+								) : null}
+								{agent.ownerId ? (
+									<MetaItem
+										label="Owner"
+										value={<ActorLabel actorId={agent.ownerId} />}
+									/>
+								) : null}
+								{agent.parentAgentId ? (
+									<MetaItem
+										label="Parent agent"
+										value={<ActorLabel actorId={agent.parentAgentId} />}
+									/>
+								) : null}
+							</dl>
+						</DetailSection>
 						<BoundToolkitsCard agentId={agent.id} agentStatus={agent.status} />
 						{/* Actor-scoped audit slice — same "Recent changes" grammar as
 						    the toolkit console (admin only; empty for non-admins). */}

--- a/ui/src/modules/agents/pages/AgentDetailPage.tsx
+++ b/ui/src/modules/agents/pages/AgentDetailPage.tsx
@@ -39,6 +39,7 @@ import {
 	BackButton,
 	Button,
 	DetailSection,
+	KillSwitch,
 	LoadingState,
 	PageHeader,
 	PageShell,
@@ -174,11 +175,13 @@ export default function AgentDetailPage() {
 	}
 
 	const agent = agentQuery.data;
-	// The identity header only offers constructive actions (Approve / Deny /
-	// Enable); destructive ones (Disable / Archive) live in the Settings tab's
-	// danger zone (canvas plan, phase 4).
+	// The identity header offers the kill switch for the reversible
+	// active/disabled flip (same control as the toolkit console) plus the
+	// constructive actions (Approve / Deny); destructive-irreversible ones
+	// (Archive) live in the Settings tab's danger zone.
+	const killSwitchStatus = agent.status === 'active' || agent.status === 'disabled';
 	const headerActions = ACTIONS_FOR_STATUS[agent.status].filter(
-		(a) => a !== 'disable' && a !== 'archive',
+		(a) => a !== 'disable' && a !== 'archive' && (!killSwitchStatus || a !== 'enable'),
 	);
 	const actionPending =
 		approve.isPending ||
@@ -246,7 +249,29 @@ export default function AgentDetailPage() {
 				}
 				actions={
 					<>
-						<ActorStatusBadge status={agent.status} data-testid="detail-status-badge" />
+						{killSwitchStatus ? (
+							// Same reversible suspend/restore control as the toolkit
+							// header — disable/enable is the agent's kill switch.
+							<KillSwitch
+								active={agent.status === 'active'}
+								pending={disable.isPending || enable.isPending}
+								onToggle={(next) =>
+									next ? enable.mutate(agent.id) : disable.mutate(agent.id)
+								}
+								inactiveLabel="Disabled"
+								suspendAriaLabel={`Disable ${agent.name} (kill switch)`}
+								restoreAriaLabel={`Enable ${agent.name}`}
+								suspendPrompt="Block this agent?"
+								restorePrompt="Restore access?"
+								suspendConfirmLabel="Disable"
+								data-testid="detail-status-badge"
+							/>
+						) : (
+							<ActorStatusBadge
+								status={agent.status}
+								data-testid="detail-status-badge"
+							/>
+						)}
 						{headerActions.map((action) => (
 							<Button
 								key={action}

--- a/ui/src/modules/agents/pages/ServiceAccountDetailPage.tsx
+++ b/ui/src/modules/agents/pages/ServiceAccountDetailPage.tsx
@@ -18,8 +18,9 @@
  *   - Settings  → the copyable account id + danger zone; there is no PATCH
  *                 /service-accounts (backend gap, documented inline)
  *
- * The PageHeader only offers constructive actions (Approve / Deny / Enable);
- * destructive ones (Disable / Archive) live in Settings' danger zone.
+ * The PageHeader carries the kill switch for the reversible active/disabled
+ * flip (same control as the toolkit console) plus the constructive Approve /
+ * Deny actions; the terminal Archive lives in Settings' danger zone.
  */
 import { useState } from 'react';
 import { useParams, useSearchParams } from 'react-router';
@@ -181,37 +182,24 @@ function SaSettingsPanel({
 	lifecyclePending,
 }: {
 	account: ServiceAccountEntity;
-	onLifecycle: (action: 'disable' | 'archive') => void;
+	onLifecycle: (action: 'archive') => void;
 	lifecyclePending: boolean;
 }) {
 	const actions = ACTIONS_FOR_STATUS[account.status];
-	const dangerActions: DangerZoneAction[] = [
-		...(actions.includes('disable')
-			? [
-					{
-						key: 'disable',
-						title: 'Disable service account',
-						description:
-							'Immediately revokes this account’s access. Reversible — you can re-enable it later.',
-						buttonLabel: 'Disable',
-						ariaLabel: `Disable ${account.name}`,
-						emphasis: 'outline' as const,
-					},
-				]
-			: []),
-		...(actions.includes('archive')
-			? [
-					{
-						key: 'archive',
-						title: 'Archive service account',
-						description:
-							'Removes this account from the fleet and cascades to its grants. This cannot be undone.',
-						buttonLabel: 'Archive',
-						ariaLabel: `Archive ${account.name}`,
-					},
-				]
-			: []),
-	];
+	// Terminal Archive only — the reversible Disable/Enable flip lives in the
+	// page header's kill switch, exactly like the toolkit console.
+	const dangerActions: DangerZoneAction[] = actions.includes('archive')
+		? [
+				{
+					key: 'archive',
+					title: 'Archive service account',
+					description:
+						'Removes this account from the fleet and cascades to its grants. This cannot be undone.',
+					buttonLabel: 'Archive',
+					ariaLabel: `Archive ${account.name}`,
+				},
+			]
+		: [];
 
 	return (
 		<div className="space-y-4">
@@ -226,7 +214,7 @@ function SaSettingsPanel({
 			<DangerZone
 				actions={dangerActions}
 				pending={lifecyclePending}
-				onAction={(key) => onLifecycle(key as 'disable' | 'archive')}
+				onAction={() => onLifecycle('archive')}
 			/>
 		</div>
 	);
@@ -313,10 +301,11 @@ export default function ServiceAccountDetailPage() {
 	const account = accountQuery.data;
 	// The header offers the kill switch for the reversible active/disabled
 	// flip (same control as the toolkit console) plus constructive actions
-	// (Approve / Deny); Archive lives in Settings.
+	// (Approve / Deny); Archive lives in Settings. `enable`/`disable` never
+	// render as header buttons — the kill switch owns that verb pair.
 	const killSwitchStatus = account.status === 'active' || account.status === 'disabled';
 	const headerActions = ACTIONS_FOR_STATUS[account.status].filter(
-		(a) => a !== 'disable' && a !== 'archive' && (!killSwitchStatus || a !== 'enable'),
+		(a) => a !== 'disable' && a !== 'archive' && a !== 'enable',
 	);
 	const actionPending =
 		approve.isPending ||
@@ -330,26 +319,15 @@ export default function ServiceAccountDetailPage() {
 		? 'approve'
 		: deny.isPending
 			? 'deny'
-			: enable.isPending
-				? 'enable'
-				: null;
+			: null;
 
 	function handleAction(action: AgentAction) {
 		switch (action) {
 			case 'approve':
 				approve.mutate(account.id);
 				break;
-			case 'enable':
-				enable.mutate(account.id);
-				break;
 			case 'deny':
 				setConfirm({ kind: 'deny', id: account.id, name: account.name });
-				break;
-			case 'disable':
-				setConfirm({ kind: 'disable', id: account.id, name: account.name });
-				break;
-			case 'archive':
-				setConfirm({ kind: 'archive', id: account.id, name: account.name });
 				break;
 		}
 	}

--- a/ui/src/modules/agents/pages/ServiceAccountDetailPage.tsx
+++ b/ui/src/modules/agents/pages/ServiceAccountDetailPage.tsx
@@ -42,6 +42,7 @@ import {
 	DangerZone,
 	DetailSection,
 	IdentitySettingsCard,
+	KillSwitch,
 	LoadingState,
 	PageHeader,
 	PageShell,
@@ -310,9 +311,12 @@ export default function ServiceAccountDetailPage() {
 	}
 
 	const account = accountQuery.data;
-	// Constructive actions only — Disable/Archive live in Settings (phase 4/5).
+	// The header offers the kill switch for the reversible active/disabled
+	// flip (same control as the toolkit console) plus constructive actions
+	// (Approve / Deny); Archive lives in Settings.
+	const killSwitchStatus = account.status === 'active' || account.status === 'disabled';
 	const headerActions = ACTIONS_FOR_STATUS[account.status].filter(
-		(a) => a !== 'disable' && a !== 'archive',
+		(a) => a !== 'disable' && a !== 'archive' && (!killSwitchStatus || a !== 'enable'),
 	);
 	const actionPending =
 		approve.isPending ||
@@ -379,10 +383,29 @@ export default function ServiceAccountDetailPage() {
 				}
 				actions={
 					<>
-						<ActorStatusBadge
-							status={account.status}
-							data-testid="detail-status-badge"
-						/>
+						{killSwitchStatus ? (
+							// Same reversible suspend/restore control as the toolkit
+							// header — disable/enable is the account's kill switch.
+							<KillSwitch
+								active={account.status === 'active'}
+								pending={disable.isPending || enable.isPending}
+								onToggle={(next) =>
+									next ? enable.mutate(account.id) : disable.mutate(account.id)
+								}
+								inactiveLabel="Disabled"
+								suspendAriaLabel={`Disable ${account.name} (kill switch)`}
+								restoreAriaLabel={`Enable ${account.name}`}
+								suspendPrompt="Block this service account?"
+								restorePrompt="Restore access?"
+								suspendConfirmLabel="Disable"
+								data-testid="detail-status-badge"
+							/>
+						) : (
+							<ActorStatusBadge
+								status={account.status}
+								data-testid="detail-status-badge"
+							/>
+						)}
 						{headerActions.map((action) => (
 							<Button
 								key={action}

--- a/ui/src/modules/agents/pages/ServiceAccountDetailPage.tsx
+++ b/ui/src/modules/agents/pages/ServiceAccountDetailPage.tsx
@@ -39,15 +39,14 @@ import {
 	AppLink,
 	BackButton,
 	Button,
-	Card,
-	CardBody,
-	CardHeader,
-	CardTitle,
-	CopyButton,
+	DangerZone,
+	DetailSection,
+	IdentitySettingsCard,
 	LoadingState,
 	PageHeader,
 	PageShell,
 	TabNav,
+	type DangerZoneAction,
 	type TabNavOption,
 } from '@/shared/ui';
 import { cn, formatTimestamp } from '@/shared/lib/utils';
@@ -81,11 +80,7 @@ import {
 import { KpiStrip } from '@/modules/agents/components/detail/KpiStrip';
 import { ActivityPanel } from '@/modules/agents/components/detail/ActivityPanel';
 import { ActorAuditPanel } from '@/modules/agents/components/detail/ActorAuditPanel';
-import {
-	DangerZone,
-	MetaItem,
-	type DangerZoneItem,
-} from '@/modules/agents/components/detail/shared';
+import { MetaItem } from '@/modules/agents/components/detail/shared';
 import { ROUTES, ROUTE_PATHS } from '@/shared/app/routes';
 
 const DETAIL_TABS = ['overview', 'activity', 'access', 'keys', 'settings'] as const;
@@ -124,38 +119,34 @@ function SaKeysPanel({
 	const generateApiKey = useGenerateServiceAccountApiKey();
 	const [confirmGenerate, setConfirmGenerate] = useState(false);
 	return (
-		<Card>
-			<CardHeader>
-				<CardTitle className="flex items-center gap-2">
-					<KeyRound className="text-muted-foreground h-4 w-4" aria-hidden />
-					API key
-				</CardTitle>
-			</CardHeader>
-			<CardBody className="space-y-3">
-				<p className="text-muted-foreground text-sm">
-					Generate a bearer key this service account authenticates with. The plaintext is
-					shown once — store it securely. jentic-one doesn’t expose key metadata or
-					rotation history for service accounts yet.
+		<DetailSection
+			title="API key"
+			icon={<KeyRound className="h-4 w-4" />}
+			bodyClassName="space-y-3"
+		>
+			<p className="text-muted-foreground text-sm">
+				Generate a bearer key this service account authenticates with. The plaintext is
+				shown once — store it securely. jentic-one doesn’t expose key metadata or rotation
+				history for service accounts yet.
+			</p>
+			<div className="flex justify-end">
+				<Button
+					size="sm"
+					variant="outline"
+					disabled={account.status !== 'active' || generateApiKey.isPending}
+					loading={generateApiKey.isPending}
+					onClick={() => setConfirmGenerate(true)}
+					aria-label={`Generate API key for ${account.name}`}
+				>
+					<KeyRound className="h-3.5 w-3.5" />
+					Generate API Key
+				</Button>
+			</div>
+			{account.status !== 'active' && (
+				<p className="text-muted-foreground text-xs">
+					Keys can only be generated for active service accounts.
 				</p>
-				<div className="flex justify-end">
-					<Button
-						size="sm"
-						variant="outline"
-						disabled={account.status !== 'active' || generateApiKey.isPending}
-						loading={generateApiKey.isPending}
-						onClick={() => setConfirmGenerate(true)}
-						aria-label={`Generate API key for ${account.name}`}
-					>
-						<KeyRound className="h-3.5 w-3.5" />
-						Generate API Key
-					</Button>
-				</div>
-				{account.status !== 'active' && (
-					<p className="text-muted-foreground text-xs">
-						Keys can only be generated for active service accounts.
-					</p>
-				)}
-			</CardBody>
+			)}
 			<ConfirmDialog
 				open={confirmGenerate}
 				title={`Generate API key for ${account.name}`}
@@ -173,15 +164,15 @@ function SaKeysPanel({
 				}}
 				onClose={() => setConfirmGenerate(false)}
 			/>
-		</Card>
+		</DetailSection>
 	);
 }
 
 /**
- * The Settings tab body. Hosts the immutable, copyable account id (same
- * placement as the toolkit console's Toolkit ID) and the danger zone. There
- * is no PATCH /service-accounts in jentic-one (backend gap), so — unlike the
- * agent page — there's no metadata form here.
+ * The Settings tab body — the shared console cards in read-only mode: the
+ * immutable, copyable account id (same {@link IdentitySettingsCard} the agent
+ * and toolkit consoles render — there is no PATCH /service-accounts in
+ * jentic-one, a backend gap, so no metadata form) plus the shared danger zone.
  */
 function SaSettingsPanel({
 	account,
@@ -193,25 +184,28 @@ function SaSettingsPanel({
 	lifecyclePending: boolean;
 }) {
 	const actions = ACTIONS_FOR_STATUS[account.status];
-	const dangerItems: DangerZoneItem[] = [
+	const dangerActions: DangerZoneAction[] = [
 		...(actions.includes('disable')
 			? [
 					{
-						action: 'disable' as const,
+						key: 'disable',
 						title: 'Disable service account',
 						description:
 							'Immediately revokes this account’s access. Reversible — you can re-enable it later.',
+						buttonLabel: 'Disable',
 						ariaLabel: `Disable ${account.name}`,
+						emphasis: 'outline' as const,
 					},
 				]
 			: []),
 		...(actions.includes('archive')
 			? [
 					{
-						action: 'archive' as const,
+						key: 'archive',
 						title: 'Archive service account',
 						description:
 							'Removes this account from the fleet and cascades to its grants. This cannot be undone.',
+						buttonLabel: 'Archive',
 						ariaLabel: `Archive ${account.name}`,
 					},
 				]
@@ -220,33 +214,19 @@ function SaSettingsPanel({
 
 	return (
 		<div className="space-y-4">
-			<Card>
-				<CardHeader>
-					<CardTitle>General</CardTitle>
-				</CardHeader>
-				<CardBody className="space-y-4">
-					{/* The immutable account id — what API calls and audit rows
-					    reference. Lives here (not in the page chrome), same as the
-					    toolkit console's Toolkit ID. */}
-					<div className="flex flex-wrap items-center justify-between gap-2">
-						<span className="text-muted-foreground flex items-center gap-1.5 text-xs">
-							<Fingerprint className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-							Account ID
-						</span>
-						<span className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 font-mono text-xs">
-							{account.id}
-							<CopyButton value={account.id} size="icon" variant="ghost" />
-						</span>
-					</div>
-					<p className="text-muted-foreground text-sm">
-						Renaming or re-describing a service account isn’t supported yet — jentic-one
-						has no PATCH /service-accounts endpoint. Create a replacement account if the
-						metadata must change.
-					</p>
-				</CardBody>
-			</Card>
+			<IdentitySettingsCard
+				idLabel="Account ID"
+				idValue={account.id}
+				name={account.name}
+				description={account.description ?? null}
+				readOnlyNote="Renaming or re-describing a service account isn’t supported yet — jentic-one has no PATCH /service-accounts endpoint. Create a replacement account if the metadata must change."
+			/>
 
-			<DangerZone items={dangerItems} pending={lifecyclePending} onAction={onLifecycle} />
+			<DangerZone
+				actions={dangerActions}
+				pending={lifecyclePending}
+				onAction={(key) => onLifecycle(key as 'disable' | 'archive')}
+			/>
 		</div>
 	);
 }
@@ -480,48 +460,47 @@ export default function ServiceAccountDetailPage() {
 			>
 				{activeTab === 'overview' && (
 					<>
-						<Card>
-							<CardBody>
-								<dl className="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
+						<DetailSection
+							title="Attribution"
+							icon={<Fingerprint className="h-4 w-4" />}
+						>
+							<dl className="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
+								<MetaItem
+									label="Created"
+									value={formatTimestamp(account.createdAt)}
+								/>
+								{account.attribution.registeredBy ? (
 									<MetaItem
-										label="Created"
-										value={formatTimestamp(account.createdAt)}
+										label="Created by"
+										value={
+											<ActorLabel
+												actorId={account.attribution.registeredBy}
+											/>
+										}
 									/>
-									{account.attribution.registeredBy ? (
-										<MetaItem
-											label="Created by"
-											value={
-												<ActorLabel
-													actorId={account.attribution.registeredBy}
-												/>
-											}
-										/>
-									) : null}
-									{account.approvedAt ? (
-										<MetaItem
-											label="Approved"
-											value={formatTimestamp(account.approvedAt)}
-										/>
-									) : null}
-									{account.attribution.approvedBy ? (
-										<MetaItem
-											label="Approved by"
-											value={
-												<ActorLabel
-													actorId={account.attribution.approvedBy}
-												/>
-											}
-										/>
-									) : null}
-									{account.ownerId ? (
-										<MetaItem
-											label="Owner"
-											value={<ActorLabel actorId={account.ownerId} />}
-										/>
-									) : null}
-								</dl>
-							</CardBody>
-						</Card>
+								) : null}
+								{account.approvedAt ? (
+									<MetaItem
+										label="Approved"
+										value={formatTimestamp(account.approvedAt)}
+									/>
+								) : null}
+								{account.attribution.approvedBy ? (
+									<MetaItem
+										label="Approved by"
+										value={
+											<ActorLabel actorId={account.attribution.approvedBy} />
+										}
+									/>
+								) : null}
+								{account.ownerId ? (
+									<MetaItem
+										label="Owner"
+										value={<ActorLabel actorId={account.ownerId} />}
+									/>
+								) : null}
+							</dl>
+						</DetailSection>
 						{/* Actor-scoped audit slice — same "Recent changes" grammar as
 						    the agent + toolkit consoles (admin only). */}
 						<ActorAuditPanel actorKind="service-account" actorId={account.id} />

--- a/ui/src/modules/toolkits/components/ToolkitAuditPanel.tsx
+++ b/ui/src/modules/toolkits/components/ToolkitAuditPanel.tsx
@@ -1,39 +1,16 @@
-import { AnimatePresence, motion } from 'framer-motion';
-import { History, ScrollText } from 'lucide-react';
-import { Badge, ErrorAlert, ActorLabel } from '@/shared/ui';
+import { AuditTrailCard } from '@/shared/ui';
 import { useToolkitAudit } from '@/modules/toolkits/api';
-import { timeAgo } from '@/modules/toolkits/lib/time';
-import type { ToolkitAuditEntry } from '@/modules/toolkits/api/types';
 
 /**
- * Read-only, toolkit-scoped slice of the org-wide audit log. Surfaces the
+ * ToolkitAuditPanel — the toolkit console's "Recent changes" card: a thin,
+ * toolkit-scoped wrapper over the shared {@link AuditTrailCard}. Surfaces the
  * toolkit-level events (create / update / suspend / restore) tagged
- * `target_type=toolkit`. Key- and binding-level sub-events live in the org-wide
- * Audit lens (Monitor module) — the `/audit` endpoint only filters by a single
- * `target_id`, so we don't duplicate those here. Requires `org:admin`; for
- * non-admins the repository maps 401/403 to an empty list and we render the
- * graceful "no entries" state.
+ * `target_type=toolkit`. Key- and binding-level sub-events live in the
+ * org-wide Audit lens (Monitor module) — the `/audit` endpoint only filters
+ * by a single `target_id`, so we don't duplicate those here. Requires
+ * `org:admin`; for non-admins the repository maps 401/403 to an empty list
+ * and we render the graceful "no entries" state.
  */
-const rowMotion = {
-	initial: { opacity: 0, y: -4 },
-	animate: { opacity: 1, y: 0 },
-	exit: { opacity: 0, y: -4 },
-	transition: { duration: 0.16, ease: 'easeOut' as const },
-};
-
-function actionVariant(action: string): 'default' | 'success' | 'danger' {
-	const a = action.toLowerCase();
-	if (a.includes('delete') || a.includes('suspend') || a.includes('revoke')) return 'danger';
-	if (a.includes('create')) return 'success';
-	return 'default';
-}
-
-/** Fallback display when an entry has no resolvable actor id (system events). */
-function fallbackActor(entry: ToolkitAuditEntry): string {
-	if (entry.actor_type) return entry.actor_type;
-	return 'system';
-}
-
 export interface ToolkitAuditPanelProps {
 	toolkitId: string;
 	poll?: boolean;
@@ -43,79 +20,20 @@ export function ToolkitAuditPanel({ toolkitId, poll = true }: ToolkitAuditPanelP
 	const { data: entries = [], isLoading, isError } = useToolkitAudit(toolkitId, { poll });
 
 	return (
-		<div className="bg-card border-border overflow-hidden rounded-xl border">
-			<div className="border-border flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3.5 sm:px-5 sm:py-4">
-				<h3 className="font-heading text-foreground flex items-center gap-2.5 font-semibold">
-					<span
-						aria-hidden="true"
-						className="bg-muted text-muted-foreground ring-border flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ring-1"
-					>
-						<History className="h-4 w-4" />
-					</span>
-					Recent changes
-				</h3>
-				<span className="text-muted-foreground text-xs">
-					Toolkit-level events · admin only
-				</span>
-			</div>
-			<div className="space-y-2 px-4 py-3.5 sm:px-5 sm:py-4">
-				{isError && <ErrorAlert message="Failed to load the activity log." />}
-				{!isError && isLoading && (
-					<>
-						<div className="bg-muted h-10 animate-pulse rounded-lg" />
-						<div className="bg-muted h-10 animate-pulse rounded-lg" />
-					</>
-				)}
-				{!isError && !isLoading && entries.length === 0 && (
-					<div className="border-border/50 rounded-lg border border-dashed px-5 py-6 text-center">
-						<ScrollText className="text-muted-foreground/50 mx-auto h-6 w-6" />
-						<p className="text-muted-foreground mt-2 text-sm">
-							No recorded activity for this toolkit yet. The full audit trail lives in
-							Monitor → Audit.
-						</p>
-					</div>
-				)}
-				<AnimatePresence initial={false}>
-					{entries.map((entry) => {
-						const occurred = Date.parse(entry.occurred_at);
-						return (
-							<motion.div
-								key={entry.id}
-								{...rowMotion}
-								className="bg-muted/30 border-border/60 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border px-3 py-2"
-							>
-								<Badge variant={actionVariant(entry.action)}>{entry.action}</Badge>
-								<span className="text-foreground min-w-0 flex-1 truncate text-sm">
-									{entry.actor_id ? (
-										<ActorLabel
-											actorId={entry.actor_id}
-											actorType={entry.actor_type}
-										/>
-									) : (
-										fallbackActor(entry)
-									)}
-									{entry.reason ? (
-										<span className="text-muted-foreground">
-											{' '}
-											— {entry.reason}
-										</span>
-									) : null}
-								</span>
-								<span
-									className="text-muted-foreground shrink-0 text-xs"
-									title={
-										Number.isFinite(occurred)
-											? new Date(occurred).toLocaleString()
-											: entry.occurred_at
-									}
-								>
-									{Number.isFinite(occurred) ? timeAgo(occurred) : ''}
-								</span>
-							</motion.div>
-						);
-					})}
-				</AnimatePresence>
-			</div>
-		</div>
+		<AuditTrailCard
+			entries={entries.map((entry) => ({
+				id: entry.id,
+				action: entry.action,
+				actorId: entry.actor_id,
+				actorType: entry.actor_type,
+				reason: entry.reason,
+				occurredAt: entry.occurred_at,
+			}))}
+			isLoading={isLoading}
+			isError={isError}
+			caption="Toolkit-level events · admin only"
+			errorMessage="Failed to load the activity log."
+			emptyMessage="No recorded activity for this toolkit yet. The full audit trail lives in Monitor → Audit."
+		/>
 	);
 }

--- a/ui/src/modules/toolkits/components/ToolkitKillSwitch.tsx
+++ b/ui/src/modules/toolkits/components/ToolkitKillSwitch.tsx
@@ -1,15 +1,11 @@
-import { useEffect, useId, useRef, useState } from 'react';
-import { motion } from 'framer-motion';
-import { Ban, Power, ShieldCheck } from 'lucide-react';
-import { Button } from '@/shared/ui';
-import { cn } from '@/shared/lib/utils';
+import { KillSwitch } from '@/shared/ui';
 import { useSetToolkitActive } from '@/modules/toolkits/api';
 
 /**
- * Toolkit-level kill switch — a Power-toggle pill that suspends or restores ALL
- * access for a toolkit by flipping its `active` flag, which the broker enforces
- * for both toolkit API keys and agent-identity callers. Click to arm an inline
- * confirm, click confirm to apply.
+ * Toolkit-level kill switch — suspends or restores ALL access for a toolkit
+ * by flipping its `active` flag, which the broker enforces for both toolkit
+ * API keys and agent-identity callers. A thin wrapper binding the shared
+ * `KillSwitch` control to the toolkit mutation and copy.
  */
 export interface ToolkitKillSwitchProps {
 	toolkitId: string;
@@ -18,100 +14,17 @@ export interface ToolkitKillSwitchProps {
 }
 
 export function ToolkitKillSwitch({ toolkitId, active, className }: ToolkitKillSwitchProps) {
-	const [confirming, setConfirming] = useState(false);
-	const confirmId = useId();
-	const confirmRef = useRef<HTMLButtonElement>(null);
 	const setActive = useSetToolkitActive(toolkitId);
-
-	useEffect(() => {
-		if (confirming) confirmRef.current?.focus();
-	}, [confirming]);
-
-	const pending = setActive.isPending;
-
-	const apply = () => {
-		setActive.mutate(!active, { onSettled: () => setConfirming(false) });
-	};
-
 	return (
-		<div className={cn('inline-flex items-center gap-2', className)}>
-			<Button
-				variant="ghost"
-				loading={pending}
-				onClick={() => setConfirming((c) => !c)}
-				disabled={pending}
-				aria-pressed={active}
-				aria-expanded={confirming}
-				aria-controls={confirming ? confirmId : undefined}
-				aria-label={active ? 'Suspend toolkit (kill switch)' : 'Restore toolkit access'}
-				className={cn(
-					'group relative h-8 gap-2 rounded-full px-3 text-xs font-medium',
-					active
-						? 'bg-success/10 text-success border-success/30 hover:bg-success/20 border'
-						: 'bg-danger/10 text-danger border-danger/30 hover:bg-danger/20 border',
-				)}
-			>
-				{!pending && (
-					<motion.span whileHover={{ scale: 1.1 }} className="flex items-center">
-						{active ? (
-							<Power className="h-3.5 w-3.5" />
-						) : (
-							<Ban className="h-3.5 w-3.5" />
-						)}
-					</motion.span>
-				)}
-				<span>{active ? 'Active' : 'Suspended'}</span>
-			</Button>
-
-			{confirming && (
-				<motion.div
-					id={confirmId}
-					role="group"
-					aria-label={
-						active ? 'Confirm suspending toolkit' : 'Confirm restoring toolkit access'
-					}
-					initial={{ opacity: 0, x: -4 }}
-					animate={{ opacity: 1, x: 0 }}
-					transition={{ duration: 0.15 }}
-					className={cn(
-						'inline-flex items-center gap-2 rounded-full border px-3 py-1',
-						active ? 'border-danger/30 bg-danger/5' : 'border-success/30 bg-success/5',
-					)}
-				>
-					<span className="text-muted-foreground text-xs">
-						{active ? 'Block keys + agents?' : 'Restore access?'}
-					</span>
-					<Button
-						ref={confirmRef}
-						variant="ghost"
-						onClick={apply}
-						disabled={pending}
-						className={cn(
-							'gap-1 rounded-full px-2 py-0.5 text-xs font-semibold',
-							active
-								? 'bg-danger/15 text-danger hover:bg-danger/25'
-								: 'bg-success/15 text-success hover:bg-success/25',
-						)}
-					>
-						{active ? (
-							<>
-								<Ban className="h-3 w-3" /> Kill
-							</>
-						) : (
-							<>
-								<ShieldCheck className="h-3 w-3" /> Restore
-							</>
-						)}
-					</Button>
-					<Button
-						variant="ghost"
-						onClick={() => setConfirming(false)}
-						className="text-muted-foreground hover:text-foreground px-1 py-0 text-xs"
-					>
-						Cancel
-					</Button>
-				</motion.div>
-			)}
-		</div>
+		<KillSwitch
+			active={active}
+			pending={setActive.isPending}
+			onToggle={(next) => setActive.mutate(next)}
+			suspendAriaLabel="Suspend toolkit (kill switch)"
+			restoreAriaLabel="Restore toolkit access"
+			suspendPrompt="Block keys + agents?"
+			restorePrompt="Restore access?"
+			className={className}
+		/>
 	);
 }

--- a/ui/src/modules/toolkits/components/detail/AccessTab.tsx
+++ b/ui/src/modules/toolkits/components/detail/AccessTab.tsx
@@ -9,15 +9,13 @@ import {
 	ShieldCheck,
 	Unlink,
 } from 'lucide-react';
-import { Button, ErrorAlert } from '@/shared/ui';
+import { Button, DetailSection, EmptyRow, ErrorAlert } from '@/shared/ui';
 import { OperationsSummary } from '@/shared/app';
 import { useToolkitBindings, useUnbindCredential } from '@/modules/toolkits/api';
 import { BindCredentialDialog } from '@/modules/toolkits/components/BindCredentialDialog';
 import { CredentialPermissionEditor } from '@/modules/toolkits/components/CredentialPermissionEditor';
 import { InlineConfirm } from '@/modules/toolkits/components/InlineConfirm';
 import {
-	DetailSection,
-	EmptyRow,
 	panelMotion,
 	rowMotion,
 	toDisplayRules,

--- a/ui/src/modules/toolkits/components/detail/ActivityTab.tsx
+++ b/ui/src/modules/toolkits/components/detail/ActivityTab.tsx
@@ -11,7 +11,7 @@ import { ROUTE_PATHS } from '@/shared/app/routes';
 
 /**
  * Activity tab — what this toolkit has actually been doing: the shared
- * console chart pair (stacked execution volume + total-call trend,
+ * console chart pair (stacked execution volume + success-rate trend,
  * `ExecutionVolumeCharts`, fed by `GET /monitoring/usage?toolkit_id=…`) and
  * the shared recent-executions feed (`RecentExecutionsCard`, fed by
  * `GET /executions?toolkit_id=…`), with a deep-link into Monitor's full

--- a/ui/src/modules/toolkits/components/detail/ActivityTab.tsx
+++ b/ui/src/modules/toolkits/components/detail/ActivityTab.tsx
@@ -1,26 +1,20 @@
-import { Activity, ListOrdered, Lock, TrendingUp } from 'lucide-react';
-import { ActorLabel, AppLink, DetailSection, EmptyRow, TrendLineChart } from '@/shared/ui';
+import { Activity, ListOrdered, Lock } from 'lucide-react';
+import { ActorLabel, AppLink, DetailSection, EmptyRow, ExecutionVolumeCharts } from '@/shared/ui';
 import { useToolkitExecutions, useToolkitUsage } from '@/modules/toolkits/api';
 import type { ToolkitExecution } from '@/modules/toolkits/api/types';
 import { timeAgo } from '@/modules/toolkits/lib/time';
 import { ROUTE_PATHS } from '@/shared/app/routes';
 
 /**
- * Activity tab — what this toolkit has actually been doing: the 7-day
- * execution-volume chart (`GET /monitoring/usage?toolkit_id=…`) and a recent
- * executions feed (`GET /executions?toolkit_id=…`), with a deep-link into
- * Monitor's full filterable log carrying the toolkit filter.
+ * Activity tab — what this toolkit has actually been doing: the shared
+ * console chart pair (stacked execution volume + total-call trend,
+ * `ExecutionVolumeCharts`, fed by `GET /monitoring/usage?toolkit_id=…`) and a
+ * recent executions feed (`GET /executions?toolkit_id=…`), with a deep-link
+ * into Monitor's full filterable log carrying the toolkit filter.
  *
  * Both endpoints are admin-gated; the repository maps 401/403 to `null` and
  * this tab degrades to a single explanatory panel for non-admins.
  */
-
-function formatBucketTs(ts: number): string {
-	return new Date(ts * 1000).toLocaleDateString(undefined, {
-		month: 'short',
-		day: 'numeric',
-	});
-}
 
 function formatDuration(ms: number | null): string {
 	if (ms == null) return '—';
@@ -101,31 +95,16 @@ export function ActivityTab({ toolkitId }: { toolkitId: string }) {
 	}
 
 	const buckets = usage?.buckets ?? [];
-	const chartData = buckets.map((b) => ({ ts: b.ts, value: b.total }));
 	const rows = executions ?? [];
 
 	return (
 		<div className="space-y-6">
-			<DetailSection title="Execution volume · 7d" icon={<TrendingUp className="h-4 w-4" />}>
-				{loading ? (
-					<div className="bg-muted h-28 animate-pulse rounded-lg" aria-hidden="true" />
-				) : chartData.length >= 2 ? (
-					<TrendLineChart
-						data={chartData}
-						formatValue={(v) => v.toLocaleString()}
-						formatTs={formatBucketTs}
-						height={112}
-						ariaLabel={`Execution volume for this toolkit over the last 7 days: ${
-							usage?.stats.total ?? 0
-						} total executions.`}
-					/>
-				) : (
-					<EmptyRow icon={<Activity />}>
-						No executions in the last 7 days. Volume appears here once agents start
-						calling this toolkit.
-					</EmptyRow>
-				)}
-			</DetailSection>
+			<ExecutionVolumeCharts
+				buckets={buckets}
+				bucketSeconds={usage?.bucket_seconds ?? 86_400}
+				isLoading={loading}
+				emptyMessage="No executions in the last 7 days. Volume appears here once agents start calling this toolkit."
+			/>
 
 			<DetailSection
 				title="Recent executions"

--- a/ui/src/modules/toolkits/components/detail/ActivityTab.tsx
+++ b/ui/src/modules/toolkits/components/detail/ActivityTab.tsx
@@ -1,81 +1,25 @@
-import { Activity, ListOrdered, Lock } from 'lucide-react';
-import { ActorLabel, AppLink, DetailSection, EmptyRow, ExecutionVolumeCharts } from '@/shared/ui';
+import { Activity, Lock } from 'lucide-react';
+import {
+	ActorLabel,
+	DetailSection,
+	EmptyRow,
+	ExecutionVolumeCharts,
+	RecentExecutionsCard,
+} from '@/shared/ui';
 import { useToolkitExecutions, useToolkitUsage } from '@/modules/toolkits/api';
-import type { ToolkitExecution } from '@/modules/toolkits/api/types';
-import { timeAgo } from '@/modules/toolkits/lib/time';
 import { ROUTE_PATHS } from '@/shared/app/routes';
 
 /**
  * Activity tab — what this toolkit has actually been doing: the shared
  * console chart pair (stacked execution volume + total-call trend,
- * `ExecutionVolumeCharts`, fed by `GET /monitoring/usage?toolkit_id=…`) and a
- * recent executions feed (`GET /executions?toolkit_id=…`), with a deep-link
- * into Monitor's full filterable log carrying the toolkit filter.
+ * `ExecutionVolumeCharts`, fed by `GET /monitoring/usage?toolkit_id=…`) and
+ * the shared recent-executions feed (`RecentExecutionsCard`, fed by
+ * `GET /executions?toolkit_id=…`), with a deep-link into Monitor's full
+ * filterable log carrying the toolkit filter.
  *
  * Both endpoints are admin-gated; the repository maps 401/403 to `null` and
  * this tab degrades to a single explanatory panel for non-admins.
  */
-
-function formatDuration(ms: number | null): string {
-	if (ms == null) return '—';
-	if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
-	return `${ms}ms`;
-}
-
-/**
- * Execution lifecycle → dot colour, aligned with Monitor's vocabulary
- * (running/completed/failed/cancelled — see `ExecutionStatusPill`). Unknown
- * wire values fall through to the neutral dot rather than leaking a colour.
- */
-const STATUS_DOT_CLASS: Record<string, string> = {
-	completed: 'bg-success',
-	failed: 'bg-danger',
-	running: 'bg-accent-blue',
-	cancelled: 'bg-warning',
-};
-
-function ExecutionRow({ row }: { row: ToolkitExecution }) {
-	const dotClass = STATUS_DOT_CLASS[row.status] ?? 'bg-muted-foreground';
-	const failed = row.status === 'failed';
-	return (
-		<div
-			data-testid="toolkit-execution-row"
-			className="bg-muted/30 border-border/60 flex flex-wrap items-center gap-3 rounded-lg border px-4 py-2.5"
-		>
-			<span
-				className={`h-2 w-2 shrink-0 rounded-full ${dotClass}`}
-				aria-hidden="true"
-				title={row.status}
-			/>
-			{/* The dot alone is invisible to AT — carry the status as text too. */}
-			<span className="sr-only">{row.status}</span>
-			<div className="min-w-0 flex-1 basis-48">
-				<p className="text-foreground truncate font-mono text-xs">
-					{row.operation_id ?? row.api_label ?? row.trace_id}
-					{row.http_status != null && (
-						<span
-							className={failed ? 'text-danger ml-2' : 'text-muted-foreground ml-2'}
-						>
-							{row.http_status}
-						</span>
-					)}
-				</p>
-				{row.error && <p className="text-danger mt-0.5 truncate text-xs">{row.error}</p>}
-			</div>
-			<span className="text-muted-foreground shrink-0 text-xs">
-				{/* Resolve the raw actor id like every other attribution surface. */}
-				<ActorLabel actorId={row.actor_id} actorType={row.actor_type} />
-			</span>
-			<span className="text-muted-foreground w-14 shrink-0 text-right font-mono text-xs">
-				{formatDuration(row.duration_ms)}
-			</span>
-			<span className="text-muted-foreground w-20 shrink-0 text-right text-xs">
-				{timeAgo(Date.parse(row.started_at))}
-			</span>
-		</div>
-	);
-}
-
 export function ActivityTab({ toolkitId }: { toolkitId: string }) {
 	const { data: usage, isLoading: usageLoading } = useToolkitUsage(toolkitId);
 	const { data: executions, isLoading: executionsLoading } = useToolkitExecutions(toolkitId);
@@ -106,31 +50,22 @@ export function ActivityTab({ toolkitId }: { toolkitId: string }) {
 				emptyMessage="No executions in the last 7 days. Volume appears here once agents start calling this toolkit."
 			/>
 
-			<DetailSection
-				title="Recent executions"
-				icon={<ListOrdered className="h-4 w-4" />}
-				trailing={
-					<AppLink
-						href={ROUTE_PATHS.monitorExecutions({ toolkitId })}
-						className="text-primary inline-flex items-center gap-1 text-xs font-medium"
-					>
-						{/* In-app route — the Activity glyph, matching the agents page;
-						    ExternalLink is reserved for real external targets. */}
-						Open Monitor <Activity className="h-3 w-3" aria-hidden="true" />
-					</AppLink>
-				}
-			>
-				{loading ? (
-					<div className="space-y-2" aria-hidden="true">
-						<div className="bg-muted h-10 animate-pulse rounded-lg" />
-						<div className="bg-muted h-10 animate-pulse rounded-lg" />
-					</div>
-				) : rows.length === 0 ? (
-					<EmptyRow icon={<Activity />}>No recent executions for this toolkit.</EmptyRow>
-				) : (
-					rows.map((row) => <ExecutionRow key={row.execution_id} row={row} />)
-				)}
-			</DetailSection>
+			<RecentExecutionsCard
+				isLoading={loading}
+				monitorHref={ROUTE_PATHS.monitorExecutions({ toolkitId })}
+				emptyMessage="No recent executions for this toolkit."
+				items={rows.map((row) => ({
+					id: row.execution_id,
+					status: row.status,
+					httpStatus: row.http_status,
+					label: row.operation_id ?? row.api_label ?? row.trace_id,
+					error: row.error,
+					// Resolve the raw actor id like every other attribution surface.
+					meta: <ActorLabel actorId={row.actor_id} actorType={row.actor_type} />,
+					durationMs: row.duration_ms,
+					startedAt: row.started_at,
+				}))}
+			/>
 		</div>
 	);
 }

--- a/ui/src/modules/toolkits/components/detail/ActivityTab.tsx
+++ b/ui/src/modules/toolkits/components/detail/ActivityTab.tsx
@@ -1,8 +1,7 @@
 import { Activity, ListOrdered, Lock, TrendingUp } from 'lucide-react';
-import { ActorLabel, AppLink, TrendLineChart } from '@/shared/ui';
+import { ActorLabel, AppLink, DetailSection, EmptyRow, TrendLineChart } from '@/shared/ui';
 import { useToolkitExecutions, useToolkitUsage } from '@/modules/toolkits/api';
 import type { ToolkitExecution } from '@/modules/toolkits/api/types';
-import { DetailSection, EmptyRow } from '@/modules/toolkits/components/detail/shared';
 import { timeAgo } from '@/modules/toolkits/lib/time';
 import { ROUTE_PATHS } from '@/shared/app/routes';
 

--- a/ui/src/modules/toolkits/components/detail/KeysTab.tsx
+++ b/ui/src/modules/toolkits/components/detail/KeysTab.tsx
@@ -1,16 +1,11 @@
 import { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Ban, Check, Globe, Key, Pencil, Plus, X } from 'lucide-react';
-import { Badge, Button, ErrorAlert, Input } from '@/shared/ui';
+import { Badge, Button, DetailSection, EmptyRow, ErrorAlert, Input } from '@/shared/ui';
 import { useCreateKey, useRevokeKey, useToolkitKeys, useUpdateKey } from '@/modules/toolkits/api';
 import { InlineConfirm } from '@/modules/toolkits/components/InlineConfirm';
 import { OneTimeKeyDisplay } from '@/modules/toolkits/components/OneTimeKeyDisplay';
-import {
-	DetailSection,
-	EmptyRow,
-	panelMotion,
-	rowMotion,
-} from '@/modules/toolkits/components/detail/shared';
+import { panelMotion, rowMotion } from '@/modules/toolkits/components/detail/shared';
 import { timeAgo } from '@/modules/toolkits/lib/time';
 import type { ToolkitKey } from '@/modules/toolkits/api/types';
 

--- a/ui/src/modules/toolkits/components/detail/OverviewTab.tsx
+++ b/ui/src/modules/toolkits/components/detail/OverviewTab.tsx
@@ -8,7 +8,16 @@ import {
 	Link as LinkIcon,
 	Unlink,
 } from 'lucide-react';
-import { ActorLabel, ActorStatusBadge, AppLink, Button, Dialog, ErrorAlert } from '@/shared/ui';
+import {
+	ActorLabel,
+	ActorStatusBadge,
+	AppLink,
+	Button,
+	DetailSection,
+	Dialog,
+	EmptyRow,
+	ErrorAlert,
+} from '@/shared/ui';
 import { ruleSummary } from '@/shared/lib';
 import {
 	useLinkAgentToToolkit,
@@ -21,12 +30,7 @@ import { AgentPicker } from '@/modules/toolkits/components/AgentPicker';
 import { BindCredentialDialog } from '@/modules/toolkits/components/BindCredentialDialog';
 import { InlineConfirm } from '@/modules/toolkits/components/InlineConfirm';
 import { ToolkitAuditPanel } from '@/modules/toolkits/components/ToolkitAuditPanel';
-import {
-	DetailSection,
-	EmptyRow,
-	rowMotion,
-	toDisplayRules,
-} from '@/modules/toolkits/components/detail/shared';
+import { rowMotion, toDisplayRules } from '@/modules/toolkits/components/detail/shared';
 import { timeAgo } from '@/modules/toolkits/lib/time';
 import { ROUTE_PATHS, ROUTES } from '@/shared/app/routes';
 

--- a/ui/src/modules/toolkits/components/detail/SettingsTab.tsx
+++ b/ui/src/modules/toolkits/components/detail/SettingsTab.tsx
@@ -1,12 +1,6 @@
 import { useState } from 'react';
-import type {
-	CascadeDependentGroup,
-	CascadeDeleteDialog,
-	DangerZone,
-	IdentitySettingsCard,
-	toast,
-	type DangerZoneAction,
-} from '@/shared/ui';
+import { CascadeDeleteDialog, DangerZone, IdentitySettingsCard, toast } from '@/shared/ui';
+import type { CascadeDependentGroup, DangerZoneAction } from '@/shared/ui';
 import {
 	useDeleteToolkit,
 	useToolkitAgents,

--- a/ui/src/modules/toolkits/components/detail/SettingsTab.tsx
+++ b/ui/src/modules/toolkits/components/detail/SettingsTab.tsx
@@ -1,16 +1,12 @@
-import { useEffect, useRef, useState } from 'react';
-import { Fingerprint, SlidersHorizontal, Trash2 } from 'lucide-react';
-import {
-	Button,
+import { useState } from 'react';
+import type {
+	CascadeDependentGroup,
 	CascadeDeleteDialog,
-	CopyButton,
-	ErrorAlert,
-	Input,
-	Label,
-	Textarea,
+	DangerZone,
+	IdentitySettingsCard,
 	toast,
+	type DangerZoneAction,
 } from '@/shared/ui';
-import type { CascadeDependentGroup } from '@/shared/ui';
 import {
 	useDeleteToolkit,
 	useToolkitAgents,
@@ -19,7 +15,6 @@ import {
 	useUpdateToolkit,
 } from '@/modules/toolkits/api';
 import type { Toolkit } from '@/modules/toolkits/api/types';
-import { DetailSection } from '@/modules/toolkits/components/detail/shared';
 
 interface SettingsTabProps {
 	toolkit: Toolkit;
@@ -28,10 +23,12 @@ interface SettingsTabProps {
 }
 
 /**
- * Settings tab — identity editing (inline form, replacing the old Edit
- * dialog) and the danger zone. Destructive actions live here rather than in
- * the header chrome so identity actions and irreversible ones stop sharing a
- * row; only the kill switch (reversible, operational) stays pinned up top.
+ * Settings tab — identity editing and the danger zone, both on the shared
+ * console cards ({@link IdentitySettingsCard} / {@link DangerZone}) so the
+ * toolkit, agent, and service-account Settings tabs read identically.
+ * Destructive actions live here rather than in the header chrome so identity
+ * actions and irreversible ones stop sharing a row; only the kill switch
+ * (reversible, operational) stays pinned up top.
  */
 export function SettingsTab({ toolkit, onDeleted }: SettingsTabProps) {
 	const toolkitId = toolkit.toolkit_id;
@@ -45,23 +42,7 @@ export function SettingsTab({ toolkit, onDeleted }: SettingsTabProps) {
 	const { data: bindings = [] } = useToolkitBindings(toolkitId);
 	const { data: agents = [] } = useToolkitAgents(toolkitId);
 
-	const [editName, setEditName] = useState(toolkit.name);
-	const [editDesc, setEditDesc] = useState(toolkit.description ?? '');
 	const [deleteOpen, setDeleteOpen] = useState(false);
-
-	// Seed-from-props syncs only when the seed identity changes (dialog-state
-	// rule applied to an inline form): re-visiting the tab must not clobber an
-	// in-progress draft, but navigating to a different toolkit must reseed.
-	const seededIdRef = useRef(toolkitId);
-	useEffect(() => {
-		if (seededIdRef.current !== toolkitId) {
-			seededIdRef.current = toolkitId;
-			setEditName(toolkit.name);
-			setEditDesc(toolkit.description ?? '');
-		}
-	}, [toolkitId, toolkit.name, toolkit.description]);
-
-	const dirty = editName !== toolkit.name || editDesc !== (toolkit.description ?? '');
 
 	const deleteDependents: CascadeDependentGroup[] = [
 		{
@@ -81,91 +62,36 @@ export function SettingsTab({ toolkit, onDeleted }: SettingsTabProps) {
 		},
 	].filter((g) => g.count > 0);
 
+	const dangerActions: DangerZoneAction[] = [
+		{
+			key: 'delete',
+			title: 'Delete toolkit',
+			description:
+				'Deleting cascades: agent grants, API keys, and credential bindings are removed with it. This cannot be undone. To pause access without deleting anything, use the kill switch in the header instead.',
+			buttonLabel: 'Delete',
+			ariaLabel: `Delete ${toolkit.name}`,
+		},
+	];
+
 	return (
 		<div className="space-y-6">
-			<DetailSection title="Identity" icon={<SlidersHorizontal className="h-4 w-4" />}>
-				{/* The immutable toolkit id — what agents and API calls reference.
-				    Lives here (not in the page chrome) so the header stays clean. */}
-				<div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-					<span className="text-muted-foreground flex items-center gap-1.5 text-xs">
-						<Fingerprint className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-						Toolkit ID
-					</span>
-					<span className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 font-mono text-xs">
-						{toolkitId}
-						<CopyButton value={toolkitId} size="icon" variant="ghost" />
-					</span>
-				</div>
-				<form
-					className="space-y-4"
-					onSubmit={(e) => {
-						e.preventDefault();
-						updateToolkit.mutate(
-							{ name: editName || null, description: editDesc || null },
-							{
-								onSuccess: () =>
-									toast({ title: 'Toolkit updated', variant: 'success' }),
-							},
-						);
-					}}
-				>
-					<div>
-						<Label
-							htmlFor="tk-settings-name"
-							className="text-muted-foreground mb-1 block text-xs"
-						>
-							Name
-						</Label>
-						<Input
-							id="tk-settings-name"
-							type="text"
-							value={editName}
-							onChange={(e) => setEditName(e.target.value)}
-						/>
-					</div>
-					<div>
-						<Label
-							htmlFor="tk-settings-description"
-							className="text-muted-foreground mb-1 block text-xs"
-						>
-							Description
-						</Label>
-						<Textarea
-							id="tk-settings-description"
-							value={editDesc}
-							onChange={(e) => setEditDesc(e.target.value)}
-							rows={2}
-						/>
-					</div>
-					{updateToolkit.isError && <ErrorAlert message={updateToolkit.error.message} />}
-					<Button
-						type="submit"
-						size="sm"
-						disabled={!dirty || updateToolkit.isPending}
-						loading={updateToolkit.isPending}
-					>
-						{updateToolkit.isPending ? 'Saving…' : 'Save changes'}
-					</Button>
-				</form>
-			</DetailSection>
+			<IdentitySettingsCard
+				idLabel="Toolkit ID"
+				idValue={toolkitId}
+				name={toolkit.name}
+				description={toolkit.description ?? null}
+				saving={updateToolkit.isPending}
+				error={updateToolkit.isError ? updateToolkit.error.message : null}
+				onSave={async (draft) => {
+					await updateToolkit.mutateAsync({
+						name: draft.name,
+						description: draft.description || null,
+					});
+					toast({ title: 'Toolkit updated', variant: 'success' });
+				}}
+			/>
 
-			<DetailSection title="Danger zone" icon={<Trash2 className="h-4 w-4" />} danger>
-				<div className="flex flex-wrap items-center justify-between gap-3 p-1">
-					<p className="text-muted-foreground max-w-prose text-sm">
-						Deleting this toolkit cascades: agent grants, API keys, and credential
-						bindings are removed with it. This cannot be undone. To pause access without
-						deleting anything, use the kill switch in the header instead.
-					</p>
-					<Button
-						variant="danger"
-						size="sm"
-						onClick={() => setDeleteOpen(true)}
-						aria-label={`Delete ${toolkit.name}`}
-					>
-						<Trash2 className="h-4 w-4" /> Delete
-					</Button>
-				</div>
-			</DetailSection>
+			<DangerZone actions={dangerActions} onAction={() => setDeleteOpen(true)} />
 
 			<CascadeDeleteDialog
 				open={deleteOpen}

--- a/ui/src/modules/toolkits/components/detail/shared.tsx
+++ b/ui/src/modules/toolkits/components/detail/shared.tsx
@@ -1,14 +1,11 @@
-import type { ReactNode } from 'react';
-import { Button, Card, CardBody, CardHeader, CardTitle } from '@/shared/ui';
-import { cn } from '@/shared/lib/utils';
 import type { PermissionRule as DisplayRule } from '@/shared/lib';
 import type { PermissionRule } from '@/modules/toolkits/api/types';
 
 /**
  * Shared scaffolding for the toolkit detail tabs (see `ToolkitDetailBody`).
- * Every tab renders one or more `DetailSection` cards; rows animate in/out
- * with the same motion presets the pre-tab layout used, so the split does not
- * change the page's feel.
+ * Every tab renders one or more `DetailSection` cards (the shared primitive —
+ * `@/shared/ui`); rows animate in/out with the same motion presets the
+ * pre-tab layout used, so the split does not change the page's feel.
  */
 
 /**
@@ -59,107 +56,6 @@ export function RowSkeleton() {
 				<div className="bg-muted h-3.5 w-1/3 animate-pulse rounded" />
 				<div className="bg-muted h-3 w-1/2 animate-pulse rounded" />
 			</div>
-		</div>
-	);
-}
-
-export interface SectionActionProps {
-	label: ReactNode;
-	onClick: () => void;
-	variant?: 'primary' | 'secondary';
-}
-
-interface DetailSectionProps {
-	/** Section heading (sentence-case, `font-heading font-semibold` ladder). */
-	title: ReactNode;
-	/**
-	 * Leading glyph for the heading (`h-4 w-4`), rendered in the same muted
-	 * icon medallion the dashboard sections use — one grammar everywhere.
-	 */
-	icon?: ReactNode;
-	/** Extra inline content next to the title (e.g. a "Keys blocked" pill). */
-	titleExtra?: ReactNode;
-	/** Right-aligned header action button. */
-	action?: SectionActionProps;
-	/** Danger-tinted borders (suspended keys section). */
-	danger?: boolean;
-	/** Extra classes on the card shell (e.g. `h-full` in equal-height grids). */
-	className?: string;
-	/** Right-aligned header content when `action` (a button) doesn't fit — e.g. a link. */
-	trailing?: ReactNode;
-	children: ReactNode;
-}
-
-/**
- * The card shell every toolkit-detail section renders inside — the shared
- * `Card` family with a header grammar (icon medallion + heading + right-slot)
- * layered on top, so the section chrome stays one primitive with the rest of
- * the product.
- */
-export function DetailSection({
-	title,
-	icon,
-	titleExtra,
-	action,
-	danger,
-	className,
-	trailing,
-	children,
-}: DetailSectionProps) {
-	return (
-		<Card className={cn('flex flex-col', danger && 'border-danger/50', className)}>
-			<CardHeader
-				className={cn(
-					'flex flex-wrap items-center justify-between gap-2 px-4 py-3.5 sm:px-5 sm:py-4',
-					danger && 'border-danger/30 bg-danger/5',
-				)}
-			>
-				<div className="flex items-center gap-2.5">
-					{icon && (
-						<span
-							aria-hidden="true"
-							className={cn(
-								'flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ring-1',
-								danger
-									? 'bg-danger/10 text-danger ring-danger/25'
-									: 'bg-muted text-muted-foreground ring-border',
-							)}
-						>
-							{icon}
-						</span>
-					)}
-					<CardTitle>{title}</CardTitle>
-					{titleExtra}
-				</div>
-				{action && (
-					<Button
-						variant={action.variant ?? 'secondary'}
-						size="sm"
-						onClick={action.onClick}
-					>
-						{action.label}
-					</Button>
-				)}
-				{trailing}
-			</CardHeader>
-			<CardBody className="flex-1 space-y-2 px-4 py-3.5 sm:px-5 sm:py-4">{children}</CardBody>
-		</Card>
-	);
-}
-
-interface EmptyRowProps {
-	icon: ReactNode;
-	children: ReactNode;
-}
-
-/** Dashed empty-state panel used inside a `DetailSection`. */
-export function EmptyRow({ icon, children }: EmptyRowProps) {
-	return (
-		<div className="border-border/50 rounded-lg border border-dashed px-5 py-6 text-center">
-			<span className="text-muted-foreground/50 mx-auto block h-6 w-6 [&>svg]:h-6 [&>svg]:w-6">
-				{icon}
-			</span>
-			<p className="text-muted-foreground mt-2 text-sm">{children}</p>
 		</div>
 	);
 }

--- a/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
+++ b/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
@@ -157,18 +157,21 @@ describe('ToolkitDetailPage', () => {
 		expect(
 			await screen.findByRole('img', { name: /execution volume over the last 7d/i }),
 		).toBeInTheDocument();
-		expect(screen.getByRole('img', { name: /total calls per bucket/i })).toBeInTheDocument();
+		expect(screen.getByRole('img', { name: /success rate per bucket/i })).toBeInTheDocument();
 
 		// Executions feed (from /executions?toolkit_id=…), including the denial.
 		expect(await screen.findByText(/github\.create_issue/)).toBeInTheDocument();
 		expect(screen.getByText(/denied by permission rule/i)).toBeInTheDocument();
 
-		// Deep-link into Monitor carries the toolkit filter.
-		const link = screen.getByRole('link', { name: /open monitor/i });
-		expect(link).toHaveAttribute(
-			'href',
-			expect.stringContaining('tab=executions&toolkit_id=tk_demo_github'),
-		);
+		// Deep-links into Monitor (back row + feed card) carry the toolkit filter.
+		const links = screen.getAllByRole('link', { name: /open monitor/i });
+		expect(links.length).toBeGreaterThan(0);
+		for (const link of links) {
+			expect(link).toHaveAttribute(
+				'href',
+				expect.stringContaining('tab=executions&toolkit_id=tk_demo_github'),
+			);
+		}
 	});
 
 	it('hides the KPI strip and degrades the Activity tab for non-admins (403)', async () => {

--- a/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
+++ b/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
@@ -153,10 +153,11 @@ describe('ToolkitDetailPage', () => {
 
 		await user.click(screen.getByRole('tab', { name: 'Activity' }));
 
-		// Volume chart (from /monitoring/usage?toolkit_id=…).
+		// Chart pair (from /monitoring/usage?toolkit_id=…): stacked volume + call trend.
 		expect(
-			await screen.findByRole('img', { name: /execution volume for this toolkit/i }),
+			await screen.findByRole('img', { name: /execution volume over the last 7d/i }),
 		).toBeInTheDocument();
+		expect(screen.getByRole('img', { name: /total calls per bucket/i })).toBeInTheDocument();
 
 		// Executions feed (from /executions?toolkit_id=…), including the denial.
 		expect(await screen.findByText(/github\.create_issue/)).toBeInTheDocument();

--- a/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
+++ b/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
@@ -163,9 +163,10 @@ describe('ToolkitDetailPage', () => {
 		expect(await screen.findByText(/github\.create_issue/)).toBeInTheDocument();
 		expect(screen.getByText(/denied by permission rule/i)).toBeInTheDocument();
 
-		// Deep-links into Monitor (back row + feed card) carry the toolkit filter.
+		// Deep-links into Monitor carry the toolkit filter — exactly two: the
+		// back-row link and the feed-card link.
 		const links = screen.getAllByRole('link', { name: /open monitor/i });
-		expect(links.length).toBeGreaterThan(0);
+		expect(links).toHaveLength(2);
 		for (const link of links) {
 			expect(link).toHaveAttribute(
 				'href',

--- a/ui/src/modules/toolkits/pages/ToolkitDetailPage.tsx
+++ b/ui/src/modules/toolkits/pages/ToolkitDetailPage.tsx
@@ -1,9 +1,10 @@
 import { useNavigate, useParams } from 'react-router';
-import { BackButton, PageHeader, PageShell } from '@/shared/ui';
+import { Activity } from 'lucide-react';
+import { AppLink, BackButton, PageHeader, PageShell } from '@/shared/ui';
 import { useToolkit } from '@/modules/toolkits/api';
 import { ToolkitDetailBody } from '@/modules/toolkits/components/ToolkitDetailBody';
 import { ToolkitKillSwitch } from '@/modules/toolkits/components/ToolkitKillSwitch';
-import { ROUTES } from '@/shared/app/routes';
+import { ROUTES, ROUTE_PATHS } from '@/shared/app/routes';
 
 /**
  * `/toolkits/:toolkitId` (→ `/app/toolkits/:toolkitId`) — full-page host for the
@@ -46,10 +47,17 @@ export function ToolkitDetailPage() {
 				}
 			/>
 
-			<div className="-mt-2">
+			<div className="-mt-2 flex items-center justify-between">
 				{/* Static link (not history-back): tab switches push history entries,
 				    so popping would step through tabs instead of leaving the page. */}
 				<BackButton to={ROUTES.toolkits} label="All toolkits" useHistory={false} />
+				{/* Same pre-filtered Monitor deep-link the agent console carries. */}
+				<AppLink
+					href={ROUTE_PATHS.monitorExecutions({ toolkitId })}
+					className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs font-medium transition-colors"
+				>
+					<Activity className="h-3.5 w-3.5" /> Open Monitor
+				</AppLink>
 			</div>
 
 			<ToolkitDetailBody

--- a/ui/src/shared/app/UserMenu.tsx
+++ b/ui/src/shared/app/UserMenu.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { ExternalLink, KeyRound, LogOut } from 'lucide-react';
+import { KeyRound, LogOut } from 'lucide-react';
 import { AppLink } from '@/shared/ui/AppLink';
 import { Button } from '@/shared/ui/Button';
 import { MenuPanel, MenuSeparator, menuItemClass, useDismissable } from '@/shared/ui/Menu';
@@ -67,18 +67,6 @@ export function UserMenu() {
 					>
 						<KeyRound className="h-4 w-4 shrink-0" aria-hidden="true" />
 						Change password
-					</AppLink>
-
-					<AppLink
-						href="https://example.com"
-						role="menuitem"
-						onClick={close}
-						className={menuItemClass()}
-						aria-label="More at example.com (opens in a new tab)"
-						title="More at example.com (opens in a new tab)"
-					>
-						<ExternalLink className="h-4 w-4 shrink-0" aria-hidden="true" />
-						More at example.com
 					</AppLink>
 
 					<MenuSeparator />

--- a/ui/src/shared/ui/AuditTrailCard.tsx
+++ b/ui/src/shared/ui/AuditTrailCard.tsx
@@ -92,43 +92,48 @@ export function AuditTrailCard({
 			{!isError && !isLoading && entries.length === 0 && (
 				<EmptyRow icon={<ScrollText />}>{emptyMessage}</EmptyRow>
 			)}
-			<AnimatePresence initial={false}>
-				{entries.map((entry) => {
-					const occurred = Date.parse(entry.occurredAt);
-					return (
-						<motion.div
-							key={entry.id}
-							{...rowMotion}
-							className="bg-muted/30 border-border/60 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border px-3 py-2"
-						>
-							<Badge variant={actionVariant(entry.action)}>{entry.action}</Badge>
-							<span className="text-foreground min-w-0 flex-1 truncate text-sm">
-								{entry.actorId ? (
-									<ActorLabel
-										actorId={entry.actorId}
-										actorType={entry.actorType ?? undefined}
-									/>
-								) : (
-									(entry.actorType ?? 'system')
-								)}
-								{entry.reason ? (
-									<span className="text-muted-foreground"> — {entry.reason}</span>
-								) : null}
-							</span>
-							<span
-								className="text-muted-foreground shrink-0 text-xs"
-								title={
-									Number.isFinite(occurred)
-										? formatTimestamp(entry.occurredAt)
-										: entry.occurredAt
-								}
+			{!isError && !isLoading && (
+				<AnimatePresence initial={false}>
+					{entries.map((entry) => {
+						const occurred = Date.parse(entry.occurredAt);
+						return (
+							<motion.div
+								key={entry.id}
+								{...rowMotion}
+								className="bg-muted/30 border-border/60 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border px-3 py-2"
 							>
-								{Number.isFinite(occurred) ? timeAgo(entry.occurredAt) : ''}
-							</span>
-						</motion.div>
-					);
-				})}
-			</AnimatePresence>
+								<Badge variant={actionVariant(entry.action)}>{entry.action}</Badge>
+								<span className="text-foreground min-w-0 flex-1 truncate text-sm">
+									{entry.actorId ? (
+										<ActorLabel
+											actorId={entry.actorId}
+											actorType={entry.actorType ?? undefined}
+										/>
+									) : (
+										(entry.actorType ?? 'system')
+									)}
+									{entry.reason ? (
+										<span className="text-muted-foreground">
+											{' '}
+											— {entry.reason}
+										</span>
+									) : null}
+								</span>
+								<span
+									className="text-muted-foreground shrink-0 text-xs"
+									title={
+										Number.isFinite(occurred)
+											? formatTimestamp(entry.occurredAt)
+											: entry.occurredAt
+									}
+								>
+									{Number.isFinite(occurred) ? timeAgo(entry.occurredAt) : ''}
+								</span>
+							</motion.div>
+						);
+					})}
+				</AnimatePresence>
+			)}
 		</DetailSection>
 	);
 }

--- a/ui/src/shared/ui/AuditTrailCard.tsx
+++ b/ui/src/shared/ui/AuditTrailCard.tsx
@@ -1,0 +1,134 @@
+import type { ReactNode } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { History, ScrollText } from 'lucide-react';
+import { ActorLabel } from '@/shared/ui/ActorLabel';
+import { Badge } from '@/shared/ui/Badge';
+import { ErrorAlert } from '@/shared/ui/ErrorAlert';
+import { DetailSection, EmptyRow } from '@/shared/ui/DetailSection';
+import { formatTimestamp, timeAgo } from '@/shared/lib/utils';
+
+/**
+ * AuditTrailCard — the "Recent changes" card shared by the detail consoles
+ * (toolkit, agent, service account): a read-only, entity-scoped slice of the
+ * org-wide audit log. One component so "Recent changes" reads identically
+ * everywhere; callers own the data fetch (per-module hooks) and map their
+ * wire rows into {@link AuditTrailEntry}.
+ */
+
+export interface AuditTrailEntry {
+	id: string;
+	/** The audit verb, rendered as a badge ("toolkit.suspend", "agent.approve"). */
+	action: string;
+	/** The PERFORMING principal (resolved via ActorLabel); null for system events. */
+	actorId?: string | null;
+	actorType?: string | null;
+	/** Optional operator-supplied reason, rendered after the actor. */
+	reason?: string | null;
+	/** ISO timestamp of the event. */
+	occurredAt: string;
+}
+
+const rowMotion = {
+	initial: { opacity: 0, y: -4 },
+	animate: { opacity: 1, y: 0 },
+	exit: { opacity: 0, y: -4 },
+	transition: { duration: 0.16, ease: 'easeOut' as const },
+};
+
+/**
+ * Audit verb → badge tint. The union of the consoles' vocabularies so a verb
+ * reads the same wherever it appears; unknown verbs fall through to neutral.
+ */
+function actionVariant(action: string): 'default' | 'success' | 'danger' {
+	const a = action.toLowerCase();
+	if (
+		a.includes('delete') ||
+		a.includes('deny') ||
+		a.includes('disable') ||
+		a.includes('archive') ||
+		a.includes('suspend') ||
+		a.includes('revoke')
+	) {
+		return 'danger';
+	}
+	if (a.includes('create') || a.includes('register') || a.includes('approve')) return 'success';
+	return 'default';
+}
+
+export interface AuditTrailCardProps {
+	entries: AuditTrailEntry[];
+	isLoading?: boolean;
+	isError?: boolean;
+	/** Quiet right-slot caption, e.g. "Toolkit-level events · admin only". */
+	caption?: string;
+	/** Dashed empty-state copy when there are no entries. */
+	emptyMessage: ReactNode;
+	errorMessage?: string;
+}
+
+export function AuditTrailCard({
+	entries,
+	isLoading = false,
+	isError = false,
+	caption,
+	emptyMessage,
+	errorMessage = 'Failed to load the audit log.',
+}: AuditTrailCardProps) {
+	return (
+		<DetailSection
+			title="Recent changes"
+			icon={<History className="h-4 w-4" />}
+			trailing={
+				caption ? <span className="text-muted-foreground text-xs">{caption}</span> : null
+			}
+		>
+			{isError && <ErrorAlert message={errorMessage} />}
+			{!isError && isLoading && (
+				<>
+					<div className="bg-muted h-10 animate-pulse rounded-lg" />
+					<div className="bg-muted h-10 animate-pulse rounded-lg" />
+				</>
+			)}
+			{!isError && !isLoading && entries.length === 0 && (
+				<EmptyRow icon={<ScrollText />}>{emptyMessage}</EmptyRow>
+			)}
+			<AnimatePresence initial={false}>
+				{entries.map((entry) => {
+					const occurred = Date.parse(entry.occurredAt);
+					return (
+						<motion.div
+							key={entry.id}
+							{...rowMotion}
+							className="bg-muted/30 border-border/60 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border px-3 py-2"
+						>
+							<Badge variant={actionVariant(entry.action)}>{entry.action}</Badge>
+							<span className="text-foreground min-w-0 flex-1 truncate text-sm">
+								{entry.actorId ? (
+									<ActorLabel
+										actorId={entry.actorId}
+										actorType={entry.actorType ?? undefined}
+									/>
+								) : (
+									(entry.actorType ?? 'system')
+								)}
+								{entry.reason ? (
+									<span className="text-muted-foreground"> — {entry.reason}</span>
+								) : null}
+							</span>
+							<span
+								className="text-muted-foreground shrink-0 text-xs"
+								title={
+									Number.isFinite(occurred)
+										? formatTimestamp(entry.occurredAt)
+										: entry.occurredAt
+								}
+							>
+								{Number.isFinite(occurred) ? timeAgo(entry.occurredAt) : ''}
+							</span>
+						</motion.div>
+					);
+				})}
+			</AnimatePresence>
+		</DetailSection>
+	);
+}

--- a/ui/src/shared/ui/DangerZone.tsx
+++ b/ui/src/shared/ui/DangerZone.tsx
@@ -57,10 +57,13 @@ export function DangerZone({ actions, pending = false, onAction }: DangerZonePro
 					</div>
 					<Button
 						size="sm"
-						variant={action.emphasis === 'outline' ? 'outline' : 'danger'}
+						// `outline` emphasis needs a fully danger-tinted treatment —
+						// the stock outline variant is primary-tinted and would leak
+						// teal through on hover.
+						variant={action.emphasis === 'outline' ? 'ghost' : 'danger'}
 						className={
 							action.emphasis === 'outline'
-								? 'border-danger/40 text-danger hover:bg-danger/10 shrink-0'
+								? 'border-danger/40 text-danger hover:bg-danger/10 hover:text-danger shrink-0 border'
 								: 'shrink-0'
 						}
 						disabled={pending}

--- a/ui/src/shared/ui/DangerZone.tsx
+++ b/ui/src/shared/ui/DangerZone.tsx
@@ -1,0 +1,76 @@
+import { TriangleAlert } from 'lucide-react';
+import { Button } from '@/shared/ui/Button';
+import { DetailSection } from '@/shared/ui/DetailSection';
+
+/**
+ * DangerZone — the Settings tab's destructive-actions card, shared by the
+ * detail consoles (toolkit, agent, service account) so irreversible actions
+ * read identically everywhere: the danger-tinted `DetailSection` shell with
+ * one row per action.
+ *
+ * Purely presentational: every button defers to the caller (which owns the
+ * confirm dialog and the mutation) — this component never mutates state.
+ * Renders nothing when no destructive verb applies.
+ */
+
+export interface DangerZoneAction {
+	/** Stable key handed back through `onAction`. */
+	key: string;
+	title: string;
+	description: string;
+	buttonLabel: string;
+	/** Accessible label carrying the entity name (e.g. "Disable support-agent"). */
+	ariaLabel: string;
+	/**
+	 * `solid` for terminal actions (archive, delete); `outline` for reversible
+	 * ones (disable).
+	 */
+	emphasis?: 'solid' | 'outline';
+}
+
+export interface DangerZoneProps {
+	actions: DangerZoneAction[];
+	/** True while any related mutation is in flight (disables every button). */
+	pending?: boolean;
+	onAction: (key: string) => void;
+}
+
+export function DangerZone({ actions, pending = false, onAction }: DangerZoneProps) {
+	if (actions.length === 0) return null;
+	return (
+		<DetailSection
+			title="Danger zone"
+			icon={<TriangleAlert className="h-4 w-4" />}
+			danger
+			bodyClassName="divide-border/60 divide-y space-y-0"
+		>
+			{actions.map((action) => (
+				<div
+					key={action.key}
+					className="flex flex-wrap items-center justify-between gap-3 py-3 first:pt-0 last:pb-0"
+				>
+					<div className="min-w-0">
+						<p className="text-foreground text-sm font-medium">{action.title}</p>
+						<p className="text-muted-foreground max-w-prose text-xs">
+							{action.description}
+						</p>
+					</div>
+					<Button
+						size="sm"
+						variant={action.emphasis === 'outline' ? 'outline' : 'danger'}
+						className={
+							action.emphasis === 'outline'
+								? 'border-danger/40 text-danger hover:bg-danger/10 shrink-0'
+								: 'shrink-0'
+						}
+						disabled={pending}
+						onClick={() => onAction(action.key)}
+						aria-label={action.ariaLabel}
+					>
+						{action.buttonLabel}
+					</Button>
+				</div>
+			))}
+		</DetailSection>
+	);
+}

--- a/ui/src/shared/ui/DetailSection.tsx
+++ b/ui/src/shared/ui/DetailSection.tsx
@@ -1,0 +1,117 @@
+import type { ReactNode } from 'react';
+import { Button } from '@/shared/ui/Button';
+import { Card, CardBody, CardHeader, CardTitle } from '@/shared/ui/Card';
+import { cn } from '@/shared/lib/utils';
+
+/**
+ * DetailSection — the card shell every detail-console section renders inside
+ * (toolkit, agent, and service-account consoles): the shared `Card` family
+ * with a header grammar (icon medallion + heading + right-slot) layered on
+ * top, so section chrome stays one primitive across the product.
+ *
+ * Promoted from the toolkit console's `components/detail/shared.tsx` once the
+ * agent console needed the identical shell (library-first rule).
+ */
+
+export interface SectionActionProps {
+	label: ReactNode;
+	onClick: () => void;
+	variant?: 'primary' | 'secondary' | 'outline';
+	/** Accessible name when the visible label alone is ambiguous. */
+	ariaLabel?: string;
+}
+
+export interface DetailSectionProps {
+	/** Section heading (sentence-case, `font-heading font-semibold` ladder). */
+	title: ReactNode;
+	/**
+	 * Leading glyph for the heading (`h-4 w-4`), rendered in the same muted
+	 * icon medallion the dashboard sections use — one grammar everywhere.
+	 */
+	icon?: ReactNode;
+	/** Extra inline content next to the title (e.g. a "Keys blocked" pill). */
+	titleExtra?: ReactNode;
+	/** Right-aligned header action button. */
+	action?: SectionActionProps;
+	/** Danger-tinted borders (suspended keys, danger zone). */
+	danger?: boolean;
+	/** Extra classes on the card shell (e.g. `h-full` in equal-height grids). */
+	className?: string;
+	/** Extra classes on the body (e.g. `px-0 py-0` to host a flush table). */
+	bodyClassName?: string;
+	/** Right-aligned header content when `action` (a button) doesn't fit — e.g. a link. */
+	trailing?: ReactNode;
+	children: ReactNode;
+}
+
+export function DetailSection({
+	title,
+	icon,
+	titleExtra,
+	action,
+	danger,
+	className,
+	bodyClassName,
+	trailing,
+	children,
+}: DetailSectionProps) {
+	return (
+		<Card className={cn('flex flex-col', danger && 'border-danger/50', className)}>
+			<CardHeader
+				className={cn(
+					'flex flex-wrap items-center justify-between gap-2 px-4 py-3.5 sm:px-5 sm:py-4',
+					danger && 'border-danger/30 bg-danger/5',
+				)}
+			>
+				<div className="flex items-center gap-2.5">
+					{icon && (
+						<span
+							aria-hidden="true"
+							className={cn(
+								'flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ring-1',
+								danger
+									? 'bg-danger/10 text-danger ring-danger/25'
+									: 'bg-muted text-muted-foreground ring-border',
+							)}
+						>
+							{icon}
+						</span>
+					)}
+					<CardTitle className={cn(danger && 'text-danger')}>{title}</CardTitle>
+					{titleExtra}
+				</div>
+				{action && (
+					<Button
+						variant={action.variant ?? 'secondary'}
+						size="sm"
+						onClick={action.onClick}
+						aria-label={action.ariaLabel}
+					>
+						{action.label}
+					</Button>
+				)}
+				{trailing}
+			</CardHeader>
+			<CardBody className={cn('flex-1 space-y-2 px-4 py-3.5 sm:px-5 sm:py-4', bodyClassName)}>
+				{children}
+			</CardBody>
+		</Card>
+	);
+}
+
+interface EmptyRowProps {
+	icon: ReactNode;
+	children: ReactNode;
+}
+
+/** Dashed empty-state panel used inside a `DetailSection`. */
+export function EmptyRow({ icon, children }: EmptyRowProps) {
+	return (
+		<div className="border-border/50 rounded-lg border border-dashed px-5 py-6 text-center">
+			<span className="text-muted-foreground/50 mx-auto block h-6 w-6 [&>svg]:h-6 [&>svg]:w-6">
+				{icon}
+			</span>
+			<p className="text-muted-foreground mt-2 text-sm">{children}</p>
+		</div>
+	);
+}

--- a/ui/src/shared/ui/ExecutionVolumeCharts.tsx
+++ b/ui/src/shared/ui/ExecutionVolumeCharts.tsx
@@ -1,7 +1,7 @@
 /**
  * ExecutionVolumeCharts — the console-standard activity chart pair, mirroring
  * the dashboard's arrangement: a stacked succeeded/failed volume chart on the
- * left (2/3) and a total-call-volume trend line on the right (1/3). Toolkit,
+ * left (2/3) and a success-rate trend line on the right (1/3). Toolkit,
  * agent and service-account detail consoles all render the same pair so
  * "activity" reads identically everywhere.
  *
@@ -85,7 +85,9 @@ export function ExecutionVolumeCharts({
 		],
 	}));
 
-	const trendData = buckets.map((b) => ({ ts: b.ts, value: b.total }));
+	const trendData = buckets
+		.filter((b) => b.total > 0)
+		.map((b) => ({ ts: b.ts, value: (b.success / b.total) * 100 }));
 
 	if (!isLoading && buckets.length === 0) {
 		return (
@@ -118,7 +120,7 @@ export function ExecutionVolumeCharts({
 			</DetailSection>
 
 			<DetailSection
-				title={`Call trend · ${windowLabel}`}
+				title={`Success rate · ${windowLabel}`}
 				icon={<TrendingUp className="h-4 w-4" />}
 			>
 				{isLoading ? (
@@ -127,10 +129,11 @@ export function ExecutionVolumeCharts({
 					<TrendLineChart
 						data={trendData}
 						height={128}
-						formatValue={(v) => Math.round(v).toLocaleString()}
+						yDomain={[0, 100]}
+						formatValue={(v) => `${Math.round(v)}%`}
 						formatTs={(ts) => bucketLabel(ts, bucketSeconds)}
-						colorClassName="text-accent-blue"
-						ariaLabel={`Total calls per bucket over the last ${windowLabel}.`}
+						colorClassName="text-accent-green"
+						ariaLabel={`Success rate per bucket over the last ${windowLabel}.`}
 					/>
 				) : (
 					<p className="text-muted-foreground py-6 text-center text-sm">

--- a/ui/src/shared/ui/ExecutionVolumeCharts.tsx
+++ b/ui/src/shared/ui/ExecutionVolumeCharts.tsx
@@ -1,0 +1,143 @@
+/**
+ * ExecutionVolumeCharts — the console-standard activity chart pair, mirroring
+ * the dashboard's arrangement: a stacked succeeded/failed volume chart on the
+ * left (2/3) and a total-call-volume trend line on the right (1/3). Toolkit,
+ * agent and service-account detail consoles all render the same pair so
+ * "activity" reads identically everywhere.
+ *
+ * Both charts are fed by the same `/monitoring/usage` bucket shape
+ * (`ts` / `total` / `success` / `failed`); callers just forward their
+ * module's bucket array and window metadata.
+ */
+import { Activity, ChartColumn, TrendingUp } from 'lucide-react';
+import { DetailSection, EmptyRow } from '@/shared/ui/DetailSection';
+import { StackedBarChart, type StackedBarDatum } from '@/shared/ui/charts/StackedBarChart';
+import { TrendLineChart } from '@/shared/ui/charts/TrendLineChart';
+
+export interface UsageChartBucket {
+	/** Bucket start, unix seconds. */
+	ts: number;
+	total: number;
+	success: number;
+	failed: number;
+}
+
+export interface ExecutionVolumeChartsProps {
+	buckets: UsageChartBucket[];
+	/** Width of each bucket in seconds (drives x-axis label formatting). */
+	bucketSeconds: number;
+	/** Short window caption appended to the card titles. Defaults to `7d`. */
+	windowLabel?: string;
+	/** Loading skeletons instead of charts. */
+	isLoading?: boolean;
+	/** Copy for the shared empty state when there are no buckets at all. */
+	emptyMessage?: string;
+}
+
+/**
+ * Label a bucket timestamp for the x-axis: clock time for sub-day buckets,
+ * month + day otherwise (the dashboard's bucket-label convention).
+ */
+function bucketLabel(ts: number, bucketSeconds: number): string {
+	const date = new Date(ts * 1000);
+	if (bucketSeconds < 86_400) {
+		return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+	}
+	return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function Legend() {
+	return (
+		<div className="text-muted-foreground flex items-center gap-3 text-xs">
+			<span className="inline-flex items-center gap-1.5">
+				<span className="bg-accent-green/80 h-2 w-2 rounded-sm" aria-hidden="true" />
+				Succeeded
+			</span>
+			<span className="inline-flex items-center gap-1.5">
+				<span className="bg-danger/80 h-2 w-2 rounded-sm" aria-hidden="true" />
+				Failed
+			</span>
+		</div>
+	);
+}
+
+export function ExecutionVolumeCharts({
+	buckets,
+	bucketSeconds,
+	windowLabel = '7d',
+	isLoading = false,
+	emptyMessage = 'No executions in this window yet. Volume appears here once calls start flowing.',
+}: ExecutionVolumeChartsProps) {
+	const total = buckets.reduce((sum, b) => sum + b.total, 0);
+	const failed = buckets.reduce((sum, b) => sum + b.failed, 0);
+
+	const bars: StackedBarDatum[] = buckets.map((b) => ({
+		key: String(b.ts),
+		label: bucketLabel(b.ts, bucketSeconds),
+		segments: [
+			{
+				key: 'success',
+				label: 'succeeded',
+				value: b.success,
+				colorClassName: 'bg-accent-green/80',
+			},
+			{ key: 'failed', label: 'failed', value: b.failed, colorClassName: 'bg-danger/70' },
+		],
+	}));
+
+	const trendData = buckets.map((b) => ({ ts: b.ts, value: b.total }));
+
+	if (!isLoading && buckets.length === 0) {
+		return (
+			<DetailSection
+				title={`Execution volume · ${windowLabel}`}
+				icon={<ChartColumn className="h-4 w-4" />}
+			>
+				<EmptyRow icon={<Activity />}>{emptyMessage}</EmptyRow>
+			</DetailSection>
+		);
+	}
+
+	return (
+		<div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+			<DetailSection
+				title={`Execution volume · ${windowLabel}`}
+				icon={<ChartColumn className="h-4 w-4" />}
+				trailing={<Legend />}
+				className="lg:col-span-2"
+			>
+				{isLoading ? (
+					<div className="bg-muted h-32 animate-pulse rounded-lg" aria-hidden="true" />
+				) : (
+					<StackedBarChart
+						bars={bars}
+						height={128}
+						ariaLabel={`Execution volume over the last ${windowLabel}: ${total} total, ${failed} failed.`}
+					/>
+				)}
+			</DetailSection>
+
+			<DetailSection
+				title={`Call trend · ${windowLabel}`}
+				icon={<TrendingUp className="h-4 w-4" />}
+			>
+				{isLoading ? (
+					<div className="bg-muted h-32 animate-pulse rounded-lg" aria-hidden="true" />
+				) : trendData.length >= 2 ? (
+					<TrendLineChart
+						data={trendData}
+						height={128}
+						formatValue={(v) => Math.round(v).toLocaleString()}
+						formatTs={(ts) => bucketLabel(ts, bucketSeconds)}
+						colorClassName="text-accent-blue"
+						ariaLabel={`Total calls per bucket over the last ${windowLabel}.`}
+					/>
+				) : (
+					<p className="text-muted-foreground py-6 text-center text-sm">
+						Not enough data for a trend yet.
+					</p>
+				)}
+			</DetailSection>
+		</div>
+	);
+}

--- a/ui/src/shared/ui/ExecutionVolumeCharts.tsx
+++ b/ui/src/shared/ui/ExecutionVolumeCharts.tsx
@@ -81,7 +81,7 @@ export function ExecutionVolumeCharts({
 				value: b.success,
 				colorClassName: 'bg-accent-green/80',
 			},
-			{ key: 'failed', label: 'failed', value: b.failed, colorClassName: 'bg-danger/70' },
+			{ key: 'failed', label: 'failed', value: b.failed, colorClassName: 'bg-danger/80' },
 		],
 	}));
 

--- a/ui/src/shared/ui/IdentitySettingsCard.tsx
+++ b/ui/src/shared/ui/IdentitySettingsCard.tsx
@@ -70,19 +70,34 @@ export function IdentitySettingsCard({
 	// any cache refetch) and a background refetch can't flip a clean form dirty.
 	const [saved, setSaved] = useState({ name, description: description ?? '' });
 
-	// Seed-from-props syncs only when the entity itself changed — never on
-	// re-renders of the same entity, or a background refetch would clobber
-	// the user's draft (and a warm cache could carry entity A's draft onto
-	// entity B and PATCH the wrong row).
-	const seededIdRef = useRef(idValue);
+	// Seed-from-props syncs when the entity itself changed, and otherwise
+	// absorbs server-side changes only while the form is CLEAN — a background
+	// refetch must never clobber an in-progress draft (and a warm cache could
+	// carry entity A's draft onto entity B and PATCH the wrong row), but
+	// late-arriving data for the same entity must still land. The ref gate
+	// makes the effect react to PROP changes only: right after a save,
+	// `saved` is ahead of the (stale) props, and syncing then would revert
+	// the form to pre-save values.
+	const lastPropsRef = useRef({ idValue, name, description: description ?? '' });
 	useEffect(() => {
-		if (seededIdRef.current === idValue) return;
-		seededIdRef.current = idValue;
-		setDraftName(name);
-		setDraftDescription(description ?? '');
-		setSaved({ name, description: description ?? '' });
-		setNameError(null);
-	}, [idValue, name, description]);
+		const next = { name, description: description ?? '' };
+		const prev = lastPropsRef.current;
+		lastPropsRef.current = { idValue, ...next };
+		if (prev.idValue !== idValue) {
+			setDraftName(next.name);
+			setDraftDescription(next.description);
+			setSaved(next);
+			setNameError(null);
+			return;
+		}
+		if (prev.name === next.name && prev.description === next.description) return;
+		const clean = draftName === saved.name && draftDescription === saved.description;
+		setSaved(next);
+		if (clean) {
+			setDraftName(next.name);
+			setDraftDescription(next.description);
+		}
+	}, [idValue, name, description, saved, draftName, draftDescription]);
 
 	const trimmedName = draftName.trim();
 	const trimmedDescription = draftDescription.trim();

--- a/ui/src/shared/ui/IdentitySettingsCard.tsx
+++ b/ui/src/shared/ui/IdentitySettingsCard.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { Fingerprint, SlidersHorizontal } from 'lucide-react';
+import { Button } from '@/shared/ui/Button';
+import { CopyButton } from '@/shared/ui/CopyButton';
+import { DetailSection } from '@/shared/ui/DetailSection';
+import { ErrorAlert } from '@/shared/ui/ErrorAlert';
+import { Input } from '@/shared/ui/Input';
+import { Label } from '@/shared/ui/Label';
+import { Textarea } from '@/shared/ui/Textarea';
+
+/**
+ * IdentitySettingsCard — the Settings tab's "General" card shared by the
+ * detail consoles (toolkit, agent, service account): the immutable, copyable
+ * entity id plus the editable name/description form.
+ *
+ * One grammar everywhere:
+ *   - the id row leads (what API calls and audit rows reference — it lives
+ *     here, not in the page chrome, so the header stays clean);
+ *   - name is required, description optional;
+ *   - "Save changes" sits bottom-RIGHT (form-primary convention) and stays
+ *     disabled until something actually changed;
+ *   - drafts seed from props only when the entity id changes (dialog-state
+ *     rule applied to an inline form): a background refetch must never
+ *     clobber an in-progress draft, but navigating to a sibling entity must
+ *     reseed.
+ *
+ * Consoles without an update endpoint (service accounts today) omit `onSave`
+ * and pass `readOnlyNote` — the card renders the id row plus the explanation
+ * instead of a dead form.
+ */
+
+export interface IdentitySettingsCardProps {
+	/** Label for the immutable id row ("Agent ID", "Toolkit ID", "Account ID"). */
+	idLabel: string;
+	idValue: string;
+	/** The entity's current (saved) name. */
+	name: string;
+	/** The entity's current (saved) description. */
+	description: string | null;
+	/**
+	 * Persist a draft. Callers diff against their entity for PATCH semantics
+	 * and MUST throw/reject on failure so the draft is kept for a retry.
+	 * `description` is the trimmed draft — empty string means "clear it".
+	 */
+	onSave?: (draft: { name: string; description: string }) => Promise<void>;
+	saving?: boolean;
+	/** Mutation error surfaced inline above the actions row. */
+	error?: string | null;
+	/** Read-only explanation when there is no update endpoint (no `onSave`). */
+	readOnlyNote?: ReactNode;
+	descriptionPlaceholder?: string;
+}
+
+export function IdentitySettingsCard({
+	idLabel,
+	idValue,
+	name,
+	description,
+	onSave,
+	saving = false,
+	error,
+	readOnlyNote,
+	descriptionPlaceholder,
+}: IdentitySettingsCardProps) {
+	const [draftName, setDraftName] = useState(name);
+	const [draftDescription, setDraftDescription] = useState(description ?? '');
+	const [nameError, setNameError] = useState<string | null>(null);
+	// What the server last acknowledged — dirtiness compares against THIS, not
+	// live props, so the form reads clean the instant a save resolves (before
+	// any cache refetch) and a background refetch can't flip a clean form dirty.
+	const [saved, setSaved] = useState({ name, description: description ?? '' });
+
+	// Seed-from-props syncs only when the entity itself changed — never on
+	// re-renders of the same entity, or a background refetch would clobber
+	// the user's draft (and a warm cache could carry entity A's draft onto
+	// entity B and PATCH the wrong row).
+	const seededIdRef = useRef(idValue);
+	useEffect(() => {
+		if (seededIdRef.current === idValue) return;
+		seededIdRef.current = idValue;
+		setDraftName(name);
+		setDraftDescription(description ?? '');
+		setSaved({ name, description: description ?? '' });
+		setNameError(null);
+	}, [idValue, name, description]);
+
+	const trimmedName = draftName.trim();
+	const trimmedDescription = draftDescription.trim();
+	const dirty = trimmedName !== saved.name || trimmedDescription !== saved.description;
+
+	async function handleSave() {
+		if (!onSave) return;
+		if (!trimmedName) {
+			setNameError('A name is required.');
+			return;
+		}
+		setNameError(null);
+		try {
+			await onSave({ name: trimmedName, description: trimmedDescription });
+			// Re-seed from what was submitted so the form returns to a clean
+			// (non-dirty) state even before the cache refetch lands.
+			setDraftName(trimmedName);
+			setDraftDescription(trimmedDescription);
+			setSaved({ name: trimmedName, description: trimmedDescription });
+		} catch {
+			// The caller surfaces the failure (toast / `error` prop); keep the
+			// draft so the user can retry.
+		}
+	}
+
+	return (
+		<DetailSection title="General" icon={<SlidersHorizontal className="h-4 w-4" />}>
+			{/* The immutable entity id — what API calls and audit rows reference. */}
+			<div className="flex flex-wrap items-center justify-between gap-2">
+				<span className="text-muted-foreground flex items-center gap-1.5 text-xs">
+					<Fingerprint className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+					{idLabel}
+				</span>
+				<span className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 font-mono text-xs">
+					{idValue}
+					<CopyButton value={idValue} size="icon" variant="ghost" />
+				</span>
+			</div>
+
+			{onSave ? (
+				<form
+					className="space-y-4 pt-2"
+					onSubmit={(e) => {
+						e.preventDefault();
+						void handleSave();
+					}}
+				>
+					<div className="space-y-1.5">
+						<Label htmlFor="identity-settings-name">Name</Label>
+						<Input
+							id="identity-settings-name"
+							value={draftName}
+							onChange={(e) => setDraftName(e.target.value)}
+							error={nameError ?? undefined}
+							maxLength={255}
+						/>
+					</div>
+					<div className="space-y-1.5">
+						<Label htmlFor="identity-settings-description">Description</Label>
+						<Textarea
+							id="identity-settings-description"
+							value={draftDescription}
+							onChange={(e) => setDraftDescription(e.target.value)}
+							placeholder={descriptionPlaceholder}
+							rows={3}
+							maxLength={1024}
+						/>
+					</div>
+					{error && <ErrorAlert message={error} />}
+					<div className="flex justify-end">
+						<Button
+							type="submit"
+							size="sm"
+							loading={saving}
+							disabled={!dirty || saving}
+						>
+							Save changes
+						</Button>
+					</div>
+				</form>
+			) : (
+				readOnlyNote && <p className="text-muted-foreground pt-1 text-sm">{readOnlyNote}</p>
+			)}
+		</DetailSection>
+	);
+}

--- a/ui/src/shared/ui/KillSwitch.tsx
+++ b/ui/src/shared/ui/KillSwitch.tsx
@@ -1,0 +1,151 @@
+/**
+ * KillSwitch — the console-standard suspend/restore toggle: a Power pill
+ * showing the entity's live state, with a two-step inline confirm (click to
+ * arm, click again to apply) so the destructive flip never fires on a single
+ * mis-click. Grown on the toolkit console; agent and service-account headers
+ * render the same control wired to their own lifecycle mutations.
+ *
+ * Purely presentational: the caller owns the mutation and passes `pending`
+ * back in, so the pill can show its spinner while the flip is in flight.
+ */
+import { useEffect, useId, useRef, useState } from 'react';
+import { motion } from 'framer-motion';
+import { Ban, Power, ShieldCheck } from 'lucide-react';
+import { Button } from '@/shared/ui/Button';
+import { cn } from '@/shared/lib/utils';
+
+export interface KillSwitchProps {
+	/** Current state — the pill mirrors it ("Active" vs the suspended label). */
+	active: boolean;
+	/** True while the caller's mutation is in flight (drives the spinner). */
+	pending?: boolean;
+	/** Apply the flip — called with the DESIRED state after inline confirm. */
+	onToggle: (nextActive: boolean) => void;
+	/** Pill text when active. */
+	activeLabel?: string;
+	/** Pill text when suspended (e.g. "Suspended", "Disabled"). */
+	inactiveLabel?: string;
+	/** Accessible name for the pill while active (e.g. "Suspend toolkit (kill switch)"). */
+	suspendAriaLabel: string;
+	/** Accessible name for the pill while suspended (e.g. "Restore toolkit access"). */
+	restoreAriaLabel: string;
+	/** Inline confirm question when suspending (e.g. "Block keys + agents?"). */
+	suspendPrompt: string;
+	/** Inline confirm question when restoring. */
+	restorePrompt?: string;
+	/** Confirm button label when suspending. */
+	suspendConfirmLabel?: string;
+	/** Confirm button label when restoring. */
+	restoreConfirmLabel?: string;
+	className?: string;
+	'data-testid'?: string;
+}
+
+export function KillSwitch({
+	active,
+	pending = false,
+	onToggle,
+	activeLabel = 'Active',
+	inactiveLabel = 'Suspended',
+	suspendAriaLabel,
+	restoreAriaLabel,
+	suspendPrompt,
+	restorePrompt = 'Restore access?',
+	suspendConfirmLabel = 'Kill',
+	restoreConfirmLabel = 'Restore',
+	className,
+	'data-testid': dataTestId,
+}: KillSwitchProps) {
+	const [confirming, setConfirming] = useState(false);
+	const confirmId = useId();
+	const confirmRef = useRef<HTMLButtonElement>(null);
+
+	useEffect(() => {
+		if (confirming) confirmRef.current?.focus();
+	}, [confirming]);
+
+	const apply = () => {
+		setConfirming(false);
+		onToggle(!active);
+	};
+
+	return (
+		<div className={cn('inline-flex items-center gap-2', className)} data-testid={dataTestId}>
+			<Button
+				variant="ghost"
+				loading={pending}
+				onClick={() => setConfirming((c) => !c)}
+				disabled={pending}
+				aria-pressed={active}
+				aria-expanded={confirming}
+				aria-controls={confirming ? confirmId : undefined}
+				aria-label={active ? suspendAriaLabel : restoreAriaLabel}
+				className={cn(
+					'group relative h-8 gap-2 rounded-full px-3 text-xs font-medium',
+					active
+						? 'bg-success/10 text-success border-success/30 hover:bg-success/20 border'
+						: 'bg-danger/10 text-danger border-danger/30 hover:bg-danger/20 border',
+				)}
+			>
+				{!pending && (
+					<motion.span whileHover={{ scale: 1.1 }} className="flex items-center">
+						{active ? (
+							<Power className="h-3.5 w-3.5" />
+						) : (
+							<Ban className="h-3.5 w-3.5" />
+						)}
+					</motion.span>
+				)}
+				<span>{active ? activeLabel : inactiveLabel}</span>
+			</Button>
+
+			{confirming && (
+				<motion.div
+					id={confirmId}
+					role="group"
+					aria-label={active ? suspendPrompt : restorePrompt}
+					initial={{ opacity: 0, x: -4 }}
+					animate={{ opacity: 1, x: 0 }}
+					transition={{ duration: 0.15 }}
+					className={cn(
+						'inline-flex items-center gap-2 rounded-full border px-3 py-1',
+						active ? 'border-danger/30 bg-danger/5' : 'border-success/30 bg-success/5',
+					)}
+				>
+					<span className="text-muted-foreground text-xs">
+						{active ? suspendPrompt : restorePrompt}
+					</span>
+					<Button
+						ref={confirmRef}
+						variant="ghost"
+						onClick={apply}
+						disabled={pending}
+						className={cn(
+							'gap-1 rounded-full px-2 py-0.5 text-xs font-semibold',
+							active
+								? 'bg-danger/15 text-danger hover:bg-danger/25'
+								: 'bg-success/15 text-success hover:bg-success/25',
+						)}
+					>
+						{active ? (
+							<>
+								<Ban className="h-3 w-3" /> {suspendConfirmLabel}
+							</>
+						) : (
+							<>
+								<ShieldCheck className="h-3 w-3" /> {restoreConfirmLabel}
+							</>
+						)}
+					</Button>
+					<Button
+						variant="ghost"
+						onClick={() => setConfirming(false)}
+						className="text-muted-foreground hover:text-foreground px-1 py-0 text-xs"
+					>
+						Cancel
+					</Button>
+				</motion.div>
+			)}
+		</div>
+	);
+}

--- a/ui/src/shared/ui/KillSwitch.tsx
+++ b/ui/src/shared/ui/KillSwitch.tsx
@@ -59,19 +59,36 @@ export function KillSwitch({
 	const [confirming, setConfirming] = useState(false);
 	const confirmId = useId();
 	const confirmRef = useRef<HTMLButtonElement>(null);
+	const pillRef = useRef<HTMLButtonElement>(null);
 
 	useEffect(() => {
 		if (confirming) confirmRef.current?.focus();
 	}, [confirming]);
 
-	const apply = () => {
+	/** Close the confirm group and hand focus back to the pill. */
+	const dismiss = () => {
 		setConfirming(false);
+		pillRef.current?.focus();
+	};
+
+	const apply = () => {
+		dismiss();
 		onToggle(!active);
 	};
 
 	return (
-		<div className={cn('inline-flex items-center gap-2', className)} data-testid={dataTestId}>
+		<div
+			className={cn('inline-flex items-center gap-2', className)}
+			data-testid={dataTestId}
+			onKeyDown={(e) => {
+				if (confirming && e.key === 'Escape') {
+					e.stopPropagation();
+					dismiss();
+				}
+			}}
+		>
 			<Button
+				ref={pillRef}
 				variant="ghost"
 				loading={pending}
 				onClick={() => setConfirming((c) => !c)}
@@ -139,7 +156,7 @@ export function KillSwitch({
 					</Button>
 					<Button
 						variant="ghost"
-						onClick={() => setConfirming(false)}
+						onClick={dismiss}
 						className="text-muted-foreground hover:text-foreground px-1 py-0 text-xs"
 					>
 						Cancel

--- a/ui/src/shared/ui/RecentExecutionsCard.tsx
+++ b/ui/src/shared/ui/RecentExecutionsCard.tsx
@@ -1,0 +1,158 @@
+/**
+ * RecentExecutionsCard — the console-standard "Recent executions" feed used
+ * by toolkit, agent, and service-account detail pages. One visual grammar
+ * (grown on the toolkit console): a status-dot row with the mono operation
+ * label, inline HTTP status, optional error line, optional attribution slot,
+ * duration, and relative time — ending in a pre-filtered "Open Monitor"
+ * deep-link. Monitor owns the full history (paging, filters, trace sheets);
+ * this card is deliberately a shallow feed.
+ */
+import type { ReactNode } from 'react';
+import { Activity, ListOrdered } from 'lucide-react';
+import { AppLink } from '@/shared/ui/AppLink';
+import { DetailSection, EmptyRow } from '@/shared/ui/DetailSection';
+import { formatTimestamp, timeAgo } from '@/shared/lib/utils';
+
+export interface RecentExecutionItem {
+	id: string;
+	/** Execution lifecycle status (completed/failed/running/cancelled). */
+	status: string;
+	/** HTTP status of the upstream call, shown inline after the label. */
+	httpStatus?: number | null;
+	/** Mono operation label (e.g. `github.create_issue`). */
+	label: string;
+	/** Error detail rendered under the label for failures/denials. */
+	error?: string | null;
+	/** Optional attribution slot (e.g. an `ActorLabel` on the toolkit page). */
+	meta?: ReactNode;
+	durationMs: number | null;
+	/** ISO string, epoch seconds, or epoch ms (shared `timeAgo` rules). */
+	startedAt: string | number;
+}
+
+export interface RecentExecutionsCardProps {
+	items: RecentExecutionItem[];
+	/** Pre-filtered Monitor deep-link for the header. */
+	monitorHref: string;
+	isLoading?: boolean;
+	emptyMessage?: string;
+	/**
+	 * Render the "there's more" footnote (e.g. when the API reports another
+	 * page) — links back into Monitor for the full history.
+	 */
+	hasMore?: boolean;
+}
+
+/** "412ms" / "1.2s", or an em-dash for executions without a duration. */
+function formatDuration(ms: number | null): string {
+	if (ms == null) return '—';
+	if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+	return `${Math.round(ms)}ms`;
+}
+
+/**
+ * Execution lifecycle → dot colour, aligned with Monitor's vocabulary
+ * (running/completed/failed/cancelled — see `ExecutionStatusPill`). Unknown
+ * wire values fall through to the neutral dot rather than leaking a colour.
+ */
+const STATUS_DOT_CLASS: Record<string, string> = {
+	completed: 'bg-success',
+	failed: 'bg-danger',
+	running: 'bg-accent-blue',
+	cancelled: 'bg-warning',
+};
+
+function ExecutionRow({ item }: { item: RecentExecutionItem }) {
+	const dotClass = STATUS_DOT_CLASS[item.status] ?? 'bg-muted-foreground';
+	const failed = item.status === 'failed';
+	return (
+		<div
+			data-testid="execution-feed-row"
+			className="bg-muted/30 border-border/60 flex flex-wrap items-center gap-3 rounded-lg border px-4 py-2.5"
+		>
+			<span
+				className={`h-2 w-2 shrink-0 rounded-full ${dotClass}`}
+				aria-hidden="true"
+				title={item.status}
+			/>
+			{/* The dot alone is invisible to AT — carry the status as text too. */}
+			<span className="sr-only">{item.status}</span>
+			<div className="min-w-0 flex-1 basis-48">
+				<p className="text-foreground truncate font-mono text-xs">
+					{item.label}
+					{item.httpStatus != null && (
+						<span
+							className={failed ? 'text-danger ml-2' : 'text-muted-foreground ml-2'}
+						>
+							{item.httpStatus}
+						</span>
+					)}
+				</p>
+				{item.error && <p className="text-danger mt-0.5 truncate text-xs">{item.error}</p>}
+			</div>
+			{item.meta != null && (
+				<span className="text-muted-foreground shrink-0 text-xs">{item.meta}</span>
+			)}
+			<span className="text-muted-foreground w-14 shrink-0 text-right font-mono text-xs">
+				{formatDuration(item.durationMs)}
+			</span>
+			<span
+				className="text-muted-foreground w-20 shrink-0 text-right text-xs"
+				title={
+					typeof item.startedAt === 'string' ? formatTimestamp(item.startedAt) : undefined
+				}
+			>
+				{timeAgo(item.startedAt)}
+			</span>
+		</div>
+	);
+}
+
+export function RecentExecutionsCard({
+	items,
+	monitorHref,
+	isLoading = false,
+	emptyMessage = 'No recent executions.',
+	hasMore = false,
+}: RecentExecutionsCardProps) {
+	return (
+		<DetailSection
+			title="Recent executions"
+			icon={<ListOrdered className="h-4 w-4" />}
+			trailing={
+				<AppLink
+					href={monitorHref}
+					className="text-primary inline-flex items-center gap-1 text-xs font-medium"
+				>
+					{/* In-app route — the Activity glyph; ExternalLink is reserved
+					    for real external targets. */}
+					Open Monitor <Activity className="h-3 w-3" aria-hidden="true" />
+				</AppLink>
+			}
+		>
+			{isLoading ? (
+				<div className="space-y-2" aria-hidden="true">
+					<div className="bg-muted h-10 animate-pulse rounded-lg" />
+					<div className="bg-muted h-10 animate-pulse rounded-lg" />
+				</div>
+			) : items.length === 0 ? (
+				<EmptyRow icon={<Activity />}>{emptyMessage}</EmptyRow>
+			) : (
+				<>
+					{items.map((item) => (
+						<ExecutionRow key={item.id} item={item} />
+					))}
+					{hasMore && (
+						<p className="text-muted-foreground pt-1 text-xs">
+							Showing the {items.length} most recent —{' '}
+							<AppLink href={monitorHref} className="text-primary font-medium">
+								see the full history in Monitor
+							</AppLink>
+							.
+						</p>
+					)}
+				</>
+			)}
+		</DetailSection>
+	);
+}

--- a/ui/src/shared/ui/RecentExecutionsCard.tsx
+++ b/ui/src/shared/ui/RecentExecutionsCard.tsx
@@ -13,6 +13,14 @@ import { AppLink } from '@/shared/ui/AppLink';
 import { DetailSection, EmptyRow } from '@/shared/ui/DetailSection';
 import { formatTimestamp, timeAgo } from '@/shared/lib/utils';
 
+/** Absolute-time tooltip for either wire shape (ISO string or epoch number). */
+function absoluteTime(value: string | number): string {
+	if (typeof value === 'string') return formatTimestamp(value);
+	// Same 10-digit heuristic as the shared `timeAgo`: seconds vs milliseconds.
+	const ms = value < 1e12 ? value * 1000 : value;
+	return formatTimestamp(new Date(ms).toISOString());
+}
+
 export interface RecentExecutionItem {
 	id: string;
 	/** Execution lifecycle status (completed/failed/running/cancelled). */
@@ -98,9 +106,7 @@ function ExecutionRow({ item }: { item: RecentExecutionItem }) {
 			</span>
 			<span
 				className="text-muted-foreground w-20 shrink-0 text-right text-xs"
-				title={
-					typeof item.startedAt === 'string' ? formatTimestamp(item.startedAt) : undefined
-				}
+				title={absoluteTime(item.startedAt)}
 			>
 				{timeAgo(item.startedAt)}
 			</span>

--- a/ui/src/shared/ui/__tests__/AuditTrailCard.test.tsx
+++ b/ui/src/shared/ui/__tests__/AuditTrailCard.test.tsx
@@ -46,13 +46,24 @@ describe('AuditTrailCard', () => {
 	it('shows the error state instead of rows', () => {
 		renderWithProviders(
 			<AuditTrailCard
-				entries={[]}
+				entries={entries}
 				isError
 				errorMessage="Failed to load the audit log."
 				emptyMessage="Nothing recorded yet."
 			/>,
 		);
 		expect(screen.getByText('Failed to load the audit log.')).toBeInTheDocument();
+		expect(screen.queryByText('Nothing recorded yet.')).not.toBeInTheDocument();
+		// Stale cache entries must not render behind the error alert.
+		expect(screen.queryByText('agent.approve')).not.toBeInTheDocument();
+	});
+
+	it('suppresses rows and the empty state while loading', () => {
+		renderWithProviders(
+			<AuditTrailCard entries={entries} isLoading emptyMessage="Nothing recorded yet." />,
+		);
+		expect(screen.getByText('Recent changes')).toBeInTheDocument();
+		expect(screen.queryByText('agent.approve')).not.toBeInTheDocument();
 		expect(screen.queryByText('Nothing recorded yet.')).not.toBeInTheDocument();
 	});
 

--- a/ui/src/shared/ui/__tests__/AuditTrailCard.test.tsx
+++ b/ui/src/shared/ui/__tests__/AuditTrailCard.test.tsx
@@ -1,0 +1,65 @@
+import { renderWithProviders, screen, checkA11y } from '@/__tests__/test-utils';
+import { AuditTrailCard, type AuditTrailEntry } from '@/shared/ui/AuditTrailCard';
+
+const entries: AuditTrailEntry[] = [
+	{
+		id: 'a1',
+		action: 'agent.approve',
+		actorId: 'user_1',
+		actorType: 'user',
+		occurredAt: new Date(Date.now() - 60_000).toISOString(),
+	},
+	{
+		id: 'a2',
+		action: 'toolkit.suspend',
+		actorId: null,
+		actorType: null,
+		reason: 'incident response',
+		occurredAt: new Date(Date.now() - 3_600_000).toISOString(),
+	},
+];
+
+describe('AuditTrailCard', () => {
+	it('renders the "Recent changes" heading, caption, and entry rows', () => {
+		renderWithProviders(
+			<AuditTrailCard
+				entries={entries}
+				caption="Lifecycle events · admin only"
+				emptyMessage="No recorded changes."
+			/>,
+		);
+		expect(screen.getByText('Recent changes')).toBeInTheDocument();
+		expect(screen.getByText('Lifecycle events · admin only')).toBeInTheDocument();
+		expect(screen.getByText('agent.approve')).toBeInTheDocument();
+		expect(screen.getByText('toolkit.suspend')).toBeInTheDocument();
+		// Reason surfaces after the (system) actor; system fallback shown when
+		// there is no actor id.
+		expect(screen.getByText(/incident response/)).toBeInTheDocument();
+		expect(screen.getByText(/system/)).toBeInTheDocument();
+	});
+
+	it('shows the dashed empty state when there are no entries', () => {
+		renderWithProviders(<AuditTrailCard entries={[]} emptyMessage="Nothing recorded yet." />);
+		expect(screen.getByText('Nothing recorded yet.')).toBeInTheDocument();
+	});
+
+	it('shows the error state instead of rows', () => {
+		renderWithProviders(
+			<AuditTrailCard
+				entries={[]}
+				isError
+				errorMessage="Failed to load the audit log."
+				emptyMessage="Nothing recorded yet."
+			/>,
+		);
+		expect(screen.getByText('Failed to load the audit log.')).toBeInTheDocument();
+		expect(screen.queryByText('Nothing recorded yet.')).not.toBeInTheDocument();
+	});
+
+	it('is accessible', async () => {
+		const { container } = renderWithProviders(
+			<AuditTrailCard entries={entries} emptyMessage="No recorded changes." />,
+		);
+		await checkA11y(container);
+	});
+});

--- a/ui/src/shared/ui/__tests__/DangerZone.test.tsx
+++ b/ui/src/shared/ui/__tests__/DangerZone.test.tsx
@@ -1,0 +1,53 @@
+import { renderWithProviders, screen, checkA11y } from '@/__tests__/test-utils';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { DangerZone, type DangerZoneAction } from '@/shared/ui/DangerZone';
+
+const actions: DangerZoneAction[] = [
+	{
+		key: 'disable',
+		title: 'Disable agent',
+		description: 'Reversible — you can re-enable it later.',
+		buttonLabel: 'Disable',
+		ariaLabel: 'Disable support-agent',
+		emphasis: 'outline',
+	},
+	{
+		key: 'archive',
+		title: 'Archive agent',
+		description: 'This cannot be undone.',
+		buttonLabel: 'Archive',
+		ariaLabel: 'Archive support-agent',
+	},
+];
+
+describe('DangerZone', () => {
+	it('renders one row per action and hands the key back on click', async () => {
+		const user = userEvent.setup();
+		const onAction = vi.fn();
+		renderWithProviders(<DangerZone actions={actions} onAction={onAction} />);
+		expect(screen.getByText('Danger zone')).toBeInTheDocument();
+		expect(screen.getByText('Disable agent')).toBeInTheDocument();
+		expect(screen.getByText('Archive agent')).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Archive support-agent' }));
+		expect(onAction).toHaveBeenCalledWith('archive');
+	});
+
+	it('disables every button while a mutation is pending', () => {
+		renderWithProviders(<DangerZone actions={actions} pending onAction={() => {}} />);
+		expect(screen.getByRole('button', { name: 'Disable support-agent' })).toBeDisabled();
+		expect(screen.getByRole('button', { name: 'Archive support-agent' })).toBeDisabled();
+	});
+
+	it('renders nothing when no destructive verb applies', () => {
+		const { container } = renderWithProviders(<DangerZone actions={[]} onAction={() => {}} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it('is accessible', async () => {
+		const { container } = renderWithProviders(
+			<DangerZone actions={actions} onAction={() => {}} />,
+		);
+		await checkA11y(container);
+	});
+});

--- a/ui/src/shared/ui/__tests__/DetailSection.test.tsx
+++ b/ui/src/shared/ui/__tests__/DetailSection.test.tsx
@@ -1,0 +1,51 @@
+import { renderWithProviders, screen, checkA11y } from '@/__tests__/test-utils';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { Shield } from 'lucide-react';
+import { DetailSection, EmptyRow } from '@/shared/ui/DetailSection';
+
+describe('DetailSection', () => {
+	it('renders the heading, icon medallion, and children', () => {
+		renderWithProviders(
+			<DetailSection title="Bound toolkits" icon={<Shield className="h-4 w-4" />}>
+				<p>body</p>
+			</DetailSection>,
+		);
+		expect(screen.getByText('Bound toolkits')).toBeInTheDocument();
+		expect(screen.getByText('body')).toBeInTheDocument();
+	});
+
+	it('wires the header action button', async () => {
+		const user = userEvent.setup();
+		const onClick = vi.fn();
+		renderWithProviders(
+			<DetailSection
+				title="Keys"
+				action={{ label: 'New key', onClick, ariaLabel: 'Create a new key' }}
+			>
+				<p>body</p>
+			</DetailSection>,
+		);
+		await user.click(screen.getByRole('button', { name: 'Create a new key' }));
+		expect(onClick).toHaveBeenCalledOnce();
+	});
+
+	it('renders trailing content when a button does not fit', () => {
+		renderWithProviders(
+			<DetailSection title="Recent" trailing={<a href="/monitor">Open Monitor</a>}>
+				<p>body</p>
+			</DetailSection>,
+		);
+		expect(screen.getByRole('link', { name: 'Open Monitor' })).toBeInTheDocument();
+	});
+
+	it('is accessible (with an EmptyRow body)', async () => {
+		const { container } = renderWithProviders(
+			<DetailSection title="Scopes" icon={<Shield className="h-4 w-4" />}>
+				<EmptyRow icon={<Shield />}>No scopes granted.</EmptyRow>
+			</DetailSection>,
+		);
+		expect(screen.getByText('No scopes granted.')).toBeInTheDocument();
+		await checkA11y(container);
+	});
+});

--- a/ui/src/shared/ui/__tests__/ExecutionVolumeCharts.test.tsx
+++ b/ui/src/shared/ui/__tests__/ExecutionVolumeCharts.test.tsx
@@ -1,0 +1,80 @@
+import { renderWithProviders, screen, checkA11y } from '@/__tests__/test-utils';
+import { ExecutionVolumeCharts, type UsageChartBucket } from '@/shared/ui/ExecutionVolumeCharts';
+
+const DAY = 86_400;
+const BASE_TS = 1_700_000_000;
+
+function bucket(i: number, success: number, failed: number): UsageChartBucket {
+	return { ts: BASE_TS + i * DAY, total: success + failed, success, failed };
+}
+
+const BUCKETS = [bucket(0, 60, 4), bucket(1, 80, 8), bucket(2, 70, 1)];
+
+describe('ExecutionVolumeCharts', () => {
+	it('renders the stacked volume chart and the call trend side by side', () => {
+		renderWithProviders(<ExecutionVolumeCharts buckets={BUCKETS} bucketSeconds={DAY} />);
+
+		expect(screen.getByText('Execution volume · 7d')).toBeInTheDocument();
+		expect(screen.getByText('Call trend · 7d')).toBeInTheDocument();
+
+		// Volume chart summarises totals from the buckets (223 total, 13 failed).
+		expect(
+			screen.getByRole('img', {
+				name: 'Execution volume over the last 7d: 223 total, 13 failed.',
+			}),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('img', { name: /total calls per bucket over the last 7d/i }),
+		).toBeInTheDocument();
+
+		// Legend for the stacked segments.
+		expect(screen.getByText('Succeeded')).toBeInTheDocument();
+		expect(screen.getByText('Failed')).toBeInTheDocument();
+	});
+
+	it('respects a custom window label', () => {
+		renderWithProviders(
+			<ExecutionVolumeCharts buckets={BUCKETS} bucketSeconds={DAY} windowLabel="24h" />,
+		);
+		expect(screen.getByText('Execution volume · 24h')).toBeInTheDocument();
+		expect(screen.getByText('Call trend · 24h')).toBeInTheDocument();
+	});
+
+	it('collapses to a single empty panel when there are no buckets', () => {
+		renderWithProviders(
+			<ExecutionVolumeCharts
+				buckets={[]}
+				bucketSeconds={DAY}
+				emptyMessage="No executions yet."
+			/>,
+		);
+		expect(screen.getByText('No executions yet.')).toBeInTheDocument();
+		expect(screen.queryByText('Call trend · 7d')).not.toBeInTheDocument();
+		expect(screen.queryByRole('img')).not.toBeInTheDocument();
+	});
+
+	it('shows a quiet note instead of a trend line with fewer than two buckets', () => {
+		renderWithProviders(
+			<ExecutionVolumeCharts buckets={[bucket(0, 10, 2)]} bucketSeconds={DAY} />,
+		);
+		// The stacked chart still renders a single column…
+		expect(
+			screen.getByRole('img', { name: /execution volume over the last 7d/i }),
+		).toBeInTheDocument();
+		// …but a one-point trend line would be meaningless.
+		expect(screen.getByText('Not enough data for a trend yet.')).toBeInTheDocument();
+	});
+
+	it('renders skeletons while loading', () => {
+		renderWithProviders(<ExecutionVolumeCharts buckets={[]} bucketSeconds={DAY} isLoading />);
+		expect(screen.getByText('Execution volume · 7d')).toBeInTheDocument();
+		expect(screen.queryByRole('img')).not.toBeInTheDocument();
+	});
+
+	it('is accessible', async () => {
+		const { container } = renderWithProviders(
+			<ExecutionVolumeCharts buckets={BUCKETS} bucketSeconds={DAY} />,
+		);
+		await checkA11y(container);
+	});
+});

--- a/ui/src/shared/ui/__tests__/ExecutionVolumeCharts.test.tsx
+++ b/ui/src/shared/ui/__tests__/ExecutionVolumeCharts.test.tsx
@@ -15,7 +15,7 @@ describe('ExecutionVolumeCharts', () => {
 		renderWithProviders(<ExecutionVolumeCharts buckets={BUCKETS} bucketSeconds={DAY} />);
 
 		expect(screen.getByText('Execution volume · 7d')).toBeInTheDocument();
-		expect(screen.getByText('Call trend · 7d')).toBeInTheDocument();
+		expect(screen.getByText('Success rate · 7d')).toBeInTheDocument();
 
 		// Volume chart summarises totals from the buckets (223 total, 13 failed).
 		expect(
@@ -24,7 +24,7 @@ describe('ExecutionVolumeCharts', () => {
 			}),
 		).toBeInTheDocument();
 		expect(
-			screen.getByRole('img', { name: /total calls per bucket over the last 7d/i }),
+			screen.getByRole('img', { name: /success rate per bucket over the last 7d/i }),
 		).toBeInTheDocument();
 
 		// Legend for the stacked segments.
@@ -37,7 +37,7 @@ describe('ExecutionVolumeCharts', () => {
 			<ExecutionVolumeCharts buckets={BUCKETS} bucketSeconds={DAY} windowLabel="24h" />,
 		);
 		expect(screen.getByText('Execution volume · 24h')).toBeInTheDocument();
-		expect(screen.getByText('Call trend · 24h')).toBeInTheDocument();
+		expect(screen.getByText('Success rate · 24h')).toBeInTheDocument();
 	});
 
 	it('collapses to a single empty panel when there are no buckets', () => {
@@ -49,7 +49,7 @@ describe('ExecutionVolumeCharts', () => {
 			/>,
 		);
 		expect(screen.getByText('No executions yet.')).toBeInTheDocument();
-		expect(screen.queryByText('Call trend · 7d')).not.toBeInTheDocument();
+		expect(screen.queryByText('Success rate · 7d')).not.toBeInTheDocument();
 		expect(screen.queryByRole('img')).not.toBeInTheDocument();
 	});
 

--- a/ui/src/shared/ui/__tests__/IdentitySettingsCard.test.tsx
+++ b/ui/src/shared/ui/__tests__/IdentitySettingsCard.test.tsx
@@ -78,6 +78,47 @@ describe('IdentitySettingsCard', () => {
 		expect(screen.getByRole('button', { name: 'Save changes' })).toBeEnabled();
 	});
 
+	it('absorbs late-arriving props while clean but never clobbers a dirty draft', async () => {
+		const user = userEvent.setup();
+		const { rerender } = renderWithProviders(
+			<IdentitySettingsCard
+				idLabel="Agent ID"
+				idValue="agent_1"
+				name=""
+				description={null}
+				onSave={vi.fn()}
+			/>,
+		);
+
+		// Late fetch resolves for the SAME entity: a clean form re-seeds.
+		rerender(
+			<IdentitySettingsCard
+				idLabel="Agent ID"
+				idValue="agent_1"
+				name="support-agent"
+				description="Answers tickets"
+				onSave={vi.fn()}
+			/>,
+		);
+		expect(screen.getByLabelText('Name')).toHaveValue('support-agent');
+		expect(screen.getByLabelText('Description')).toHaveValue('Answers tickets');
+		expect(screen.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+
+		// Once the user edits, a background refetch must not clobber the draft.
+		await user.clear(screen.getByLabelText('Name'));
+		await user.type(screen.getByLabelText('Name'), 'renamed-agent');
+		rerender(
+			<IdentitySettingsCard
+				idLabel="Agent ID"
+				idValue="agent_1"
+				name="support-agent-v2"
+				description="Answers tickets"
+				onSave={vi.fn()}
+			/>,
+		);
+		expect(screen.getByLabelText('Name')).toHaveValue('renamed-agent');
+	});
+
 	it('renders read-only (id + note, no form) when there is no update endpoint', () => {
 		renderWithProviders(
 			<IdentitySettingsCard

--- a/ui/src/shared/ui/__tests__/IdentitySettingsCard.test.tsx
+++ b/ui/src/shared/ui/__tests__/IdentitySettingsCard.test.tsx
@@ -1,0 +1,108 @@
+import { renderWithProviders, screen, checkA11y } from '@/__tests__/test-utils';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { IdentitySettingsCard } from '@/shared/ui/IdentitySettingsCard';
+
+describe('IdentitySettingsCard', () => {
+	it('renders the immutable id row and seeds the form from props', () => {
+		renderWithProviders(
+			<IdentitySettingsCard
+				idLabel="Agent ID"
+				idValue="agent_1"
+				name="support-agent"
+				description="Answers tickets"
+				onSave={vi.fn()}
+			/>,
+		);
+		expect(screen.getByText('Agent ID')).toBeInTheDocument();
+		expect(screen.getByText('agent_1')).toBeInTheDocument();
+		expect(screen.getByLabelText('Name')).toHaveValue('support-agent');
+		expect(screen.getByLabelText('Description')).toHaveValue('Answers tickets');
+	});
+
+	it('keeps Save disabled until something changed, then submits the draft', async () => {
+		const user = userEvent.setup();
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		renderWithProviders(
+			<IdentitySettingsCard
+				idLabel="Toolkit ID"
+				idValue="tk_1"
+				name="stripe"
+				description={null}
+				onSave={onSave}
+			/>,
+		);
+		const save = screen.getByRole('button', { name: 'Save changes' });
+		expect(save).toBeDisabled();
+		await user.type(screen.getByLabelText('Description'), 'Payments toolkit');
+		expect(save).toBeEnabled();
+		await user.click(save);
+		expect(onSave).toHaveBeenCalledWith({ name: 'stripe', description: 'Payments toolkit' });
+		// After a successful save the drafts re-seed and the form reads clean.
+		expect(screen.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+	});
+
+	it('requires a name and surfaces the inline error instead of saving', async () => {
+		const user = userEvent.setup();
+		const onSave = vi.fn();
+		renderWithProviders(
+			<IdentitySettingsCard
+				idLabel="Agent ID"
+				idValue="agent_1"
+				name="support-agent"
+				description={null}
+				onSave={onSave}
+			/>,
+		);
+		await user.clear(screen.getByLabelText('Name'));
+		await user.click(screen.getByRole('button', { name: 'Save changes' }));
+		expect(screen.getByText('A name is required.')).toBeInTheDocument();
+		expect(onSave).not.toHaveBeenCalled();
+	});
+
+	it('keeps the draft when the save rejects (retryable)', async () => {
+		const user = userEvent.setup();
+		const onSave = vi.fn().mockRejectedValue(new Error('boom'));
+		renderWithProviders(
+			<IdentitySettingsCard
+				idLabel="Agent ID"
+				idValue="agent_1"
+				name="support-agent"
+				description={null}
+				onSave={onSave}
+			/>,
+		);
+		await user.type(screen.getByLabelText('Name'), '-2');
+		await user.click(screen.getByRole('button', { name: 'Save changes' }));
+		expect(screen.getByLabelText('Name')).toHaveValue('support-agent-2');
+		expect(screen.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+	});
+
+	it('renders read-only (id + note, no form) when there is no update endpoint', () => {
+		renderWithProviders(
+			<IdentitySettingsCard
+				idLabel="Account ID"
+				idValue="sa_1"
+				name="ci-bot"
+				description={null}
+				readOnlyNote="Renaming isn’t supported yet."
+			/>,
+		);
+		expect(screen.getByText('Renaming isn’t supported yet.')).toBeInTheDocument();
+		expect(screen.queryByLabelText('Name')).not.toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Save changes' })).not.toBeInTheDocument();
+	});
+
+	it('is accessible', async () => {
+		const { container } = renderWithProviders(
+			<IdentitySettingsCard
+				idLabel="Agent ID"
+				idValue="agent_1"
+				name="support-agent"
+				description="Answers tickets"
+				onSave={vi.fn()}
+			/>,
+		);
+		await checkA11y(container);
+	});
+});

--- a/ui/src/shared/ui/__tests__/KillSwitch.test.tsx
+++ b/ui/src/shared/ui/__tests__/KillSwitch.test.tsx
@@ -1,0 +1,82 @@
+import { renderWithProviders, screen, checkA11y } from '@/__tests__/test-utils';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { KillSwitch } from '@/shared/ui/KillSwitch';
+
+const BASE_PROPS = {
+	suspendAriaLabel: 'Suspend toolkit (kill switch)',
+	restoreAriaLabel: 'Restore toolkit access',
+	suspendPrompt: 'Block keys + agents?',
+	restorePrompt: 'Restore access?',
+};
+
+describe('KillSwitch', () => {
+	it('arms an inline confirm and only toggles after the confirm click', async () => {
+		const user = userEvent.setup();
+		const onToggle = vi.fn();
+		renderWithProviders(<KillSwitch active onToggle={onToggle} {...BASE_PROPS} />);
+
+		const pill = screen.getByRole('button', { name: 'Suspend toolkit (kill switch)' });
+		expect(pill).toHaveTextContent('Active');
+		expect(pill).toHaveAttribute('aria-pressed', 'true');
+
+		await user.click(pill);
+		expect(onToggle).not.toHaveBeenCalled();
+		expect(screen.getByText('Block keys + agents?')).toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: /Kill/ }));
+		expect(onToggle).toHaveBeenCalledExactlyOnceWith(false);
+		// Confirm group closes after applying.
+		expect(screen.queryByText('Block keys + agents?')).not.toBeInTheDocument();
+	});
+
+	it('offers the restore flow when suspended', async () => {
+		const user = userEvent.setup();
+		const onToggle = vi.fn();
+		renderWithProviders(
+			<KillSwitch
+				active={false}
+				onToggle={onToggle}
+				inactiveLabel="Disabled"
+				{...BASE_PROPS}
+			/>,
+		);
+
+		const pill = screen.getByRole('button', { name: 'Restore toolkit access' });
+		expect(pill).toHaveTextContent('Disabled');
+		expect(pill).toHaveAttribute('aria-pressed', 'false');
+
+		await user.click(pill);
+		expect(screen.getByText('Restore access?')).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Restore' }));
+		expect(onToggle).toHaveBeenCalledExactlyOnceWith(true);
+	});
+
+	it('cancels without toggling', async () => {
+		const user = userEvent.setup();
+		const onToggle = vi.fn();
+		renderWithProviders(<KillSwitch active onToggle={onToggle} {...BASE_PROPS} />);
+
+		await user.click(screen.getByRole('button', { name: 'Suspend toolkit (kill switch)' }));
+		await user.click(screen.getByRole('button', { name: 'Cancel' }));
+		expect(onToggle).not.toHaveBeenCalled();
+		expect(screen.queryByText('Block keys + agents?')).not.toBeInTheDocument();
+	});
+
+	it('disables the pill while the mutation is pending', () => {
+		renderWithProviders(<KillSwitch active pending onToggle={vi.fn()} {...BASE_PROPS} />);
+		expect(
+			screen.getByRole('button', { name: 'Suspend toolkit (kill switch)' }),
+		).toBeDisabled();
+	});
+
+	it('is accessible with the confirm group open', async () => {
+		const user = userEvent.setup();
+		const { container } = renderWithProviders(
+			<KillSwitch active onToggle={vi.fn()} {...BASE_PROPS} />,
+		);
+		await user.click(screen.getByRole('button', { name: 'Suspend toolkit (kill switch)' }));
+		expect(screen.getByRole('group', { name: 'Block keys + agents?' })).toBeInTheDocument();
+		await checkA11y(container);
+	});
+});

--- a/ui/src/shared/ui/__tests__/KillSwitch.test.tsx
+++ b/ui/src/shared/ui/__tests__/KillSwitch.test.tsx
@@ -61,6 +61,21 @@ describe('KillSwitch', () => {
 		await user.click(screen.getByRole('button', { name: 'Cancel' }));
 		expect(onToggle).not.toHaveBeenCalled();
 		expect(screen.queryByText('Block keys + agents?')).not.toBeInTheDocument();
+		// Focus returns to the pill so keyboard users aren't dropped to <body>.
+		expect(screen.getByRole('button', { name: 'Suspend toolkit (kill switch)' })).toHaveFocus();
+	});
+
+	it('dismisses the armed confirm with Escape', async () => {
+		const user = userEvent.setup();
+		const onToggle = vi.fn();
+		renderWithProviders(<KillSwitch active onToggle={onToggle} {...BASE_PROPS} />);
+
+		await user.click(screen.getByRole('button', { name: 'Suspend toolkit (kill switch)' }));
+		expect(screen.getByText('Block keys + agents?')).toBeInTheDocument();
+		await user.keyboard('{Escape}');
+		expect(onToggle).not.toHaveBeenCalled();
+		expect(screen.queryByText('Block keys + agents?')).not.toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Suspend toolkit (kill switch)' })).toHaveFocus();
 	});
 
 	it('disables the pill while the mutation is pending', () => {

--- a/ui/src/shared/ui/__tests__/RecentExecutionsCard.test.tsx
+++ b/ui/src/shared/ui/__tests__/RecentExecutionsCard.test.tsx
@@ -1,0 +1,92 @@
+import { renderWithProviders, screen, checkA11y } from '@/__tests__/test-utils';
+import { RecentExecutionsCard, type RecentExecutionItem } from '@/shared/ui/RecentExecutionsCard';
+
+const ITEMS: RecentExecutionItem[] = [
+	{
+		id: 'exec_1',
+		status: 'completed',
+		httpStatus: 201,
+		label: 'github.create_issue',
+		durationMs: 310,
+		startedAt: new Date(Date.now() - 4 * 60_000).toISOString(),
+	},
+	{
+		id: 'exec_2',
+		status: 'failed',
+		httpStatus: 403,
+		label: 'github.delete_repo',
+		error: 'Denied by permission rule (deny /admin/*).',
+		durationMs: 22,
+		startedAt: new Date(Date.now() - 18 * 60_000).toISOString(),
+	},
+	{
+		id: 'exec_3',
+		status: 'running',
+		label: 'slack.post_message',
+		durationMs: null,
+		startedAt: new Date(Date.now() - 30_000).toISOString(),
+	},
+];
+
+describe('RecentExecutionsCard', () => {
+	it('renders one row per execution with label, HTTP status, error, and duration', () => {
+		renderWithProviders(<RecentExecutionsCard items={ITEMS} monitorHref="/monitor" />);
+
+		expect(screen.getAllByTestId('execution-feed-row')).toHaveLength(3);
+		expect(screen.getByText('github.create_issue')).toBeInTheDocument();
+		expect(screen.getByText('201')).toBeInTheDocument();
+		expect(screen.getByText('403')).toBeInTheDocument();
+		expect(screen.getByText(/denied by permission rule/i)).toBeInTheDocument();
+		expect(screen.getByText('310ms')).toBeInTheDocument();
+		// No duration yet → em-dash placeholder.
+		expect(screen.getByText('—')).toBeInTheDocument();
+		// Lifecycle status is carried as text for AT, not just the dot colour.
+		expect(screen.getByText('running')).toBeInTheDocument();
+	});
+
+	it('links into Monitor from the header and the has-more footnote', () => {
+		renderWithProviders(
+			<RecentExecutionsCard items={ITEMS} monitorHref="/monitor?actor_id=a1" hasMore />,
+		);
+		const header = screen.getByRole('link', { name: /open monitor/i });
+		expect(header).toHaveAttribute('href', '/monitor?actor_id=a1');
+		expect(screen.getByText(/showing the 3 most recent/i)).toBeInTheDocument();
+		expect(
+			screen.getByRole('link', { name: /see the full history in monitor/i }),
+		).toHaveAttribute('href', '/monitor?actor_id=a1');
+	});
+
+	it('renders the optional attribution slot', () => {
+		renderWithProviders(
+			<RecentExecutionsCard
+				items={[{ ...ITEMS[0]!, meta: <span>support-agent</span> }]}
+				monitorHref="/monitor"
+			/>,
+		);
+		expect(screen.getByText('support-agent')).toBeInTheDocument();
+	});
+
+	it('shows the empty state and loading skeletons', () => {
+		const { rerender } = renderWithProviders(
+			<RecentExecutionsCard
+				items={[]}
+				monitorHref="/monitor"
+				emptyMessage="No recent executions for this toolkit."
+			/>,
+		);
+		expect(screen.getByText('No recent executions for this toolkit.')).toBeInTheDocument();
+
+		rerender(<RecentExecutionsCard items={[]} monitorHref="/monitor" isLoading />);
+		expect(
+			screen.queryByText('No recent executions for this toolkit.'),
+		).not.toBeInTheDocument();
+		expect(screen.queryAllByTestId('execution-feed-row')).toHaveLength(0);
+	});
+
+	it('is accessible', async () => {
+		const { container } = renderWithProviders(
+			<RecentExecutionsCard items={ITEMS} monitorHref="/monitor" hasMore />,
+		);
+		await checkA11y(container);
+	});
+});

--- a/ui/src/shared/ui/index.ts
+++ b/ui/src/shared/ui/index.ts
@@ -15,6 +15,12 @@ export type {
 	UsageChartBucket,
 } from '@/shared/ui/ExecutionVolumeCharts';
 
+export { RecentExecutionsCard } from '@/shared/ui/RecentExecutionsCard';
+export type {
+	RecentExecutionItem,
+	RecentExecutionsCardProps,
+} from '@/shared/ui/RecentExecutionsCard';
+
 export { DangerZone } from '@/shared/ui/DangerZone';
 export type { DangerZoneProps, DangerZoneAction } from '@/shared/ui/DangerZone';
 

--- a/ui/src/shared/ui/index.ts
+++ b/ui/src/shared/ui/index.ts
@@ -21,6 +21,9 @@ export type {
 	RecentExecutionsCardProps,
 } from '@/shared/ui/RecentExecutionsCard';
 
+export { KillSwitch } from '@/shared/ui/KillSwitch';
+export type { KillSwitchProps } from '@/shared/ui/KillSwitch';
+
 export { DangerZone } from '@/shared/ui/DangerZone';
 export type { DangerZoneProps, DangerZoneAction } from '@/shared/ui/DangerZone';
 

--- a/ui/src/shared/ui/index.ts
+++ b/ui/src/shared/ui/index.ts
@@ -9,6 +9,12 @@ export type { DetailSectionProps, SectionActionProps } from '@/shared/ui/DetailS
 export { AuditTrailCard } from '@/shared/ui/AuditTrailCard';
 export type { AuditTrailCardProps, AuditTrailEntry } from '@/shared/ui/AuditTrailCard';
 
+export { ExecutionVolumeCharts } from '@/shared/ui/ExecutionVolumeCharts';
+export type {
+	ExecutionVolumeChartsProps,
+	UsageChartBucket,
+} from '@/shared/ui/ExecutionVolumeCharts';
+
 export { DangerZone } from '@/shared/ui/DangerZone';
 export type { DangerZoneProps, DangerZoneAction } from '@/shared/ui/DangerZone';
 

--- a/ui/src/shared/ui/index.ts
+++ b/ui/src/shared/ui/index.ts
@@ -3,6 +3,18 @@ export type { ButtonProps } from '@/shared/ui/Button';
 
 export { Card, CardHeader, CardBody, CardFooter, CardTitle } from '@/shared/ui/Card';
 
+export { DetailSection, EmptyRow } from '@/shared/ui/DetailSection';
+export type { DetailSectionProps, SectionActionProps } from '@/shared/ui/DetailSection';
+
+export { AuditTrailCard } from '@/shared/ui/AuditTrailCard';
+export type { AuditTrailCardProps, AuditTrailEntry } from '@/shared/ui/AuditTrailCard';
+
+export { DangerZone } from '@/shared/ui/DangerZone';
+export type { DangerZoneProps, DangerZoneAction } from '@/shared/ui/DangerZone';
+
+export { IdentitySettingsCard } from '@/shared/ui/IdentitySettingsCard';
+export type { IdentitySettingsCardProps } from '@/shared/ui/IdentitySettingsCard';
+
 export { Badge, MethodBadge, StatusBadge } from '@/shared/ui/Badge';
 export type { Variant as BadgeVariant } from '@/shared/ui/Badge';
 


### PR DESCRIPTION
## Summary
- Promotes the console detail grammar to shared primitives in `ui/src/shared/ui`: `DetailSection`/`EmptyRow`, `AuditTrailCard` (Recent changes), `DangerZone`, `IdentitySettingsCard`, `ExecutionVolumeCharts` (stacked volume + success-rate trend, dashboard-style), `RecentExecutionsCard`, and `KillSwitch`.
- Toolkit, agent, and service-account detail pages all consume the same primitives: identical activity charts and execution feeds, the header kill switch for the reversible active/disabled flip (danger zones now carry only terminal actions), Monitor deep-link parity in both back rows, and one settings/danger/audit card grammar.
- Removes the placeholder "More at example.com" entry from the user menu.
- Review hardening: DangerZone hover tint, KillSwitch Escape + focus return, AuditTrailCard loading/error row suppression, IdentitySettingsCard late-data seeding, absolute-time tooltips for numeric timestamps.

## Test plan
- [x] `vitest run` — 903 tests green, incl. new suites for every shared primitive
- [x] Mocked Playwright e2e (`e2e/agents.spec.ts`) green; docker spec selectors updated
- [x] `tsc --noEmit` + `eslint` clean
- [x] Screenshots of toolkit/agent/SA consoles verified against the dashboard grammar

Please squash-merge.

Made with [Cursor](https://cursor.com)