### PR TITLE
fix(install.sh): default to the latest release tag, not main

### DIFF
--- a/tests/tools/install_test.sh
+++ b/tests/tools/install_test.sh
@@ -170,6 +170,44 @@ else
   pass "detect_platform: unsupported arch exits non-zero"
 fi
 
+# --- highest_release_tag: latest canonical release tag from ls-remote output ---
+# Mirrors the Go highestReleaseTag (cli/internal/update/version.go): keep only
+# clean vX.Y.Z tags; ignore cli/v* noise, pre-releases, and peeled "^{}" lines.
+# The fixture is deliberately unordered and mixes all the shapes we must ignore.
+lsr_fixture="$(printf '%s\n' \
+  'b99f974	refs/tags/cli/v0.14.3' \
+  'b99f974	refs/tags/cli/v0.14.3^{}' \
+  '1b37598	refs/tags/v0.1.0' \
+  'f4b8f89	refs/tags/v0.10.0' \
+  'aaaaaaa	refs/tags/v0.24.0' \
+  'bbbbbbb	refs/tags/v0.24.0^{}' \
+  'ccccccc	refs/tags/v1.0.0-rc1' \
+  'ddddddd	refs/tags/v0.9.0')"
+
+out="$(printf '%s\n' "$lsr_fixture" | highest_release_tag)"
+assert_eq "highest_release_tag: picks the highest vX.Y.Z" "v0.24.0" "$out"
+
+# Numeric (not lexical) ordering: v0.9.0 must beat v0.10.0 only when it's really
+# larger — here v0.10.0 > v0.9.0, and neither is the max, so the earlier check
+# already covers ordering. Add a focused pair to guard against lexical sort.
+out="$(printf '%s\n' 'x	refs/tags/v0.2.0' 'y	refs/tags/v0.10.0' | highest_release_tag)"
+assert_eq "highest_release_tag: numeric ordering (v0.10.0 > v0.2.0)" "v0.10.0" "$out"
+
+# Only noise/non-release tags -> non-zero exit and no output.
+set +e
+out="$(printf '%s\n' 'a	refs/tags/cli/v0.14.3' 'b	refs/tags/v1.0.0-rc1' 'c	refs/heads/main' | highest_release_tag)"
+rc=$?
+set -e
+assert_eq "highest_release_tag: no release tags -> non-zero exit" "1" "$rc"
+assert_eq "highest_release_tag: no release tags -> empty output" "" "$out"
+
+# Empty input -> non-zero exit, empty output.
+set +e
+out="$(printf '' | highest_release_tag)"
+rc=$?
+set -e
+assert_eq "highest_release_tag: empty input -> non-zero exit" "1" "$rc"
+
 # ---------------------------------------------------------------------------
 # Contract tier: run the installer through each shell and prove it re-execs and
 # reaches main() without a bash syntax error. We build a minimal PATH that has

--- a/tools/install-README.md
+++ b/tools/install-README.md
@@ -37,11 +37,14 @@ You can also run it from a checkout:
    supported directly — use WSL.
 3. Ensures Go: uses your existing `go` if it's new enough, otherwise downloads a
    pinned Go into `~/.jentic/toolchain` (reused on subsequent runs).
-4. Shallow + sparse clones only the `cli/` subtree of the repo into a temp dir.
-5. Builds both binaries with version metadata stamped in via `-ldflags`.
-6. Installs them to `~/.jentic/bin/{jenticctl,jentic}` and makes them reachable
+4. Resolves the ref to build: unless you set `JENTIC_REF`, it queries the repo's
+   tags and builds the **latest release** (`vX.Y.Z`), falling back to `main` if
+   no release tag is found. Set `JENTIC_REF` to build `main` or a dev branch.
+5. Shallow + sparse clones only the `cli/` subtree of the repo into a temp dir.
+6. Builds both binaries with version metadata stamped in via `-ldflags`.
+7. Installs them to `~/.jentic/bin/{jenticctl,jentic}` and makes them reachable
    by name (see [PATH handling](#path-handling) below).
-7. Runs `jenticctl --version` and `jentic --version` to verify.
+8. Runs `jenticctl --version` and `jentic --version` to verify.
 
 The temp clone/build directory is removed on exit; the only things left behind
 are the binaries (and the cached Go toolchain, if it was downloaded).
@@ -80,7 +83,7 @@ All optional, set as environment variables:
 | Variable | Default | Description |
 | --- | --- | --- |
 | `JENTIC_REPO` | `jentic/jentic-one` | `owner/name` of the source repo |
-| `JENTIC_REF` | `main` | Branch, tag, or commit to build (also used as the reported version) |
+| `JENTIC_REF` | _latest release tag_ | Branch, tag, or commit to build (also used as the reported version). When unset, the installer resolves the highest `vX.Y.Z` release tag and builds that, falling back to `main` if none is found. Set it to build `main` or a dev branch. |
 | `JENTIC_INSTALL_DIR` | `~/.jentic/bin` | Where the binaries are installed |
 | `JENTIC_GO_VERSION` | `1.26.2` | Go version to download if no suitable `go` is found |
 | `GITHUB_TOKEN` | _(unset)_ | Only needed to clone a **private fork** — a token with repo read access (HTTP Basic, never written to disk). Not needed for the public repo. |
@@ -88,8 +91,17 @@ All optional, set as environment variables:
 Examples:
 
 ```bash
+# Default: build the latest release tag
+./tools/install.sh
+
+# Build the bleeding-edge main branch instead of the latest release
+JENTIC_REF=main ./tools/install.sh
+
 # Build a specific branch into /usr/local/bin
 JENTIC_REF=feat/my-branch JENTIC_INSTALL_DIR=/usr/local/bin ./tools/install.sh
+
+# Pin an exact release tag
+JENTIC_REF=v0.24.0 ./tools/install.sh
 
 # Pin the Go version used for the download fallback
 JENTIC_GO_VERSION=1.26.2 ./tools/install.sh
@@ -99,10 +111,10 @@ JENTIC_GO_VERSION=1.26.2 ./tools/install.sh
 
 ```bash
 jenticctl --version
-# jenticctl main (commit a1b2c3d, built 2026-06-19T14:00:00Z)
+# jenticctl v0.24.0 (commit a1b2c3d, built 2026-06-19T14:00:00Z)
 
 jentic --version
-# jentic main (commit a1b2c3d, built 2026-06-19T14:00:00Z)
+# jentic v0.24.0 (commit a1b2c3d, built 2026-06-19T14:00:00Z)
 
 jenticctl --help
 jentic --help
@@ -111,7 +123,8 @@ jentic --help
 ## Troubleshooting
 
 - **`clone failed ...`** — the public repo clones anonymously, so this usually
-  means a network/proxy issue or a bad `JENTIC_REF`. If you're building from a
+  means a network/proxy issue or a bad `JENTIC_REF` (the ref must be a branch,
+  tag, or commit that exists in the repo). If you're building from a
   **private fork**, it means no token was provided (or the token lacks access) —
   create a token with repo read scope and re-run with `GITHUB_TOKEN=...`.
 - **`Found go1.xx but Go 1.26+ is required`** — your system Go is too old. The

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -17,7 +17,9 @@
 #
 # Configuration (environment variables, all optional):
 #   JENTIC_REPO         owner/name of the source repo   (default: jentic/jentic-one)
-#   JENTIC_REF          branch, tag, or commit to build  (default: main)
+#   JENTIC_REF          branch, tag, or commit to build  (default: latest release
+#                       tag, e.g. v0.24.0; falls back to main if none is found.
+#                       Set explicitly to build main or a dev branch.)
 #   JENTIC_INSTALL_DIR  where to install the binaries     (default: ~/.jentic/bin)
 #   JENTIC_GO_VERSION   Go to download if none suitable   (default: 1.26.2)
 #   GITHUB_TOKEN        token for cloning a private fork  (default: unset/anonymous)
@@ -112,7 +114,10 @@ set -euo pipefail
 
 # --- configuration ----------------------------------------------------------
 JENTIC_REPO="${JENTIC_REPO:-jentic/jentic-one}"
-JENTIC_REF="${JENTIC_REF:-main}"
+# Empty by default: fetch_source() resolves the latest release tag when unset.
+# An explicit value (a branch like `main`, a tag, or a commit) is honored
+# verbatim — that's the override for building main or a dev/local branch.
+JENTIC_REF="${JENTIC_REF:-}"
 JENTIC_INSTALL_DIR="${JENTIC_INSTALL_DIR:-$HOME/.jentic/bin}"
 JENTIC_GO_VERSION="${JENTIC_GO_VERSION:-1.26.2}"
 GITHUB_TOKEN="${GITHUB_TOKEN:-}"
@@ -366,6 +371,55 @@ ensure_go() {
 }
 
 # --- source fetch -----------------------------------------------------------
+# highest_release_tag reads `git ls-remote --tags` output on stdin and prints
+# the highest canonical release tag (vMAJOR.MINOR.PATCH, with its `v`). It
+# mirrors the Go `highestReleaseTag` (cli/internal/update/version.go): it keeps
+# only clean three-part `v` tags and deliberately ignores `cli/v*` noise tags,
+# pre-releases (`v1.0.0-rc1`), and the peeled `^{}` lines ls-remote also prints.
+# Returns non-zero (and prints nothing) when no release tag is present. Sorting
+# is done field-by-field with a plain `sort` so it works on stock macOS bash 3.2
+# / BSD tools (no `sort -V`).
+highest_release_tag() {
+  # Lines look like "<sha>\trefs/tags/<name>". Extract the tag name, keep only
+  # canonical vX.Y.Z (anchored, so `cli/v*` and `-rc` suffixes are dropped),
+  # strip the leading `v`, numeric-sort by each component, take the largest,
+  # then re-add the `v`.
+  local top
+  top="$(
+    sed -n 's|^.*refs/tags/\(v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)$|\1|p' \
+      | sed 's/^v//' \
+      | sort -t. -k1,1n -k2,2n -k3,3n \
+      | tail -n 1
+  )"
+  [ -n "$top" ] || return 1
+  printf 'v%s\n' "$top"
+}
+
+# resolve_default_ref sets JENTIC_REF to the latest release tag when the caller
+# left it unset. On any failure (no release tags — e.g. a fork — or a network
+# error) it warns loudly and falls back to main so a build still happens. An
+# explicit JENTIC_REF is honored verbatim and this is a no-op. git auth args are
+# passed through so private repos resolve. Must run after the git auth setup in
+# fetch_source.
+resolve_default_ref() {
+  local clone_url="$1"; shift
+  local -a git_base_auth=("$@")   # git_base + git_auth, already assembled
+
+  [ -n "$JENTIC_REF" ] && return 0
+
+  local ls_out tag
+  if ls_out="$(git "${git_base_auth[@]}" ls-remote --tags "$clone_url" 'v*' 2>/dev/null)" \
+      && tag="$(printf '%s\n' "$ls_out" | highest_release_tag)"; then
+    JENTIC_REF="$tag"
+    ok "Latest release: ${C_BOLD}${JENTIC_REF}${C_RESET}"
+    return 0
+  fi
+
+  JENTIC_REF="main"
+  warn "Could not resolve a release tag in ${JENTIC_REPO} — building from ${C_BOLD}main${C_RESET}."
+  warn "  Pin a specific build with ${C_BOLD}JENTIC_REF=<tag|branch|commit>${C_RESET}."
+}
+
 fetch_source() {
   step "Fetching source"
   WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/jentic-install.XXXXXX")"
@@ -390,6 +444,9 @@ fetch_source() {
     basic="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
     git_auth=(-c "http.extraheader=Authorization: Basic ${basic}")
   fi
+
+  # Default the build ref to the latest release tag (unless the user pinned one).
+  resolve_default_ref "$clone_url" "${git_base[@]}" ${git_auth[@]+"${git_auth[@]}"}
 
   if ! spin "Cloning ${JENTIC_REPO}@${JENTIC_REF}" \
         git "${git_base[@]}" ${git_auth[@]+"${git_auth[@]}"} clone \


### PR DESCRIPTION
## Summary

A fresh install via `tools/install.sh` built from `main` (the `JENTIC_REF` default), stamping the binaries and manifest with the non-semver ref `main`. `jenticctl update` compares the installed version against the latest release tag, and `NewerAvailable` treats any non-semver installed version as out of date — so **every fresh install immediately claimed an update was available**.

The installer now resolves the highest canonical `vX.Y.Z` release tag by default (same filter as the Go update command: ignores `cli/v*` noise tags, pre-releases, and peeled `^{}` lines) and builds that. `JENTIC_REF` remains the explicit override for building `main` or a dev branch.

- `highest_release_tag`: pure stdin→stdout helper picking the highest `vX.Y.Z` tag; portable numeric sort (bash-3.2 / BSD safe).
- `resolve_default_ref` in `fetch_source`, reusing the existing no-prompt + `http.extraheader` token auth so private forks resolve. On failure (no release tags / `ls-remote` error) it warns loudly and falls back to `main`.
- `JENTIC_REF` unset → latest release tag; set (`main`, a branch, a tag) → honored verbatim.
- README: updated the `JENTIC_REF` default, added override examples, refreshed the `--version` sample output.
- Tests: unit coverage for `highest_release_tag` (highest pick, `cli/v*`/`^{}`/pre-release exclusion, numeric ordering, empty/no-release exit).

No Go changes needed: `jenticctl update` already passes an explicit `JENTIC_REF=<resolved ref>` to the installer, so the update path is unaffected.

Closes #908

## Test plan

- [x] `bash tests/tools/install_test.sh` — all 27 checks pass
- [x] Default install (`JENTIC_NO_INSTALL=1 JENTIC_INSTALL_DIR=… ./tools/install.sh`) clones/builds `@v0.24.0`; `--version` reports `v0.24.0`
- [x] `JENTIC_REF=main` install clones/builds `@main`; `--version` reports `main`
- [ ] Reviewer: confirm tag resolution behaves on a fork with no `v*` tags (warns + falls back to main)

> Please **squash + merge**.

Made with [Cursor](https://cursor.com)