### PR TITLE
feat: act on access-request satisfaction hints across reviewer and fulfilment surfaces

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -371,7 +371,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 16327
+        "line_number": 16332
       }
     ],
     "release-please-config.json": [
@@ -1492,6 +1492,15 @@
         "line_number": 89
       }
     ],
+    "tests/web/control/test_credentials.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/web/control/test_credentials.py",
+        "hashed_secret": "5a22d03a3a0988b8bd98d9a1fe374b6f8793a6b7",
+        "is_verified": false,
+        "line_number": 109
+      }
+    ],
     "ui/public/mockServiceWorker.js": [
       {
         "type": "Hex High Entropy String",
@@ -1618,5 +1627,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T10:31:03Z"
+  "generated_at": "2026-07-31T10:43:30Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -371,7 +371,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 16332
+        "line_number": 16333
       }
     ],
     "release-please-config.json": [
@@ -810,6 +810,22 @@
         "hashed_secret": "7277847a690bab70c1fbc5ab8eddbbcecdad996c",
         "is_verified": false,
         "line_number": 14
+      }
+    ],
+    "src/jentic_one/migrations/registry/versions/d3e4f5a6b7c8_add_catalog_update_checks_table.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/jentic_one/migrations/registry/versions/d3e4f5a6b7c8_add_catalog_update_checks_table.py",
+        "hashed_secret": "dcef2ed5c987677807031f50f5b15aee0527dfd3",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/jentic_one/migrations/registry/versions/d3e4f5a6b7c8_add_catalog_update_checks_table.py",
+        "hashed_secret": "a25d3ab3a62142e06a5940fb9eac04c77bec7919",
+        "is_verified": false,
+        "line_number": 17
       }
     ],
     "src/jentic_one/migrations/registry/versions/d4e5f6a7b8c9_add_revision_pagination_index.py": [
@@ -1627,5 +1643,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T10:43:30Z"
+  "generated_at": "2026-07-31T12:16:07Z"
 }

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -1721,7 +1721,7 @@ components:
           - additionalProperties: true
             type: object
           - type: 'null'
-          description: Redacted, type-specific projection (hints/last-N chars; never the secret).
+          description: 'Redacted, type-specific projection (hints/last-N chars; never the secret). For oauth2: client_id, token_url, grant_type (authorization_code | client_credentials), scopes, and — for authorization_code only — `connected`, whether the interactive sign-in completed and is still usable (null for other grants).'
           title: Details
         name:
           description: Human-readable label.
@@ -4709,9 +4709,9 @@ components:
           title: Active
           type: boolean
         apis:
-          description: Distinct (vendor, name, version) APIs served by this toolkit's credential bindings, sorted by vendor/name/version. Empty when no credentials are bound.
+          description: Distinct APIs served by this toolkit's credential bindings that are visible to the caller, sorted by vendor/name/version. NULL api_name/api_version mean the credential covers all names/versions for the vendor. Empty when no visible credentials are bound.
           items:
-            $ref: '#/components/schemas/APIReference'
+            $ref: '#/components/schemas/ServedApiRef'
           title: Apis
           type: array
         created_at:

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -4708,6 +4708,12 @@ components:
         active:
           title: Active
           type: boolean
+        apis:
+          description: Distinct (vendor, name, version) APIs served by this toolkit's credential bindings, sorted by vendor/name/version. Empty when no credentials are bound.
+          items:
+            $ref: '#/components/schemas/APIReference'
+          title: Apis
+          type: array
         created_at:
           format: date-time
           title: Created At

--- a/src/jentic_one/control/repos/oauth_token_repo.py
+++ b/src/jentic_one/control/repos/oauth_token_repo.py
@@ -85,6 +85,10 @@ class OAuthTokenRepository:
         row.expires_at = expires_at
         if scope is not None:
             row.scope = scope
+        # Fresh tokens supersede any past revocation: a re-connect over a
+        # previously revoked row must yield a live token, not a permanently
+        # revoked one (the derived `connected` flag reads `revoked_at`).
+        row.revoked_at = None
         row.last_refreshed = datetime.now(UTC)
         await session.flush()
         return row

--- a/src/jentic_one/control/repos/toolkit_repo.py
+++ b/src/jentic_one/control/repos/toolkit_repo.py
@@ -10,6 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.elements import ColumnElement
 
+from jentic_one.control.core.schema.credentials import Credential
+from jentic_one.control.core.schema.toolkit_credential_bindings import ToolkitCredentialBinding
 from jentic_one.control.core.schema.toolkits import Toolkit
 
 
@@ -95,6 +97,44 @@ class ToolkitRepository:
         stmt = stmt.limit(limit + 1)
         result = await session.execute(stmt)
         return list(result.scalars().all())
+
+    @staticmethod
+    async def list_served_apis(
+        session: AsyncSession,
+        toolkit_ids: Sequence[str],
+        *,
+        credential_filters: Sequence[ColumnElement[bool]] | None = None,
+    ) -> list[tuple[str, str, str | None, str | None]]:
+        """Distinct (toolkit_id, api_vendor, api_name, api_version) across bindings.
+
+        ``credential_filters`` scopes the joined credentials to the caller's
+        visibility (see ``build_access_filters``): a binding whose credential the
+        caller cannot read contributes nothing. One query for the whole page.
+        """
+        if not toolkit_ids:
+            return []
+        stmt = (
+            select(
+                ToolkitCredentialBinding.toolkit_id,
+                Credential.api_vendor,
+                Credential.api_name,
+                Credential.api_version,
+            )
+            .join(Credential, Credential.id == ToolkitCredentialBinding.credential_id)
+            .where(ToolkitCredentialBinding.toolkit_id.in_(list(toolkit_ids)))
+            .distinct()
+            .order_by(
+                ToolkitCredentialBinding.toolkit_id,
+                Credential.api_vendor,
+                Credential.api_name,
+                Credential.api_version,
+            )
+        )
+        if credential_filters is not None:
+            for f in credential_filters:
+                stmt = stmt.where(f)
+        result = await session.execute(stmt)
+        return [(row[0], row[1], row[2], row[3]) for row in result.all()]
 
     @staticmethod
     async def update(

--- a/src/jentic_one/control/scoping/filters.py
+++ b/src/jentic_one/control/scoping/filters.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from typing import Any
 
 from sqlalchemy import exists, or_, select
+from sqlalchemy.orm import aliased
 from sqlalchemy.sql.elements import ColumnElement
 
 from jentic_one.control.core.schema.access_requests import AccessRequest
@@ -106,9 +107,13 @@ def _binding_visibility_clause(
     if model is Toolkit:
         return Toolkit.id.in_(bound_toolkit_ids)
     if model is Credential:
-        subq = select(ToolkitCredentialBinding.credential_id).where(
-            ToolkitCredentialBinding.toolkit_id.in_(bound_toolkit_ids),
-            ToolkitCredentialBinding.credential_id == Credential.id,
+        # Alias so the subquery keeps its own FROM even when the outer query
+        # also selects from ToolkitCredentialBinding (e.g. the served-APIs
+        # aggregation join) — otherwise auto-correlation strips it away.
+        tcb = aliased(ToolkitCredentialBinding)
+        subq = select(tcb.credential_id).where(
+            tcb.toolkit_id.in_(bound_toolkit_ids),
+            tcb.credential_id == Credential.id,
         )
         return exists(subq)
     return None

--- a/src/jentic_one/control/services/credentials/schemas/credentials.py
+++ b/src/jentic_one/control/services/credentials/schemas/credentials.py
@@ -142,11 +142,14 @@ class OAuth2Redacted(BaseModel):
     token_url: str
     grant_type: str
     scopes: list[str] | None = None
-    # Whether the interactive sign-in completed (a live token row exists).
-    # Only meaningful for authorization_code credentials — client_credentials
-    # mint tokens automatically at execute time, so it stays None there. Lets
-    # list consumers (e.g. the fulfilment wizard's adopt picker) warn about a
-    # never-connected credential before adopting it.
+    # Whether the interactive sign-in completed and is still usable: a
+    # provider_account_ref (managed providers store no local token), or a live
+    # un-revoked token row that can still mint (has a refresh token, or an
+    # unexpired/never-expiring access token). Only meaningful for
+    # authorization_code credentials — client_credentials need no interactive
+    # step, so it stays None there. Lets list consumers (e.g. the fulfilment
+    # wizard's adopt picker) warn about a never-connected credential before
+    # adopting it.
     connected: bool | None = None
 
 

--- a/src/jentic_one/control/services/credentials/schemas/credentials.py
+++ b/src/jentic_one/control/services/credentials/schemas/credentials.py
@@ -142,6 +142,12 @@ class OAuth2Redacted(BaseModel):
     token_url: str
     grant_type: str
     scopes: list[str] | None = None
+    # Whether the interactive sign-in completed (a live token row exists).
+    # Only meaningful for authorization_code credentials — client_credentials
+    # mint tokens automatically at execute time, so it stays None there. Lets
+    # list consumers (e.g. the fulfilment wizard's adopt picker) warn about a
+    # never-connected credential before adopting it.
+    connected: bool | None = None
 
 
 class NoAuthRedacted(BaseModel):

--- a/src/jentic_one/control/services/credentials/service.py
+++ b/src/jentic_one/control/services/credentials/service.py
@@ -534,11 +534,18 @@ class CredentialService:
 
         elif wire_type == CredentialType.OAUTH2:
             occ = credential.oauth_client_credential
+            is_auth_code = stored_type == StoredCredentialType.OAUTH2_AUTHORIZATION_CODE
+            connected: bool | None = None
+            if is_auth_code:
+                # oauth_token is selectin-eager on the ORM, so this is free.
+                token = credential.oauth_token
+                connected = token is not None and token.revoked_at is None
             details = OAuth2Redacted(
                 client_id=occ.client_id if occ else "",
                 token_url=occ.token_url if occ else "",
-                grant_type="client_credentials",
+                grant_type="authorization_code" if is_auth_code else "client_credentials",
                 scopes=occ.scope.split() if occ and occ.scope else None,
+                connected=connected,
             )
         elif wire_type == CredentialType.NO_AUTH:
             details = NoAuthRedacted()

--- a/src/jentic_one/control/services/credentials/service.py
+++ b/src/jentic_one/control/services/credentials/service.py
@@ -537,9 +537,24 @@ class CredentialService:
             is_auth_code = stored_type == StoredCredentialType.OAUTH2_AUTHORIZATION_CODE
             connected: bool | None = None
             if is_auth_code:
-                # oauth_token is selectin-eager on the ORM, so this is free.
-                token = credential.oauth_token
-                connected = token is not None and token.revoked_at is None
+                # Managed providers (e.g. Pipedream) complete connect by
+                # stamping `provider_account_ref` without a local token row —
+                # the ref alone means the sign-in finished.
+                if credential.provider_account_ref:
+                    connected = True
+                else:
+                    # oauth_token is selectin-eager on the ORM, so this is free.
+                    token = credential.oauth_token
+                    if token is None or token.revoked_at is not None:
+                        connected = False
+                    else:
+                        # A live row that has expired with no refresh token
+                        # cannot mint again — the sign-in must be redone.
+                        connected = (
+                            token.encrypted_refresh_token is not None
+                            or token.expires_at is None
+                            or token.expires_at > datetime.now(UTC)
+                        )
             details = OAuth2Redacted(
                 client_id=occ.client_id if occ else "",
                 token_url=occ.token_url if occ else "",

--- a/src/jentic_one/control/services/toolkits/service.py
+++ b/src/jentic_one/control/services/toolkits/service.py
@@ -6,6 +6,7 @@ from typing import NoReturn
 
 import structlog
 
+from jentic_one.control.core.schema.credentials import Credential
 from jentic_one.control.core.schema.toolkit_keys import ToolkitKey
 from jentic_one.control.core.schema.toolkit_permission_rules import ToolkitPermissionRule
 from jentic_one.control.core.schema.toolkits import Toolkit
@@ -43,6 +44,7 @@ from jentic_one.shared.events import emit_event_best_effort
 from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.pagination import decode_cursor_str, encode_cursor
 from jentic_one.shared.permissions.matching import compile_matcher
+from jentic_one.shared.schemas import ServedApiRef
 from jentic_one.shared.scopes import ORG_ADMIN
 
 logger = structlog.get_logger()
@@ -228,6 +230,36 @@ class ToolkitService:
             next_cursor = encode_cursor(last.created_at, last.id)
 
         return rows, has_more, next_cursor
+
+    async def served_apis(
+        self, toolkit_ids: list[str], *, identity: Identity
+    ) -> dict[str, list[ServedApiRef]]:
+        """Visible served APIs per toolkit, for annotating list/get responses.
+
+        Scoped by *credential* visibility, not toolkit visibility: a caller who
+        can see a toolkit only through a share or a binding learns which APIs it
+        serves only for credentials their own ``Credential`` read filter admits.
+        This keeps the sharing seam's invariant intact — a share grants
+        top-level visibility, not the bound credentials' metadata (the bindings
+        child endpoint stays owner-only). NULL ``api_name``/``api_version``
+        (the covers-all wildcard, #775) are preserved, matching ``/me``.
+        """
+        credential_filters = build_access_filters(
+            identity,
+            Credential,
+            bound_toolkit_ids=await self._bound_toolkit_ids(identity),
+            include_shared=True,
+        )
+        async with self._ctx.control_db.session() as session:
+            rows = await ToolkitRepository.list_served_apis(
+                session, toolkit_ids, credential_filters=credential_filters
+            )
+        served: dict[str, list[ServedApiRef]] = {}
+        for toolkit_id, vendor, name, version in rows:
+            served.setdefault(toolkit_id, []).append(
+                ServedApiRef(api_vendor=vendor, api_name=name, api_version=version)
+            )
+        return served
 
     async def list_agents(
         self,

--- a/src/jentic_one/control/web/routers/toolkits.py
+++ b/src/jentic_one/control/web/routers/toolkits.py
@@ -40,10 +40,34 @@ from jentic_one.control.web.schemas.toolkits import (
     ToolkitUpdateRequest,
 )
 from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.schemas import APIReference
 from jentic_one.shared.web import get_current_identity
 from jentic_one.shared.web.openapi_responses import conflict, not_found, with_responses
 
 router = APIRouter()
+
+
+def _served_apis(toolkit: Toolkit) -> list[APIReference]:
+    """Distinct APIs across the toolkit's credential bindings, stably sorted.
+
+    ``bindings`` and each binding's ``credential`` are selectin-eager on the
+    ORM, so this is pure in-memory aggregation — no extra queries on the list
+    path. Dedupes on the identity tuple: two credentials for the same API
+    yield one entry.
+    """
+    tuples = {
+        (
+            binding.credential.api_vendor,
+            binding.credential.api_name or "",
+            binding.credential.api_version or "",
+        )
+        for binding in toolkit.bindings
+        if binding.credential is not None
+    }
+    return [
+        APIReference(vendor=vendor, name=name, version=version)
+        for vendor, name, version in sorted(tuples)
+    ]
 
 
 def _to_toolkit_response(toolkit: Toolkit) -> ToolkitResponse:
@@ -54,6 +78,7 @@ def _to_toolkit_response(toolkit: Toolkit) -> ToolkitResponse:
         active=toolkit.active,
         key_count=len(toolkit.keys),
         credential_count=len(toolkit.bindings),
+        apis=_served_apis(toolkit),
         created_by=toolkit.created_by,
         created_at=toolkit.created_at,
         updated_at=toolkit.updated_at,

--- a/src/jentic_one/control/web/routers/toolkits.py
+++ b/src/jentic_one/control/web/routers/toolkits.py
@@ -40,37 +40,16 @@ from jentic_one.control.web.schemas.toolkits import (
     ToolkitUpdateRequest,
 )
 from jentic_one.shared.auth.identity import Identity
-from jentic_one.shared.schemas import APIReference
+from jentic_one.shared.schemas import ServedApiRef
 from jentic_one.shared.web import get_current_identity
 from jentic_one.shared.web.openapi_responses import conflict, not_found, with_responses
 
 router = APIRouter()
 
 
-def _served_apis(toolkit: Toolkit) -> list[APIReference]:
-    """Distinct APIs across the toolkit's credential bindings, stably sorted.
-
-    ``bindings`` and each binding's ``credential`` are selectin-eager on the
-    ORM, so this is pure in-memory aggregation — no extra queries on the list
-    path. Dedupes on the identity tuple: two credentials for the same API
-    yield one entry.
-    """
-    tuples = {
-        (
-            binding.credential.api_vendor,
-            binding.credential.api_name or "",
-            binding.credential.api_version or "",
-        )
-        for binding in toolkit.bindings
-        if binding.credential is not None
-    }
-    return [
-        APIReference(vendor=vendor, name=name, version=version)
-        for vendor, name, version in sorted(tuples)
-    ]
-
-
-def _to_toolkit_response(toolkit: Toolkit) -> ToolkitResponse:
+def _to_toolkit_response(
+    toolkit: Toolkit, served: dict[str, list[ServedApiRef]] | None = None
+) -> ToolkitResponse:
     return ToolkitResponse(
         toolkit_id=toolkit.id,
         name=toolkit.name,
@@ -78,7 +57,7 @@ def _to_toolkit_response(toolkit: Toolkit) -> ToolkitResponse:
         active=toolkit.active,
         key_count=len(toolkit.keys),
         credential_count=len(toolkit.bindings),
-        apis=_served_apis(toolkit),
+        apis=(served or {}).get(toolkit.id, []),
         created_by=toolkit.created_by,
         created_at=toolkit.created_at,
         updated_at=toolkit.updated_at,
@@ -187,8 +166,9 @@ async def create_toolkit(
         active=body.active,
         credential_ids=body.credential_ids,
     )
+    served = await svc.served_apis([result.toolkit.id], identity=identity)
     return ToolkitCreateResponse(
-        toolkit=_to_toolkit_response(result.toolkit),
+        toolkit=_to_toolkit_response(result.toolkit, served),
         api_key=result.plaintext_key,
         warnings=[_to_binding_warning(w) for w in result.warnings],
     )
@@ -205,8 +185,9 @@ async def list_toolkits(
 ) -> ToolkitListResponse:
     """List toolkits with cursor-based pagination."""
     data, has_more, next_cursor = await svc.list_all(cursor=cursor, limit=limit, identity=identity)
+    served = await svc.served_apis([t.id for t in data], identity=identity)
     return ToolkitListResponse(
-        data=[_to_toolkit_response(t) for t in data],
+        data=[_to_toolkit_response(t, served) for t in data],
         has_more=has_more,
         next_cursor=next_cursor,
     )
@@ -222,7 +203,8 @@ async def get_toolkit(
 ) -> ToolkitResponse:
     """Get a single toolkit by its `tk_…` ID."""
     toolkit = await svc.get(toolkit_id, identity=identity)
-    return _to_toolkit_response(toolkit)
+    served = await svc.served_apis([toolkit.id], identity=identity)
+    return _to_toolkit_response(toolkit, served)
 
 
 @router.patch("/toolkits/{toolkit_id}", summary="Update toolkit", responses=not_found())
@@ -240,7 +222,8 @@ async def update_toolkit(
         description=body.description,
         active=body.active,
     )
-    return _to_toolkit_response(toolkit)
+    served = await svc.served_apis([toolkit.id], identity=identity)
+    return _to_toolkit_response(toolkit, served)
 
 
 @router.delete(

--- a/src/jentic_one/control/web/schemas/credentials.py
+++ b/src/jentic_one/control/web/schemas/credentials.py
@@ -320,7 +320,13 @@ class CredentialRedactedResponse(BaseModel):
     updated_at: datetime | None = Field(default=None, description="Last update timestamp (UTC).")
     details: dict[str, Any] | None = Field(
         default=None,
-        description="Redacted, type-specific projection (hints/last-N chars; never the secret).",
+        description=(
+            "Redacted, type-specific projection (hints/last-N chars; never the "
+            "secret). For oauth2: client_id, token_url, grant_type "
+            "(authorization_code | client_credentials), scopes, and — for "
+            "authorization_code only — `connected`, whether the interactive "
+            "sign-in completed and is still usable (null for other grants)."
+        ),
     )
     server_variables: dict[str, str] | None = Field(
         default=None,

--- a/src/jentic_one/control/web/schemas/toolkits.py
+++ b/src/jentic_one/control/web/schemas/toolkits.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from jentic_one.control.web.schemas.permission_rules import BasePermissionRuleSchema
 from jentic_one.shared.permissions.matching import MatchMode
+from jentic_one.shared.schemas import APIReference
 
 # --- Request models ---
 
@@ -139,6 +140,18 @@ class ToolkitResponse(BaseModel):
     active: bool
     key_count: int
     credential_count: int
+    # Distinct APIs served by the toolkit's credential bindings, so list
+    # consumers (e.g. the fulfilment wizard's adopt picker) can rank or badge
+    # toolkits by the API a plan targets without a per-toolkit child fetch.
+    # The same identity tuples the bindings child endpoint already exposes.
+    apis: list[APIReference] = Field(
+        default_factory=list,
+        description=(
+            "Distinct (vendor, name, version) APIs served by this toolkit's "
+            "credential bindings, sorted by vendor/name/version. Empty when "
+            "no credentials are bound."
+        ),
+    )
     created_by: str | None = None
     created_at: datetime
     updated_at: datetime | None = None

--- a/src/jentic_one/control/web/schemas/toolkits.py
+++ b/src/jentic_one/control/web/schemas/toolkits.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from jentic_one.control.web.schemas.permission_rules import BasePermissionRuleSchema
 from jentic_one.shared.permissions.matching import MatchMode
-from jentic_one.shared.schemas import APIReference
+from jentic_one.shared.schemas import ServedApiRef
 
 # --- Request models ---
 
@@ -143,13 +143,16 @@ class ToolkitResponse(BaseModel):
     # Distinct APIs served by the toolkit's credential bindings, so list
     # consumers (e.g. the fulfilment wizard's adopt picker) can rank or badge
     # toolkits by the API a plan targets without a per-toolkit child fetch.
-    # The same identity tuples the bindings child endpoint already exposes.
-    apis: list[APIReference] = Field(
+    # Scoped by the caller's credential visibility (see
+    # ``ToolkitService.served_apis``) — a sharee or bound agent sees only the
+    # APIs of credentials their own read filter admits.
+    apis: list[ServedApiRef] = Field(
         default_factory=list,
         description=(
-            "Distinct (vendor, name, version) APIs served by this toolkit's "
-            "credential bindings, sorted by vendor/name/version. Empty when "
-            "no credentials are bound."
+            "Distinct APIs served by this toolkit's credential bindings that "
+            "are visible to the caller, sorted by vendor/name/version. NULL "
+            "api_name/api_version mean the credential covers all names/versions "
+            "for the vendor. Empty when no visible credentials are bound."
         ),
     )
     created_by: str | None = None

--- a/tests/integration/control/test_connect_flow.py
+++ b/tests/integration/control/test_connect_flow.py
@@ -367,3 +367,41 @@ async def test_pipedream_replay_rejected(
         credential = await CredentialRepository.get_by_id(session, credential_id)
         assert credential is not None
         assert credential.provider_account_ref == "acct_1"
+
+
+# --- Token-row lifecycle (repo-level) ---
+
+
+async def test_reconnect_clears_revocation(
+    integration_context: Context, clean_connect_tables: None
+) -> None:
+    """`update_tokens` (the re-connect/refresh write path) clears `revoked_at`.
+
+    A revoked row that receives fresh tokens is live again — leaving the old
+    revocation stamp would permanently pin the derived `connected` flag to
+    False after a successful re-connect (#890 review board).
+    """
+    ctx = integration_context
+    credential_id = await _create_oauth2_credential(ctx, provider="static")
+
+    async with ctx.control_db.transaction() as session:
+        await OAuthTokenRepository.create(
+            session,
+            credential_id=credential_id,
+            encrypted_access_token="enc-old",
+            created_by="usr_test",
+        )
+        await OAuthTokenRepository.mark_revoked(session, credential_id)
+
+    async with ctx.control_db.transaction() as session:
+        row = await OAuthTokenRepository.get_by_credential(session, credential_id)
+        assert row is not None
+        assert row.revoked_at is not None
+
+        updated = await OAuthTokenRepository.update_tokens(
+            session,
+            credential_id,
+            encrypted_access_token="enc-new",
+        )
+        assert updated is not None
+        assert updated.revoked_at is None

--- a/tests/web/control/test_credentials.py
+++ b/tests/web/control/test_credentials.py
@@ -15,6 +15,9 @@ from datetime import datetime
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from jentic_one.shared.context import Context
 
 pytestmark = pytest.mark.integration
 
@@ -89,3 +92,77 @@ def test_patch_key_rotation_moves_updated_at(cred_writer_client: TestClient) -> 
     )
     assert resp.status_code == 200, resp.text
     assert _parse_ts(resp.json()["updated_at"]) > _parse_ts(before["updated_at"])
+
+
+# --- OAuth connect state on the redacted projection (#890) ---
+
+
+def _create_oauth2(client: TestClient, *, grant_type: str, name: str) -> str:
+    payload: dict[str, object] = {
+        "type": "oauth2",
+        "name": name,
+        "api": {"vendor": "webtest-oauth.example", "name": "", "version": ""},
+        "provider": "static",
+        "grant_type": grant_type,
+        "token_url": "https://auth.example/token",
+        "client_id": "webtest-client",
+        "client_secret": "webtest-secret",
+    }
+    if grant_type == "authorization_code":
+        payload["authorize_url"] = "https://auth.example/authorize"
+    resp = client.post("/credentials", json=payload)
+    assert resp.status_code == 201, resp.text
+    credential_id: str = resp.json()["credential"]["credential_id"]
+    return credential_id
+
+
+async def test_authorization_code_connected_flips_on_token(
+    cred_writer_client: TestClient, web_context: Context
+) -> None:
+    """An authorization_code credential reports connected=False until its
+    sign-in lands a token row, then True — so list consumers (the fulfilment
+    wizard's adopt picker) can warn about a never-connected pick before it
+    fails at execute time (#890). grant_type is the honest stored grant, not
+    the historical client_credentials hardcode.
+    """
+    cred_id = _create_oauth2(
+        cred_writer_client, grant_type="authorization_code", name="web-cred-connect"
+    )
+
+    got = cred_writer_client.get(f"/credentials/{cred_id}").json()
+    assert got["details"]["grant_type"] == "authorization_code"
+    assert got["details"]["connected"] is False
+
+    listed = cred_writer_client.get("/credentials", params={"vendor": "webtest-oauth-example"})
+    rows = [c for c in listed.json()["data"] if c["credential_id"] == cred_id]
+    # The vendor filter matches the slugified stored form of the dotted input.
+    assert len(rows) == 1
+    assert rows[0]["details"]["connected"] is False
+
+    # A completed connect flow persists the token row (simulated directly —
+    # the flow itself is exercised in tests/integration/control/test_connect_flow.py).
+    async with web_context.control_db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO oauth_tokens (id, credential_id, encrypted_access_token) "
+                "VALUES ('oat_webtest_conn', :cred, 'enc-webtest') ON CONFLICT DO NOTHING"
+            ),
+            {"cred": cred_id},
+        )
+        await session.commit()
+    # No local cleanup: the credential-delete teardown cascades to oauth_tokens.
+
+    got = cred_writer_client.get(f"/credentials/{cred_id}").json()
+    assert got["details"]["connected"] is True
+
+
+def test_client_credentials_has_no_connect_state(cred_writer_client: TestClient) -> None:
+    """client_credentials mints tokens automatically at execute time, so
+    connect state is meaningless there: the key is absent (None is dropped
+    from the wire), never a scary false."""
+    cred_id = _create_oauth2(
+        cred_writer_client, grant_type="client_credentials", name="web-cred-cc"
+    )
+    got = cred_writer_client.get(f"/credentials/{cred_id}").json()
+    assert got["details"]["grant_type"] == "client_credentials"
+    assert "connected" not in got["details"]

--- a/tests/web/control/test_credentials.py
+++ b/tests/web/control/test_credentials.py
@@ -120,10 +120,12 @@ async def test_authorization_code_connected_flips_on_token(
     cred_writer_client: TestClient, web_context: Context
 ) -> None:
     """An authorization_code credential reports connected=False until its
-    sign-in lands a token row, then True — so list consumers (the fulfilment
-    wizard's adopt picker) can warn about a never-connected pick before it
-    fails at execute time (#890). grant_type is the honest stored grant, not
-    the historical client_credentials hardcode.
+    sign-in lands a usable token row, then True — and back to False when the
+    token is revoked or can no longer mint (expired with no refresh token).
+    Lets list consumers (the fulfilment wizard's adopt picker) warn about a
+    never-connected pick before it fails at execute time (#890). grant_type
+    is the honest stored grant, not the historical client_credentials
+    hardcode.
     """
     cred_id = _create_oauth2(
         cred_writer_client, grant_type="authorization_code", name="web-cred-connect"
@@ -155,11 +157,66 @@ async def test_authorization_code_connected_flips_on_token(
     got = cred_writer_client.get(f"/credentials/{cred_id}").json()
     assert got["details"]["connected"] is True
 
+    # Expired with no refresh token: the row exists but cannot mint again —
+    # the sign-in must be redone, so the flag drops back to False.
+    async with web_context.control_db.session() as session:
+        await session.execute(
+            text(
+                "UPDATE oauth_tokens SET expires_at = '2020-01-01T00:00:00Z' "
+                "WHERE id = 'oat_webtest_conn'"
+            )
+        )
+        await session.commit()
+    got = cred_writer_client.get(f"/credentials/{cred_id}").json()
+    assert got["details"]["connected"] is False
+
+    # A refresh token rescues an expired access token (the broker re-mints).
+    async with web_context.control_db.session() as session:
+        await session.execute(
+            text(
+                "UPDATE oauth_tokens SET encrypted_refresh_token = 'enc-refresh' "
+                "WHERE id = 'oat_webtest_conn'"
+            )
+        )
+        await session.commit()
+    got = cred_writer_client.get(f"/credentials/{cred_id}").json()
+    assert got["details"]["connected"] is True
+
+    # Revocation trumps everything.
+    async with web_context.control_db.session() as session:
+        await session.execute(
+            text("UPDATE oauth_tokens SET revoked_at = now() WHERE id = 'oat_webtest_conn'")
+        )
+        await session.commit()
+    got = cred_writer_client.get(f"/credentials/{cred_id}").json()
+    assert got["details"]["connected"] is False
+
+
+async def test_managed_provider_account_ref_counts_as_connected(
+    cred_writer_client: TestClient, web_context: Context
+) -> None:
+    """Managed providers (e.g. Pipedream) complete connect by stamping
+    `provider_account_ref` without a local token row — the ref alone must
+    read as connected, or the picker would warn forever on a working
+    credential.
+    """
+    cred_id = _create_oauth2(
+        cred_writer_client, grant_type="authorization_code", name="web-cred-managed"
+    )
+    async with web_context.control_db.session() as session:
+        await session.execute(
+            text("UPDATE credentials SET provider_account_ref = 'acc_webtest' WHERE id = :cred"),
+            {"cred": cred_id},
+        )
+        await session.commit()
+    got = cred_writer_client.get(f"/credentials/{cred_id}").json()
+    assert got["details"]["connected"] is True
+
 
 def test_client_credentials_has_no_connect_state(cred_writer_client: TestClient) -> None:
-    """client_credentials mints tokens automatically at execute time, so
-    connect state is meaningless there: the key is absent (None is dropped
-    from the wire), never a scary false."""
+    """client_credentials needs no interactive sign-in step, so connect state
+    is meaningless there: the key is absent (None is dropped from the wire),
+    never a scary false."""
     cred_id = _create_oauth2(
         cred_writer_client, grant_type="client_credentials", name="web-cred-cc"
     )

--- a/tests/web/control/test_toolkits.py
+++ b/tests/web/control/test_toolkits.py
@@ -345,10 +345,10 @@ async def test_toolkit_response_carries_served_apis(
     try:
         got = tk_owner_client.get(f"/toolkits/{toolkit_id}").json()
         assert got["apis"] == [
-            {"vendor": "webtest-alpha", "name": "alpha-api", "version": "v1"},
-            # NULL name/version project as the empty string, matching the
-            # credential response's APIReference convention.
-            {"vendor": "webtest-beta", "name": "", "version": ""},
+            {"api_vendor": "webtest-alpha", "api_name": "alpha-api", "api_version": "v1"},
+            # NULL name/version are preserved (the covers-all wildcard, #775),
+            # matching the `/me` response's ServedApiRef convention.
+            {"api_vendor": "webtest-beta", "api_name": None, "api_version": None},
         ]
 
         listed = tk_owner_client.get("/toolkits").json()
@@ -364,4 +364,47 @@ async def test_toolkit_response_carries_served_apis(
                     "WHERE id IN ('cred_srvapi_1', 'cred_srvapi_2', 'cred_srvapi_3')"
                 )
             )
+            await session.commit()
+
+
+async def test_served_apis_scoped_by_credential_visibility(
+    tk_owner_client: TestClient, web_context: Context
+) -> None:
+    """`apis` reveals only the APIs of credentials the caller can read.
+
+    A binding to someone else's credential (possible via an org:admin bind)
+    still counts in `credential_count`, but its API identity stays hidden —
+    the aggregation runs under the caller's Credential read filter, so
+    top-level toolkit visibility (including enterprise shares) never leaks
+    the bound credentials' metadata.
+    """
+    created = _create_toolkit(tk_owner_client, name="served-apis-scope-test")
+    toolkit_id = created["toolkit"]["toolkit_id"]
+
+    async with web_context.control_db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO credentials "
+                "(id, type, name, api_vendor, api_name, api_version, created_by) VALUES "
+                "('cred_srvapi_foreign', 'token_value', 'srvapi-foreign', "
+                "'webtest-hidden', 'hidden-api', 'v1', 'usr_webtest_other') "
+                "ON CONFLICT DO NOTHING"
+            )
+        )
+        await session.execute(
+            text(
+                "INSERT INTO toolkit_credential_bindings (id, toolkit_id, credential_id) "
+                "VALUES ('tcb_srvapi_foreign', :tk, 'cred_srvapi_foreign') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"tk": toolkit_id},
+        )
+        await session.commit()
+    try:
+        got = tk_owner_client.get(f"/toolkits/{toolkit_id}").json()
+        assert got["credential_count"] == 1
+        assert got["apis"] == []
+    finally:
+        async with web_context.control_db.session() as session:
+            await session.execute(text("DELETE FROM credentials WHERE id = 'cred_srvapi_foreign'"))
             await session.commit()

--- a/tests/web/control/test_toolkits.py
+++ b/tests/web/control/test_toolkits.py
@@ -10,6 +10,9 @@ from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from jentic_one.shared.context import Context
 
 pytestmark = pytest.mark.integration
 
@@ -297,3 +300,68 @@ def test_list_toolkit_agents_respects_limit_bounds(tk_owner_client: TestClient) 
 
     assert tk_owner_client.get(f"/toolkits/{toolkit_id}/agents?limit=0").status_code == 422
     assert tk_owner_client.get(f"/toolkits/{toolkit_id}/agents?limit=201").status_code == 422
+
+
+# --- Served APIs on the list/get response (#890) ---
+
+
+async def test_toolkit_response_carries_served_apis(
+    tk_owner_client: TestClient, web_context: Context
+) -> None:
+    """`apis` aggregates the distinct APIs behind the toolkit's credential
+    bindings — deduped (two credentials for one API yield one entry) and
+    vendor-sorted — so pickers can rank/badge toolkits by the API a plan
+    targets without a per-toolkit child fetch (#890). Unbound toolkits report
+    an empty list.
+    """
+    created = _create_toolkit(tk_owner_client, name="served-apis-test")
+    toolkit_id = created["toolkit"]["toolkit_id"]
+    assert created["toolkit"]["apis"] == []
+
+    async with web_context.control_db.session() as session:
+        await session.execute(
+            text(
+                "INSERT INTO credentials "
+                "(id, type, name, api_vendor, api_name, api_version, created_by) VALUES "
+                "('cred_srvapi_1', 'token_value', 'srvapi-one', "
+                "'webtest-alpha', 'alpha-api', 'v1', 'usr_webtest_tk_owner'), "
+                "('cred_srvapi_2', 'token_value', 'srvapi-two', "
+                "'webtest-alpha', 'alpha-api', 'v1', 'usr_webtest_tk_owner'), "
+                "('cred_srvapi_3', 'token_value', 'srvapi-three', "
+                "'webtest-beta', NULL, NULL, 'usr_webtest_tk_owner') "
+                "ON CONFLICT DO NOTHING"
+            )
+        )
+        await session.execute(
+            text(
+                "INSERT INTO toolkit_credential_bindings (id, toolkit_id, credential_id) VALUES "
+                "('tcb_srvapi_1', :tk, 'cred_srvapi_1'), "
+                "('tcb_srvapi_2', :tk, 'cred_srvapi_2'), "
+                "('tcb_srvapi_3', :tk, 'cred_srvapi_3') ON CONFLICT DO NOTHING"
+            ),
+            {"tk": toolkit_id},
+        )
+        await session.commit()
+    try:
+        got = tk_owner_client.get(f"/toolkits/{toolkit_id}").json()
+        assert got["apis"] == [
+            {"vendor": "webtest-alpha", "name": "alpha-api", "version": "v1"},
+            # NULL name/version project as the empty string, matching the
+            # credential response's APIReference convention.
+            {"vendor": "webtest-beta", "name": "", "version": ""},
+        ]
+
+        listed = tk_owner_client.get("/toolkits").json()
+        row = next(t for t in listed["data"] if t["toolkit_id"] == toolkit_id)
+        assert row["apis"] == got["apis"]
+    finally:
+        # Bindings cascade with the toolkit (clean_toolkits); the credentials
+        # belong to no cleanup fixture, so drop them here.
+        async with web_context.control_db.session() as session:
+            await session.execute(
+                text(
+                    "DELETE FROM credentials "
+                    "WHERE id IN ('cred_srvapi_1', 'cred_srvapi_2', 'cred_srvapi_3')"
+                )
+            )
+            await session.commit()

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -7393,6 +7393,14 @@
             "title": "Active",
             "type": "boolean"
           },
+          "apis": {
+            "description": "Distinct (vendor, name, version) APIs served by this toolkit's credential bindings, sorted by vendor/name/version. Empty when no credentials are bound.",
+            "items": {
+              "$ref": "#/components/schemas/APIReference"
+            },
+            "title": "Apis",
+            "type": "array"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -2735,7 +2735,7 @@
                 "type": "null"
               }
             ],
-            "description": "Redacted, type-specific projection (hints/last-N chars; never the secret).",
+            "description": "Redacted, type-specific projection (hints/last-N chars; never the secret). For oauth2: client_id, token_url, grant_type (authorization_code | client_credentials), scopes, and — for authorization_code only — `connected`, whether the interactive sign-in completed and is still usable (null for other grants).",
             "title": "Details"
           },
           "name": {
@@ -7394,9 +7394,9 @@
             "type": "boolean"
           },
           "apis": {
-            "description": "Distinct (vendor, name, version) APIs served by this toolkit's credential bindings, sorted by vendor/name/version. Empty when no credentials are bound.",
+            "description": "Distinct APIs served by this toolkit's credential bindings that are visible to the caller, sorted by vendor/name/version. NULL api_name/api_version mean the credential covers all names/versions for the vendor. Empty when no visible credentials are bound.",
             "items": {
-              "$ref": "#/components/schemas/APIReference"
+              "$ref": "#/components/schemas/ServedApiRef"
             },
             "title": "Apis",
             "type": "array"

--- a/ui/src/modules/toolkits/components/BindCredentialDialog.tsx
+++ b/ui/src/modules/toolkits/components/BindCredentialDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ArrowLeft, KeyRound, ListChecks, ShieldBan, ShieldCheck } from 'lucide-react';
 import {
 	AppLink,
@@ -89,8 +89,9 @@ export interface BindCredentialDialogProps {
 	 */
 	agentless?: boolean;
 	/**
-	 * Where "Link an agent" leads (open the picker, or jump to the tab that
-	 * hosts it). The post-bind prompt is only offered when this is provided.
+	 * Opens the link-agent picker (every caller must end there — a button
+	 * labelled "Link an agent" may not land on a tab and stop). The post-bind
+	 * prompt is only offered when this is provided.
 	 */
 	onLinkAgent?: () => void;
 }
@@ -110,9 +111,20 @@ export function BindCredentialDialog({
 	const [rules, setRules] = useState<PermissionRuleInput[]>([]);
 	// Post-success state: the bind landed but nothing can use it yet — hold the
 	// dialog open on a "link an agent?" prompt instead of closing into silence.
-	const [justBound, setJustBound] = useState(false);
+	const [showLinkPrompt, setShowLinkPrompt] = useState(false);
 
-	const step: 'pick' | 'access' | 'linkPrompt' = justBound
+	// Transient flag, not user input: clear it whenever the dialog closes
+	// (dialog-state rule). The ref carries the *live* open state into the
+	// mutation callback — a bind resolving after an Escape-close must not arm
+	// the prompt for the next open (the callback's `open` prop is a stale
+	// closure by then).
+	const openRef = useRef(open);
+	useEffect(() => {
+		openRef.current = open;
+		if (!open) setShowLinkPrompt(false);
+	}, [open]);
+
+	const step: 'pick' | 'access' | 'linkPrompt' = showLinkPrompt
 		? 'linkPrompt'
 		: selected
 			? 'access'
@@ -132,11 +144,6 @@ export function BindCredentialDialog({
 		bindCredential.reset();
 	};
 
-	const close = () => {
-		setJustBound(false);
-		onClose();
-	};
-
 	const submit = () => {
 		if (!selected || customInvalid) return;
 		bindCredential.mutate(
@@ -148,8 +155,9 @@ export function BindCredentialDialog({
 			{
 				onSuccess: () => {
 					reset();
+					if (!openRef.current) return;
 					if (agentless && onLinkAgent) {
-						setJustBound(true);
+						setShowLinkPrompt(true);
 					} else {
 						onClose();
 					}
@@ -161,7 +169,7 @@ export function BindCredentialDialog({
 	return (
 		<Dialog
 			open={open}
-			onClose={close}
+			onClose={onClose}
 			title="Bind credential"
 			subtitle={
 				step === 'pick'
@@ -173,17 +181,16 @@ export function BindCredentialDialog({
 			size="lg"
 			footer={
 				step === 'pick' ? (
-					<Button variant="secondary" onClick={close}>
+					<Button variant="secondary" onClick={onClose}>
 						Cancel
 					</Button>
 				) : step === 'linkPrompt' ? (
 					<>
-						<Button variant="secondary" onClick={close}>
+						<Button variant="secondary" onClick={onClose}>
 							Not now
 						</Button>
 						<Button
 							onClick={() => {
-								setJustBound(false);
 								onLinkAgent?.();
 								onClose();
 							}}
@@ -219,7 +226,14 @@ export function BindCredentialDialog({
 					<CredentialPicker boundIds={boundIds} onSelect={setSelected} enabled={open} />
 				</div>
 			) : step === 'linkPrompt' ? (
-				<div className="flex items-start gap-3" data-testid="bind-link-agent-prompt">
+				// role="status": the body swap after the bind unmounts the focused
+				// submit button, so announce the outcome (matches the detail page's
+				// no-agents banner).
+				<div
+					className="flex items-start gap-3"
+					role="status"
+					data-testid="bind-link-agent-prompt"
+				>
 					<div className="bg-accent-green/10 text-accent-green flex h-9 w-9 shrink-0 items-center justify-center rounded-lg">
 						<ShieldCheck className="h-5 w-5" aria-hidden="true" />
 					</div>
@@ -227,8 +241,7 @@ export function BindCredentialDialog({
 						<p className="text-foreground text-sm font-medium">Credential bound.</p>
 						<p className="text-muted-foreground mt-1 text-sm">
 							But no agent is linked to this toolkit yet, so nothing can reach the
-							credential — calls will only start working once an agent is linked (or
-							an API key is issued).
+							credential — calls will only start working once an agent is linked.
 						</p>
 					</div>
 				</div>

--- a/ui/src/modules/toolkits/components/BindCredentialDialog.tsx
+++ b/ui/src/modules/toolkits/components/BindCredentialDialog.tsx
@@ -30,6 +30,12 @@ import { CredentialPicker } from '@/modules/toolkits/components/CredentialPicker
  *
  * Lifecycle: wizard — draft (selection, mode, rules) persists across casual
  * dismissals and resets only on a successful bind (dialog-state rule).
+ *
+ * When the bind lands on a toolkit that nothing can use yet (no linked agent,
+ * no API key — see `agentless`), the dialog holds open on a "link an agent?"
+ * prompt instead of closing into silence: the proactive half of the
+ * manual-setup dead-end fix (issue #826), complementing the detail page's
+ * reactive no-linked-agents banner.
  */
 
 type AccessMode = 'allow_all' | 'custom' | 'blocked';
@@ -75,6 +81,18 @@ export interface BindCredentialDialogProps {
 	onClose: () => void;
 	/** Credential ids already bound to this toolkit — hidden from the picker. */
 	boundIds: Set<string>;
+	/**
+	 * True when the freshly-bound credential would serve nothing: no agent is
+	 * linked to the toolkit and no API key exists. Enables the post-bind
+	 * "link an agent?" prompt — the proactive half of the manual-setup
+	 * dead-end fix (issue #826; the detail-page banner is the reactive half).
+	 */
+	agentless?: boolean;
+	/**
+	 * Where "Link an agent" leads (open the picker, or jump to the tab that
+	 * hosts it). The post-bind prompt is only offered when this is provided.
+	 */
+	onLinkAgent?: () => void;
 }
 
 export function BindCredentialDialog({
@@ -82,14 +100,23 @@ export function BindCredentialDialog({
 	open,
 	onClose,
 	boundIds,
+	agentless = false,
+	onLinkAgent,
 }: BindCredentialDialogProps) {
 	const bindCredential = useBindCredential(toolkitId);
 
 	const [selected, setSelected] = useState<BindableCredential | null>(null);
 	const [mode, setMode] = useState<AccessMode>('allow_all');
 	const [rules, setRules] = useState<PermissionRuleInput[]>([]);
+	// Post-success state: the bind landed but nothing can use it yet — hold the
+	// dialog open on a "link an agent?" prompt instead of closing into silence.
+	const [justBound, setJustBound] = useState(false);
 
-	const step: 'pick' | 'access' = selected ? 'access' : 'pick';
+	const step: 'pick' | 'access' | 'linkPrompt' = justBound
+		? 'linkPrompt'
+		: selected
+			? 'access'
+			: 'pick';
 
 	// Strip empty conditions the same way the permissions editor's save does, so
 	// the bind body never carries `methods: []` / `path: ""` noise (and prefix/
@@ -105,6 +132,11 @@ export function BindCredentialDialog({
 		bindCredential.reset();
 	};
 
+	const close = () => {
+		setJustBound(false);
+		onClose();
+	};
+
 	const submit = () => {
 		if (!selected || customInvalid) return;
 		bindCredential.mutate(
@@ -116,7 +148,11 @@ export function BindCredentialDialog({
 			{
 				onSuccess: () => {
 					reset();
-					onClose();
+					if (agentless && onLinkAgent) {
+						setJustBound(true);
+					} else {
+						onClose();
+					}
 				},
 			},
 		);
@@ -125,19 +161,36 @@ export function BindCredentialDialog({
 	return (
 		<Dialog
 			open={open}
-			onClose={onClose}
+			onClose={close}
 			title="Bind credential"
 			subtitle={
 				step === 'pick'
 					? 'Step 1 of 2 · pick a credential'
-					: 'Step 2 of 2 · decide what it may do'
+					: step === 'access'
+						? 'Step 2 of 2 · decide what it may do'
+						: 'Bound · one step left to put it to use'
 			}
 			size="lg"
 			footer={
 				step === 'pick' ? (
-					<Button variant="secondary" onClick={onClose}>
+					<Button variant="secondary" onClick={close}>
 						Cancel
 					</Button>
+				) : step === 'linkPrompt' ? (
+					<>
+						<Button variant="secondary" onClick={close}>
+							Not now
+						</Button>
+						<Button
+							onClick={() => {
+								setJustBound(false);
+								onLinkAgent?.();
+								onClose();
+							}}
+						>
+							Link an agent
+						</Button>
+					</>
 				) : (
 					<>
 						<Button variant="secondary" onClick={() => setSelected(null)}>
@@ -164,6 +217,20 @@ export function BindCredentialDialog({
 						page.
 					</p>
 					<CredentialPicker boundIds={boundIds} onSelect={setSelected} enabled={open} />
+				</div>
+			) : step === 'linkPrompt' ? (
+				<div className="flex items-start gap-3" data-testid="bind-link-agent-prompt">
+					<div className="bg-accent-green/10 text-accent-green flex h-9 w-9 shrink-0 items-center justify-center rounded-lg">
+						<ShieldCheck className="h-5 w-5" aria-hidden="true" />
+					</div>
+					<div className="min-w-0 flex-1">
+						<p className="text-foreground text-sm font-medium">Credential bound.</p>
+						<p className="text-muted-foreground mt-1 text-sm">
+							But no agent is linked to this toolkit yet, so nothing can reach the
+							credential — calls will only start working once an agent is linked (or
+							an API key is issued).
+						</p>
+					</div>
 				</div>
 			) : (
 				selected && (

--- a/ui/src/modules/toolkits/components/ToolkitDetailBody.tsx
+++ b/ui/src/modules/toolkits/components/ToolkitDetailBody.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { AnimatePresence, motion } from 'framer-motion';
 import {
@@ -72,6 +73,11 @@ export function ToolkitDetailBody({ toolkitId, onRequestClose }: ToolkitDetailBo
 	const tabParam = searchParams.get('tab');
 	const activeTab: ToolkitTab = isToolkitTab(tabParam) ? tabParam : 'overview';
 
+	// Set when a "Link an agent" CTA fires from a tab that doesn't host the
+	// picker (Access's post-bind prompt): switch to Overview AND open the
+	// picker there — the button must land in the picker, not on a tab.
+	const [linkAgentRequested, setLinkAgentRequested] = useState(false);
+
 	const setTab = (tab: string) => {
 		setSearchParams(
 			(prev) => {
@@ -127,6 +133,13 @@ export function ToolkitDetailBody({ toolkitId, onRequestClose }: ToolkitDetailBo
 		toolkit.key_count === 0 &&
 		boundAgents !== undefined &&
 		boundAgents.length === 0;
+
+	// The single source of truth for "a fresh bind would serve nothing" (the
+	// post-bind link-an-agent prompt's gate). Loading-safe: `undefined` (query
+	// still in flight) means NOT agentless — the prompt only ever fires on
+	// resolved evidence, never on a default empty array.
+	const agentless =
+		boundAgents !== undefined && boundAgents.length === 0 && toolkit.key_count === 0;
 
 	const tabOptions = [
 		{
@@ -236,18 +249,23 @@ export function ToolkitDetailBody({ toolkitId, onRequestClose }: ToolkitDetailBo
 				className="focus-visible:outline-none"
 			>
 				{activeTab === 'overview' && (
-					<OverviewTab toolkitId={toolkitId} onManageAccess={() => setTab('access')} />
+					<OverviewTab
+						toolkitId={toolkitId}
+						onManageAccess={() => setTab('access')}
+						agentless={agentless}
+						openLinkAgent={linkAgentRequested}
+						onLinkAgentOpened={() => setLinkAgentRequested(false)}
+					/>
 				)}
 				{activeTab === 'activity' && <ActivityTab toolkitId={toolkitId} />}
 				{activeTab === 'access' && (
 					<AccessTab
 						toolkitId={toolkitId}
-						agentless={
-							boundAgents !== undefined &&
-							boundAgents.length === 0 &&
-							toolkit.key_count === 0
-						}
-						onLinkAgent={() => setTab('overview')}
+						agentless={agentless}
+						onLinkAgent={() => {
+							setLinkAgentRequested(true);
+							setTab('overview');
+						}}
 					/>
 				)}
 				{activeTab === 'keys' && <KeysTab toolkitId={toolkitId} suspended={suspended} />}

--- a/ui/src/modules/toolkits/components/ToolkitDetailBody.tsx
+++ b/ui/src/modules/toolkits/components/ToolkitDetailBody.tsx
@@ -239,7 +239,17 @@ export function ToolkitDetailBody({ toolkitId, onRequestClose }: ToolkitDetailBo
 					<OverviewTab toolkitId={toolkitId} onManageAccess={() => setTab('access')} />
 				)}
 				{activeTab === 'activity' && <ActivityTab toolkitId={toolkitId} />}
-				{activeTab === 'access' && <AccessTab toolkitId={toolkitId} />}
+				{activeTab === 'access' && (
+					<AccessTab
+						toolkitId={toolkitId}
+						agentless={
+							boundAgents !== undefined &&
+							boundAgents.length === 0 &&
+							toolkit.key_count === 0
+						}
+						onLinkAgent={() => setTab('overview')}
+					/>
+				)}
 				{activeTab === 'keys' && <KeysTab toolkitId={toolkitId} suspended={suspended} />}
 				{activeTab === 'settings' && (
 					<SettingsTab toolkit={toolkit} onDeleted={onRequestClose} />

--- a/ui/src/modules/toolkits/components/detail/AccessTab.tsx
+++ b/ui/src/modules/toolkits/components/detail/AccessTab.tsx
@@ -36,7 +36,7 @@ export function AccessTab({
 	toolkitId: string;
 	/** No linked agent and no API key — enables the post-bind link prompt. */
 	agentless?: boolean;
-	/** Jump to the surface hosting the link-agent affordance (Overview). */
+	/** Switch to Overview AND open the link-agent picker there (host-wired). */
 	onLinkAgent?: () => void;
 }) {
 	const { data: bindings = [], isError: bindingsError } = useToolkitBindings(toolkitId);

--- a/ui/src/modules/toolkits/components/detail/AccessTab.tsx
+++ b/ui/src/modules/toolkits/components/detail/AccessTab.tsx
@@ -28,7 +28,17 @@ import {
  * access-request review cards use, so "what can this credential do" reads
  * identically at review time and on the live binding.
  */
-export function AccessTab({ toolkitId }: { toolkitId: string }) {
+export function AccessTab({
+	toolkitId,
+	agentless = false,
+	onLinkAgent,
+}: {
+	toolkitId: string;
+	/** No linked agent and no API key — enables the post-bind link prompt. */
+	agentless?: boolean;
+	/** Jump to the surface hosting the link-agent affordance (Overview). */
+	onLinkAgent?: () => void;
+}) {
 	const { data: bindings = [], isError: bindingsError } = useToolkitBindings(toolkitId);
 	const unbindCredential = useUnbindCredential(toolkitId);
 
@@ -202,6 +212,8 @@ export function AccessTab({ toolkitId }: { toolkitId: string }) {
 				open={bindOpen}
 				onClose={() => setBindOpen(false)}
 				boundIds={boundIds}
+				agentless={agentless}
+				onLinkAgent={onLinkAgent}
 			/>
 		</>
 	);

--- a/ui/src/modules/toolkits/components/detail/OverviewTab.tsx
+++ b/ui/src/modules/toolkits/components/detail/OverviewTab.tsx
@@ -274,12 +274,15 @@ export function OverviewTab({ toolkitId, onManageAccess }: OverviewTabProps) {
 			</Dialog>
 
 			{/* Two-step bind wizard — the same component the Access tab opens, so
-			    binding reads identically wherever it starts. */}
+			    binding reads identically wherever it starts. The post-bind
+			    "link an agent?" prompt opens the link dialog hosted right here. */}
 			<BindCredentialDialog
 				toolkitId={toolkitId}
 				open={bindOpen}
 				onClose={() => setBindOpen(false)}
 				boundIds={boundIds}
+				agentless={!agentsError && agents.length === 0 && (toolkit?.key_count ?? 0) === 0}
+				onLinkAgent={() => setLinkAgentOpen(true)}
 			/>
 		</div>
 	);

--- a/ui/src/modules/toolkits/components/detail/OverviewTab.tsx
+++ b/ui/src/modules/toolkits/components/detail/OverviewTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import {
 	AlertTriangle,
@@ -50,9 +50,25 @@ export interface OverviewTabProps {
 	toolkitId: string;
 	/** Jump to the Access tab (the credentials summary's Manage action). */
 	onManageAccess: () => void;
+	/**
+	 * Loading-safe "a fresh bind would serve nothing" flag, derived once in
+	 * `ToolkitDetailBody` (false while the agents query is in flight). Gates
+	 * the bind dialog's post-bind link-an-agent prompt.
+	 */
+	agentless?: boolean;
+	/** One-shot signal: open the link-agent picker (e.g. arriving from the
+	 * Access tab's "Link an agent" CTA). Acknowledge via onLinkAgentOpened. */
+	openLinkAgent?: boolean;
+	onLinkAgentOpened?: () => void;
 }
 
-export function OverviewTab({ toolkitId, onManageAccess }: OverviewTabProps) {
+export function OverviewTab({
+	toolkitId,
+	onManageAccess,
+	agentless = false,
+	openLinkAgent = false,
+	onLinkAgentOpened,
+}: OverviewTabProps) {
 	const { data: toolkit } = useToolkit(toolkitId);
 	const { data: agents = [], isError: agentsError } = useToolkitAgents(toolkitId);
 	const { data: bindings = [], isError: bindingsError } = useToolkitBindings(toolkitId);
@@ -60,6 +76,15 @@ export function OverviewTab({ toolkitId, onManageAccess }: OverviewTabProps) {
 	const unlinkAgent = useUnlinkAgentFromToolkit(toolkitId);
 	const [linkAgentOpen, setLinkAgentOpen] = useState(false);
 	const [bindOpen, setBindOpen] = useState(false);
+
+	// Consume the host's one-shot open-the-picker signal (Access tab's
+	// "Link an agent" must end in the picker, not just on this tab).
+	useEffect(() => {
+		if (openLinkAgent) {
+			setLinkAgentOpen(true);
+			onLinkAgentOpened?.();
+		}
+	}, [openLinkAgent, onLinkAgentOpened]);
 
 	const linkedAgentIds = new Set(agents.map((a) => a.agent_id));
 	const boundIds = new Set(bindings.map((b) => b.credential_id));
@@ -281,7 +306,7 @@ export function OverviewTab({ toolkitId, onManageAccess }: OverviewTabProps) {
 				open={bindOpen}
 				onClose={() => setBindOpen(false)}
 				boundIds={boundIds}
-				agentless={!agentsError && agents.length === 0 && (toolkit?.key_count ?? 0) === 0}
+				agentless={agentless}
 				onLinkAgent={() => setLinkAgentOpen(true)}
 			/>
 		</div>

--- a/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
+++ b/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
@@ -958,3 +958,80 @@ describe('ToolkitDetailPage — no-linked-agents banner', () => {
 		expect(screen.queryByTestId('toolkit-no-agents-banner')).not.toBeInTheDocument();
 	});
 });
+
+describe('ToolkitDetailPage — post-bind link-an-agent prompt', () => {
+	/** Same keys-less override as the banner tests (see above). */
+	function stubKeylessToolkit(credentialCount = 1) {
+		worker.use(
+			http.get('/toolkits/:toolkitId', () =>
+				HttpResponse.json({
+					toolkit_id: 'tk_demo_github',
+					name: 'GitHub Tools',
+					description: null,
+					active: true,
+					created_by: 'admin@local',
+					created_at: '2026-05-01T10:00:00Z',
+					updated_at: null,
+					credential_count: credentialCount,
+					key_count: 0,
+				}),
+			),
+		);
+	}
+
+	it('holds the dialog open on a link prompt when nothing can use the bind', async () => {
+		// The proactive half of the #826 dead-end fix: a bind that lands on an
+		// agent-less, key-less toolkit serves nothing — instead of closing
+		// into silence, the dialog says so and offers the link-agent jump.
+		stubKeylessToolkit(0);
+		seedAgents({ bound: [], workspace: [] });
+		const credId = `cred_prompt_${Math.random().toString(36).slice(2, 7)}`;
+		seedCredentials([
+			{ credential_id: credId, name: 'Prompt key', type: 'api_key', vendor: 'prompt' },
+		]);
+		const user = userEvent.setup();
+		renderWithProviders(<ToolkitDetailPage />, { route: ROUTE, path: PATH });
+		await screen.findByRole('heading', { name: 'GitHub Tools' });
+
+		await user.click(screen.getByRole('tab', { name: /^Access/ }));
+		await user.click(await screen.findByRole('button', { name: /^bind credential$/i }));
+		await user.click(await screen.findByText('Prompt key'));
+		const dialog = screen.getByRole('dialog');
+		await user.click(await within(dialog).findByRole('button', { name: /^bind credential$/i }));
+
+		// The bind landed, but the dialog holds on the prompt instead of closing.
+		const prompt = await screen.findByTestId('bind-link-agent-prompt');
+		expect(prompt).toHaveTextContent(/no agent is linked to this toolkit yet/i);
+
+		// The CTA jumps to the surface hosting the link-agent affordance
+		// (Overview) and closes the dialog.
+		await user.click(screen.getByRole('button', { name: 'Link an agent' }));
+		await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+		expect(screen.getByRole('tab', { name: /^Overview/ })).toHaveAttribute(
+			'aria-selected',
+			'true',
+		);
+	});
+
+	it('closes silently when an agent already serves the toolkit', async () => {
+		// Default handlers bind Support Bot — the bind is immediately useful,
+		// so no prompt (the existing close-on-success behavior is unchanged).
+		stubKeylessToolkit(0);
+		const credId = `cred_served_${Math.random().toString(36).slice(2, 7)}`;
+		seedCredentials([
+			{ credential_id: credId, name: 'Served key', type: 'api_key', vendor: 'served' },
+		]);
+		const user = userEvent.setup();
+		renderWithProviders(<ToolkitDetailPage />, { route: ROUTE, path: PATH });
+		await screen.findByRole('heading', { name: 'GitHub Tools' });
+
+		await user.click(screen.getByRole('tab', { name: /^Access/ }));
+		await user.click(await screen.findByRole('button', { name: /^bind credential$/i }));
+		await user.click(await screen.findByText('Served key'));
+		const dialog = screen.getByRole('dialog');
+		await user.click(await within(dialog).findByRole('button', { name: /^bind credential$/i }));
+
+		await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+		expect(screen.queryByTestId('bind-link-agent-prompt')).not.toBeInTheDocument();
+	});
+});

--- a/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
+++ b/ui/src/modules/toolkits/pages/ToolkitDetailPage.test.tsx
@@ -1002,15 +1002,48 @@ describe('ToolkitDetailPage — post-bind link-an-agent prompt', () => {
 		// The bind landed, but the dialog holds on the prompt instead of closing.
 		const prompt = await screen.findByTestId('bind-link-agent-prompt');
 		expect(prompt).toHaveTextContent(/no agent is linked to this toolkit yet/i);
+		// Announced, not just swapped in: the focused submit button unmounted.
+		expect(prompt).toHaveAttribute('role', 'status');
 
-		// The CTA jumps to the surface hosting the link-agent affordance
-		// (Overview) and closes the dialog.
+		// The CTA must END in the link-agent picker (not merely land on the
+		// Overview tab and stop): the bind dialog closes, Overview activates,
+		// and the picker dialog is open.
 		await user.click(screen.getByRole('button', { name: 'Link an agent' }));
-		await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+		expect(await screen.findByRole('dialog', { name: /link agent/i })).toBeInTheDocument();
 		expect(screen.getByRole('tab', { name: /^Overview/ })).toHaveAttribute(
 			'aria-selected',
 			'true',
 		);
+		expect(screen.queryByTestId('bind-link-agent-prompt')).not.toBeInTheDocument();
+	});
+
+	it('starts back at step 1 when reopened after dismissing the prompt', async () => {
+		// The prompt is transient state, not user input: "Not now" (or any
+		// close) must clear it, so the next open never lands on a stale
+		// "Credential bound." for a bind from a previous session.
+		stubKeylessToolkit(0);
+		seedAgents({ bound: [], workspace: [] });
+		const credId = `cred_reopen_${Math.random().toString(36).slice(2, 7)}`;
+		seedCredentials([
+			{ credential_id: credId, name: 'Reopen key', type: 'api_key', vendor: 'reopen' },
+		]);
+		const user = userEvent.setup();
+		renderWithProviders(<ToolkitDetailPage />, { route: ROUTE, path: PATH });
+		await screen.findByRole('heading', { name: 'GitHub Tools' });
+
+		await user.click(screen.getByRole('tab', { name: /^Access/ }));
+		await user.click(await screen.findByRole('button', { name: /^bind credential$/i }));
+		await user.click(await screen.findByText('Reopen key'));
+		const dialog = screen.getByRole('dialog');
+		await user.click(await within(dialog).findByRole('button', { name: /^bind credential$/i }));
+		await screen.findByTestId('bind-link-agent-prompt');
+
+		await user.click(screen.getByRole('button', { name: 'Not now' }));
+		await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+		await user.click(await screen.findByRole('button', { name: /^bind credential$/i }));
+		expect(await screen.findByText(/step 1 of 2/i)).toBeInTheDocument();
+		expect(screen.queryByTestId('bind-link-agent-prompt')).not.toBeInTheDocument();
 	});
 
 	it('closes silently when an agent already serves the toolkit', async () => {

--- a/ui/src/shared/api/generated/models/CredentialRedactedResponse.ts
+++ b/ui/src/shared/api/generated/models/CredentialRedactedResponse.ts
@@ -29,7 +29,7 @@ export type CredentialRedactedResponse = {
      */
     credential_id: string;
     /**
-     * Redacted, type-specific projection (hints/last-N chars; never the secret).
+     * Redacted, type-specific projection (hints/last-N chars; never the secret). For oauth2: client_id, token_url, grant_type (authorization_code | client_credentials), scopes, and — for authorization_code only — `connected`, whether the interactive sign-in completed and is still usable (null for other grants).
      */
     details?: (Record<string, any> | null);
     /**

--- a/ui/src/shared/api/generated/models/ToolkitResponse.ts
+++ b/ui/src/shared/api/generated/models/ToolkitResponse.ts
@@ -2,11 +2,16 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { APIReference } from './APIReference';
 /**
  * Toolkit response.
  */
 export type ToolkitResponse = {
     active: boolean;
+    /**
+     * Distinct (vendor, name, version) APIs served by this toolkit's credential bindings, sorted by vendor/name/version. Empty when no credentials are bound.
+     */
+    apis?: Array<APIReference>;
     created_at: string;
     created_by?: (string | null);
     credential_count: number;

--- a/ui/src/shared/api/generated/models/ToolkitResponse.ts
+++ b/ui/src/shared/api/generated/models/ToolkitResponse.ts
@@ -2,16 +2,16 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { APIReference } from './APIReference';
+import type { ServedApiRef } from './ServedApiRef';
 /**
  * Toolkit response.
  */
 export type ToolkitResponse = {
     active: boolean;
     /**
-     * Distinct (vendor, name, version) APIs served by this toolkit's credential bindings, sorted by vendor/name/version. Empty when no credentials are bound.
+     * Distinct APIs served by this toolkit's credential bindings that are visible to the caller, sorted by vendor/name/version. NULL api_name/api_version mean the credential covers all names/versions for the vendor. Empty when no visible credentials are bound.
      */
-    apis?: Array<APIReference>;
+    apis?: Array<ServedApiRef>;
     created_at: string;
     created_by?: (string | null);
     credential_count: number;

--- a/ui/src/shared/app/rail/AccessRequestItemCard.tsx
+++ b/ui/src/shared/app/rail/AccessRequestItemCard.tsx
@@ -69,6 +69,11 @@ export function AccessRequestItemCard({
 	// Rules present on an item type that can't enforce them (e.g. a legacy
 	// toolkit.bind): show a notice instead of an allowlist that won't apply.
 	const hasUnenforceableRules = rules.length > 0 && !enforceable;
+	// The enriched GET stamps `already_satisfied` on pending items whose
+	// outcome is already in effect (see the backend annotator): surfaced as a
+	// chip so a reviewer of manually-fulfilled work approves instead of
+	// re-provisioning. Absent/null (not computed) renders nothing.
+	const alreadySatisfied = item.already_satisfied === true;
 	const initials = label
 		.replace(/[^a-zA-Z0-9]/g, '')
 		.slice(0, 2)
@@ -169,6 +174,19 @@ export function AccessRequestItemCard({
 								</span>
 							)}
 						</>
+					)}
+					{alreadySatisfied && (
+						<span
+							className="bg-accent-green/10 text-accent-green inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-medium"
+							title={
+								item.already_satisfied_by
+									? `Already satisfied by toolkit ${item.already_satisfied_by} — approving records the decision without redoing the setup.`
+									: 'What this item asks for already exists — approving records the decision without redoing the setup.'
+							}
+						>
+							<CheckCircle2 className="h-3 w-3" aria-hidden="true" />
+							Already in place
+						</span>
 					)}
 				</div>
 

--- a/ui/src/shared/app/rail/AccessRequestItemCard.tsx
+++ b/ui/src/shared/app/rail/AccessRequestItemCard.tsx
@@ -176,19 +176,30 @@ export function AccessRequestItemCard({
 						</>
 					)}
 					{alreadySatisfied && (
-						<span
-							className="bg-accent-green/10 text-accent-green inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-medium"
-							title={
-								item.already_satisfied_by
-									? `Already satisfied by toolkit ${item.already_satisfied_by} — approving records the decision without redoing the setup.`
-									: 'What this item asks for already exists — approving records the decision without redoing the setup.'
-							}
-						>
+						<span className="bg-accent-green/10 text-accent-green inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-medium">
 							<CheckCircle2 className="h-3 w-3" aria-hidden="true" />
 							Already in place
 						</span>
 					)}
 				</div>
+
+				{/* The chip's substance in discernible text (not a hover-only
+				    `title`): keyboard/touch users and screen readers get the
+				    guidance too. No raw ids — the card has no name resolution, so
+				    an opaque `tk_…` would be noise, not information. */}
+				{alreadySatisfied && (
+					<div className="text-muted-foreground border-border bg-card/40 mt-2.5 flex items-start gap-1.5 rounded-lg border px-2.5 py-2 text-xs">
+						<Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+						<span>
+							{item.already_satisfied_by
+								? 'An existing toolkit already covers this item. '
+								: 'What this item asks for already exists. '}
+							{enforceable && rules.length > 0
+								? 'Approving records the decision and applies this item\u2019s access rules to the existing binding, replacing its current rules.'
+								: 'Approving records the decision without redoing the setup.'}
+						</span>
+					</div>
+				)}
 
 				{!scopeGrant && enforceable && (
 					<OperationsSummary rules={rules} targetLabel={label} />

--- a/ui/src/shared/app/rail/ProvisioningRequestDialog.tsx
+++ b/ui/src/shared/app/rail/ProvisioningRequestDialog.tsx
@@ -23,6 +23,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
 	ArrowLeft,
 	ArrowRight,
+	AlertTriangle,
 	CheckCircle2,
 	KeyRound,
 	MessageSquare,
@@ -104,6 +105,10 @@ interface ChainProgress {
 	/** The credential was adopted from existing credentials — no connect flow,
 	 * excluded from orphan discard on cancel. */
 	credentialAdopted: boolean;
+	/** The adopted credential was never connected (OAuth `connected === false`
+	 * at adoption time) — keeps the adopted-state panel warning instead of
+	 * declaring a working reuse. */
+	credentialUnconnected: boolean;
 	rules: PermissionRuleInput[];
 	/** Operator chose not to set this API up now; its items are denied at submit. */
 	skipped: boolean;
@@ -255,6 +260,7 @@ function seedChainProgress(chains: PlanChain[], agentName: string | undefined): 
 		credentialType: null,
 		credentialName: null,
 		credentialAdopted: false,
+		credentialUnconnected: false,
 		rules: proposedChainRules(chain),
 		skipped: chainUnfulfillable(chain),
 	}));
@@ -361,6 +367,7 @@ export function ProvisioningRequestDialog({
 				toolkitAdopted: cs.toolkitAdopted ?? false,
 				credentialName: cs.credentialName ?? null,
 				credentialAdopted: cs.credentialAdopted ?? false,
+				credentialUnconnected: cs.credentialUnconnected ?? false,
 			});
 		}
 		return { ...draft, chains: aligned };
@@ -620,6 +627,14 @@ export function ProvisioningRequestDialog({
 		setPendingToolkitChoice('');
 		setPendingCredentialChoice('');
 	}, [step, chainIndex]);
+	// Derived before JSX (file convention — no closures in the tree): the
+	// staged credential and whether it needs the unconnected-OAuth warning.
+	const pendingCredential =
+		chainCredentialOptions !== 'error' && chainCredentialOptions !== null
+			? chainCredentialOptions.find((c) => c.credential_id === pendingCredentialChoice)
+			: undefined;
+	const pendingUnconnectedOAuth =
+		pendingCredential !== undefined && isUnconnectedOAuth(pendingCredential);
 
 	/** Adopt an existing toolkit for the current chain. */
 	const handleAdoptToolkit = useCallback(
@@ -675,6 +690,7 @@ export function ProvisioningRequestDialog({
 				credentialType: cred.type,
 				credentialName: cred.name,
 				credentialAdopted: true,
+				credentialUnconnected: isUnconnectedOAuth(cred),
 			});
 			setStep('rules');
 		},
@@ -687,6 +703,7 @@ export function ProvisioningRequestDialog({
 			credentialType: null,
 			credentialName: null,
 			credentialAdopted: false,
+			credentialUnconnected: false,
 		});
 	}, [updateChain]);
 
@@ -747,6 +764,7 @@ export function ProvisioningRequestDialog({
 				credentialType: info.type,
 				credentialName: null,
 				credentialAdopted: false,
+				credentialUnconnected: false,
 			});
 			// An OAuth2 credential that needs a browser sign-in (authorization-code
 			// with an authorize URL) has NO token until the connect flow completes —
@@ -1038,19 +1056,20 @@ export function ProvisioningRequestDialog({
 		? satisfiedByItemId.get(chain.toolkitBind.id)
 		: undefined;
 	// Whether a toolkit already serves this chain's API (from the list
-	// response's `apis` aggregation): in the canonical manual-setup state
-	// (toolkit + credential exist, agent unbound) nothing is satisfied, so the
-	// wired-toolkit float never fires — ranking by served API rescues that
-	// exact case (issue #890). Vendor must match; names only when both are
-	// known — a version-less/name-less chain reference matches any row for the
-	// vendor, mirroring decide-time reference resolution's laxity.
+	// response's `apis` aggregation — ServedApiRef, NULL name/version meaning
+	// "covers all"): in the canonical manual-setup state (toolkit + credential
+	// exist, agent unbound) nothing is satisfied, so the wired-toolkit float
+	// never fires — ranking by served API rescues that exact case (issue
+	// #890). Vendor must match; names only when both are known — a NULL/empty
+	// name on either side matches any row for the vendor, mirroring
+	// decide-time reference resolution's laxity.
 	const chainNameSlug = chain?.apiRef.name ? slugifyApiField(chain.apiRef.name) : '';
 	const servesChainApi = (tk: ToolkitResponse) =>
 		chainVendor !== undefined &&
 		(tk.apis ?? []).some(
 			(api) =>
-				api.vendor === chainVendor &&
-				(!chainNameSlug || !api.name || api.name === chainNameSlug),
+				api.api_vendor === chainVendor &&
+				(!chainNameSlug || !api.api_name || api.api_name === chainNameSlug),
 		);
 	const toolkitPickerOptions =
 		existingToolkits === 'error' || existingToolkits === null
@@ -1470,7 +1489,11 @@ export function ProvisioningRequestDialog({
 																{tk.toolkit_id === wiredToolkitId
 																	? ' — already linked to this agent'
 																	: servesChainApi(tk)
-																		? ` — already serves ${chainLabel}`
+																		? // Fixed-width suffix (long names push past the
+																			// closed control's ellipsis) and hedged: a
+																			// NULL-name credential matches the vendor
+																			// laxly, so don't assert the exact API.
+																			' — already serves this API'
 																		: ''}
 															</option>
 														))}
@@ -1519,20 +1542,43 @@ export function ProvisioningRequestDialog({
 							>
 								{progress?.credentialId && progress.credentialAdopted ? (
 									<div className="max-w-md space-y-3">
-										<div className="border-success/30 bg-success/5 flex items-center gap-2.5 rounded-lg border p-4 text-sm">
-											<CheckCircle2 className="text-success h-5 w-5 shrink-0" />
-											<span>
-												Using existing credential{' '}
-												<span className="font-medium">
-													{progress.credentialName ??
-														credentialLabel ??
-														'credential'}
-												</span>{' '}
-												— reused as-is. Its sign-in isn’t re-verified; if it
-												has stopped working, calls will fail until you
-												reconnect it.
-											</span>
-										</div>
+										{progress.credentialUnconnected ? (
+											// The warning must not vanish at the moment it
+											// becomes binding: a never-connected adoption
+											// stays warning-toned, not a green success.
+											<div
+												className="border-warning/30 bg-warning/5 flex items-center gap-2.5 rounded-lg border p-4 text-sm"
+												role="status"
+											>
+												<AlertTriangle className="text-warning h-5 w-5 shrink-0" />
+												<span>
+													Using existing credential{' '}
+													<span className="font-medium">
+														{progress.credentialName ??
+															credentialLabel ??
+															'credential'}
+													</span>{' '}
+													— it was never connected, so calls will fail
+													until someone connects it from the Credentials
+													page.
+												</span>
+											</div>
+										) : (
+											<div className="border-success/30 bg-success/5 flex items-center gap-2.5 rounded-lg border p-4 text-sm">
+												<CheckCircle2 className="text-success h-5 w-5 shrink-0" />
+												<span>
+													Using existing credential{' '}
+													<span className="font-medium">
+														{progress.credentialName ??
+															credentialLabel ??
+															'credential'}
+													</span>{' '}
+													— reused as-is. Its sign-in isn’t re-verified;
+													if it has stopped working, calls will fail until
+													you reconnect it.
+												</span>
+											</div>
+										)}
 										<Button
 											variant="ghost"
 											onClick={handleClearAdoptedCredential}
@@ -1617,27 +1663,22 @@ export function ProvisioningRequestDialog({
 																	cred.type}
 																)
 																{isUnconnectedOAuth(cred)
-																	? ' — not signed in yet'
+																	? ' — not connected yet'
 																	: ''}
 															</option>
 														))}
 													</Select>
-													{(() => {
-														const pending = chainCredentialOptions.find(
-															(cred) =>
-																cred.credential_id ===
-																pendingCredentialChoice,
-														);
-														return pending &&
-															isUnconnectedOAuth(pending) ? (
-															<p className="text-accent-orange text-sm">
-																This OAuth credential was never
-																signed in, so calls using it will
-																fail until someone completes its
-																sign-in from the Credentials page.
-															</p>
-														) : null;
-													})()}
+													{pendingUnconnectedOAuth && (
+														<p
+															className="text-warning text-sm"
+															role="status"
+														>
+															This OAuth credential was never
+															connected, so calls using it will fail
+															until someone connects it from the
+															Credentials page.
+														</p>
+													)}
 													{pendingCredentialChoice && (
 														<Button
 															variant="secondary"

--- a/ui/src/shared/app/rail/ProvisioningRequestDialog.tsx
+++ b/ui/src/shared/app/rail/ProvisioningRequestDialog.tsx
@@ -601,6 +601,14 @@ export function ProvisioningRequestDialog({
 		};
 	}, [open, step, chainVendor, existingCredentials]);
 	const chainCredentialOptions = chainVendor ? (existingCredentials[chainVendor] ?? null) : null;
+	// A never-connected OAuth credential (authorization_code whose interactive
+	// sign-in was never completed — the backend's derived `connected` flag on
+	// the redacted details) would fail at execute time if adopted. Flag it in
+	// the picker so the operator is warned before adopting, not after (#890).
+	// `connected` is absent for other types/grants, so only an explicit false
+	// marks a credential as unconnected.
+	const isUnconnectedOAuth = (cred: CredentialRedactedResponse) =>
+		cred.type === CredentialType.OAUTH2 && cred.details?.connected === false;
 
 	// Picker selections are staged locally and committed by an explicit
 	// button: committing on <select> change is a keyboard trap (arrowing
@@ -649,10 +657,11 @@ export function ProvisioningRequestDialog({
 
 	/**
 	 * Adopt an existing credential — reused as-is, no connect flow. The picker
-	 * only offers active credentials; whether an OAuth credential actually
-	 * completed its sign-in is not observable from the redacted listing, so
-	 * adoption trusts the operator's choice (a broken pick fails at execute
-	 * time, same as it would for the manual setup being adopted).
+	 * only offers active credentials; a never-connected OAuth credential is
+	 * flagged in the picker (see `isUnconnectedOAuth`) with a warning before
+	 * commit, but adoption still trusts the operator's choice — warned, not
+	 * blocked (a broken pick fails at execute time, same as it would for the
+	 * manual setup being adopted).
 	 */
 	const handleAdoptCredential = useCallback(
 		(credentialId: string) => {
@@ -1028,12 +1037,32 @@ export function ProvisioningRequestDialog({
 	const wiredToolkitId = chain?.toolkitBind
 		? satisfiedByItemId.get(chain.toolkitBind.id)
 		: undefined;
+	// Whether a toolkit already serves this chain's API (from the list
+	// response's `apis` aggregation): in the canonical manual-setup state
+	// (toolkit + credential exist, agent unbound) nothing is satisfied, so the
+	// wired-toolkit float never fires — ranking by served API rescues that
+	// exact case (issue #890). Vendor must match; names only when both are
+	// known — a version-less/name-less chain reference matches any row for the
+	// vendor, mirroring decide-time reference resolution's laxity.
+	const chainNameSlug = chain?.apiRef.name ? slugifyApiField(chain.apiRef.name) : '';
+	const servesChainApi = (tk: ToolkitResponse) =>
+		chainVendor !== undefined &&
+		(tk.apis ?? []).some(
+			(api) =>
+				api.vendor === chainVendor &&
+				(!chainNameSlug || !api.name || api.name === chainNameSlug),
+		);
 	const toolkitPickerOptions =
-		existingToolkits === 'error' || existingToolkits === null || !wiredToolkitId
+		existingToolkits === 'error' || existingToolkits === null
 			? existingToolkits
 			: [
 					...existingToolkits.filter((tk) => tk.toolkit_id === wiredToolkitId),
-					...existingToolkits.filter((tk) => tk.toolkit_id !== wiredToolkitId),
+					...existingToolkits.filter(
+						(tk) => tk.toolkit_id !== wiredToolkitId && servesChainApi(tk),
+					),
+					...existingToolkits.filter(
+						(tk) => tk.toolkit_id !== wiredToolkitId && !servesChainApi(tk),
+					),
 				];
 	const wiredToolkitName =
 		wiredToolkitId && existingToolkits !== 'error'
@@ -1440,7 +1469,9 @@ export function ProvisioningRequestDialog({
 																{tk.name}
 																{tk.toolkit_id === wiredToolkitId
 																	? ' — already linked to this agent'
-																	: ''}
+																	: servesChainApi(tk)
+																		? ` — already serves ${chainLabel}`
+																		: ''}
 															</option>
 														))}
 													</Select>
@@ -1585,9 +1616,28 @@ export function ProvisioningRequestDialog({
 																{credentialTypeLabel(cred.type) ??
 																	cred.type}
 																)
+																{isUnconnectedOAuth(cred)
+																	? ' — not signed in yet'
+																	: ''}
 															</option>
 														))}
 													</Select>
+													{(() => {
+														const pending = chainCredentialOptions.find(
+															(cred) =>
+																cred.credential_id ===
+																pendingCredentialChoice,
+														);
+														return pending &&
+															isUnconnectedOAuth(pending) ? (
+															<p className="text-accent-orange text-sm">
+																This OAuth credential was never
+																signed in, so calls using it will
+																fail until someone completes its
+																sign-in from the Credentials page.
+															</p>
+														) : null;
+													})()}
 													{pendingCredentialChoice && (
 														<Button
 															variant="secondary"

--- a/ui/src/shared/app/rail/__tests__/AccessRequestItemCard.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/AccessRequestItemCard.test.tsx
@@ -108,9 +108,15 @@ describe('AccessRequestItemCard — already-satisfied hint', () => {
 			already_satisfied: true,
 		});
 		expect(screen.getByText('Already in place')).toBeInTheDocument();
+		// The guidance is discernible text (not a hover-only title), so keyboard
+		// and screen-reader users get it too.
+		expect(screen.getByText(/already exists/i)).toBeInTheDocument();
+		expect(
+			screen.getByText(/records the decision without redoing the setup/i),
+		).toBeInTheDocument();
 	});
 
-	it('names the satisfying toolkit in the chip tooltip when the hint carries it', () => {
+	it('credits an existing toolkit (never a raw id) when the hint names one', () => {
 		renderCard({
 			resource_type: 'toolkit',
 			action: 'bind',
@@ -118,10 +124,26 @@ describe('AccessRequestItemCard — already-satisfied hint', () => {
 			already_satisfied: true,
 			already_satisfied_by: 'tk_target',
 		});
-		expect(screen.getByText('Already in place')).toHaveAttribute(
-			'title',
-			expect.stringContaining('tk_target'),
-		);
+		expect(
+			screen.getByText(/an existing toolkit already covers this item/i),
+		).toBeInTheDocument();
+		// The card has no name resolution, so an opaque tk_… id would be noise —
+		// the notice must not leak it (the headline already shows resource_id).
+		expect(screen.queryByText(/satisfied by toolkit tk_target/i)).not.toBeInTheDocument();
+	});
+
+	it('warns that approving a satisfied credential.bind replaces the binding rules', () => {
+		// The satisfaction probe checks binding EXISTENCE only, while approve
+		// writes this item's rules over the live binding — the copy must not
+		// promise "without redoing the setup" when rules ride along.
+		renderCard({
+			resource_type: 'credential',
+			action: 'bind',
+			already_satisfied: true,
+			rules: [{ effect: 'allow', methods: ['GET'] }],
+		});
+		expect(screen.getByText(/replacing its current rules/i)).toBeInTheDocument();
+		expect(screen.queryByText(/without redoing the setup/i)).not.toBeInTheDocument();
 	});
 
 	it('renders nothing for false or not-computed hints', () => {

--- a/ui/src/shared/app/rail/__tests__/AccessRequestItemCard.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/AccessRequestItemCard.test.tsx
@@ -99,6 +99,42 @@ describe('AccessRequestItemCard — credential.bind operations', () => {
 	});
 });
 
+describe('AccessRequestItemCard — already-satisfied hint', () => {
+	it('shows the "Already in place" chip when the enriched GET marks the item satisfied', () => {
+		renderCard({
+			resource_type: 'scope',
+			action: 'grant',
+			resource_id: 'capabilities:execute',
+			already_satisfied: true,
+		});
+		expect(screen.getByText('Already in place')).toBeInTheDocument();
+	});
+
+	it('names the satisfying toolkit in the chip tooltip when the hint carries it', () => {
+		renderCard({
+			resource_type: 'toolkit',
+			action: 'bind',
+			resource_id: 'tk_target',
+			already_satisfied: true,
+			already_satisfied_by: 'tk_target',
+		});
+		expect(screen.getByText('Already in place')).toHaveAttribute(
+			'title',
+			expect.stringContaining('tk_target'),
+		);
+	});
+
+	it('renders nothing for false or not-computed hints', () => {
+		// False (determinately unsatisfied) and null/absent (not computed) both
+		// stay silent: the chip only ever asserts, never speculates.
+		const { unmount } = renderCard({ already_satisfied: false });
+		expect(screen.queryByText('Already in place')).not.toBeInTheDocument();
+		unmount();
+		renderCard({});
+		expect(screen.queryByText('Already in place')).not.toBeInTheDocument();
+	});
+});
+
 describe('AccessRequestItemCard — non-enforceable rules', () => {
 	it('hides the allowlist and shows a notice for a toolkit.bind carrying rules', () => {
 		// Broker rules key per credential, so a toolkit.bind (agent↔toolkit) can't

--- a/ui/src/shared/app/rail/__tests__/ProvisioningRequestDialog.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/ProvisioningRequestDialog.test.tsx
@@ -910,6 +910,121 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 		).toBeInTheDocument();
 	});
 
+	it('ranks toolkits already serving the chain API first and badges them', async () => {
+		// The canonical #826 manual state (toolkit + credential exist, agent
+		// unbound) satisfies nothing, so the wired-toolkit float never fires —
+		// ranking by the served API (the list's `apis` aggregation) rescues
+		// that exact case: the right toolkit surfaces even from a name-only
+		// list (#890).
+		const request = planRequest();
+		stubDirectoryAndRequest(request);
+		worker.use(
+			http.get('/toolkits', () =>
+				HttpResponse.json({
+					data: [
+						{
+							// Server order puts the non-serving toolkit first: the
+							// ranking, not luck, must float the serving one.
+							toolkit_id: 'tk_unrelated',
+							name: 'Unrelated toolkit',
+							description: null,
+							active: true,
+							created_by: 'usr_admin',
+							created_at: '2026-01-01T00:00:00Z',
+							updated_at: null,
+							credential_count: 1,
+							key_count: 0,
+							apis: [{ vendor: 'github-com', name: 'rest', version: '' }],
+						},
+						{
+							toolkit_id: 'tk_serves',
+							name: 'Weather toolkit',
+							description: null,
+							active: true,
+							created_by: 'usr_admin',
+							created_at: '2026-01-01T00:00:00Z',
+							updated_at: null,
+							credential_count: 1,
+							key_count: 0,
+							apis: [{ vendor: 'open-meteo-com', name: 'forecast', version: '' }],
+						},
+					],
+					has_more: false,
+					next_cursor: null,
+				}),
+			),
+		);
+		renderWithProviders(
+			<ProvisioningRequestDialog open request={request} onClose={() => {}} />,
+		);
+
+		const picker = await screen.findByLabelText(/use an existing toolkit/i);
+		const options = within(picker).getAllByRole('option');
+		// [0] is the placeholder; the serving toolkit floats above the rest.
+		expect(options[1]).toHaveTextContent(/Weather toolkit — already serves/);
+		expect(options[2]).toHaveTextContent('Unrelated toolkit');
+		expect(options[2]).not.toHaveTextContent(/already serves/);
+	});
+
+	it('flags a never-connected OAuth credential and warns before adoption', async () => {
+		// The adopt picker previously trusted the operator's choice: a
+		// never-signed-in OAuth credential only failed at execute time. The
+		// redacted listing now carries the derived connect state, so the
+		// picker warns BEFORE the pick is committed (#890).
+		const request = authPlanRequest();
+		stubAdoption(request);
+		worker.use(
+			http.get('/credentials', () =>
+				HttpResponse.json({
+					data: [
+						{
+							credential_id: 'cred_oauth_pending',
+							name: 'GitHub OAuth',
+							type: 'oauth2',
+							provider: 'static',
+							active: true,
+							api: { vendor: 'open-meteo-com', name: 'forecast', version: null },
+							created_at: '2026-01-01T00:00:00Z',
+							updated_at: null,
+							details: {
+								client_id: 'cid',
+								token_url: 'https://auth.example/token',
+								grant_type: 'authorization_code',
+								connected: false,
+							},
+						},
+					],
+					has_more: false,
+					next_cursor: null,
+				}),
+			),
+			http.post('/toolkits', () =>
+				HttpResponse.json({
+					toolkit: { toolkit_id: 'tk_auth', name: 'Weather Agent toolkit' },
+					api_key: 'k',
+				}),
+			),
+		);
+		renderWithProviders(
+			<ProvisioningRequestDialog open request={request} onClose={() => {}} />,
+		);
+		const user = userEvent.setup();
+
+		await screen.findByLabelText('Toolkit name');
+		await user.click(screen.getByRole('button', { name: /Create toolkit/i }));
+
+		const picker = await screen.findByLabelText(/use an existing credential/i);
+		const options = within(picker).getAllByRole('option');
+		expect(options[1]).toHaveTextContent(/not signed in yet/);
+
+		// No warning until the risky option is actually staged.
+		expect(screen.queryByText(/was never signed in/i)).not.toBeInTheDocument();
+		await user.selectOptions(picker, 'cred_oauth_pending');
+		expect(await screen.findByText(/was never signed in/i)).toBeInTheDocument();
+		// The pick is still allowed — warned, not blocked.
+		expect(screen.getByRole('button', { name: 'Use this credential' })).toBeEnabled();
+	});
+
 	it('offers a retry instead of silently collapsing when the toolkit list fails', async () => {
 		// The nudge may be telling the operator to adopt — a failed fetch must
 		// say so and offer a way out, not silently hide the picker.

--- a/ui/src/shared/app/rail/__tests__/ProvisioningRequestDialog.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/ProvisioningRequestDialog.test.tsx
@@ -934,7 +934,7 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 							updated_at: null,
 							credential_count: 1,
 							key_count: 0,
-							apis: [{ vendor: 'github-com', name: 'rest', version: '' }],
+							apis: [{ api_vendor: 'github-com', api_name: 'rest' }],
 						},
 						{
 							toolkit_id: 'tk_serves',
@@ -946,7 +946,7 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 							updated_at: null,
 							credential_count: 1,
 							key_count: 0,
-							apis: [{ vendor: 'open-meteo-com', name: 'forecast', version: '' }],
+							apis: [{ api_vendor: 'open-meteo-com', api_name: 'forecast' }],
 						},
 					],
 					has_more: false,
@@ -961,7 +961,10 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 		const picker = await screen.findByLabelText(/use an existing toolkit/i);
 		const options = within(picker).getAllByRole('option');
 		// [0] is the placeholder; the serving toolkit floats above the rest.
-		expect(options[1]).toHaveTextContent(/Weather toolkit — already serves/);
+		// The badge is hedged/fixed-width ("this API", not the chain label):
+		// NULL-name credentials match laxly, and long names would push a long
+		// suffix past the closed control's ellipsis.
+		expect(options[1]).toHaveTextContent(/Weather toolkit — already serves this API/);
 		expect(options[2]).toHaveTextContent('Unrelated toolkit');
 		expect(options[2]).not.toHaveTextContent(/already serves/);
 	});
@@ -1015,14 +1018,23 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 
 		const picker = await screen.findByLabelText(/use an existing credential/i);
 		const options = within(picker).getAllByRole('option');
-		expect(options[1]).toHaveTextContent(/not signed in yet/);
+		expect(options[1]).toHaveTextContent(/not connected yet/);
 
 		// No warning until the risky option is actually staged.
-		expect(screen.queryByText(/was never signed in/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/was never connected/i)).not.toBeInTheDocument();
 		await user.selectOptions(picker, 'cred_oauth_pending');
-		expect(await screen.findByText(/was never signed in/i)).toBeInTheDocument();
+		expect(await screen.findByText(/was never connected/i)).toBeInTheDocument();
 		// The pick is still allowed — warned, not blocked.
 		expect(screen.getByRole('button', { name: 'Use this credential' })).toBeEnabled();
+
+		// Committing the pick must not flip the warning into a green success:
+		// stepping back to the credential step shows the adopted-state panel,
+		// which keeps the never-connected wording (the warning stays visible
+		// after it becomes binding).
+		await user.click(screen.getByRole('button', { name: 'Use this credential' }));
+		await user.click(await screen.findByRole('button', { name: /Back/ }));
+		expect(await screen.findByText(/it was never connected/i)).toBeInTheDocument();
+		expect(screen.queryByText(/reused as-is/i)).not.toBeInTheDocument();
 	});
 
 	it('offers a retry instead of silently collapsing when the toolkit list fails', async () => {


### PR DESCRIPTION
## Summary

Lands the follow-ups from #890 — the polish items the #885 review board scoped out of the wizard PR (items 1, 3, 4, 5; **item 2 — the list-level triage signal — is deliberately deferred**: it needs the batched-annotation design flagged in the issue, and #890 stays the tracker for it). Two small backend enrichments, and four UI surfaces that finally *act* on the satisfaction hints the backend already computes.

### Backend

- **Served APIs on toolkit lists** — `ToolkitResponse` gains an `apis` field: the distinct APIs across the toolkit's credential bindings, as `ServedApiRef` (the same shared model `/me` uses; NULL `api_name`/`api_version` = the covers-all wildcard, #775). Computed in the service (`ToolkitService.served_apis`, one grouped query per page) and **scoped by the caller's credential visibility** — a sharee or bound agent sees only the APIs of credentials their own read filter admits, so the enterprise sharing seam's "child data stays owner-only" invariant holds.
- **OAuth connect state on redacted credentials** — `OAuth2Redacted` gains a derived `connected` flag for `authorization_code` credentials: true for a managed-provider `provider_account_ref` or a live, un-revoked token row that can still mint (refresh token, or unexpired/never-expiring access token). `client_credentials` need no interactive step, so it stays `None` there. `grant_type` now reports `authorization_code` honestly instead of hard-coding `client_credentials` — **a behavior change for any consumer that pattern-matched the old constant** (nothing in-repo did). Re-connecting a revoked token row now clears `revoked_at` (fresh tokens supersede revocation).

Both are backward-compatible additive schema changes; `connected` is named in the `details` field's contract description; OpenAPI spec + UI client regenerated (`make openapi-parity` clean).

### UI

- **"Already in place" notice (plain approve/deny dialog)** — pending item cards show a green chip plus a discernible-text notice (keyboard/SR-reachable, no hover-only `title`, no raw `tk_…` ids) when the enriched GET marks them `already_satisfied`. When the item carries enforceable rules, the notice says approving **replaces the binding's current rules** — not "without redoing the setup". `false` and not-computed stay silent.
- **Toolkit adopt picker ranks by served API** — in the canonical manual-setup state (toolkit + credential exist, agent unbound) *nothing* is satisfied, so the old wired-toolkit float never fired. Options already serving the chain's API now float up, badged with the hedged fixed-width " — already serves this API".
- **Credential adopt picker warns on never-connected OAuth** — suffixed " — not connected yet"; staging one shows a `role="status"` warning in the semantic warning tone, pointing at the Credentials page's Connect action. Adoption keeps the warning (a warning-toned adopted panel, not a green success). Warned, never blocked.
- **Post-bind "link an agent?" prompt** — when a bind lands on a toolkit nothing can use (no linked agent, no API key — derived once, loading-safe, in `ToolkitDetailBody`), the bind dialog holds open on a `role="status"` prompt. "Link an agent" **ends in the link-agent picker from both tabs** (the Access-tab path hands a one-shot open signal to Overview). The flag resets on close (Esc-during-bind race covered), so a reopen always starts at step 1.

### Review board

8 lenses (feasibility, product fit, security, architecture, code quality, operator UX, cold-eyes fact check, Bugbot) reviewed the first revision; all blockers/should-fixes addressed in the follow-up commit — including the sharing-seam scoping of `apis`, three `connected` correctness gaps (managed providers, revoked→re-connect, expired-no-refresh), the `agentless` loading-window false positive, and the stale post-bind prompt race.

## Test plan

- [x] `make check` — ruff, mypy, secrets, arch (scorecard runs in CI)
- [x] `make test-fast` — 2383 passed
- [x] `make openapi-parity` — clean
- [x] UI: eslint, tsc, prettier clean; vitest 893 passed (104 files)
- [x] Backend web tests: `connected` flips across insert → expired-no-refresh → refresh-rescued → revoked; managed `provider_account_ref` counts as connected; `apis` dedupes, sorts, preserves NULL wildcards, and hides credentials outside the caller's visibility
- [x] Repo test: `update_tokens` clears `revoked_at` on re-connect
- [x] UI tests: notice variants (generic / toolkit-covered / rules-replacement), picker ranking + hedged badge, warning before AND after adoption, post-bind prompt announces + CTA ends in picker, reopen starts at step 1