### PR TITLE
feat(flow3): jitter the catalog update-sweep interval to de-phase replicas

### DIFF
--- a/src/jentic_one/shared/config.py
+++ b/src/jentic_one/shared/config.py
@@ -775,6 +775,13 @@ class CatalogConfig(BaseModel):
     # registry DB pool so the sweep never starves live request traffic.
     update_sweep_deadline_seconds: int = 300
     update_sweep_max_concurrency: int = 4
+    # Full-jitter fraction added to the per-cycle sweep interval, to de-phase the
+    # scanner across replicas (thundering-herd mitigation). Each time a sweep runs,
+    # the next one is due after ``interval * (1 + uniform(0, jitter_ratio))``, so N
+    # replicas that start in lock-step drift apart instead of all re-probing the
+    # upstream at the same interval boundary. Bounded (default 15%) so the cadence
+    # stays ~daily; 0 disables jitter (deterministic, e.g. for tests).
+    update_sweep_jitter_ratio: float = 0.15
 
 
 class ServerConfig(BaseModel):

--- a/src/jentic_one/shared/config.py
+++ b/src/jentic_one/shared/config.py
@@ -779,9 +779,9 @@ class CatalogConfig(BaseModel):
     # scanner across replicas (thundering-herd mitigation). Each time a sweep runs,
     # the next one is due after ``interval * (1 + uniform(0, jitter_ratio))``, so N
     # replicas that start in lock-step drift apart instead of all re-probing the
-    # upstream at the same interval boundary. Bounded (default 15%) so the cadence
-    # stays ~daily; 0 disables jitter (deterministic, e.g. for tests).
-    update_sweep_jitter_ratio: float = 0.15
+    # upstream at the same interval boundary. Bounded (default 15%, capped at 100%)
+    # so the cadence stays ~daily; 0 disables jitter (deterministic, e.g. for tests).
+    update_sweep_jitter_ratio: float = Field(default=0.15, ge=0.0, le=1.0)
 
 
 class ServerConfig(BaseModel):

--- a/src/jentic_one/shared/jobs/catalog_update_scanner.py
+++ b/src/jentic_one/shared/jobs/catalog_update_scanner.py
@@ -82,6 +82,17 @@ class CatalogUpdateScanner:
             self._running = False
             logger.info("catalog_update_scanner_stopped")
 
+    def _max_due_interval(self, interval: int) -> float:
+        """Upper bound of the jittered gate for the *current* interval.
+
+        ``interval * (1 + max(ratio, 0))`` — the ceiling ``_compute_due_interval`` can
+        return. Used to clamp a stale ``_due_interval`` (computed from an older, larger
+        interval) so a mid-run interval drop is honoured within one current-interval
+        ceiling rather than waiting out the old gate.
+        """
+        ratio = max(self._cfg.update_sweep_jitter_ratio, 0.0)
+        return interval * (1.0 + ratio)
+
     def _compute_due_interval(self, interval: int) -> float:
         """The jittered wait before the next sweep is due (thundering-herd spread).
 
@@ -103,8 +114,12 @@ class CatalogUpdateScanner:
         loop_now = asyncio.get_running_loop().time()
         # Gate on the jittered interval computed when the last sweep fired; on the very
         # first tick there's no prior sweep, so run immediately (then pick a jittered
-        # gate for the next cycle).
+        # gate for the next cycle). Clamp to the *current* interval's jitter ceiling so
+        # a mid-run drop in ``update_check_interval_seconds`` (if config is ever hot-
+        # reloaded) can't keep the scanner waiting on a stale, larger gate — the wait
+        # never exceeds what the current interval would itself allow.
         due = self._due_interval if self._due_interval is not None else float(interval)
+        due = min(due, self._max_due_interval(interval))
         if self._last_swept_at is not None and (loop_now - self._last_swept_at) < due:
             return
         # Stamp before running so a long sweep doesn't immediately re-trigger; the

--- a/src/jentic_one/shared/jobs/catalog_update_scanner.py
+++ b/src/jentic_one/shared/jobs/catalog_update_scanner.py
@@ -21,6 +21,7 @@ Gated on both the ``registry`` DB (candidates + check rows) and the ``admin`` DB
 from __future__ import annotations
 
 import asyncio
+import random
 from typing import TYPE_CHECKING
 
 import structlog
@@ -53,6 +54,9 @@ class CatalogUpdateScanner:
         self._tick_seconds = tick_seconds
         self._running = False
         self._last_swept_at: float | None = None
+        #: The (jittered) interval the *current* wait is gated on. Recomputed each time
+        #: a sweep fires so replicas de-phase across cycles (see ``_due_interval``).
+        self._due_interval: float | None = None
 
     async def run(self) -> None:
         """Main loop — run a sweep whenever one is due, until cancelled.
@@ -78,17 +82,36 @@ class CatalogUpdateScanner:
             self._running = False
             logger.info("catalog_update_scanner_stopped")
 
+    def _compute_due_interval(self, interval: int) -> float:
+        """The jittered wait before the next sweep is due (thundering-herd spread).
+
+        Full jitter over a bounded fraction of the base interval: the next sweep is due
+        after ``interval * (1 + uniform(0, jitter_ratio))``. Applied per cycle (not once
+        at startup) so replicas that begin in lock-step keep drifting apart rather than
+        re-syncing. ``jitter_ratio <= 0`` yields exactly ``interval`` (deterministic).
+        """
+        ratio = self._cfg.update_sweep_jitter_ratio
+        if ratio <= 0:
+            return float(interval)
+        return interval * (1.0 + random.uniform(0.0, ratio))
+
     async def _tick(self) -> None:
         interval = self._cfg.update_check_interval_seconds
         if interval <= 0:
             # Kill switch (air-gapped installs): never sweep.
             return
         loop_now = asyncio.get_running_loop().time()
-        if self._last_swept_at is not None and (loop_now - self._last_swept_at) < interval:
+        # Gate on the jittered interval computed when the last sweep fired; on the very
+        # first tick there's no prior sweep, so run immediately (then pick a jittered
+        # gate for the next cycle).
+        due = self._due_interval if self._due_interval is not None else float(interval)
+        if self._last_swept_at is not None and (loop_now - self._last_swept_at) < due:
             return
         # Stamp before running so a long sweep doesn't immediately re-trigger; the
-        # per-API DB gate is the authoritative dedupe across restarts.
+        # per-API DB gate is the authoritative dedupe across restarts. Recompute the
+        # jittered gate for the next cycle so the phase keeps drifting.
         self._last_swept_at = loop_now
+        self._due_interval = self._compute_due_interval(interval)
         await self.sweep()
 
     async def sweep(self) -> None:

--- a/tests/unit/shared/jobs/test_catalog_update_scanner.py
+++ b/tests/unit/shared/jobs/test_catalog_update_scanner.py
@@ -117,3 +117,64 @@ async def test_next_cycle_gate_uses_jittered_interval() -> None:
         await scanner._tick()  # t=1100 → 1100 < 1150 → still gated, no re-sweep
     sweep.assert_awaited_once()
     assert scanner._due_interval == 1150.0
+
+
+@pytest.mark.asyncio
+async def test_first_tick_sweeps_immediately_with_jitter_enabled() -> None:
+    """Jitter must not gate the very first tick — it sweeps immediately, then jitters.
+
+    The first-tick path short-circuits on ``_last_swept_at is None`` before the gate
+    comparison, so an enabled jitter ratio can't delay the initial sweep. After it, the
+    next-cycle gate is a jittered value strictly above the raw interval (max draw).
+    """
+    scanner = CatalogUpdateScanner(_make_ctx(interval=1000, jitter_ratio=0.15))
+    with (
+        patch.object(scanner, "sweep", new_callable=AsyncMock) as sweep,
+        patch(
+            "jentic_one.shared.jobs.catalog_update_scanner.random.uniform",
+            return_value=0.15,
+        ),
+    ):
+        await scanner._tick()
+    sweep.assert_awaited_once()
+    assert scanner._due_interval == 1150.0
+
+
+@pytest.mark.asyncio
+async def test_lowered_interval_clamps_stale_gate() -> None:
+    """A mid-run drop in the interval must not leave the scanner on the old, larger gate.
+
+    Simulate config being lowered after a sweep: the stale ``_due_interval`` (from the
+    old 1000s interval → 1150) must be clamped to the *new* interval's jitter ceiling
+    (100 * 1.15 = 115), so an elapsed of 120 re-sweeps instead of waiting out the stale
+    gate. Guards the correctness-lens stale-gate finding.
+    """
+    scanner = CatalogUpdateScanner(_make_ctx(interval=1000, jitter_ratio=0.15))
+    scanner._last_swept_at = 0.0
+    scanner._due_interval = 1150.0  # gate frozen from the old large interval
+    scanner._cfg.update_check_interval_seconds = 100  # operator lowered it
+
+    times = iter([120.0])
+
+    class _Loop:
+        def time(self) -> float:
+            return next(times)
+
+    with (
+        patch.object(scanner, "sweep", new_callable=AsyncMock) as sweep,
+        patch("asyncio.get_running_loop", return_value=_Loop()),
+        patch(
+            "jentic_one.shared.jobs.catalog_update_scanner.random.uniform",
+            return_value=0.0,
+        ),
+    ):
+        await scanner._tick()  # elapsed 120 > clamped ceiling 115 → sweep
+    sweep.assert_awaited_once()
+
+
+def test_max_due_interval_is_current_ceiling() -> None:
+    scanner = CatalogUpdateScanner(_make_ctx(interval=200, jitter_ratio=0.25))
+    assert scanner._max_due_interval(200) == 250.0
+    # A negative ratio is floored at 0 → ceiling is exactly the interval.
+    scanner._cfg.update_sweep_jitter_ratio = -1.0
+    assert scanner._max_due_interval(200) == 200.0

--- a/tests/unit/shared/jobs/test_catalog_update_scanner.py
+++ b/tests/unit/shared/jobs/test_catalog_update_scanner.py
@@ -9,9 +9,10 @@ import pytest
 from jentic_one.shared.jobs.catalog_update_scanner import CatalogUpdateScanner
 
 
-def _make_ctx(*, interval: int = 86400) -> MagicMock:
+def _make_ctx(*, interval: int = 86400, jitter_ratio: float = 0.15) -> MagicMock:
     ctx = MagicMock()
     ctx.config.catalog.update_check_interval_seconds = interval
+    ctx.config.catalog.update_sweep_jitter_ratio = jitter_ratio
     return ctx
 
 
@@ -34,7 +35,8 @@ async def test_first_tick_sweeps_then_gated_within_interval() -> None:
 
 @pytest.mark.asyncio
 async def test_tick_sweeps_again_after_interval_elapses() -> None:
-    scanner = CatalogUpdateScanner(_make_ctx(interval=100))
+    # jitter_ratio=0 → deterministic exact-interval gate for this boundary assertion.
+    scanner = CatalogUpdateScanner(_make_ctx(interval=100, jitter_ratio=0.0))
     times = iter([1000.0, 1200.0])
 
     class _Loop:
@@ -69,3 +71,49 @@ def test_stop_flips_running() -> None:
     scanner._running = True
     scanner.stop()
     assert scanner._running is False
+
+
+def test_compute_due_interval_disabled_returns_base() -> None:
+    # jitter_ratio <= 0 must yield exactly the base interval (deterministic).
+    scanner = CatalogUpdateScanner(_make_ctx(interval=100, jitter_ratio=0.0))
+    assert scanner._compute_due_interval(100) == 100.0
+
+
+def test_compute_due_interval_jitters_within_bounds() -> None:
+    # With ratio r, the due interval is in [interval, interval*(1+r)] — never below
+    # the base (so we never sweep early) and never above the bounded ceiling.
+    scanner = CatalogUpdateScanner(_make_ctx(interval=1000, jitter_ratio=0.15))
+    samples = [scanner._compute_due_interval(1000) for _ in range(200)]
+    assert all(1000.0 <= s <= 1150.0 for s in samples)
+    # Not a constant: jitter actually varies the gate (herd-spread is real).
+    assert len(set(samples)) > 1
+
+
+@pytest.mark.asyncio
+async def test_next_cycle_gate_uses_jittered_interval() -> None:
+    """After a sweep, the next-cycle gate is the jittered interval, not the raw one.
+
+    Pin the jitter draw so the boundary is deterministic: with the drawn due interval
+    at 1150, an elapsed of 1100 (< 1150) must NOT re-sweep, proving the gate widened
+    past the raw 1000s interval by the jitter.
+    """
+    scanner = CatalogUpdateScanner(_make_ctx(interval=1000, jitter_ratio=0.15))
+    times = iter([0.0, 1100.0])
+
+    class _Loop:
+        def time(self) -> float:
+            return next(times)
+
+    with (
+        patch.object(scanner, "sweep", new_callable=AsyncMock) as sweep,
+        patch("asyncio.get_running_loop", return_value=_Loop()),
+        # Draw the max jitter → due interval = 1000 * (1 + 0.15) = 1150.
+        patch(
+            "jentic_one.shared.jobs.catalog_update_scanner.random.uniform",
+            return_value=0.15,
+        ),
+    ):
+        await scanner._tick()  # t=0 → first sweep, gate for next cycle = 1150
+        await scanner._tick()  # t=1100 → 1100 < 1150 → still gated, no re-sweep
+    sweep.assert_awaited_once()
+    assert scanner._due_interval == 1150.0

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -15,6 +15,7 @@ from jentic_one.shared.config import (
     AdminAuthConfig,
     AdminInviteConfig,
     AppConfig,
+    CatalogConfig,
     ConfigError,
     CredentialsConfig,
     EgressConfig,
@@ -185,6 +186,28 @@ def test_non_positive_session_lifetimes_rejected(field: str):
         pytest.raises(ValidationError, match=field),
     ):
         AdminAuthConfig.model_validate({field: 0})
+
+
+def test_catalog_jitter_ratio_default():
+    """The sweep jitter ratio defaults to a bounded 15%."""
+    assert CatalogConfig().update_sweep_jitter_ratio == 0.15
+
+
+@pytest.mark.parametrize("bad", [-0.01, 1.01, 10.0])
+def test_catalog_jitter_ratio_out_of_bounds_rejected(bad: float):
+    """The ratio is bounded [0, 1]: a value outside that fails fast at load.
+
+    Without the Field(ge=0, le=1) bound a value like 10.0 would silently make the
+    "cadence stays ~daily" contract false (up to 11x the interval), so reject it.
+    """
+    with pytest.raises(ValidationError, match="update_sweep_jitter_ratio"):
+        CatalogConfig.model_validate({"update_sweep_jitter_ratio": bad})
+
+
+def test_catalog_jitter_ratio_bounds_accepted():
+    """The inclusive bounds 0.0 (disable) and 1.0 (max) are both valid."""
+    assert CatalogConfig(update_sweep_jitter_ratio=0.0).update_sweep_jitter_ratio == 0.0
+    assert CatalogConfig(update_sweep_jitter_ratio=1.0).update_sweep_jitter_ratio == 1.0
 
 
 def test_default_invite_pepper_rejected_in_production():


### PR DESCRIPTION
## Summary

The `CatalogUpdateScanner` runs the Flow-3 update-notify sweep on an owned
cadence, gated on a fixed `update_check_interval_seconds`. With a fixed interval,
N replicas that start in lock-step all re-probe the upstream manifest / spec URLs
at the same interval boundary — a small but avoidable thundering herd.

This PR adds **bounded full-jitter** to the per-cycle interval gate:

- After each sweep, the next one is due after `interval * (1 + uniform(0, jitter_ratio))`.
- The gate is **recomputed every cycle**, so replicas that begin in lock-step keep
  drifting apart rather than re-syncing on a single fixed offset.
- Jitter only ever **widens** the wait — it never causes an early sweep.
- Bounded by a new knob `CatalogConfig.update_sweep_jitter_ratio`, validated with
  `Field(ge=0.0, le=1.0)` (default `0.15`, so a ~daily cadence stays ~daily). `0`
  disables it → deterministic, exact interval. An out-of-range value fails fast at
  config load rather than silently breaking the cadence contract.
- The active gate is **clamped to the current interval's jitter ceiling**
  (`interval * (1 + max(ratio, 0))`), so if `update_check_interval_seconds` is ever
  lowered mid-run (hot reload) the scanner self-heals within one current-interval
  ceiling instead of waiting out a stale gate computed from the old interval.

This is a **jitter primitive local to the scheduler**, distinct from the broker's
retry full-jitter (`broker/adapters/runners/retry.py`, which replaces a backoff with
`uniform(0, cap)`); here it's an *additive* spread over the base interval that only
widens the wait. It is **purely herd mitigation**, not a correctness change: the
event emit is already deduped/idempotent, sweeps are in-process serialized, and the
authoritative per-API dedupe is the persistent `last_checked_at` re-probe gate plus
the `last_notified_digest` emit gate. Nothing about *which* events fire or *when* an
update is detected changes — only the phase at which each replica wakes to probe.

## Why here (insertion point)

The scanner has no separate "next-run scheduler"; the cadence lives entirely in
the `_tick()` interval gate. So the jitter is applied there — computed once per
sweep and stored on `self._due_interval`, which the next tick compares against
(clamped to the current interval's ceiling).

```mermaid
flowchart TD
  A[tick wakes every 30s] --> B{interval greater than 0}
  B -->|no kill switch| Z[return, never sweep]
  B -->|yes| C{elapsed less than clamped due}
  C -->|yes still gated| Z2[return]
  C -->|no due| D[stamp last_swept_at]
  D --> E[due equals interval times 1 plus jitter]
  E --> F[run sweep]
```

## Test plan

- [x] `test_compute_due_interval_disabled_returns_base` — `ratio <= 0` yields exactly the base interval.
- [x] `test_compute_due_interval_jitters_within_bounds` — 200 draws all land in `[interval, interval*(1+ratio)]` and are not constant.
- [x] `test_next_cycle_gate_uses_jittered_interval` — with the jitter draw pinned to max, an elapsed inside the widened gate does **not** re-sweep.
- [x] `test_first_tick_sweeps_immediately_with_jitter_enabled` — jitter never gates the initial sweep.
- [x] `test_lowered_interval_clamps_stale_gate` — a mid-run interval drop re-sweeps within the new ceiling instead of waiting out the stale gate.
- [x] `test_max_due_interval_is_current_ceiling` — the clamp ceiling is `interval*(1+ratio)`, floored at ratio 0.
- [x] Config bounds (`tests/unit/test_config.py`): default `0.15`, out-of-range `[-0.01, 1.01, 10.0]` rejected, inclusive bounds `0.0`/`1.0` accepted.
- [x] Existing cadence test pinned to `jitter_ratio=0` for its exact-boundary assertion; kill-switch / delegate tests unchanged.
- [x] `make lint` (ruff + format + mypy) green; scanner + config unit suites green.

Independent of the `overlays:confirm` work (#916, now merged) and of the Phase-6 A
spine; rebased onto current `main` (which includes both #912's scanner and #916).