### PR TITLE
feat(overlays): persist superseded_revision_id at materialize time (A5a)

### DIFF
--- a/src/jentic_one/migrations/registry/versions/a2b3c4d5e6f7_add_superseded_revision_id_to_overlays.py
+++ b/src/jentic_one/migrations/registry/versions/a2b3c4d5e6f7_add_superseded_revision_id_to_overlays.py
@@ -1,0 +1,27 @@
+"""add superseded_revision_id to overlays
+
+Revision ID: a2b3c4d5e6f7
+Revises: f5a6b7c8d9e0
+Create Date: 2026-07-31
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from jentic_one.shared.db.types import GUID
+
+revision: str = "a2b3c4d5e6f7"
+down_revision: str | None = "f5a6b7c8d9e0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("overlays", sa.Column("superseded_revision_id", GUID(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("overlays", "superseded_revision_id")

--- a/src/jentic_one/registry/core/schema/overlays.py
+++ b/src/jentic_one/registry/core/schema/overlays.py
@@ -45,6 +45,14 @@ class Overlay(AuditableMixin, RegistryBase):
     #: the link is advisory — a pruned revision simply leaves this dangling, and the
     #: overlay is re-materialized on the next confirm/re-import.
     confirmed_revision_id: Mapped[uuid.UUID | None] = mapped_column(GUID(), nullable=True)
+    #: The revision this overlay *superseded* — i.e. the API's current revision at the
+    #: moment materialization archived it and promoted the overlay's revision. Captured
+    #: at confirm/materialize time so a later un-confirm/rollback (A5b) can promote the
+    #: prior revision back to current deterministically, even once overlays stack.
+    #: Nullable (pre-existing overlays and non-superseding materializations read NULL —
+    #: treat NULL as "unknown prior → no deterministic rollback target"). No FK, for the
+    #: same advisory reason as ``confirmed_revision_id``.
+    superseded_revision_id: Mapped[uuid.UUID | None] = mapped_column(GUID(), nullable=True)
     status: Mapped[str] = mapped_column(
         String(20), nullable=False, server_default=text("'pending'")
     )

--- a/src/jentic_one/registry/ingest/ingestor.py
+++ b/src/jentic_one/registry/ingest/ingestor.py
@@ -62,6 +62,11 @@ class Ingestor:
 
                     operation_ids: set[str] = pipeline_ctx.require("operation_ids", set)
                     revision_id: uuid.UUID = pipeline_ctx.require("revision_id", uuid.UUID)
+                    # Optional: only produced by CreateRevisionStage for an overlay
+                    # materialization that superseded an existing current revision.
+                    superseded_revision_id: uuid.UUID | None = pipeline_ctx.get(
+                        "superseded_revision_id"
+                    )
 
                 result_state = (
                     ApiRevisionState.IMPORTED if spec.origin is not None else ApiRevisionState.DRAFT
@@ -71,6 +76,7 @@ class Ingestor:
                     api_name=spec.api_identifier.name,
                     api_version=spec.api_identifier.version,
                     revision_id=revision_id,
+                    superseded_revision_id=superseded_revision_id,
                     state=result_state,
                     operation_count=len(operation_ids),
                 )

--- a/src/jentic_one/registry/ingest/schemas.py
+++ b/src/jentic_one/registry/ingest/schemas.py
@@ -16,5 +16,10 @@ class IngestResult(BaseModel):
     api_name: str
     api_version: str
     revision_id: uuid.UUID
+    #: The revision this ingest superseded (the API's current revision before an
+    #: overlay materialization archived it). Only set for overlay-origin ingests that
+    #: replaced an existing current revision; ``None`` otherwise (drafts, catalog
+    #: imports, or a first-ever materialize with no prior current revision).
+    superseded_revision_id: uuid.UUID | None = None
     state: ApiRevisionState = ApiRevisionState.DRAFT
     operation_count: int

--- a/src/jentic_one/registry/ingest/stages/extract_api.py
+++ b/src/jentic_one/registry/ingest/stages/extract_api.py
@@ -36,6 +36,10 @@ class CreateRevisionStage(BasePipelineStage):
 
     name: ClassVar[str] = "CreateRevisionStage"
     _requires: ClassVar[dict[str, type]] = {"api_id": uuid.UUID}
+    # Only ``revision_id`` is a *mandatory* output. This stage also conditionally
+    # produces ``superseded_revision_id`` (overlay materialize that replaced a current
+    # revision) — deliberately NOT declared here, since ``_produces`` keys are asserted
+    # present for every run; the ingestor reads that one via the non-raising ctx.get().
     _produces: ClassVar[dict[str, type]] = {"revision_id": uuid.UUID}
 
     async def _run(self, ctx: PipelineContext) -> None:

--- a/src/jentic_one/registry/ingest/stages/extract_api.py
+++ b/src/jentic_one/registry/ingest/stages/extract_api.py
@@ -63,6 +63,14 @@ class CreateRevisionStage(BasePipelineStage):
                 # origin-scoped archive would leave those active and the new imported
                 # revision would then violate ix_api_revisions_one_active (one active
                 # revision per api). Archive every active revision (published+imported).
+                #
+                # Capture the revision being superseded (the API's current revision
+                # *before* the archive) so the overlay can record it for a later
+                # deterministic rollback (A5b). None if the API had no current revision
+                # (a first-ever materialize) — the overlay then has no rollback target.
+                api = await ApiRepository.get_by_id(ctx.session, api_id)
+                if api is not None and api.current_revision_id is not None:
+                    ctx.produce("superseded_revision_id", api.current_revision_id, uuid.UUID)
                 await ApiRevisionRepository.archive_all_active(ctx.session, api_id)
             else:
                 await ApiRevisionRepository.archive_active_imported(

--- a/src/jentic_one/registry/repos/overlay_repo.py
+++ b/src/jentic_one/registry/repos/overlay_repo.py
@@ -153,19 +153,29 @@ class OverlayRepository:
         session: AsyncSession,
         overlay_id: str,
         confirmed_revision_id: uuid.UUID,
+        *,
+        superseded_revision_id: uuid.UUID | None = None,
     ) -> int:
         """Record the revision produced by materializing this overlay.
 
         Written by the ingest job after a confirm's re-ingest succeeds, so the
         overlay points at the concrete revision now serving the overlaid spec.
+
+        ``superseded_revision_id`` records the revision this materialization archived
+        (the API's current revision immediately before), giving a later
+        un-confirm/rollback (A5b) a deterministic prior-revision target. It is only
+        written when non-``None`` — a recovery/relink that doesn't know the superseded
+        revision must not overwrite a previously-captured value with ``NULL``.
         """
+        values: dict[str, Any] = {
+            "confirmed_revision_id": confirmed_revision_id,
+            "updated_at": func.now(),
+        }
+        if superseded_revision_id is not None:
+            values["superseded_revision_id"] = superseded_revision_id
         result = cast(
             "CursorResult[Any]",
-            await session.execute(
-                update(Overlay)
-                .where(Overlay.id == overlay_id)
-                .values(confirmed_revision_id=confirmed_revision_id, updated_at=func.now())
-            ),
+            await session.execute(update(Overlay).where(Overlay.id == overlay_id).values(**values)),
         )
         await session.flush()
         return result.rowcount

--- a/src/jentic_one/registry/repos/revision_repo.py
+++ b/src/jentic_one/registry/repos/revision_repo.py
@@ -174,6 +174,34 @@ class ApiRevisionRepository:
         return result.scalar_one_or_none()
 
     @staticmethod
+    async def latest_archived_non_overlay(
+        session: AsyncSession, api_id: uuid.UUID, overlay_origin: str
+    ) -> uuid.UUID | None:
+        """The most-recently-archived non-overlay revision for an API, if any.
+
+        Used to *reconstruct* the revision an overlay materialize superseded when the
+        original confirm crashed after committing the re-ingest (which archived that
+        revision) but before back-linking it onto the overlay — the recovery re-ingest
+        no longer carries the superseded id in memory. A successful materialize archives
+        exactly the prior current (non-overlay) revision and nothing archives afterwards
+        until the next confirm, so the newest such archive is that superseded revision.
+        Best-effort: ``None`` if the API never had a non-overlay revision (a first-ever
+        materialize superseded nothing) — the overlay then legitimately has no rollback
+        target.
+        """
+        result = await session.execute(
+            select(ApiRevision.id)
+            .where(
+                ApiRevision.api_id == api_id,
+                ApiRevision.state == ApiRevisionState.ARCHIVED,
+                or_(ApiRevision.origin != overlay_origin, ApiRevision.origin.is_(None)),
+            )
+            .order_by(ApiRevision.archived_at.desc(), ApiRevision.id.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    @staticmethod
     async def delete_replaceable_by_digest(
         session: AsyncSession, api_id: uuid.UUID, spec_digest: str
     ) -> int:

--- a/src/jentic_one/registry/services/import_service.py
+++ b/src/jentic_one/registry/services/import_service.py
@@ -89,6 +89,11 @@ class ImportHandler:
                                 "version": result.api_version,
                             },
                             "revision_id": str(result.revision_id),
+                            "superseded_revision_id": (
+                                str(result.superseded_revision_id)
+                                if result.superseded_revision_id is not None
+                                else None
+                            ),
                             "state": result.state,
                         }
                     )
@@ -138,7 +143,10 @@ class ImportHandler:
             if overlay_id:
                 if len(revisions) == 1 and not failures:
                     await self._link_overlay_revision(
-                        job_id, str(overlay_id), revisions[0]["revision_id"]
+                        job_id,
+                        str(overlay_id),
+                        revisions[0]["revision_id"],
+                        revisions[0].get("superseded_revision_id"),
                     )
                 elif not revisions and len(sources) == 1:
                     # Recovery: a prior attempt of this exact confirm already produced
@@ -180,7 +188,13 @@ class ImportHandler:
         finally:
             unbind_contextvars("job_id")
 
-    async def _link_overlay_revision(self, job_id: str, overlay_id: str, revision_id: str) -> None:
+    async def _link_overlay_revision(
+        self,
+        job_id: str,
+        overlay_id: str,
+        revision_id: str,
+        superseded_revision_id: str | None = None,
+    ) -> None:
         """Record the materialized revision on the overlay (best-effort).
 
         Runs in its own registry_db transaction — the Ingestor already committed the
@@ -188,11 +202,23 @@ class ImportHandler:
         (durable) re-ingest, so it is logged rather than raised: the served spec is
         already correct; only the overlay->revision back-reference is missing and can
         be repaired by re-confirming.
+
+        ``superseded_revision_id`` (the revision this materialization archived) is
+        recorded alongside so a later un-confirm/rollback (A5b) has a deterministic
+        prior-revision target. ``None`` when the materialize superseded nothing (a
+        first-ever current revision).
         """
         try:
             async with self._ctx.registry_db.transaction() as session:
                 updated = await OverlayRepository.set_confirmed_revision(
-                    session, overlay_id, uuid.UUID(revision_id)
+                    session,
+                    overlay_id,
+                    uuid.UUID(revision_id),
+                    superseded_revision_id=(
+                        uuid.UUID(superseded_revision_id)
+                        if superseded_revision_id is not None
+                        else None
+                    ),
                 )
             if updated == 0:
                 logger.warning(

--- a/src/jentic_one/registry/services/import_service.py
+++ b/src/jentic_one/registry/services/import_service.py
@@ -18,6 +18,7 @@ from jentic_one.registry.ingest.fetch import IngestSource, load_specification
 from jentic_one.registry.ingest.ingestor import Ingestor
 from jentic_one.registry.repos.api_repo import ApiRepository
 from jentic_one.registry.repos.overlay_repo import OverlayRepository
+from jentic_one.registry.repos.revision_repo import ApiRevisionRepository
 from jentic_one.shared.audit import AuditAction, AuditTargetType, record_audit_best_effort
 from jentic_one.shared.context import Context
 from jentic_one.shared.db.errors import DatabaseIntegrityError
@@ -308,14 +309,26 @@ class ImportHandler:
                 if api.current_revision.origin != ORIGIN_OVERLAY:
                     return False
                 assert api.current_revision_id is not None
+                # Reconstruct the revision this materialize superseded. The original
+                # confirm archived it before crashing pre-link, so it isn't in memory
+                # here — recover it as the newest archived non-overlay revision. Passed
+                # best-effort: set_confirmed_revision won't clobber an already-captured
+                # value, and None (first-ever materialize) leaves it NULL as intended.
+                superseded_id = await ApiRevisionRepository.latest_archived_non_overlay(
+                    session, api.id, ORIGIN_OVERLAY
+                )
                 updated = await OverlayRepository.set_confirmed_revision(
-                    session, overlay_id, api.current_revision_id
+                    session,
+                    overlay_id,
+                    api.current_revision_id,
+                    superseded_revision_id=superseded_id,
                 )
             logger.info(
                 "overlay_materialize_recovered_existing_revision",
                 job_id=job_id,
                 overlay_id=overlay_id,
                 revision_id=str(api.current_revision_id),
+                superseded_revision_id=str(superseded_id) if superseded_id else None,
                 linked=updated > 0,
             )
             return updated > 0

--- a/tests/integration/registry/repos/test_overlay_repo.py
+++ b/tests/integration/registry/repos/test_overlay_repo.py
@@ -272,6 +272,73 @@ async def test_set_confirmed_revision(registry_db: DatabaseSession, sample_api: 
     assert fetched.updated_at is not None
 
 
+async def test_set_confirmed_revision_records_superseded(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """set_confirmed_revision persists the superseded revision when supplied."""
+    revision_id = uuid.uuid4()
+    superseded_id = uuid.uuid4()
+
+    async with registry_db.session() as session:
+        overlay = await OverlayRepository.create(
+            session, api_id=sample_api.id, document={"m": 1}, created_by="usr_test"
+        )
+        await session.commit()
+        overlay_id = overlay.id
+
+    async with registry_db.session() as session:
+        rows = await OverlayRepository.set_confirmed_revision(
+            session, overlay_id, revision_id, superseded_revision_id=superseded_id
+        )
+        await session.commit()
+
+    assert rows == 1
+
+    async with registry_db.session() as session:
+        fetched = await OverlayRepository.get_for_api(session, sample_api.id, overlay_id)
+
+    assert fetched is not None
+    assert fetched.confirmed_revision_id == revision_id
+    assert fetched.superseded_revision_id == superseded_id
+
+
+async def test_set_confirmed_revision_none_superseded_does_not_clobber(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """A later relink without a superseded id must not NULL an already-captured one.
+
+    The recovery/relink path (duplicate re-ingest) doesn't know the superseded
+    revision, so it passes None — that must leave a previously-recorded
+    superseded_revision_id intact rather than overwriting it with NULL.
+    """
+    first_rev, superseded_id, relink_rev = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+    async with registry_db.session() as session:
+        overlay = await OverlayRepository.create(
+            session, api_id=sample_api.id, document={"m": 1}, created_by="usr_test"
+        )
+        await session.commit()
+        overlay_id = overlay.id
+
+    async with registry_db.session() as session:
+        await OverlayRepository.set_confirmed_revision(
+            session, overlay_id, first_rev, superseded_revision_id=superseded_id
+        )
+        await session.commit()
+
+    # A relink that doesn't carry the superseded id (None) must preserve it.
+    async with registry_db.session() as session:
+        await OverlayRepository.set_confirmed_revision(session, overlay_id, relink_rev)
+        await session.commit()
+
+    async with registry_db.session() as session:
+        fetched = await OverlayRepository.get_for_api(session, sample_api.id, overlay_id)
+
+    assert fetched is not None
+    assert fetched.confirmed_revision_id == relink_rev
+    assert fetched.superseded_revision_id == superseded_id  # preserved, not clobbered
+
+
 async def test_set_confirmed_revision_missing_overlay_returns_zero(
     registry_db: DatabaseSession, sample_api: Api
 ) -> None:

--- a/tests/integration/registry/services/test_import_handler.py
+++ b/tests/integration/registry/services/test_import_handler.py
@@ -433,6 +433,9 @@ async def test_overlay_materialization_rewrites_served_spec_and_links_revision(
     new_revision_id = uuid.UUID(result.body["revisions"][0]["revision_id"])
     assert result.body["revisions"][0]["state"] == "imported"
     assert new_revision_id != base_revision_id
+    # The materialize superseded the served base revision — the result carries it and
+    # it is back-linked onto the overlay for a later deterministic rollback (A5b).
+    assert result.body["revisions"][0]["superseded_revision_id"] == str(base_revision_id)
 
     async with registry_db.session() as session:
         api = (await session.execute(select(Api).where(Api.id == api_id))).scalar_one()
@@ -458,6 +461,7 @@ async def test_overlay_materialization_rewrites_served_spec_and_links_revision(
             await session.execute(select(Overlay).where(Overlay.id == overlay_id))
         ).scalar_one()
         assert overlay_row.confirmed_revision_id == new_revision_id
+        assert overlay_row.superseded_revision_id == base_revision_id
 
 
 async def test_overlay_materialization_archives_active_revision_of_other_origin(

--- a/tests/integration/registry/services/test_import_handler.py
+++ b/tests/integration/registry/services/test_import_handler.py
@@ -677,11 +677,16 @@ async def test_overlay_materialization_recovers_link_on_duplicate_reingest(
         job_id=str(uuid.uuid4()), session=None, payload=job_payload, created_by="usr_test"
     )
     materialized_rev = uuid.UUID(first.body["revisions"][0]["revision_id"])
+    superseded_rev = uuid.UUID(first.body["revisions"][0]["superseded_revision_id"])
 
-    # Simulate the lost back-link (revision exists, confirmed_revision_id is NULL).
+    # Simulate the torn state: a confirm that committed the re-ingest (revision exists,
+    # base archived) but crashed before back-linking — confirmed_revision_id AND
+    # superseded_revision_id are both NULL.
     async with registry_db.session() as session:
         await session.execute(
-            update(Overlay).where(Overlay.id == overlay_id).values(confirmed_revision_id=None)
+            update(Overlay)
+            .where(Overlay.id == overlay_id)
+            .values(confirmed_revision_id=None, superseded_revision_id=None)
         )
         await session.commit()
 
@@ -697,6 +702,9 @@ async def test_overlay_materialization_recovers_link_on_duplicate_reingest(
             await session.execute(select(Overlay).where(Overlay.id == overlay_id))
         ).scalar_one()
         assert overlay_row.confirmed_revision_id == materialized_rev
+        # M1: recovery reconstructs the superseded revision (newest archived non-overlay
+        # revision) so the torn state doesn't permanently strand A5b's rollback target.
+        assert overlay_row.superseded_revision_id == superseded_rev
 
 
 async def test_url_source_via_mock(


### PR DESCRIPTION
## Summary

First code step of the **Workstream A spine** (overlay ↔ catalog-update reconciliation, internal#779), gated behind the ratified **A1** decision. It closes a data-integrity gap that blocks deterministic overlay rollback (A5b).

An overlay today records:
- `confirmed_revision_id` — the revision it **produced** (set by the materialize job), and
- `target_revision_id` — the base it was **authored against** (advisory),

but **nothing points at the revision it *superseded*** — the API's current revision at the instant the materialize archived it. Once overlays stack, "roll back to the prior revision" is ambiguous.

This PR adds a nullable **`overlays.superseded_revision_id`** and captures it along the existing async materialize path. Pure persistence: no served-state or event behaviour changes. A5b consumes the pointer to promote the prior revision back to current under a chain-CAS.

## What changed

- **Schema.** `overlays.superseded_revision_id` (`GUID`, nullable, **no FK** — advisory, mirroring `confirmed_revision_id`; a pruned revision just leaves it dangling). One `registry` migration `a2b3c4d5e6f7`, chained onto head `f5a6b7c8d9e0`. Dialect portability is handled centrally in `migrations/env.py` (SQLite `render_as_batch`, Postgres per-schema). Nullable, **no backfill** — pre-existing overlays read `NULL` and simply have no deterministic rollback target.
- **Capture point.** `CreateRevisionStage` reads the API's `current_revision_id` **right before** `archive_all_active` (the only point that still knows the outgoing revision) and `produce()`s it into the pipeline context. `None` on a first-ever materialize (nothing superseded).
- **Threading.** `Ingestor` puts it on `IngestResult`; `ImportHandler` back-links it via `OverlayRepository.set_confirmed_revision` alongside `confirmed_revision_id`, in the overlay's own follow-up `registry_db` transaction.
- **No-clobber + recovery reconstruction.** The writer sets the column only when non-`None`, so a relink can't overwrite a captured value with `NULL`. For the torn-state window where a confirm commits the re-ingest (revision created, base archived) but crashes **before** the back-link, the superseded id is no longer in memory — the duplicate-reingest recovery path reconstructs it via `ApiRevisionRepository.latest_archived_non_overlay` (the newest archived non-overlay revision, which the materialize archived) and back-links it, so the rollback target isn't permanently stranded. `None` (first-ever materialize) still stays `NULL`.

## Capture path

```mermaid
sequenceDiagram
    participant S as CreateRevisionStage
    participant AR as ApiRevisionRepository
    participant I as Ingestor
    participant H as ImportHandler
    participant OR as OverlayRepository

    Note over S: origin == overlay
    S->>S: read api.current_revision_id (= superseded)
    S->>S: ctx.produce("superseded_revision_id", ...)  %% before the archive
    S->>AR: archive_all_active(api_id)
    S->>AR: create_imported(...) -> new revision
    S->>S: ctx.produce("revision_id", ...)
    I->>I: IngestResult(revision_id, superseded_revision_id)
    H->>OR: set_confirmed_revision(confirmed, superseded=...)
    Note over OR: writes superseded only when non-None
```

## Scope / non-goals

- **Not surfaced on the HTTP API / UI.** `superseded_revision_id` stays internal in A5a — surfacing (and any `make openapi` / UI client change) belongs with the rollback work (A5b / L3) that actually consumes it.
- No change to which revisions are archived, which becomes current, or which events fire.

## Test plan

- [x] `tests/integration/registry/repos/test_overlay_repo.py` — round-trip of `superseded_revision_id`; **`None`-relink preserves** an already-captured value (recovery no-clobber).
- [x] `tests/integration/registry/repos/test_revision_repo.py` + `tests/integration/registry/services/test_import_handler.py` — materialize asserts the superseded revision on **both** the result payload and the overlay row; the duplicate-reingest recovery test nulls **both** links to model the crash-before-link torn state and asserts recovery **backfills** `superseded_revision_id`.
- [x] Migration head verified locally as the single clean head `a2b3c4d5e6f7` (`alembic -n registry heads`); no cycles.
- [x] `make lint` + `mypy` clean; overlay service/router unit suites green.
- [ ] CI: unit + integration (postgres & sqlite) + e2e.
