### PR TITLE
fix(monitoring): include the current partial minute in usage aggregates

### DIFF
--- a/src/jentic_one/admin/services/monitoring_service.py
+++ b/src/jentic_one/admin/services/monitoring_service.py
@@ -23,7 +23,11 @@ _cache_misses = _meter.create_counter(
     "monitoring.cache.misses", description="Monitoring cache misses"
 )
 
-_CACHE_TTL_SECONDS = 120.0
+# Short enough that a repeated cache key (the fallback window is stable for a
+# whole minute — see get_usage_stats) can't pin the first response of the
+# minute much beyond the feed's freshness; long enough to absorb a dashboard
+# fan-out's thundering herd (#913).
+_CACHE_TTL_SECONDS = 30.0
 _USAGE_CACHE_MAX_ENTRIES = 256
 
 
@@ -159,9 +163,13 @@ class MonitoringService:
         filters: UsageFilters | None = None,
     ) -> UsageStats:
         current_ts = int(datetime.now(tz=UTC).timestamp())
-        # Floor the fallback to the nearest minute so default-parameter requests
-        # arriving within the same 60s window share an identical cache key.
-        stable_now_ts = (current_ts // 60) * 60
+        # Round the fallback UP to the next minute boundary: requests arriving
+        # within the same 60s window still share an identical cache key, but —
+        # because every aggregate filters `started_at < until` strictly — the
+        # current partial minute is INCLUDED. Flooring here made executions
+        # invisible to the volume chart / KPI for up to a minute while the
+        # executions feed (no upper bound) already listed them (#913).
+        stable_now_ts = (current_ts // 60 + 1) * 60
         resolved_until = until if until is not None else stable_now_ts
         resolved_since = since if since is not None else resolved_until - 86400
 

--- a/tests/integration/admin/services/test_monitoring_service_window.py
+++ b/tests/integration/admin/services/test_monitoring_service_window.py
@@ -1,0 +1,94 @@
+"""Integration tests for MonitoringService's usage window resolution (#913).
+
+The volume chart / KPI aggregate must never trail the executions feed: an
+execution recorded "now" has to be counted by a usage query that omits
+``until``. The service used to floor the fallback bound DOWN to the minute
+(for cache-key stability), and every aggregate filters ``started_at < until``
+strictly — so current-minute executions were invisible to the aggregate for up
+to 60 s while ``GET /executions`` (no upper bound) already listed them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import delete
+
+from jentic_one.admin.core.schema.execution_records import ExecutionRecord
+from jentic_one.admin.repos import ExecutionRecordRepository
+from jentic_one.admin.services.monitoring_service import MonitoringService
+from jentic_one.shared.context import Context
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+async def clean_executions(integration_context: Context) -> AsyncGenerator[None, None]:
+    async with integration_context.admin_db.session() as session:
+        await session.execute(delete(ExecutionRecord))
+        await session.commit()
+    yield
+    async with integration_context.admin_db.session() as session:
+        await session.execute(delete(ExecutionRecord))
+        await session.commit()
+
+
+async def _seed(ctx: Context, started_at: datetime) -> None:
+    async with ctx.admin_db.session() as session:
+        await ExecutionRecordRepository.create(
+            session,
+            toolkit_id="tk_test000000000000000000",
+            trace_id="ab" * 16,
+            started_at=started_at,
+            status="completed",
+            created_by="usr_test",
+            actor_id="agt_test",
+            actor_type="agent",
+        )
+        await session.commit()
+
+
+async def test_usage_without_until_counts_the_current_partial_minute(
+    integration_context: Context, clean_executions: None
+) -> None:
+    """The #913 contract: volume must not trail the feed.
+
+    A record started *now* — inside the current partial minute — must be
+    included when the caller sends only ``since`` (the agent/toolkit detail
+    pages' shape). The fallback ``until`` is ceiled to the NEXT minute
+    boundary, so the strict ``started_at < until`` covers it immediately; no
+    hard refresh or minute-boundary wait.
+    """
+    ctx = integration_context
+    now = datetime.now(UTC)
+    await _seed(ctx, now)
+
+    svc = MonitoringService(ctx)
+    result = await svc.get_usage_stats(since=int(now.timestamp()) - 7 * 86_400)
+
+    assert result.total == 1
+    assert result.success == 1
+    # The resolved bound is minute-aligned (cache keys stay stable for the
+    # whole minute) and strictly in the future relative to the seeded row.
+    assert result.until % 60 == 0
+    assert result.until > int(now.timestamp())
+
+
+async def test_usage_with_explicit_until_still_bounds_strictly(
+    integration_context: Context, clean_executions: None
+) -> None:
+    """A caller-supplied ``until`` stays authoritative (Monitor's explicit
+    windows): a record at/after the bound is excluded, one before it counts."""
+    ctx = integration_context
+    now = datetime.now(UTC).replace(microsecond=0)
+    await _seed(ctx, now - timedelta(minutes=5))
+    await _seed(ctx, now + timedelta(minutes=5))  # outside the explicit window
+
+    svc = MonitoringService(ctx)
+    result = await svc.get_usage_stats(
+        since=int(now.timestamp()) - 3_600, until=int(now.timestamp())
+    )
+
+    assert result.total == 1

--- a/tests/unit/admin/services/test_monitoring_service_usage.py
+++ b/tests/unit/admin/services/test_monitoring_service_usage.py
@@ -15,6 +15,7 @@ from jentic_one.admin.repos.monitoring_repo import (
     UsageQueryFilters,
 )
 from jentic_one.admin.services.monitoring_service import (
+    _CACHE_TTL_SECONDS,
     _USAGE_CACHE_MAX_ENTRIES,
     MonitoringService,
     UsageFilters,
@@ -118,12 +119,72 @@ async def test_default_since_until_resolution() -> None:
         call_args = mock_query.call_args[0]
         resolved_since, resolved_until = call_args[0], call_args[1]
 
-    expected_until = (int(mock_now.timestamp()) // 60) * 60
+    # The fallback bound is rounded UP to the next minute (#913): stable cache
+    # keys within a minute, but the strict `< until` filter still covers the
+    # current partial minute — executions must never be visible in the feed
+    # yet missing from the volume aggregate.
+    expected_until = (int(mock_now.timestamp()) // 60 + 1) * 60
     expected_since = expected_until - 86400
     assert resolved_until == expected_until
     assert resolved_since == expected_since
     assert resolved_until % 60 == 0
+    assert resolved_until > int(mock_now.timestamp())
     assert resolved_until - resolved_since == 86400
+
+
+@pytest.mark.asyncio
+async def test_cached_entry_expires_after_ttl() -> None:
+    """An entry older than the TTL is a miss — the aggregate is re-queried.
+
+    The TTL is deliberately short (30s, #913): with the fallback window stable
+    for a whole minute, a longer TTL would pin the minute's FIRST response and
+    hide executions arriving mid-minute from the volume chart while the
+    executions feed already shows them.
+    """
+    ctx = _make_ctx()
+    svc = MonitoringService(ctx)
+    cached = UsageStats(
+        since=1000,
+        until=87400,
+        bucket_seconds=3600,
+        group_by="api",
+        total=1,
+        success=1,
+        failed=0,
+        pending=0,
+        avg_ms=1.0,
+        p50_ms=None,
+        p95_ms=None,
+        active_now=0,
+        buckets=[],
+        top=[],
+    )
+    cache_key = (1000, 87400, GroupBy.API, 10, UsageFilters())
+    svc._usage_cache[cache_key] = _UsageCacheEntry(
+        result=cached, cached_at=time.monotonic() - (_CACHE_TTL_SECONDS + 1)
+    )
+
+    fresh = UsageStats(
+        since=1000,
+        until=87400,
+        bucket_seconds=3600,
+        group_by="api",
+        total=4,
+        success=4,
+        failed=0,
+        pending=0,
+        avg_ms=1.0,
+        p50_ms=None,
+        p95_ms=None,
+        active_now=0,
+        buckets=[],
+        top=[],
+    )
+    with patch.object(svc, "_query_usage", new_callable=AsyncMock, return_value=fresh):
+        result = await svc.get_usage_stats(
+            since=1000, until=87400, group_by=GroupBy.API, top_limit=10
+        )
+    assert result is fresh
 
 
 @pytest.mark.asyncio

--- a/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
+++ b/ui/src/modules/agents/__tests__/AgentDetailPage.test.tsx
@@ -219,6 +219,36 @@ describe('AgentDetailPage', () => {
 		expect(within(strip).getByText('Bound toolkits')).toBeInTheDocument();
 	});
 
+	it('requests the usage window with a next-minute-ceiled until bound (#913)', async () => {
+		// The aggregate filters `started_at < until` strictly, so the request
+		// must carry an explicit `until` PAST "now" — a floored (or absent →
+		// server-floored) bound excludes the current partial minute, making
+		// fresh executions visible in the Activity feed but missing from the
+		// volume chart / 7-day KPI until the minute rolls over.
+		let captured: URLSearchParams | null = null;
+		worker.use(
+			http.get('/monitoring/usage', ({ request }) => {
+				const url = new URL(request.url);
+				if (url.searchParams.get('agent_id') !== 'agnt_active_1') return undefined;
+				captured = url.searchParams;
+				return undefined; // fall through to the module's fixture handler
+			}),
+		);
+		const beforeSec = Math.floor(Date.now() / 1000);
+		renderDetail('agnt_active_1');
+		await screen.findByRole('group', { name: 'Key metrics' });
+
+		await waitFor(() => expect(captured).not.toBeNull());
+		const params: URLSearchParams = captured!;
+		const since = Number(params.get('since'));
+		const until = Number(params.get('until'));
+		expect(until % 60).toBe(0);
+		expect(until).toBeGreaterThan(beforeSec);
+		// Exact 7-day width: the backend derives its bucket tier from
+		// `until - since`, so the window must not stretch past the tier edge.
+		expect(until - since).toBe(7 * 86_400);
+	});
+
 	it('hides the KPI strip when monitoring is admin-gated (403)', async () => {
 		worker.use(
 			createErrorHandler('get', '/monitoring/usage', { status: 403 }),

--- a/ui/src/modules/agents/api/client.ts
+++ b/ui/src/modules/agents/api/client.ts
@@ -597,8 +597,15 @@ export async function fetchActorsUsage(
 	sinceDays = 7,
 ): Promise<Map<string, ActorUsage> | null> {
 	try {
+		// Window bounds ceiled to the next minute: the backend's aggregate uses
+		// a strict `started_at < until`, so a floored/now bound hides the
+		// current partial minute (#913); a fixed until also keeps the window an
+		// exact multiple of the bucket tier and the server cache key stable for
+		// a whole minute (a per-second `since` defeated it entirely).
+		const until = (Math.floor(Date.now() / 60_000) + 1) * 60;
 		const res = await MonitoringService.getUsageStats({
-			since: Math.floor(Date.now() / 1000) - sinceDays * 86400,
+			since: until - sinceDays * 86400,
+			until,
 			groupBy: GroupBy.AGENT,
 			topLimit: 50,
 		});
@@ -652,8 +659,13 @@ export async function fetchActorUsageDetail(
 	sinceDays = 7,
 ): Promise<ActorUsageDetail | null> {
 	try {
+		// Next-minute-ceiled bounds — see fetchActorsUsage: includes the current
+		// partial minute (#913, the volume chart must never trail the
+		// executions feed) with a cache-stable, tier-exact window.
+		const until = (Math.floor(Date.now() / 60_000) + 1) * 60;
 		const res = await MonitoringService.getUsageStats({
-			since: Math.floor(Date.now() / 1000) - sinceDays * 86400,
+			since: until - sinceDays * 86400,
+			until,
 			agentId: actorId,
 			// `top` is irrelevant here (the window is already one actor).
 			topLimit: 1,

--- a/ui/src/modules/agents/api/hooks.ts
+++ b/ui/src/modules/agents/api/hooks.ts
@@ -702,7 +702,11 @@ export function useActorUsageDetail(actorId: string | null) {
 		queryKey: ['agents-usage', 'detail', actorId],
 		queryFn: () => fetchActorUsageDetail(actorId as string),
 		enabled: actorId != null,
-		staleTime: 60 * 1000,
+		// Matches useActorExecutions below: the KPI/volume chart and the
+		// recent-executions feed render side by side and must go stale
+		// together, or the feed refreshes ahead of the chart and the two
+		// disagree for up to 30s (#913).
+		staleTime: 30 * 1000,
 		retry: false,
 	});
 }

--- a/ui/src/modules/dashboard/api/client.ts
+++ b/ui/src/modules/dashboard/api/client.ts
@@ -199,6 +199,11 @@ export async function fetchHasAgents(): Promise<boolean> {
 export interface UsageOverviewParams {
 	/** Unix-second window lower bound (the endpoint defaults `until` to now). */
 	since: number;
+	/** Unix-second window upper bound (exclusive). Sent explicitly so the
+	 * window width — which drives the backend's bucket-tier choice — is
+	 * deterministic, and ceiled so the current partial minute is included
+	 * (#913). */
+	until?: number;
 	/** Top-rows grouping dimension (defaults to `api` server-side). */
 	groupBy?: GroupBy;
 	/** How many top rows to return (1–50). */
@@ -218,6 +223,7 @@ export async function fetchUsageOverview(params: UsageOverviewParams): Promise<U
 	try {
 		return await MonitoringService.getUsageStats({
 			since: params.since,
+			until: params.until ?? null,
 			groupBy: params.groupBy ?? GroupBy.API,
 			topLimit: params.topLimit ?? 5,
 		});

--- a/ui/src/modules/dashboard/api/hooks.ts
+++ b/ui/src/modules/dashboard/api/hooks.ts
@@ -178,10 +178,13 @@ export function useHasAgents() {
  * initializes (TDZ).
  *
  * The query key carries the range + lens tokens (not raw timestamps — those
- * would mint a new cache slice every refetch); the actual `since` bound is
- * computed at fetch time from the range, minute-floored to match the
- * endpoint's own `until` default, so refetches within the same minute are
- * cache-coherent.
+ * would mint a new cache slice every refetch); the actual window bounds are
+ * computed at fetch time, ceiled to the NEXT minute so (a) refetches within
+ * the same minute are cache-coherent server-side, (b) the window width stays
+ * exactly the range (the backend picks its bucket tier from `until - since`,
+ * so a server-defaulted `until` would tip a 24h window into the 6h tier),
+ * and (c) the current partial minute is included — the aggregate must never
+ * trail the executions feed (#913).
  *
  * `placeholderData: keepPreviousData` — flipping range/lens re-keys the query;
  * keeping the previous aggregate on screen (with `isFetching` signalling the
@@ -195,9 +198,10 @@ export function useUsageOverview(
 	return useQuery<UsageResponse, DashboardApiError>({
 		queryKey: dashboardKeys.usage(range, lens),
 		queryFn: () => {
-			const nowFloored = Math.floor(Date.now() / 60_000) * 60;
+			const until = (Math.floor(Date.now() / 60_000) + 1) * 60;
 			return fetchUsageOverview({
-				since: nowFloored - RANGE_SECONDS[range],
+				since: until - RANGE_SECONDS[range],
+				until,
 				groupBy: lens,
 			});
 		},

--- a/ui/src/modules/monitor/components/OverviewTab.tsx
+++ b/ui/src/modules/monitor/components/OverviewTab.tsx
@@ -40,7 +40,8 @@ const TOP_LIMIT = 12;
 
 // Window-edge resolution. 5 minutes balances freshness against cache churn:
 // each roll forward is a new query key (a full refetch of all three
-// groupings), while the backend's own usage cache TTL is 120s anyway.
+// groupings), while the backend's own usage cache TTL (30s) absorbs repeats
+// within a step.
 const WINDOW_STEP_MS = 300_000;
 
 /**
@@ -92,21 +93,29 @@ export function OverviewTab() {
 			{ replace: true },
 		);
 
-	// Unix-second window bounds. The 24h window rolls with "now" (floored to
-	// 5-minute steps so the query key stays stable across re-renders yet still
-	// slides forward on long-lived tabs). The multi-day windows are aligned to
-	// local calendar days — midnight (days-1) days ago through the end of
-	// today — matching jentic-mini's day-bucketed volume chart: a rolling
-	// now-7d bound straddles 8 calendar dates, so the day axis showed "more
-	// than 7 days". Day alignment also makes the window an exact multiple of
-	// the backend's bucket tier, so the per-entity trend segments land on day
-	// boundaries. `until` is sent explicitly: the backend picks
+	// Unix-second window bounds. The 24h window rolls with "now" resolved to
+	// 5-minute steps (stable query key across re-renders, still slides forward
+	// on long-lived tabs) — with `until` at the NEXT step boundary: the
+	// backend's aggregate uses a strict `started_at < until`, so an
+	// already-elapsed bound would hide the current partial step's executions
+	// from the charts while the executions tab lists them (#913). The
+	// multi-day windows are aligned to local calendar days — midnight
+	// (days-1) days ago through the end of today — matching jentic-mini's
+	// day-bucketed volume chart: a rolling now-7d bound straddles 8 calendar
+	// dates, so the day axis showed "more than 7 days". Day alignment also
+	// makes the window an exact multiple of the backend's bucket tier, so the
+	// per-entity trend segments land on day boundaries (their `until` is
+	// end-of-today, i.e. in the future, so they never had the exclusion
+	// problem). `until` is sent explicitly: the backend picks
 	// `bucket_seconds` from the window width (until - since), and letting the
 	// server default `until` to *its* now would shift the window
 	// nondeterministically.
 	const nowSec = useCoarseNowSec(WINDOW_STEP_MS);
 	const { since, until } = useMemo(() => {
-		if (days === 1) return { since: nowSec - 86_400, until: nowSec };
+		if (days === 1) {
+			const edge = nowSec + WINDOW_STEP_MS / 1000;
+			return { since: edge - 86_400, until: edge };
+		}
 		const startOfToday = new Date(nowSec * 1000);
 		startOfToday.setHours(0, 0, 0, 0);
 		const sinceDate = new Date(startOfToday);

--- a/ui/src/modules/toolkits/api/client.ts
+++ b/ui/src/modules/toolkits/api/client.ts
@@ -436,7 +436,10 @@ export async function getToolkitUsage(
 	opts: { sinceDays?: number } = {},
 ): Promise<UsageResponse | null> {
 	const days = opts.sinceDays ?? 7;
-	const until = Math.floor(Date.now() / 60_000) * 60;
+	// Ceiled to the NEXT minute: the aggregate's strict `< until` must include
+	// the current partial minute (#913) — flooring made fresh executions
+	// invisible here while the Activity feed already listed them.
+	const until = (Math.floor(Date.now() / 60_000) + 1) * 60;
 	const since = until - days * 86_400;
 	try {
 		return await MonitoringService.getUsageStats({
@@ -499,7 +502,8 @@ export async function getUsageByToolkit(
 	opts: { sinceDays?: number } = {},
 ): Promise<Record<string, ToolkitUsageSummary> | null> {
 	const days = opts.sinceDays ?? 7;
-	const until = Math.floor(Date.now() / 60_000) * 60;
+	// Next-minute ceil — see getToolkitUsage (#913).
+	const until = (Math.floor(Date.now() / 60_000) + 1) * 60;
 	try {
 		const res = await MonitoringService.getUsageStats({
 			since: until - days * 86_400,


### PR DESCRIPTION
## Summary

Closes #913 — on the agent detail Activity tab (and the toolkit usage strip), the "Recent executions" feed showed fresh executions immediately while the "Execution volume" chart and "Executions (7 days)" KPI trailed by up to a minute, even across hard refreshes.

**Root cause**: the usage endpoint's fallback `until` was floored *down* to the minute (for cache-key stability) and every aggregate filters `started_at < until` strictly — so anything started in the current partial minute was invisible to the aggregate while `GET /executions` (no upper bound) already listed it. Compounded by asymmetric client `staleTime`s (60s chart vs 30s feed) and a 120s server cache TTL.

### Backend
- `get_usage_stats`: ceil the fallback `until` to the **next** minute boundary — cache keys stay stable for the whole minute, and the strict bound now covers "now". A caller-supplied `until` stays authoritative (Monitor's explicit ranges are untouched).
- Usage cache TTL 120s → 30s, so a repeated key can't pin the minute's first response and hide rows arriving mid-minute.

### UI
All trailing-window callers now send an **explicit next-minute-ceiled `until`** with `since = until - range`. (Deviation from "just drop `until`": the backend picks its bucket tier from `until - since`, and the tier edges sit exactly at the 1h/24h/7d ranges the clients use — a server-derived bound would widen the window by 60s and tip e.g. the dashboard's 24h chart from hourly into 6-hour buckets.)
- **agents**: both usage fetchers (the per-second `since` was also silently defeating the server cache — every request paid the full aggregate query); `useActorUsageDetail` `staleTime` 60s → 30s so the KPI/chart goes stale together with the feed.
- **toolkits**: both fetchers' floored `until` → ceiled.
- **dashboard**: `useUsageOverview` passes the ceiled `until` explicitly.
- **monitor**: the Overview 24h window used a 5-minute-*floored* edge — hiding up to 5 minutes (same bug class, found in the audit); its edge is now the next 5-minute step. Day-aligned multi-day windows already ended at end-of-today and were correct.

### Tests
- Unit: fallback resolution now asserts the ceiled bound; new TTL-expiry test.
- UI: AgentDetailPage MSW test pins the request shape — `until` minute-aligned, strictly in the future, width exactly 7d.
- Integration (both backends): new `test_monitoring_service_window.py` guards the contract — a record started "now" is counted by a `since`-only usage query; an explicit `until` still bounds strictly.

## Test plan
- [x] `make lint` (ruff, format, mypy) clean
- [x] `make test-unit` — 2196 passed, coverage 78%
- [x] Integration (SQLite): new window tests + monitoring repo tests pass
- [x] UI: eslint clean, 116 tests in touched suites pass, production build succeeds
- [ ] Manual: execute N calls as an agent, open the Activity tab within the same minute — feed and volume/KPI agree without a refresh

Please squash-merge.

Made with [Cursor](https://cursor.com)