### PR TITLE
fix(broker): derive a valid trace_id at the execute edge instead of raw headers

### DIFF
--- a/src/jentic_one/broker/services/credentials/orchestrator.py
+++ b/src/jentic_one/broker/services/credentials/orchestrator.py
@@ -40,7 +40,11 @@ from jentic_one.broker.services.credentials.resolver import CredentialResolver
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.context import Context
 from jentic_one.shared.crypto import DecryptionError
-from jentic_one.shared.events import emit_credential_access, emit_event_best_effort
+from jentic_one.shared.events import (
+    emit_credential_access,
+    emit_event_best_effort,
+    valid_trace_id_or_none,
+)
 from jentic_one.shared.jobs.protocols import InjectedAuth
 from jentic_one.shared.models.credentials import CredentialType
 from jentic_one.shared.models.events import ErrorSource, EventSeverity, EventTag, EventType
@@ -82,7 +86,8 @@ class CredentialService:
         an operator inspecting an execution can join the credential-use record
         back to the specific execution that triggered it (#740). Optional so
         non-execution call-sites (bind-time probes, service accounts) don't
-        have to fabricate one.
+        have to fabricate one. A malformed value degrades to an uncorrelated
+        event rather than failing the injection (#903).
         """
         if not api_vendor:
             return _EMPTY
@@ -160,7 +165,9 @@ class CredentialService:
                     api_vendor=api.vendor,
                     api_name=api.name,
                     api_version=api.version,
-                    trace_id=trace_id,
+                    # Sanitised: emit_event raises on a malformed trace_id, and
+                    # a 500 here would fail the whole execute request (#903).
+                    trace_id=valid_trace_id_or_none(trace_id),
                 )
             return InjectedAuth(
                 headers=result.headers,

--- a/src/jentic_one/broker/services/execution/executor.py
+++ b/src/jentic_one/broker/services/execution/executor.py
@@ -26,6 +26,7 @@ from jentic_one.broker.adapters.runners.registry import RunnerRegistry
 from jentic_one.broker.core.schemas import ExecuteRequestContext
 from jentic_one.broker.services.execution.service import default_broker, run_execution
 from jentic_one.shared.broker.broker import Broker
+from jentic_one.shared.events import valid_trace_id_or_minted
 from jentic_one.shared.jobs.protocols import (
     UpstreamExecRequest,
     UpstreamExecResult,
@@ -86,7 +87,9 @@ def _ctx_from_metadata(request: UpstreamExecRequest) -> ExecuteRequestContext:
     return ExecuteRequestContext(
         upstream_url=request.url,
         method=request.method,
-        trace_id=str(meta.get("trace_id", "unknown")),
+        # The worker always sends a valid id; minted-if-invalid keeps the
+        # "trace_id is always 32-hex" invariant for any other caller (#903).
+        trace_id=valid_trace_id_or_minted(str(meta.get("trace_id") or "")),
         toolkit_id=meta.get("toolkit_id"),
         operation_id=meta.get("operation_id"),
         api_vendor=meta.get("api_vendor"),

--- a/src/jentic_one/broker/services/execution/service.py
+++ b/src/jentic_one/broker/services/execution/service.py
@@ -9,7 +9,6 @@ caller's concern (the runner returns the verbatim upstream result).
 
 from __future__ import annotations
 
-import re
 import time
 from datetime import UTC, datetime
 from typing import Any
@@ -30,7 +29,7 @@ from jentic_one.broker.services.execution.pipeline import (
 )
 from jentic_one.shared.broker.broker import Broker
 from jentic_one.shared.config import SecurityConfig
-from jentic_one.shared.events import emit_event
+from jentic_one.shared.events import emit_event, valid_trace_id_or_none
 from jentic_one.shared.events.repeated_failure import maybe_emit_repeated_failure
 from jentic_one.shared.executions import record_execution
 from jentic_one.shared.metrics import get_meter
@@ -54,7 +53,6 @@ _execution_duration = _meter.create_histogram(
 )
 
 _circuit_event_last_emitted: dict[str, datetime] = {}
-_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 _MAX_EVENT_SUMMARY_LEN = 128
 
 #: Upstream auth-rejection status → third-party ``auth_failure`` tag. 401 is an
@@ -467,7 +465,7 @@ async def _emit_execution_lifecycle(
     separate ``auth_failure`` event that the flat, correlation-id-free payload
     could never dedupe downstream.
     """
-    event_trace_id = trace_id if trace_id and _TRACE_ID_RE.match(trace_id) else None
+    event_trace_id = valid_trace_id_or_none(trace_id)
     try:
         if status == ExecutionStatus.COMPLETED:
             await emit_event(

--- a/src/jentic_one/broker/web/routers/execute.py
+++ b/src/jentic_one/broker/web/routers/execute.py
@@ -13,6 +13,7 @@ pipeline stages / runner decorators (added in later PRs).
 from __future__ import annotations
 
 import base64
+import secrets
 from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import urlencode, urlparse, urlunparse
@@ -20,6 +21,7 @@ from urllib.parse import urlencode, urlparse, urlunparse
 import structlog
 from fastapi import APIRouter, Depends, Request, Response
 from jentic.problem_details import Forbidden
+from starlette.datastructures import Headers
 
 from jentic_one.broker.adapters.runners.base import (
     RunnerRequest,
@@ -95,7 +97,7 @@ from jentic_one.shared.broker.protocols import (
 )
 from jentic_one.shared.config import UpstreamClientConfig
 from jentic_one.shared.context import Context
-from jentic_one.shared.events import emit_event_best_effort
+from jentic_one.shared.events import emit_event_best_effort, valid_trace_id_or_none
 from jentic_one.shared.jobs.enqueue import enqueue_job
 from jentic_one.shared.jobs.protocols import InjectedAuth
 from jentic_one.shared.metrics import get_meter
@@ -103,7 +105,11 @@ from jentic_one.shared.models import ActorType, ExecutionStatus
 from jentic_one.shared.models.events import EventSeverity, EventType
 from jentic_one.shared.models.jobs import JobKind
 from jentic_one.shared.schemas import APIReference
-from jentic_one.shared.tracing import JENTIC_TRACESTATE_KEY, pack_jentic_tracestate
+from jentic_one.shared.tracing import (
+    JENTIC_TRACESTATE_KEY,
+    current_trace_id,
+    pack_jentic_tracestate,
+)
 from jentic_one.shared.url import apply_server_variables, has_host_server_variable
 from jentic_one.shared.url_validation import validate_upstream_url
 from jentic_one.shared.web.deps import get_ctx
@@ -237,6 +243,50 @@ def _revision_header(request: Request) -> str | None:
     return ",".join(values)
 
 
+def _parse_traceparent(value: str | None) -> str | None:
+    """Extract the trace-id field from a W3C ``traceparent`` header value.
+
+    ``version-traceid-spanid-flags`` → the 32-hex ``traceid`` field, or ``None``
+    when the header is absent/malformed or carries the all-zeros (invalid per
+    W3C) trace id.
+    """
+    if not value:
+        return None
+    parts = value.split("-")
+    if len(parts) < 4:
+        return None
+    trace_id = valid_trace_id_or_none(parts[1].lower())
+    if trace_id is None or trace_id == "0" * 32:
+        return None
+    return trace_id
+
+
+def _derive_trace_id(headers: Headers) -> str:
+    """Derive a valid 32-hex trace id for this request (#903).
+
+    Preference order:
+
+    1. The active OTel span — the inbound instrumentation already parsed the
+       W3C ``traceparent`` (or started a fresh trace), so this is the id the
+       rest of the platform correlates on.
+    2. The ``traceparent`` header's trace-id field, parsed per W3C (never the
+       raw header value, which is not a trace id).
+    3. A 32-hex ``x-request-id`` (kept for callers using the #903 workaround).
+    4. A freshly minted random id — never the literal ``"unknown"``, which
+       failed event emission and 500'd the whole execute request.
+    """
+    from_span = current_trace_id()
+    if from_span is not None:
+        return from_span
+    from_traceparent = _parse_traceparent(headers.get("traceparent"))
+    if from_traceparent is not None:
+        return from_traceparent
+    from_request_id = valid_trace_id_or_none((headers.get("x-request-id") or "").lower())
+    if from_request_id is not None:
+        return from_request_id
+    return secrets.token_hex(16)
+
+
 def _context_from_discovery(
     *, upstream_url: str, method: str, request: Request, resolved: ResolveResult
 ) -> ExecuteRequestContext:
@@ -244,7 +294,7 @@ def _context_from_discovery(
     return ExecuteRequestContext(
         upstream_url=upstream_url,
         method=method,
-        trace_id=headers.get("traceparent", headers.get("x-request-id", "unknown")),
+        trace_id=_derive_trace_id(headers),
         # toolkit_id is intentionally left unset here — it is derived from the
         # discovered API identity by ``select_toolkit`` after discovery (§03),
         # never taken verbatim from the inbound header.

--- a/src/jentic_one/broker/web/routers/execute.py
+++ b/src/jentic_one/broker/web/routers/execute.py
@@ -13,7 +13,6 @@ pipeline stages / runner decorators (added in later PRs).
 from __future__ import annotations
 
 import base64
-import secrets
 from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import urlencode, urlparse, urlunparse
@@ -97,7 +96,11 @@ from jentic_one.shared.broker.protocols import (
 )
 from jentic_one.shared.config import UpstreamClientConfig
 from jentic_one.shared.context import Context
-from jentic_one.shared.events import emit_event_best_effort, valid_trace_id_or_none
+from jentic_one.shared.events import (
+    emit_event_best_effort,
+    mint_trace_id,
+    valid_trace_id_or_none,
+)
 from jentic_one.shared.jobs.enqueue import enqueue_job
 from jentic_one.shared.jobs.protocols import InjectedAuth
 from jentic_one.shared.metrics import get_meter
@@ -248,17 +251,14 @@ def _parse_traceparent(value: str | None) -> str | None:
 
     ``version-traceid-spanid-flags`` → the 32-hex ``traceid`` field, or ``None``
     when the header is absent/malformed or carries the all-zeros (invalid per
-    W3C) trace id.
+    W3C) trace id — ``valid_trace_id_or_none`` rejects both.
     """
     if not value:
         return None
     parts = value.split("-")
     if len(parts) < 4:
         return None
-    trace_id = valid_trace_id_or_none(parts[1].lower())
-    if trace_id is None or trace_id == "0" * 32:
-        return None
-    return trace_id
+    return valid_trace_id_or_none(parts[1].lower())
 
 
 def _derive_trace_id(headers: Headers) -> str:
@@ -268,10 +268,15 @@ def _derive_trace_id(headers: Headers) -> str:
 
     1. The active OTel span — the inbound instrumentation already parsed the
        W3C ``traceparent`` (or started a fresh trace), so this is the id the
-       rest of the platform correlates on.
+       rest of the platform correlates on. Every production surface is
+       instrumented (``attach_http_observability``), so this branch always
+       wins there; the rest are fallbacks for uninstrumented contexts
+       (tests, embedded use).
     2. The ``traceparent`` header's trace-id field, parsed per W3C (never the
        raw header value, which is not a trace id).
-    3. A 32-hex ``x-request-id`` (kept for callers using the #903 workaround).
+    3. A 32-hex ``x-request-id`` (the #903 workaround header). Superseded by
+       the span id on instrumented surfaces — a caller who needs to pick the
+       trace id must send ``traceparent``.
     4. A freshly minted random id — never the literal ``"unknown"``, which
        failed event emission and 500'd the whole execute request.
     """
@@ -284,7 +289,7 @@ def _derive_trace_id(headers: Headers) -> str:
     from_request_id = valid_trace_id_or_none((headers.get("x-request-id") or "").lower())
     if from_request_id is not None:
         return from_request_id
-    return secrets.token_hex(16)
+    return mint_trace_id()
 
 
 def _context_from_discovery(

--- a/src/jentic_one/shared/events/__init__.py
+++ b/src/jentic_one/shared/events/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import secrets
 from typing import Any
 
 import structlog
@@ -16,6 +17,7 @@ from jentic_one.shared.telemetry.sink import get_active_sink
 logger = structlog.get_logger(__name__)
 
 _TRACE_ID_PATTERN = re.compile(r"^[0-9a-f]{32}$")
+_ZERO_TRACE_ID = "0" * 32
 
 
 def valid_trace_id_or_none(trace_id: str | None) -> str | None:
@@ -25,10 +27,27 @@ def valid_trace_id_or_none(trace_id: str | None) -> str | None:
     that receive a caller-supplied value (raw headers, job payload defaults)
     must sanitise through this helper so a garbage trace id degrades to an
     uncorrelated event instead of failing the surrounding operation (#903).
+    The all-zeros id is rejected too: W3C defines it as invalid, and an event
+    "correlated" on it would join unrelated requests together.
     """
-    if trace_id is not None and _TRACE_ID_PATTERN.match(trace_id):
+    if trace_id is not None and _TRACE_ID_PATTERN.match(trace_id) and trace_id != _ZERO_TRACE_ID:
         return trace_id
     return None
+
+
+def mint_trace_id() -> str:
+    """Mint a fresh random 32-hex trace id."""
+    return secrets.token_hex(16)
+
+
+def valid_trace_id_or_minted(trace_id: str | None) -> str:
+    """Return ``trace_id`` when it is a valid 32-hex trace id, else mint one.
+
+    For call sites that must always carry a *usable* trace id forward (job
+    payload rebuilds, persisted execution rows) rather than degrade to ``None``
+    — never the literal ``"unknown"``, which crashed event emission (#903).
+    """
+    return valid_trace_id_or_none(trace_id) or mint_trace_id()
 
 
 def _validate_tags(type: str, tags: set[EventTag] | None) -> list[EventTag]:

--- a/src/jentic_one/shared/events/__init__.py
+++ b/src/jentic_one/shared/events/__init__.py
@@ -18,6 +18,19 @@ logger = structlog.get_logger(__name__)
 _TRACE_ID_PATTERN = re.compile(r"^[0-9a-f]{32}$")
 
 
+def valid_trace_id_or_none(trace_id: str | None) -> str | None:
+    """Coerce ``trace_id`` to ``None`` unless it is a valid 32-hex trace id.
+
+    ``emit_event`` raises on a malformed ``trace_id`` by contract; emit sites
+    that receive a caller-supplied value (raw headers, job payload defaults)
+    must sanitise through this helper so a garbage trace id degrades to an
+    uncorrelated event instead of failing the surrounding operation (#903).
+    """
+    if trace_id is not None and _TRACE_ID_PATTERN.match(trace_id):
+        return trace_id
+    return None
+
+
 def _validate_tags(type: str, tags: set[EventTag] | None) -> list[EventTag]:
     """Drop tags whose closed-enum type is not allowed for this event.
 

--- a/src/jentic_one/shared/jobs/execution_handler.py
+++ b/src/jentic_one/shared/jobs/execution_handler.py
@@ -19,7 +19,6 @@ broker-side implementations injected at worker startup.
 from __future__ import annotations
 
 import base64
-import re
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlencode, urlparse, urlunparse
@@ -28,7 +27,7 @@ import structlog
 
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.config import SecurityConfig
-from jentic_one.shared.events import emit_event
+from jentic_one.shared.events import emit_event, valid_trace_id_or_none
 from jentic_one.shared.events.repeated_failure import maybe_emit_repeated_failure
 from jentic_one.shared.jobs.handlers import JobResultPayload
 from jentic_one.shared.jobs.protocols import (
@@ -45,7 +44,6 @@ from jentic_one.shared.url_validation import validate_upstream_url
 
 logger = structlog.get_logger(__name__)
 
-_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 _MAX_EVENT_SUMMARY_LEN = 128
 # A far-future expiry so the resolved-identity dataclass is well-formed; the
 # worker only runs an already-authorized, enqueued job — the inbound token was
@@ -219,7 +217,7 @@ class ExecutionHandler:
         toolkit_id: str | None = None,
         operation_id: str | None = None,
     ) -> None:
-        event_trace_id = trace_id if _TRACE_ID_RE.match(trace_id) else None
+        event_trace_id = valid_trace_id_or_none(trace_id)
         try:
             if status == ExecutionStatus.COMPLETED:
                 await emit_event(

--- a/src/jentic_one/shared/jobs/execution_handler.py
+++ b/src/jentic_one/shared/jobs/execution_handler.py
@@ -27,7 +27,7 @@ import structlog
 
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.config import SecurityConfig
-from jentic_one.shared.events import emit_event, valid_trace_id_or_none
+from jentic_one.shared.events import emit_event, valid_trace_id_or_minted, valid_trace_id_or_none
 from jentic_one.shared.events.repeated_failure import maybe_emit_repeated_failure
 from jentic_one.shared.jobs.handlers import JobResultPayload
 from jentic_one.shared.jobs.protocols import (
@@ -86,7 +86,10 @@ class ExecutionHandler:
 
         upstream_url = payload.get("upstream_url", "")
         method = payload.get("method", "GET")
-        trace_id = payload.get("trace_id", "unknown")
+        # Minted-if-invalid so the credential audit event, the lifecycle
+        # events, and the persisted execution row all share one valid id —
+        # never the literal "unknown" (#903).
+        trace_id = valid_trace_id_or_minted(str(payload.get("trace_id") or ""))
         execution_id = payload.get("execution_id", f"exec_{job_id}")
         api_vendor = payload.get("api_vendor")
         api_name = payload.get("api_name")

--- a/src/jentic_one/shared/tracing.py
+++ b/src/jentic_one/shared/tracing.py
@@ -144,6 +144,23 @@ def configure_tracing(
     return provider
 
 
+def current_trace_id() -> str | None:
+    """Return the active span's trace id as 32 lowercase hex chars, or ``None``.
+
+    Within a request handler this is the sanctioned way to obtain the request's
+    trace id: the inbound instrumentation (``instrument_inbound_app``) has
+    already extracted the W3C ``traceparent`` — or started a fresh trace when
+    the header was absent — so the active span context carries exactly the id
+    a caller would want to correlate on. Returns ``None`` when there is no
+    valid span context (e.g. tracing was never configured), so callers must
+    bring their own fallback.
+    """
+    span_context = trace.get_current_span().get_span_context()
+    if not span_context.is_valid:
+        return None
+    return format(span_context.trace_id, "032x")
+
+
 # ---------------------------------------------------------------------------
 # Outbound (upstream) propagation
 # ---------------------------------------------------------------------------

--- a/tests/unit/broker/test_credential_service.py
+++ b/tests/unit/broker/test_credential_service.py
@@ -198,7 +198,7 @@ async def test_successful_inject_emits_one_audit_event(monkeypatch: pytest.Monke
         api_name="charges",
         api_version="v1",
         identity=_IDENTITY,
-        trace_id="trace_xyz",
+        trace_id="ab" * 16,
     )
 
     assert result.headers == {"Authorization": "injected"}
@@ -219,7 +219,45 @@ async def test_successful_inject_emits_one_audit_event(monkeypatch: pytest.Monke
     assert kwargs["api_name"] == "charges"
     assert kwargs["api_version"] == "v1"
     # #740: audit event joins to the triggering execution via trace_id.
-    assert kwargs["trace_id"] == "trace_xyz"
+    assert kwargs["trace_id"] == "ab" * 16
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_trace_id", ["unknown", "00-" + "a" * 32 + "-" + "b" * 16 + "-01"])
+async def test_inject_with_invalid_trace_id_emits_uncorrelated_audit_event(
+    monkeypatch: pytest.MonkeyPatch, bad_trace_id: str
+) -> None:
+    """A malformed trace_id degrades to an uncorrelated audit event, never a crash (#903).
+
+    ``emit_event`` raises ``ValueError`` on a trace_id that is not 32 lowercase
+    hex chars; before the guard, a request without a trace header (trace_id
+    ``"unknown"``) or with a raw W3C ``traceparent`` value 500'd the whole
+    execute request during credential injection.
+    """
+    _patch_resolved(monkeypatch, _resolved())
+    monkeypatch.setattr(
+        "jentic_one.broker.services.credentials.orchestrator.inject_auth",
+        lambda resolved, *, ctx, access_token=None: MagicMock(
+            headers={"Authorization": "injected"}, query_params={}, cookies={}
+        ),
+    )
+    audit = AsyncMock(return_value="evt_1")
+    monkeypatch.setattr(
+        "jentic_one.broker.services.credentials.orchestrator.emit_credential_access", audit
+    )
+
+    result = await CredentialService(_ctx()).inject(
+        api_vendor="stripe",
+        api_name="charges",
+        api_version="v1",
+        identity=_IDENTITY,
+        trace_id=bad_trace_id,
+    )
+
+    assert result.headers == {"Authorization": "injected"}
+    audit.assert_awaited_once()
+    assert audit.await_args is not None
+    assert audit.await_args.kwargs["trace_id"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/broker/test_injected_broker_seam.py
+++ b/tests/unit/broker/test_injected_broker_seam.py
@@ -23,6 +23,7 @@ signature elsewhere); here we only assert *it was the one invoked*.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -249,3 +250,36 @@ def test_ctx_from_metadata_rebuilds_credential_attribution() -> None:
     bare = _ctx_from_metadata(_request(base_metadata))
     assert bare.credential_id is None
     assert bare.credential_name is None
+
+
+def test_ctx_from_metadata_mints_a_valid_trace_id_for_garbage() -> None:
+    """Metadata without a usable trace_id yields a minted 32-hex id — never the
+    literal "unknown", which would be persisted on the execution record and
+    crash any emit site that trusts the context (#903)."""
+    for metadata in (
+        {"actor_id": "agt_abc123", "actor_type": "agent"},
+        {"actor_id": "agt_abc123", "actor_type": "agent", "trace_id": "unknown"},
+    ):
+        ctx_req = _ctx_from_metadata(
+            UpstreamExecRequest(
+                method="GET",
+                url="https://api.example.com/v1/things",
+                headers={},
+                body=None,
+                timeout_s=30.0,
+                metadata=metadata,
+            )
+        )
+        assert re.fullmatch(r"[0-9a-f]{32}", ctx_req.trace_id)
+
+    passthrough = _ctx_from_metadata(
+        UpstreamExecRequest(
+            method="GET",
+            url="https://api.example.com/v1/things",
+            headers={},
+            body=None,
+            timeout_s=30.0,
+            metadata={"actor_id": "agt_abc123", "actor_type": "agent", "trace_id": "a" * 32},
+        )
+    )
+    assert passthrough.trace_id == "a" * 32

--- a/tests/unit/broker/test_trace_id_derivation.py
+++ b/tests/unit/broker/test_trace_id_derivation.py
@@ -1,0 +1,97 @@
+"""Unit tests for broker trace-id derivation at the execute edge (#903).
+
+Before the fix, ``_context_from_discovery`` used the **raw** ``traceparent``
+header value (never a valid trace id) and defaulted to the literal
+``"unknown"`` — both of which crashed ``emit_event`` (``ValueError``) inside
+credential injection and 500'd the whole execute request.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from opentelemetry import context as otel_context
+from opentelemetry.trace import (
+    NonRecordingSpan,
+    SpanContext,
+    TraceFlags,
+    set_span_in_context,
+)
+from starlette.datastructures import Headers
+
+from jentic_one.broker.web.routers.execute import _derive_trace_id, _parse_traceparent
+
+_HEX32 = re.compile(r"^[0-9a-f]{32}$")
+# The exact reproduction header from issue #903 (a trace id, not a secret).
+_ISSUE_TRACEPARENT = "00-801384a0e0eb70d0c180cd38bcba4d38-9baaee8f1fb43393-01"
+_ISSUE_TRACE_ID = "801384a0e0eb70d0c180cd38bcba4d38"  # pragma: allowlist secret
+
+
+def test_traceparent_trace_id_field_is_extracted() -> None:
+    """The 32-hex trace-id field is parsed out — never the raw header value."""
+    derived = _derive_trace_id(Headers({"traceparent": _ISSUE_TRACEPARENT}))
+    assert derived == _ISSUE_TRACE_ID
+
+
+def test_no_trace_headers_mints_a_valid_random_id() -> None:
+    """Absent trace headers mint a fresh 32-hex id, never the literal 'unknown'."""
+    first = _derive_trace_id(Headers({}))
+    second = _derive_trace_id(Headers({}))
+    assert _HEX32.match(first)
+    assert _HEX32.match(second)
+    assert first != second
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        "",
+        "garbage",
+        "00-zz1384a0e0eb70d0c180cd38bcba4d38-9baaee8f1fb43393-01",  # non-hex trace id
+        "00-801384a0e0eb70d0c180cd38bcba4d3-9baaee8f1fb43393-01",  # 31 chars
+        "00-" + "0" * 32 + "-9baaee8f1fb43393-01",  # all-zeros is invalid per W3C
+        "00-801384a0e0eb70d0c180cd38bcba4d38",  # too few fields
+    ],
+)
+def test_malformed_traceparent_falls_back_to_minting(malformed: str) -> None:
+    derived = _derive_trace_id(Headers({"traceparent": malformed}))
+    assert _HEX32.match(derived)
+
+
+def test_parse_traceparent_accepts_uppercase_trace_id() -> None:
+    """Hex digits are case-insensitive on the wire; the id is normalised to lower."""
+    value = "00-801384A0E0EB70D0C180CD38BCBA4D38-9baaee8f1fb43393-01"
+    assert _parse_traceparent(value) == _ISSUE_TRACE_ID
+
+
+def test_hex32_x_request_id_is_honoured() -> None:
+    """The documented #903 workaround (32-hex x-request-id) keeps working."""
+    derived = _derive_trace_id(Headers({"x-request-id": "AB" * 16}))
+    assert derived == "ab" * 16
+
+
+def test_non_hex_x_request_id_falls_back_to_minting() -> None:
+    derived = _derive_trace_id(Headers({"x-request-id": "req_abc123"}))
+    assert _HEX32.match(derived)
+
+
+def test_traceparent_takes_precedence_over_x_request_id() -> None:
+    headers = Headers({"traceparent": _ISSUE_TRACEPARENT, "x-request-id": "cd" * 16})
+    assert _derive_trace_id(headers) == _ISSUE_TRACE_ID
+
+
+def test_active_otel_span_wins_over_headers() -> None:
+    """Inside a request the instrumented span is the source of truth."""
+    span_context = SpanContext(
+        trace_id=0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF,
+        span_id=0x1234567812345678,
+        is_remote=True,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    token = otel_context.attach(set_span_in_context(NonRecordingSpan(span_context)))
+    try:
+        derived = _derive_trace_id(Headers({"traceparent": _ISSUE_TRACEPARENT}))
+    finally:
+        otel_context.detach(token)
+    assert derived == "deadbeefdeadbeefdeadbeefdeadbeef"

--- a/tests/unit/broker/test_trace_id_derivation.py
+++ b/tests/unit/broker/test_trace_id_derivation.py
@@ -66,9 +66,21 @@ def test_parse_traceparent_accepts_uppercase_trace_id() -> None:
 
 
 def test_hex32_x_request_id_is_honoured() -> None:
-    """The documented #903 workaround (32-hex x-request-id) keeps working."""
+    """The #903 workaround header works as a no-span fallback.
+
+    On an instrumented surface the active span's id supersedes it (branch 1 of
+    ``_derive_trace_id``) — a caller who needs to pick the trace id must send
+    ``traceparent``. This exercises the uninstrumented (no active span) path.
+    """
     derived = _derive_trace_id(Headers({"x-request-id": "AB" * 16}))
     assert derived == "ab" * 16
+
+
+def test_all_zeros_x_request_id_falls_back_to_minting() -> None:
+    """The all-zeros id is invalid per W3C — rejected on every branch."""
+    derived = _derive_trace_id(Headers({"x-request-id": "0" * 32}))
+    assert _HEX32.match(derived)
+    assert derived != "0" * 32
 
 
 def test_non_hex_x_request_id_falls_back_to_minting() -> None:

--- a/tests/unit/shared/events/test_trace_id_guards.py
+++ b/tests/unit/shared/events/test_trace_id_guards.py
@@ -1,0 +1,58 @@
+"""Unit tests for the shared trace-id guards (#903).
+
+``emit_event`` raises ``ValueError`` on a malformed ``trace_id`` by contract;
+these helpers are what emit sites and payload rebuilds sanitise through.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from jentic_one.shared.events import (
+    mint_trace_id,
+    valid_trace_id_or_minted,
+    valid_trace_id_or_none,
+)
+
+_HEX32 = re.compile(r"^[0-9a-f]{32}$")
+
+
+def test_valid_trace_id_passes_through() -> None:
+    assert valid_trace_id_or_none("ab" * 16) == "ab" * 16
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        None,
+        "",
+        "unknown",
+        "AB" * 16,  # uppercase — callers normalise before validating
+        "a" * 31,
+        "a" * 33,
+        "00-" + "a" * 32 + "-" + "b" * 16 + "-01",  # raw W3C traceparent value
+        "0" * 32,  # all-zeros is invalid per W3C
+    ],
+)
+def test_invalid_trace_id_degrades_to_none(invalid: str | None) -> None:
+    assert valid_trace_id_or_none(invalid) is None
+
+
+def test_mint_trace_id_is_valid_and_random() -> None:
+    first, second = mint_trace_id(), mint_trace_id()
+    assert _HEX32.match(first)
+    assert _HEX32.match(second)
+    assert first != second
+
+
+def test_valid_trace_id_or_minted_keeps_a_valid_id() -> None:
+    assert valid_trace_id_or_minted("cd" * 16) == "cd" * 16
+
+
+def test_valid_trace_id_or_minted_replaces_garbage() -> None:
+    """Payload rebuilds must never carry the literal "unknown" forward (#903)."""
+    minted = valid_trace_id_or_minted("unknown")
+    assert _HEX32.match(minted)
+    assert minted != "unknown"

--- a/tests/unit/shared/test_execution_handler.py
+++ b/tests/unit/shared/test_execution_handler.py
@@ -12,6 +12,7 @@ session that has no real backing is fine for these pure-logic unit tests.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import pytest
@@ -76,7 +77,7 @@ def _payload(**overrides: Any) -> dict[str, Any]:
         "execution_id": "exec_123",
         "upstream_url": "https://api.example.com/v1/things",
         "method": "GET",
-        "trace_id": "unknown",
+        "trace_id": "ab" * 16,
         "api_vendor": "example",
         "api_name": "api",
         "api_version": "1.0.0",
@@ -233,16 +234,53 @@ async def test_handler_carries_credential_attribution_and_trace_id() -> None:
     await handler.execute(
         "job8",
         _FakeSession(),
-        payload=_payload(trace_id="trace-xyz"),
+        payload=_payload(trace_id="ab" * 16),
         created_by="agt_abc123",
         actor_type="agent",
     )
 
-    assert injector.last_trace_id == "trace-xyz"
+    assert injector.last_trace_id == "ab" * 16
     req = executor.last_request
     assert req is not None
     assert req.metadata["credential_id"] == "cred_abc"
     assert req.metadata["credential_name"] == "stripe-live"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_trace_id", [None, "unknown", "trace-xyz"])
+async def test_handler_mints_a_valid_trace_id_for_garbage_payloads(
+    bad_trace_id: str | None,
+) -> None:
+    """A missing/malformed payload trace_id is replaced by one minted valid id
+    shared by inject() and the executor metadata — so the credential audit
+    event, the lifecycle events, and the persisted execution row still
+    correlate with each other, and the literal "unknown" never reaches the
+    execution record (#903)."""
+    executor = _RecordingExecutor(
+        UpstreamExecResult(status_code=200, body=b"", content_type=None, duration_ms=1)
+    )
+    injector = _FakeInjector(InjectedAuth(headers={}, query_params={}, cookies={}))
+    handler = ExecutionHandler(executor=executor, credential_injector=injector)
+
+    payload = _payload()
+    payload.pop("trace_id")
+    if bad_trace_id is not None:
+        payload["trace_id"] = bad_trace_id
+
+    await handler.execute(
+        "job9",
+        _FakeSession(),
+        payload=payload,
+        created_by="agt_abc123",
+        actor_type="agent",
+    )
+
+    minted = injector.last_trace_id
+    assert minted is not None
+    assert re.fullmatch(r"[0-9a-f]{32}", minted)
+    req = executor.last_request
+    assert req is not None
+    assert req.metadata["trace_id"] == minted
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -24,6 +24,7 @@ from jentic_one.shared.config import TracingConfig
 from jentic_one.shared.tracing import (
     JENTIC_TRACESTATE_KEY,
     configure_tracing,
+    current_trace_id,
     instrument_outbound_client,
     jentic_tracestate,
     pack_jentic_tracestate,
@@ -52,6 +53,30 @@ def test_configure_tracing_idempotent():
     first_provider = configure_tracing("test-service")
     second_provider = configure_tracing("test-service")
     assert first_provider is second_provider
+
+
+# --------------------------------------------------------------------------- #
+# current_trace_id
+# --------------------------------------------------------------------------- #
+
+
+def test_current_trace_id_formats_the_active_span_id_as_32_hex():
+    span_context = SpanContext(
+        trace_id=0x801384A0E0EB70D0C180CD38BCBA4D38,
+        span_id=0x9BAAEE8F1FB43393,
+        is_remote=True,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    token = otel_context.attach(set_span_in_context(NonRecordingSpan(span_context)))
+    try:
+        assert current_trace_id() == "801384a0e0eb70d0c180cd38bcba4d38"
+    finally:
+        otel_context.detach(token)
+
+
+def test_current_trace_id_is_none_without_a_valid_span():
+    """Outside a span (or with tracing unconfigured) callers get None, not garbage."""
+    assert current_trace_id() is None
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Fixes #903 — the broker 500'd on `jentic execute` without a trace header, and misused a W3C `traceparent` when one was given.

- The execute router put the **raw** `traceparent` header value — or the literal `"unknown"` when no trace header was present — into `ExecuteRequestContext.trace_id`. The credential-access audit seam passed that unguarded into `emit_event`, which raises `ValueError` on anything that is not 32 lowercase hex, failing the whole request during credential injection.
- New `_derive_trace_id` at the execute edge always yields a valid 32-hex id, preferring: (1) the active OTel span (the inbound FastAPI instrumentation already parses `traceparent` or starts a fresh trace), (2) the W3C `traceparent` trace-id field (rejecting malformed/all-zeros), (3) a 32-hex `x-request-id` (a no-span fallback — on instrumented surfaces branch 1 always wins, so a caller who needs to pick the trace id must send `traceparent`), (4) a freshly minted random id.
- `shared/tracing`: new `current_trace_id()` facade helper (32-hex id of the active span, or `None`).
- `shared/events`: new `valid_trace_id_or_none()`; the credential-access emit in the orchestrator is now sanitised through it (defence in depth — a garbage trace id degrades to an uncorrelated audit event instead of a 500), and the two pre-existing ad-hoc trace-id regex guards in `execution/service.py` and `execution_handler.py` are consolidated onto it.

### Review follow-ups (second commit)

- **The same latent crash existed on the async worker path**: `execution_handler.py` called `inject(trace_id=payload.get("trace_id", "unknown"))`. The handler and `executor._ctx_from_metadata` now sanitise-or-mint one valid id (new `valid_trace_id_or_minted()` / `mint_trace_id()` in `shared/events`), so the credential audit event, the lifecycle events, and the persisted execution row share a single valid id — the literal `"unknown"` never reaches an execution record.
- `valid_trace_id_or_none()` also rejects the all-zeros id (invalid per W3C), closing the asymmetry where a 32-zero `x-request-id` was accepted at the edge; `_parse_traceparent` drops its now-redundant special case.
- Docstrings no longer claim the `x-request-id` workaround "keeps working" unconditionally — it is a fallback that only applies when no span is active (production surfaces are always instrumented).

## Test plan

- [x] New `tests/unit/broker/test_trace_id_derivation.py`: extracts the trace-id field from the issue's exact `traceparent`, mints a valid random id when headers are absent, honours 32-hex `x-request-id` as the no-span fallback, rejects malformed/all-zeros values, active span wins
- [x] `test_credential_service.py`: malformed `trace_id` (`"unknown"`, raw W3C value) emits an uncorrelated audit event instead of raising; valid id still passes through (#740 join preserved)
- [x] `current_trace_id()` covered in `tests/unit/test_tracing.py`
- [x] New `tests/unit/shared/events/test_trace_id_guards.py` for the shared guards/minting helpers; worker-path minting covered in `test_execution_handler.py` (one minted id shared by inject + executor metadata) and `test_injected_broker_seam.py` (`_ctx_from_metadata`)
- [x] Full unit suite (2155 passed), `make lint` (ruff + mypy), `make test-arch` (incl. tracing-facade guard) all green

Made with [Cursor](https://cursor.com)