### PR TITLE
feat(access-requests): surface existing-toolkit reuse on the provision path

### DIFF
--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -147,7 +147,10 @@ jentic access request --provision stripe.com/api \
     describes the whole path (create toolkit, provision + bind a credential with
     your proposed rules, bind you), which a human fulfils and approves in the
     dashboard. The directive's `suggested_command` already points at `--provision`
-    in this case.
+    in this case. The plan does **not** force a new toolkit: during fulfilment
+    the operator can add the credential to a toolkit they already have (the
+    wizard offers both) — worth relaying when your operator mentions an
+    existing toolkit they want to extend.
   - `toolkit_serves_api: true` — a toolkit already serves this API and you just
     aren't bound to it; the directive suggests `jentic access request --toolkit
     <vendor/name> --wait`. File that and wait for approval.
@@ -451,7 +454,8 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
     bare `--toolkit` bind would be **denied** ("No toolkit serves API …"); the
     directive suggests `--provision` instead — file that plan (propose `--auth`
     and `--rules-json` from the spec, pass `--reason`) and your operator fulfils
-    it in the dashboard.
+    it in the dashboard, into a new toolkit **or one they already have** — an
+    existing toolkit never has to be recreated.
   - **424 `credential_not_provisioned`** → the directive gives a
     `provisioning_url` for your operator to connect an account (an access
     request won't help).

--- a/src/jentic_one/broker/core/exceptions.py
+++ b/src/jentic_one/broker/core/exceptions.py
@@ -281,6 +281,12 @@ def no_toolkit_binding_directive(
       because a toolkit only serves an API once a credential for it is bound
       (issue #683). So point the caller at credential provisioning first — the
       step that actually creates a serving toolkit — before the binding request.
+      The instruction also says the operator may fulfil the plan **into an
+      existing toolkit** (#897): toolkits serving *other* APIs may well exist,
+      and without the hint the flow reads as "recreate everything from scratch".
+      Deliberately text-only — the broker never enumerates other toolkits here
+      (that would leak instance inventory to an unbound agent, and this
+      stateless edge has no scoped view of what a future approver could reuse).
 
     Both variants name the exact next step so an autonomous agent can hand it to
     its operator verbatim instead of reading docs.
@@ -308,7 +314,8 @@ def no_toolkit_binding_directive(
     # first (which creates the serving toolkit), then the agent is bound. A bare
     # `toolkit:bind` request now can never be approved — so steer the agent to
     # file the whole path as one provisioning plan (`--provision`), which a human
-    # fulfils and approves in the dashboard (they enter the secret + grant).
+    # fulfils and approves in the dashboard (they enter the secret + grant, into
+    # a new toolkit or one they already have — the wizard offers both, #897).
     parameters["suggested_command"] = (
         f'jentic access request --provision {api} --reason "<why you need this>" --wait'
     )
@@ -317,8 +324,9 @@ def no_toolkit_binding_directive(
         f'File a provisioning plan with `jentic access request --provision {api} --reason "<why>" '
         "--wait` — propose the auth type (`--auth`) and permission rules (`--rules-json`) you read "
         "from the API spec, and pass a `--reason` the approver sees; then ask your operator to "
-        "fulfil it in the dashboard (they enter the credential secret and approve). Only a human "
-        "can grant this. Once approved, retry this call."
+        "fulfil it in the dashboard (they enter the credential secret and approve; the wizard "
+        "lets them add it to one of their existing toolkits instead of creating a new one). "
+        "Only a human can grant this. Once approved, retry this call."
     )
     return AgentDirective(
         strategy="prompt_human",

--- a/src/jentic_one/shared/web/content/jentic.md
+++ b/src/jentic_one/shared/web/content/jentic.md
@@ -147,7 +147,10 @@ jentic access request --provision stripe.com/api \
     describes the whole path (create toolkit, provision + bind a credential with
     your proposed rules, bind you), which a human fulfils and approves in the
     dashboard. The directive's `suggested_command` already points at `--provision`
-    in this case.
+    in this case. The plan does **not** force a new toolkit: during fulfilment
+    the operator can add the credential to a toolkit they already have (the
+    wizard offers both) — worth relaying when your operator mentions an
+    existing toolkit they want to extend.
   - `toolkit_serves_api: true` — a toolkit already serves this API and you just
     aren't bound to it; the directive suggests `jentic access request --toolkit
     <vendor/name> --wait`. File that and wait for approval.
@@ -451,7 +454,8 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
     bare `--toolkit` bind would be **denied** ("No toolkit serves API …"); the
     directive suggests `--provision` instead — file that plan (propose `--auth`
     and `--rules-json` from the spec, pass `--reason`) and your operator fulfils
-    it in the dashboard.
+    it in the dashboard, into a new toolkit **or one they already have** — an
+    existing toolkit never has to be recreated.
   - **424 `credential_not_provisioned`** → the directive gives a
     `provisioning_url` for your operator to connect an account (an access
     request won't help).

--- a/tests/integration/control/test_provisioning_plan_e2e.py
+++ b/tests/integration/control/test_provisioning_plan_e2e.py
@@ -212,6 +212,118 @@ async def test_provisioning_plan_end_to_end(integration_context: Context, clean:
     )
 
 
+async def test_provisioning_plan_fulfilled_into_existing_toolkit(
+    integration_context: Context, clean: None
+) -> None:
+    """A plan can be fulfilled into a PRE-EXISTING toolkit — the #897 reuse path.
+
+    The reporter's scenario: the operator already has a toolkit (serving other
+    APIs) and wants the new credential added to IT, not a parallel toolkit. The
+    wizard's "use existing" choice amends the bind items at the existing toolkit
+    id and — audit honesty — stamps the inert ``toolkit:create`` /
+    ``credential:provision`` placeholders with the ids that fulfilled them, so
+    the approved record reads "fulfilled by tk_…" instead of implying a create
+    that never happened. This drives that exact amend+decide shape through the
+    real service layer: it must reach FULL approval (the agent's ``--wait``
+    exits 0) with no second toolkit anywhere.
+    """
+    ctx = integration_context
+    access_svc = AccessRequestService(ctx)
+    toolkit_svc = ToolkitService(ctx)
+    cred_svc = CredentialService(ctx)
+
+    # The operator's pre-existing toolkit ("My Travel Agent") — created BEFORE
+    # the plan is filed, outside any wizard session.
+    _existing = await toolkit_svc.create(name="My Travel Agent", identity=_owner_identity())
+    existing_toolkit = _existing.toolkit
+
+    api = {"vendor": "httpbin.org", "name": "httpbin", "version": "1.0.0"}
+    plan_items: list[dict[str, Any]] = [
+        {"resource_type": "toolkit", "action": "create", "resource_reference": api},
+        {
+            "resource_type": "credential",
+            "action": "provision",
+            "resource_reference": {**api, "security_scheme": "bearer"},
+        },
+        {
+            "resource_type": "credential",
+            "action": "bind",
+            "rules": [{"effect": "allow", "methods": ["GET"], "path": ".*"}],
+        },
+        {"resource_type": "toolkit", "action": "bind", "resource_reference": api},
+    ]
+    view = await access_svc.file(
+        actor_id=AGENT_SUB,
+        reason="Extend my existing toolkit",
+        items=plan_items,
+        identity=_agent_identity(),
+    )
+    by_key = {(i.resource_type, i.action): i for i in view.items}
+
+    # Wizard fulfilment: only the credential is created; the toolkit is reused.
+    created_cred = await cred_svc.create(
+        CredentialCreate(
+            type=CredentialType.BEARER_TOKEN,
+            name="httpbin cred (reuse)",
+            api=APIReference(vendor="httpbin.org", name="httpbin", version="1.0.0"),
+            token="secret-token-value-456",
+        ),
+        identity=_owner_identity(),
+    )
+    await access_svc.amend(
+        view.id,
+        identity=_owner_identity(),
+        item_amendments=[
+            {
+                "item_id": by_key[("credential", "bind")].id,
+                "to_id": existing_toolkit.id,
+                "resource_id": created_cred.credential_id,
+                "rules": [{"effect": "allow", "methods": ["GET"], "path": ".*"}],
+            },
+            {"item_id": by_key[("toolkit", "bind")].id, "resource_id": existing_toolkit.id},
+            # Placeholder stamping: resource_id on fulfilment-only items must be
+            # amendable (the scope-grant allow-list guard only fires for
+            # scope:grant) so the record names the reused objects.
+            {"item_id": by_key[("toolkit", "create")].id, "resource_id": existing_toolkit.id},
+            {
+                "item_id": by_key[("credential", "provision")].id,
+                "resource_id": created_cred.credential_id,
+            },
+        ],
+    )
+
+    refreshed = await access_svc.get(view.id, identity=_owner_identity())
+    decisions = [
+        {"item_id": i.id, "decision": "approved"} for i in refreshed.items if i.status == "pending"
+    ]
+    decided = await access_svc.decide(view.id, identity=_owner_identity(), item_decisions=decisions)
+
+    # FULL approval — a partial approval reads as failure to the waiting agent.
+    assert decided.status == "approved", [
+        (i.resource_type, i.action, i.status, i.decision_reason) for i in decided.items
+    ]
+    decided_create = next(
+        i for i in decided.items if i.resource_type == "toolkit" and i.action == "create"
+    )
+    assert decided_create.resource_id == existing_toolkit.id
+
+    # The wiring landed on the EXISTING toolkit, and no parallel toolkit exists.
+    async with ctx.control_db.session() as session:
+        binding = await ToolkitBindingRepository.get(
+            session, existing_toolkit.id, created_cred.credential_id
+        )
+        assert binding is not None, "credential:bind did not attach to the existing toolkit"
+        toolkit_ids = (await session.execute(select(Toolkit.id))).scalars().all()
+        assert toolkit_ids == [existing_toolkit.id], f"unexpected extra toolkits: {toolkit_ids}"
+
+    async with ctx.admin_db.session() as session:
+        bound = await session.execute(
+            text("SELECT 1 FROM agent_toolkit_bindings WHERE agent_id = :a AND toolkit_id = :t"),
+            {"a": AGENT_SUB, "t": existing_toolkit.id},
+        )
+        assert bound.scalar_one_or_none() is not None, "agent was not bound to the existing toolkit"
+
+
 async def test_noauth_plan_is_executable_via_broker_resolvers(
     integration_context: Context, clean: None
 ) -> None:

--- a/tests/unit/broker/test_toolkit_select.py
+++ b/tests/unit/broker/test_toolkit_select.py
@@ -163,6 +163,25 @@ async def test_zero_candidates_no_toolkit_serves_recommends_credential_first() -
     assert "provision" in instruction.lower()
 
 
+async def test_no_toolkit_serves_instruction_mentions_existing_toolkit_reuse() -> None:
+    # #897: the provisioning plan does not force a NEW toolkit — the wizard can
+    # fulfil it into a toolkit the operator already has. The agent-relayed
+    # instruction must say so, or an operator with existing toolkits reads the
+    # flow as "recreate everything" and denies (the reporter's dead-end). The
+    # hint lives in the TEXT only: `parameters` stays machine-stable so CLI and
+    # skill parsing of `suggested_command`/`toolkit_serves_api` never breaks.
+    deriver = _StubDeriver([], toolkit_serves_api=False)
+    with pytest.raises(ActionDeniedError) as exc:
+        await _select(deriver, header_toolkit=None)
+    directive = exc.value.directive
+    assert directive is not None
+    assert "existing toolkit" in directive.human_readable_instruction.lower()
+    assert directive.parameters["suggested_command"] == (
+        'jentic access request --provision acme/widgets --reason "<why you need this>" --wait'
+    )
+    assert set(directive.parameters) == {"api", "toolkit_serves_api", "suggested_command"}
+
+
 async def test_zero_candidates_bound_with_identity_mismatch_points_at_credential() -> None:
     # #747/#748: the agent is bound, but no toolkit serves the API because the
     # bound credential's identity does not cover it. The denial must be a

--- a/ui/src/shared/app/rail/ProvisioningRequestDialog.tsx
+++ b/ui/src/shared/app/rail/ProvisioningRequestDialog.tsx
@@ -926,6 +926,19 @@ export function ProvisioningRequestDialog({
 				if (c.toolkitBind) {
 					amendments.push({ item_id: c.toolkitBind.id, resource_id: cs.toolkitId });
 				}
+				// Audit honesty (#897): stamp the fulfilled ids onto the inert
+				// placeholders too. Approving them is a recorded no-op either
+				// way, but without the id the record can't say WHICH toolkit
+				// fulfilled the "create" intent — which matters most when the
+				// operator adopted an EXISTING toolkit instead of creating one
+				// (the agent's --wait then reads a full approval naming the
+				// reused toolkit, not a phantom "created" with no object).
+				if (c.create) {
+					amendments.push({ item_id: c.create.id, resource_id: cs.toolkitId });
+				}
+				if (c.provision && bindCredentialId) {
+					amendments.push({ item_id: c.provision.id, resource_id: bindCredentialId });
+				}
 			}
 			if (amendments.length > 0) {
 				await amendAccessRequest(request.id, amendments);

--- a/ui/src/shared/app/rail/__tests__/ProvisioningRequestDialog.test.tsx
+++ b/ui/src/shared/app/rail/__tests__/ProvisioningRequestDialog.test.tsx
@@ -461,7 +461,8 @@ describe('ProvisioningRequestDialog — multi-chain composite', () => {
 		expect(await screen.findByText('Access granted')).toBeInTheDocument();
 
 		// One amend carrying BOTH chains' bind items, each keyed to its own
-		// toolkit — never cross-wired.
+		// toolkit — never cross-wired. The inert placeholders are stamped with
+		// the ids that fulfilled them (audit honesty, #897).
 		const amendments = (
 			amendBody as { items: { item_id: string; to_id?: string; resource_id?: string }[] }
 		).items;
@@ -470,6 +471,10 @@ describe('ProvisioningRequestDialog — multi-chain composite', () => {
 		expect(byItem.get('a4')?.resource_id).toBe('tk_chain_1');
 		expect(byItem.get('b3')?.to_id).toBe('tk_chain_2');
 		expect(byItem.get('b4')?.resource_id).toBe('tk_chain_2');
+		expect(byItem.get('a1')?.resource_id).toBe('tk_chain_1');
+		expect(byItem.get('b1')?.resource_id).toBe('tk_chain_2');
+		expect(byItem.get('a2')?.resource_id).toMatch(/^cred_noauth_/);
+		expect(byItem.get('b2')?.resource_id).toMatch(/^cred_noauth_/);
 
 		// One decide approving every pending item, the scope grant included.
 		const decisions = (decideBody as { items: { item_id: string; decision: string }[] }).items;
@@ -501,9 +506,10 @@ describe('ProvisioningRequestDialog — multi-chain composite', () => {
 		await user.click(screen.getByRole('button', { name: /Approve & grant access/ }));
 		expect(await screen.findByText('Access granted')).toBeInTheDocument();
 
-		// Only chain 1 was amended…
+		// Only chain 1 was amended (its placeholders included — never the
+		// skipped chain's)…
 		const amendments = (amendBody as { items: { item_id: string }[] }).items;
-		expect(amendments.map((a) => a.item_id).sort()).toEqual(['a3', 'a4']);
+		expect(amendments.map((a) => a.item_id).sort()).toEqual(['a1', 'a2', 'a3', 'a4']);
 		// …and the decide denies exactly chain 2's four items.
 		const decisions = (decideBody as { items: { item_id: string; decision: string }[] }).items;
 		const denied = decisions.filter((d) => d.decision === 'denied').map((d) => d.item_id);
@@ -738,13 +744,17 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 		await user.click(screen.getByRole('button', { name: /Approve & grant access/ }));
 		expect(await screen.findByText('Access granted')).toBeInTheDocument();
 
-		// The binds were amended to the ADOPTED id; nothing was created.
+		// The binds were amended to the ADOPTED id; nothing was created. The
+		// toolkit:create placeholder is stamped with the REUSED toolkit id so
+		// the approved record reads "fulfilled by tk_existing", not a phantom
+		// create (#897 audit honesty).
 		const amendments = (
 			amendBody as { items: { item_id: string; to_id?: string; resource_id?: string }[] }
 		).items;
 		const byItem = new Map(amendments.map((a) => [a.item_id, a]));
 		expect(byItem.get('i3')?.to_id).toBe('tk_existing');
 		expect(byItem.get('i4')?.resource_id).toBe('tk_existing');
+		expect(byItem.get('i1')?.resource_id).toBe('tk_existing');
 		expect(createCalls).toBe(0);
 	});
 
@@ -824,6 +834,8 @@ describe('ProvisioningRequestDialog — adopt existing objects (#826)', () => {
 			.items;
 		const byItem = new Map(amendments.map((a) => [a.item_id, a]));
 		expect(byItem.get('i3')?.resource_id).toBe('cred_exist');
+		// The credential:provision placeholder records the reused credential.
+		expect(byItem.get('i2')?.resource_id).toBe('cred_exist');
 	});
 
 	it('slugifies the raw filed vendor and hides inactive artifacts in the pickers', async () => {


### PR DESCRIPTION
Closes #897

## Summary

The wizard's adopt-an-existing-toolkit mechanics already shipped (#885/#902), but the `serves=False` provision flow still *read* as "recreate everything from scratch", and a reuse approval left no record of which toolkit fulfilled the plan. This PR closes that residual gap:

- **Broker directive** — the `no_toolkit_binding` / `toolkit_serves_api: false` instruction now tells the agent the operator can add the credential to an **existing** toolkit during fulfilment. `parameters` (`toolkit_serves_api`, `suggested_command`) are deliberately untouched so CLI/skill parsing stays stable; the docstring records why the broker never enumerates toolkits here (inventory leak to an unbound agent, no scoped view of a future approver).
- **Skill** (CLI embed + served copy, kept byte-identical per the drift arch test) — the `toolkit_serves_api: false` recovery bullet and the execute-denial pitfalls entry now mention the reuse choice so agents relay it to their operator.
- **Wizard audit honesty** — submit now also stamps the fulfilled toolkit/credential ids onto the inert `toolkit:create` / `credential:provision` placeholders, so a reuse approval records "fulfilled by tk_…" instead of implying a create that never happened. No backend change needed: `:amend` already accepts `resource_id` on any pending item, and approving a fulfilment-only item stays a recorded no-op.
- **Tests** — broker unit test guards the reuse hint *and* the exact parameter shape; a control e2e drives the full reuse amend+decide shape (full approval — the agent's `--wait` exits 0 — binds land on the pre-existing toolkit, no parallel toolkit row); wizard tests assert the placeholder amendments on both create and adopt paths.

CLI `--provision --toolkit-id` (filing a 3-item plan targeting a known toolkit) is deliberately deferred: the reuse choice belongs to the operator in the wizard, and agents don't know ids of toolkits they aren't bound to.

## Test plan

- [x] `make lint` (ruff + format + mypy) clean
- [x] `pytest tests/unit tests/arch` — 2459 passed
- [x] `JENTIC_TEST_BACKEND=sqlite pytest tests/integration/control/test_provisioning_plan_e2e.py` — 6 passed (Postgres backend runs in CI)
- [x] `ui`: `npm run lint:fix`, `npm run build`, `npm run test:run` — 967 passed
- [x] `cli`: `go test ./internal/skillgen/...` — ok
- [ ] Manual: trigger a `serves=False` denial and confirm the directive/skill text; fulfil a plan via "use an existing toolkit" and check the decided request names the reused toolkit on the `toolkit:create` item

Please squash-merge.

Made with [Cursor](https://cursor.com)