### PR TITLE
feat(flow3): close the overlay-update reconciliation loop

### DIFF
--- a/docs/reference/endpoints.json
+++ b/docs/reference/endpoints.json
@@ -1059,6 +1059,32 @@
       ],
       "auth_note": null,
       "authenticated": true,
+      "group": "Operator-facing (typically a human operator / admin)",
+      "implied_scopes": {
+        "overlays:confirm": [
+          "apis:read"
+        ]
+      },
+      "method": "POST",
+      "operation_id": "rollbackOverlay",
+      "path": "/apis/{vendor}/{name}/{version}/overlays/{overlay_id}:rollback",
+      "public": false,
+      "required_scopes": [
+        "overlays:confirm"
+      ],
+      "summary": "Rollback Overlay",
+      "surface": "apis",
+      "typical_caller": "operator"
+    },
+    {
+      "actor_types": [
+        "user",
+        "agent",
+        "service_account",
+        "toolkit"
+      ],
+      "auth_note": null,
+      "authenticated": true,
       "group": "Agent-facing (typically agent / service-account / toolkit)",
       "implied_scopes": {
         "apis:read": []
@@ -4550,5 +4576,5 @@
     ],
     "total": 31
   },
-  "total": 153
+  "total": 154
 }

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -27,7 +27,7 @@ Every API endpoint grouped by its **typical caller**, then by surface, annotated
 
 > The grouping and the _Typical caller_ column are an **advisory hint** at who usually calls a route, inferred from the scope family. They are **not** an enforced restriction: access is gated by the **scope**, not the actor kind, so any actor holding the required scope can call the endpoint.
 
-_Total endpoints: **153**._
+_Total endpoints: **154**._
 
 
 ## Agent-facing (typically agent / service-account / toolkit) (31)
@@ -109,7 +109,7 @@ _Total endpoints: **153**._
 |---|---|---|---|---|
 | POST | `/search` | `apis:read` | agent | Search operations |
 
-## Operator-facing (typically a human operator / admin) (45)
+## Operator-facing (typically a human operator / admin) (46)
 
 
 ### `access-requests`
@@ -150,6 +150,7 @@ _Total endpoints: **153**._
 | Method | Path | Scope(s) | Typical caller | Summary |
 |---|---|---|---|---|
 | POST | `/apis/{vendor}/{name}/{version}/overlays/{overlay_id}:confirm` | `overlays:confirm` | operator | Confirm Overlay |
+| POST | `/apis/{vendor}/{name}/{version}/overlays/{overlay_id}:rollback` | `overlays:confirm` | operator | Rollback Overlay |
 
 ### `audit`
 

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -8646,6 +8646,94 @@ paths:
       summary: Confirm Overlay
       tags:
       - Overlays
+  /apis/{vendor}/{name}/{version}/overlays/{overlay_id}:rollback:
+    post:
+      description: |-
+        Un-confirm a materialized overlay, restoring the revision it superseded (A5b).
+
+        Requires ``overlays:confirm`` — the symmetric inverse of confirm. Rolling back
+        rewrites the API's served spec (it archives the overlay's materialized revision and
+        promotes the prior revision back to current), so it is the same operator action as
+        confirm, not a contributor one. The overlay must be CONFIRMED, currently live, and
+        carry a recorded superseded revision that is still restorable; otherwise a 409 is
+        returned (``overlay_conflict`` or ``overlay_rollback_target_missing``) and nothing
+        changes.
+      operationId: rollbackOverlay
+      parameters:
+      - in: path
+        name: vendor
+        required: true
+        schema:
+          title: Vendor
+          type: string
+      - in: path
+        name: name
+        required: true
+        schema:
+          title: Name
+          type: string
+      - in: path
+        name: version
+        required: true
+        schema:
+          title: Version
+          type: string
+      - in: path
+        name: overlay_id
+        required: true
+        schema:
+          title: Overlay Id
+          type: string
+      responses:
+        '204':
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '401':
+          content:
+            application/problem+json:
+              example: *id005
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unauthorized
+        '403':
+          content:
+            application/problem+json:
+              example: *id006
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Forbidden
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security:
+      - BearerAuth: []
+      summary: Rollback Overlay
+      tags:
+      - Overlays
   /apis/{vendor}/{name}/{version}/revisions:
     get:
       description: List revisions for an API with optional state filter and cursor pagination.

--- a/skills/contribute-spec-fix/SKILL.md
+++ b/skills/contribute-spec-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contribute-spec-fix
-description: Fix a broken OpenAPI spec in jentic-public-apis with an OpenAPI Overlay, validate it (spectral lint + idempotency check), and contribute it back via a PR to the community catalog. Falls back to applying the same overlay to the local Jentic registry if the user can't wait for maintainer approval. Use when an API spec is wrong/incomplete (bad server URL, missing enum, wrong content-type, missing param, etc.) and the fix should reach the community project, not just the local box.
+description: Fix a broken OpenAPI spec in jentic-public-apis with an OpenAPI Overlay, validate it (spectral lint + idempotency check), and contribute it back via a PR to the community catalog. Falls back to applying the same overlay to the local Jentic registry if the user can't wait for maintainer approval, and closes the loop by reacting when the upstream spec later changes (adopt update, or resolve an upstream-vs-overlay conflict). Use when an API spec is wrong/incomplete (bad server URL, missing enum, wrong content-type, missing param, etc.) and the fix should reach the community project, not just the local box.
 argument-hint: [vendor/api or path to the broken spec]
 ---
 
@@ -32,6 +32,13 @@ instead; this skill only fixes specs that already exist.
      ┌─────────────────────────────────────────────┐
      │  FALLBACK: apply the SAME overlay to the      │  ← unblocks the user now;
      │  local Jentic registry — PR stays open        │    PR is still the source of truth
+     └─────────────────────────────────────────────┘
+                │
+                ▼  (later: the registry keeps watching upstream)
+     ┌─────────────────────────────────────────────┐
+     │  upstream spec changes  ──►  registry emits:  │
+     │   • update_available      → re-import to adopt│  ← fix merged upstream? adopt + retire
+     │   • update_conflicts_overlay → operator picks │  ← never silently overwrites the fix
      └─────────────────────────────────────────────┘
 ```
 
@@ -293,7 +300,7 @@ API. The PR stays open — do not close it; this is not a fork.
 
 > **Platform behaviour (current):** confirming an overlay now **materializes** it — the registry
 > re-ingests the base spec with the overlay applied and promotes the result to the API's current
-> revision, so the served spec (`GET …/openapi.json`) reflects the fix immediately after confirm.
+> revision, so the served spec (`GET …/openapi`) reflects the fix immediately after confirm.
 > Two things follow from this:
 > - **Confirm is an operator action** and requires the `overlays:confirm` permission (not
 >   `apis:write`). Contributors *submit* overlays; an operator reviews and *confirms*. Use a
@@ -335,13 +342,112 @@ Verify the fix actually landed on the served spec (this is the local verificatio
 
 ```
 # Give the ingest job a moment, then re-download and diff against your PR-branch spec.
-curl -sS "$BASE/apis/$V/$N/$VER/openapi.json" -H "Authorization: Bearer $TOKEN" > /tmp/served.json
+# The served-spec route is `…/openapi` (JSON by content negotiation) — there is no
+# `…/openapi.json` route on the registry.
+curl -sS "$BASE/apis/$V/$N/$VER/openapi" -H "Authorization: Bearer $TOKEN" > /tmp/served.json
 python3 -c "import json; print('served matches PR spec:', json.load(open('/tmp/served.json'))==json.load(open('$SPEC')))"
 ```
 
 `served matches PR spec: True` confirms the local apply reproduces the PR-branch fix. The overlay
 is now materialized locally and PR `<url>` is still the path for the community — nothing here
 replaces it.
+
+### 10. Close the loop — react when upstream changes later
+
+The flywheel isn't "submit and forget". Once an overlay is materialized locally, the registry
+keeps watching the API's **upstream** spec (the catalog `spec_url`) and, when it changes,
+surfaces an actionable event so a human isn't lied to about state. Two outcomes, and they need
+**different** reactions — the platform tells you which via the event **type**:
+
+- **`catalog.update_available`** — upstream changed, but not in a way that collides with your
+  overlay's base. Routine: re-import the upstream to adopt it. If your fix was already merged into
+  `jentic-public-apis` (your PR landed), the upstream now *contains* the fix and the overlay is
+  redundant — adopting upstream is the right move and the overlay can be retired.
+- **`catalog.update_conflicts_overlay`** — upstream changed *against the very base your overlay was
+  materialized over*. Adopting upstream would **supersede your fix**. This is deliberately an
+  operator decision, not an automatic overwrite: the system will **not** silently discard the
+  overlay.
+
+Check for these — the class distinction lives in the **event type**, not in the API view (which
+only carries a boolean `update_available`). Query the events surface and branch on which class is
+pending for this API:
+
+```
+BASE=http://127.0.0.1:8000
+V=<vendor>; N=<api>; VER=<version>
+# Is there ANY pending update? (API view; boolean, no class):
+curl -sS "$BASE/apis/$V/$N/$VER" -H "Authorization: Bearer $TOKEN" \
+  | python3 -c "import json,sys; a=json.load(sys.stdin); \
+print('origin          :', a.get('origin')); \
+print('update_available:', a.get('update_available'))"
+
+# WHICH class? Look for an actionable conflict event for this API. If this returns a row,
+# it's the operator-decision path; if empty (but update_available is true), it's the
+# routine adopt path. The conflict event's data carries the overlay_id to act on.
+# (Events live on the admin/control plane; listing needs an events:read token — an
+# org:admin/operator token has it.)
+curl -sS "$BASE/events?event_type=catalog.update_conflicts_overlay&requires_action=true" \
+  -H "Authorization: Bearer $OPERATOR_TOKEN" \
+  | python3 -c "import json,sys; \
+evs=json.load(sys.stdin).get('data', []); \
+mine=[e for e in evs if (e.get('data') or {}).get('vendor')=='$V']; \
+print('conflicts_overlay pending:', bool(mine)); \
+print('overlay_id:', (mine[0]['data'].get('overlay_id') if mine else None))"
+# Note: this filters on data.vendor, which the *sweep*-emitted conflict event carries.
+# A refuse-path conflict event (logged when an under-scoped caller attempts the adopt)
+# carries api_id/overlay_id/spec_url but NOT vendor — match on data.api_id to catch those.
+```
+
+**Reacting to `catalog.update_available`** (adopt upstream — your fix is upstream now, or the
+change is unrelated and you no longer need the overlay): re-import the catalog entry. A plain
+re-import adopts the upstream spec and **settles the event** automatically. This needs
+`catalog:import` (an `apis:write` token implies it):
+
+```
+curl -sS -X POST "$BASE/catalog/<api_id>:import" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{}'
+```
+
+**Reacting to `catalog.update_conflicts_overlay`** (upstream diverged from your fix's base): this
+is an operator call with two clean options — **never** hand-edit around it:
+
+1. **Keep your fix, ignore upstream for now.** Do nothing; the served spec stays your overlay. The
+   event stays in the inbox as a truthful "there's a divergence" flag. If your PR is still open,
+   the real resolution is landing it upstream.
+2. **Adopt upstream and retire the overlay** (you've decided upstream wins). Re-importing the
+   catalog entry over a *live confirmed overlay* is doubly gated: the `:import` route itself
+   requires **`catalog:import`**, and superseding the overlay additionally requires
+   **`overlays:confirm`** (because it discards an operator's fix). So the caller needs **both**
+   scopes — an `org:admin` token satisfies both by implication; `overlays:confirm` *alone* is
+   rejected by the route guard before the supersede is even evaluated. An authorized re-import
+   auto-deprecates the overlay and serves the fresh upstream in one step; a caller with
+   `catalog:import` but **not** `overlays:confirm` is **refused** (403 `overlay_supersede_forbidden`)
+   and the conflict is re-surfaced for someone who can decide — the fix is never silently reverted.
+
+```
+# $OPERATOR_TOKEN: a profile whose token holds BOTH catalog:import and overlays:confirm
+# (or org:admin, which implies both). Derive it like $TOKEN from an operator profile, e.g.
+#   OPERATOR_TOKEN=$(jentic profile list --json | python3 -c "import json,sys;print(json.load(sys.stdin)['active']['token'])")
+# — ask an operator to run this if your agent profile lacks the scopes.
+# Authorized adopt-upstream. The platform detects the live overlay and supersedes it because
+# you hold overlays:confirm; the same call by a catalog:import-only token returns 403.
+curl -sS -X POST "$BASE/catalog/<api_id>:import" \
+  -H "Authorization: Bearer $OPERATOR_TOKEN" -H 'Content-Type: application/json' -d '{}'
+```
+
+If instead you decide the overlay was the right answer and want to **undo** a materialization you
+just made (e.g. confirmed the wrong overlay), roll it back — this restores the exact revision the
+overlay superseded (also `overlays:confirm`):
+
+```
+curl -sS -X POST "$BASE/apis/$V/$N/$VER/overlays/<overlay_id>:rollback" \
+  -H "Authorization: Bearer $OPERATOR_TOKEN" -H 'Content-Type: application/json' -d '{}'
+```
+
+The loop is closed when the served spec, the overlay's lifecycle status, and the action inbox all
+agree: either upstream was adopted (overlay `deprecated`, event settled) or the fix is deliberately
+retained (overlay `confirmed`, divergence flagged but not hidden).
+
 
 ## Guardrails
 
@@ -353,3 +459,9 @@ replaces it.
   `False` or lint shows any error / new finding code.
 - **Reserve the local apply for genuine impatience.** If the user is fine waiting, the PR alone is
   the outcome.
+- **Never hand-resolve an upstream conflict.** When the registry emits
+  `catalog.update_conflicts_overlay`, adopt upstream via a scoped re-import or deliberately keep the
+  overlay — never edit the served spec by hand to paper over the divergence. Adopting upstream over
+  a live confirmed overlay requires **both** `catalog:import` (route) and `overlays:confirm`
+  (supersede) — i.e. an `org:admin` token or both scopes; the platform refuses with a 403 (not a
+  silent revert) if you lack `overlays:confirm`.

--- a/skills/contribute-spec-fix/SKILL.md
+++ b/skills/contribute-spec-fix/SKILL.md
@@ -70,7 +70,16 @@ Resolve `$ARGUMENTS` to a spec at
 `apis/openapi/<vendor>/<api>/<version>/openapi.json` in the jentic-public-apis checkout.
 Read the relevant section and confirm with the user exactly what's wrong and what the fixed
 value should be (e.g. "servers only has the US host; add an EU host"). Note the `<vendor>`,
-`<api>`, and `<version>` path segments — you need them for both the PR and the local apply.
+`<api>`, and `<version>` **folder** path segments — you need them for the PR (they define where
+the overlay file lives).
+
+> **Folder path ≠ registry identity.** The `jentic-public-apis` folder segments are *not* the
+> identity the registry serves under. On import the registry **slugifies** identity from the
+> spec's own `info` block: `vendor` from `x-vendor`/`contact.name` and `name` from `info.title`,
+> each lowercased with non-`[a-z0-9-]` → `-` (so `posthog.com` → `posthog-com`). Do **not** reuse
+> the folder segments in `/apis/...` URLs — they will 404. For the local-apply steps (9–10) get
+> the registry identity from the registry itself after import (shown there) and use *that* for
+> `$V/$N/$VER`.
 
 ### 2. Branch off the latest main
 
@@ -300,7 +309,8 @@ API. The PR stays open — do not close it; this is not a fork.
 
 > **Platform behaviour (current):** confirming an overlay now **materializes** it — the registry
 > re-ingests the base spec with the overlay applied and promotes the result to the API's current
-> revision, so the served spec (`GET …/openapi`) reflects the fix immediately after confirm.
+> revision, so the served spec (`GET …/openapi`) reflects the fix once the (async) materialize
+> job completes — usually a moment after confirm, not synchronously.
 > Two things follow from this:
 > - **Confirm is an operator action** and requires the `overlays:confirm` permission (not
 >   `apis:write`). Contributors *submit* overlays; an operator reviews and *confirms*. Use a
@@ -313,7 +323,9 @@ API. The PR stays open — do not close it; this is not a fork.
 >   `pending` — fix the overlay (steps 3–6) and retry.
 
 The API must already exist in the local registry (import it from the catalog first if needed:
-`jentic catalog import <api_id>`). Then submit and confirm the overlay against the local control
+`jentic catalog import <api_id>`, where `<api_id>` is the catalog entry id — the dotted
+`<vendor>/<api>` form, e.g. `posthog.com/posthog-api`). Then resolve the **registry** identity
+(slugified — not the folder segments) and submit + confirm the overlay against the local control
 plane (default `http://127.0.0.1:8000`).
 
 ```
@@ -322,7 +334,19 @@ BASE=http://127.0.0.1:8000
 # same token if your profile has both; an org:admin token also satisfies confirm).
 # Adjust to however your active token is exposed.
 TOKEN=$(jentic profile list --json 2>/dev/null | python3 -c "import json,sys;print(json.load(sys.stdin)['active']['token'])")
-V=<vendor>; N=<api>; VER=<version>
+
+# Resolve the registry identity for the catalog entry you imported. The registry slugifies
+# vendor/name from the spec's info block, so these differ from the jentic-public-apis folder
+# segments (posthog.com → posthog-com; name = slug of info.title). Match the imported API by
+# its catalog_api_id and read back the slugified (vendor, name, version) to use below.
+API_ID=<api_id>   # the dotted catalog id, e.g. posthog.com/posthog-api
+read V N VER SRC < <(curl -sS "$BASE/apis" -H "Authorization: Bearer $TOKEN" \
+  | python3 -c "import json,sys; \
+apis=json.load(sys.stdin).get('data', []); \
+m=next((x for x in apis if x.get('catalog_api_id')=='$API_ID'), None); \
+a=(m or {}).get('api', {}); \
+print(a.get('vendor',''), a.get('name',''), a.get('version',''), (m or {}).get('source_url',''))")
+echo "registry identity: $V/$N/$VER   source_url: $SRC"   # empty ⇒ not imported yet; import first
 
 # Submit the overlay (document is the SAME overlay.json used for the PR)
 curl -sS -X POST "$BASE/apis/$V/$N/$VER/overlays" \
@@ -374,7 +398,8 @@ pending for this API:
 
 ```
 BASE=http://127.0.0.1:8000
-V=<vendor>; N=<api>; VER=<version>
+# Reuse the registry identity + source_url resolved in step 9 ($V/$N/$VER/$SRC). If you
+# start fresh here, re-resolve them the same way (GET /apis, match on catalog_api_id).
 # Is there ANY pending update? (API view; boolean, no class):
 curl -sS "$BASE/apis/$V/$N/$VER" -H "Authorization: Bearer $TOKEN" \
   | python3 -c "import json,sys; a=json.load(sys.stdin); \
@@ -386,16 +411,18 @@ print('update_available:', a.get('update_available'))"
 # routine adopt path. The conflict event's data carries the overlay_id to act on.
 # (Events live on the admin/control plane; listing needs an events:read token — an
 # org:admin/operator token has it.)
-curl -sS "$BASE/events?event_type=catalog.update_conflicts_overlay&requires_action=true" \
+curl -sS "$BASE/events?event_type=catalog.update_conflicts_overlay&requires_action=true&acknowledged=false" \
   -H "Authorization: Bearer $OPERATOR_TOKEN" \
   | python3 -c "import json,sys; \
 evs=json.load(sys.stdin).get('data', []); \
-mine=[e for e in evs if (e.get('data') or {}).get('vendor')=='$V']; \
+mine=[e for e in evs if (e.get('data') or {}).get('spec_url')=='$SRC']; \
 print('conflicts_overlay pending:', bool(mine)); \
 print('overlay_id:', (mine[0]['data'].get('overlay_id') if mine else None))"
-# Note: this filters on data.vendor, which the *sweep*-emitted conflict event carries.
-# A refuse-path conflict event (logged when an under-scoped caller attempts the adopt)
-# carries api_id/overlay_id/spec_url but NOT vendor — match on data.api_id to catch those.
+# Match on data.spec_url (the upstream URL) — it is present on BOTH the sweep-emitted conflict
+# event and the refuse-path event (logged when an under-scoped caller attempts the adopt), and
+# it equals the API's source_url you read in step 9. Do NOT filter on data.vendor: the sweep
+# event carries the *slugified* vendor and the refuse-path event carries no vendor at all, so a
+# vendor filter silently misses real rows. (data.api_id is the local UUID, not the catalog id.)
 ```
 
 **Reacting to `catalog.update_available`** (adopt upstream — your fix is upstream now, or the

--- a/src/jentic_one/broker/adapters/egress.py
+++ b/src/jentic_one/broker/adapters/egress.py
@@ -1,95 +1,18 @@
-"""Egress safety adapter — connection-time DNS-rebinding guard + pin (§08 E2).
+"""Egress safety adapter — re-export of the shared DNS-rebinding guard (§08 E2).
 
-``validate_upstream_url`` (the pre-discovery check in ``shared/url_validation``)
-resolves the host and rejects a name that resolves into a blocked range. But that
-check runs *before* the request; the runner's own ``httpx`` connection re-resolves
-the name at connect time, leaving a **TOCTOU rebind window** — a hostile resolver
-can answer "public" for the validation probe and "private" (``169.254.169.254``,
-``10.x``) for the real connection.
-
-:class:`DnsPinningTransport` closes that window: on every request it resolves the
-host **once**, re-validates each returned IP against the *same* egress policy
-(``assert_ip_allowed`` — identical block rules, metadata hard-deny, and allowlist
-exemptions), and **pins** the connection to the validated IP by rewriting the URL
-host to that IP while preserving the original ``Host`` header and TLS SNI. A second
-resolution can't swap in a private address because there is no second resolution.
-
-Infrastructure adapter (it owns transport behaviour), not ``broker/core/`` — see
-the §00 layering table. Scheme-aware-ready: only ``http``/``https`` are pinned here;
-§11 generalises the seam to other schemes.
+The implementation now lives in ``jentic_one.shared.egress`` because every
+outbound-fetch site needs it (the broker execution runtime *and* the Flow-3
+catalog/ingest fetchers), not just the broker. This module re-exports it so the
+broker's existing imports (and the §00 layering references to a broker-owned
+"egress adapter") keep resolving unchanged.
 """
 
 from __future__ import annotations
 
-import ipaddress
-import socket
+from jentic_one.shared.egress import (
+    DnsPinningTransport,
+    build_pinned_transport,
+    resolve_and_validate,
+)
 
-import httpx
-
-from jentic_one.shared.config import EgressConfig
-from jentic_one.shared.url_validation import assert_ip_allowed
-
-_IpAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
-
-
-def resolve_and_validate(host: str, egress: EgressConfig | None) -> _IpAddress:
-    """Resolve *host* and return the first IP that passes the egress policy.
-
-    Validates **every** resolved address against ``assert_ip_allowed`` so a
-    multi-record answer can't smuggle a blocked IP past the check, then returns
-    the first one to pin the connection to. Raises ``ValueError`` if the host
-    can't be resolved or any resolved IP is blocked (the rebind guard).
-    """
-    try:
-        results = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
-    except socket.gaierror as exc:
-        raise ValueError(f"upstream host did not resolve: {host}") from exc
-
-    addrs = [ipaddress.ip_address(sockaddr[0]) for *_rest, sockaddr in results]
-    if not addrs:
-        raise ValueError(f"upstream host did not resolve: {host}")
-
-    for addr in addrs:
-        # A DNS name re-resolved here, so pass the hostname for the suffix
-        # exemption — matches the validation-time semantics.
-        assert_ip_allowed(addr, egress, hostname=host)
-    return addrs[0]
-
-
-class DnsPinningTransport(httpx.AsyncBaseTransport):
-    """Wraps a transport to resolve+validate+pin the host IP per request.
-
-    An IP-literal host is passed through unchanged (nothing to rebind). For a DNS
-    name the request URL host is rewritten to the validated IP, the original host
-    is preserved as the ``Host`` header, and ``sni_hostname`` is set so TLS still
-    validates against the real certificate name.
-    """
-
-    def __init__(self, inner: httpx.AsyncBaseTransport, egress: EgressConfig | None) -> None:
-        self._inner = inner
-        self._egress = egress
-
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        host = request.url.host
-        try:
-            ipaddress.ip_address(host)
-        except ValueError:
-            # A DNS name: resolve, validate (rebind guard), and pin.
-            pinned = resolve_and_validate(host, self._egress)
-            request = self._pin(request, host, pinned)
-        return await self._inner.handle_async_request(request)
-
-    @staticmethod
-    def _pin(request: httpx.Request, host: str, pinned: _IpAddress) -> httpx.Request:
-        """Rewrite *request* to connect to *pinned* while keeping Host + SNI as *host*."""
-        # Preserve the original authority for the Host header and TLS SNI.
-        if "host" not in (k.lower() for k in request.headers):
-            request.headers["Host"] = f"{host}:{request.url.port}" if request.url.port else host
-        # ip_address renders IPv6 bare; httpx.URL wants it bracketed in a netloc.
-        host_for_url = f"[{pinned}]" if pinned.version == 6 else str(pinned)
-        request.url = request.url.copy_with(host=host_for_url)
-        request.extensions = {**request.extensions, "sni_hostname": host}
-        return request
-
-    async def aclose(self) -> None:
-        await self._inner.aclose()
+__all__ = ["DnsPinningTransport", "build_pinned_transport", "resolve_and_validate"]

--- a/src/jentic_one/migrations/registry/versions/b3c4d5e6f7a8_add_overlay_base_digest_and_notified_event_class.py
+++ b/src/jentic_one/migrations/registry/versions/b3c4d5e6f7a8_add_overlay_base_digest_and_notified_event_class.py
@@ -1,0 +1,33 @@
+"""add overlay_base_digest to api_revisions and last_notified_event_class to catalog_update_checks
+
+Revision ID: b3c4d5e6f7a8
+Revises: a2b3c4d5e6f7
+Create Date: 2026-07-31
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b3c4d5e6f7a8"
+down_revision: str | None = "a2b3c4d5e6f7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "api_revisions",
+        sa.Column("overlay_base_digest", sa.String(length=100), nullable=True),
+    )
+    op.add_column(
+        "catalog_update_checks",
+        sa.Column("last_notified_event_class", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("catalog_update_checks", "last_notified_event_class")
+    op.drop_column("api_revisions", "overlay_base_digest")

--- a/src/jentic_one/registry/core/schema/api_revisions.py
+++ b/src/jentic_one/registry/core/schema/api_revisions.py
@@ -72,6 +72,14 @@ class ApiRevision(AuditableMixin, RegistryBase):
     state: Mapped[str] = mapped_column(String(20), nullable=False, server_default=text("'draft'"))
     origin: Mapped[str | None] = mapped_column(String(50), nullable=True)
     spec_digest: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    #: For an overlay-origin revision: the ``spec_digest`` of the *base* revision this
+    #: overlay was materialized on top of (the revision it superseded). Lets the Flow-3
+    #: sweep compare upstream changes against the overlay's **base** rather than the
+    #: overlaid digest, so it can tell "upstream unchanged vs base" (no-op) from
+    #: "upstream changed vs base" (a genuine conflict). NULL for non-overlay revisions
+    #: and for pre-existing overlay revisions (A3 treats NULL as "unknown base → today's
+    #: served-digest compare"; lazy self-heal on the next re-materialize).
+    overlay_base_digest: Mapped[str | None] = mapped_column(String(100), nullable=True)
     source_type: Mapped[str | None] = mapped_column(String(20), nullable=True)
     source_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     source_filename: Mapped[str | None] = mapped_column(String(512), nullable=True)

--- a/src/jentic_one/registry/core/schema/catalog_update_checks.py
+++ b/src/jentic_one/registry/core/schema/catalog_update_checks.py
@@ -55,6 +55,13 @@ class CatalogUpdateCheck(RegistryBase):
     last_seen_etag: Mapped[str | None] = mapped_column(Text, nullable=True)
     last_seen_digest: Mapped[str | None] = mapped_column(String(64), nullable=True)
     last_notified_digest: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    #: The event *class* that ``last_notified_digest`` was emitted under
+    #: (``catalog.update_available`` vs ``catalog.update_conflicts_overlay``). The sweep
+    #: dedupes on the pair ``(last_notified_digest, last_notified_event_class)`` so a
+    #: digest re-classified between the two classes (e.g. an overlaid API whose upstream
+    #: now collides with the overlay's base) emits the new class **once** instead of
+    #: being wrongly deduped against the old one. NULL until the first notify.
+    last_notified_event_class: Mapped[str | None] = mapped_column(String(64), nullable=True)
     last_checked_at: Mapped[datetime | None] = mapped_column(UTCDateTime(), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         UTCDateTime(), nullable=False, default=utcnow, server_default=func.now()

--- a/src/jentic_one/registry/ingest/fetch.py
+++ b/src/jentic_one/registry/ingest/fetch.py
@@ -13,6 +13,7 @@ from jentic_one.registry.ingest.api_identifier import resolve_api_identifier
 from jentic_one.registry.ingest.exc import IngestStageError
 from jentic_one.registry.ingest.models import IngestSpecification, SpecType
 from jentic_one.shared.config import IngestConfig
+from jentic_one.shared.egress import build_pinned_transport
 from jentic_one.shared.models import ApiRevisionSourceType
 from jentic_one.shared.url_validation import validate_upstream_url
 
@@ -37,6 +38,13 @@ class InlineSource(BaseModel):
     #: catalog-originated spec (e.g. overlay materialization). ``None`` for
     #: genuine pastes.
     catalog_api_id: str | None = None
+    #: Overlay-only: the base revision's ``spec_digest`` this overlay is materialized
+    #: over. Propagated onto the resulting revision so the Flow-3 sweep diffs upstream
+    #: against the overlay's base rather than the overlaid digest. ``None`` otherwise.
+    overlay_base_digest: str | None = None
+    #: Authorized-supersede flag (A4b): a catalog re-import allowed to replace a live
+    #: confirmed overlay. Set only by the scope-checked enqueue path.
+    supersede_active: bool = False
 
 
 class UrlSource(BaseModel):
@@ -53,6 +61,10 @@ class UrlSource(BaseModel):
     #: imports. Persisted verbatim on the Api row (the `api_name` copy of the
     #: same slug gets slugified and loses the separable structure).
     catalog_api_id: str | None = None
+    #: Authorized-supersede flag (A4b): a catalog re-import allowed to replace a live
+    #: confirmed overlay (the current revision is then overlay-origin, so the stage must
+    #: archive every active revision). Set only by the scope-checked enqueue path.
+    supersede_active: bool = False
 
 
 IngestSource = Annotated[UrlSource | InlineSource, Field(discriminator="type")]
@@ -131,7 +143,9 @@ async def load_specification(
 
         try:
             async with httpx.AsyncClient(
-                timeout=cfg.fetch_timeout_s, follow_redirects=False
+                timeout=cfg.fetch_timeout_s,
+                follow_redirects=False,
+                transport=build_pinned_transport(cfg.egress),
             ) as client:
                 resp = await client.get(validated_url)
                 for _ in range(cfg.max_redirects):
@@ -193,4 +207,6 @@ async def load_specification(
         submitted_by=source.submitted_by,
         origin=source.origin,
         catalog_api_id=source.catalog_api_id,
+        overlay_base_digest=getattr(source, "overlay_base_digest", None),
+        supersede_active=source.supersede_active,
     )

--- a/src/jentic_one/registry/ingest/models.py
+++ b/src/jentic_one/registry/ingest/models.py
@@ -49,6 +49,16 @@ class IngestSpecification(BaseModel):
     # display surfaces can derive friendly titles without reverse-engineering
     # the slugified vendor/name tuple.
     catalog_api_id: str | None = None
+    #: Overlay-only: the base revision's ``spec_digest`` this overlay was materialized
+    #: over (distinct from ``sha``, which is the overlaid digest). Persisted on the
+    #: resulting ``api_revisions`` row so the Flow-3 sweep can diff upstream against the
+    #: overlay's base. NULL for non-overlay ingests.
+    overlay_base_digest: str | None = None
+    #: Authorized-supersede flag (A4b): when a catalog re-import is allowed to replace a
+    #: live confirmed overlay, the current revision may be overlay-origin (not catalog),
+    #: so the stage must archive *every* active revision rather than only the same-origin
+    #: one. Set only by the scope-checked enqueue path; ``False`` for ordinary imports.
+    supersede_active: bool = False
 
     def to_log_string(self) -> str:
         fields = self.model_dump(exclude={"content"})

--- a/src/jentic_one/registry/ingest/stages/extract_api.py
+++ b/src/jentic_one/registry/ingest/stages/extract_api.py
@@ -77,9 +77,27 @@ class CreateRevisionStage(BasePipelineStage):
                     ctx.produce("superseded_revision_id", api.current_revision_id, uuid.UUID)
                 await ApiRevisionRepository.archive_all_active(ctx.session, api_id)
             else:
-                await ApiRevisionRepository.archive_active_imported(
-                    ctx.session, api_id, spec.origin
-                )
+                if spec.supersede_active:
+                    # A4b: an authorized catalog re-import that replaces a *live confirmed
+                    # overlay*. The overlay's current revision is overlay-origin, so the
+                    # origin-scoped archive below would leave it active and the new catalog
+                    # revision would violate ix_api_revisions_one_active. Archive every
+                    # active revision instead (the overlay is auto-deprecated by the
+                    # handler in the same transaction; see ImportHandler).
+                    #
+                    # Trust boundary: ``supersede_active`` is a *server-set* flag. It is
+                    # only ever stamped by ``CatalogService.import_entry`` after an
+                    # enqueue-time ``overlays:confirm`` scope check; no client-facing
+                    # ingest schema (``ApiSourceUrl``/``ApiSourceInline``) exposes it, and
+                    # Pydantic's ``extra="ignore"`` drops any injected key. This stage
+                    # therefore trusts the flag by construction. If a future route ever
+                    # forwards a raw ``sources`` payload, that route MUST re-assert the
+                    # scope before enqueue — the privilege boundary lives at enqueue time.
+                    await ApiRevisionRepository.archive_all_active(ctx.session, api_id)
+                else:
+                    await ApiRevisionRepository.archive_active_imported(
+                        ctx.session, api_id, spec.origin
+                    )
             revision = await ApiRevisionRepository.create_imported(
                 ctx.session,
                 api_id=api_id,
@@ -89,6 +107,7 @@ class CreateRevisionStage(BasePipelineStage):
                 source_url=spec.source_url,
                 source_filename=spec.source_filename,
                 submitted_by=spec.submitted_by,
+                overlay_base_digest=spec.overlay_base_digest,
                 created_by=ctx.created_by,
             )
         else:

--- a/src/jentic_one/registry/repos/api_repo.py
+++ b/src/jentic_one/registry/repos/api_repo.py
@@ -135,6 +135,34 @@ class ApiRepository:
         await session.flush()
 
     @staticmethod
+    async def compare_and_set_current_revision(
+        session: AsyncSession,
+        api_id: uuid.UUID,
+        *,
+        expected_revision_id: uuid.UUID | None,
+        new_revision_id: uuid.UUID,
+    ) -> int:
+        """Flip ``current_revision_id`` only if it still equals ``expected_revision_id``.
+
+        A compare-and-swap on the revision chain: returns the number of rows updated (1 on
+        success, 0 if another writer already moved the pointer). Used by the overlay
+        rollback (A5b) and the overlay-superseding re-import (A4b) so two concurrent
+        transitions can't double-flip the served revision — the loser sees rowcount 0 and
+        backs off instead of clobbering. ``expected_revision_id`` may be ``None`` to assert
+        the API currently has no served revision.
+        """
+        result = cast(
+            "CursorResult[Any]",
+            await session.execute(
+                update(Api)
+                .where(Api.id == api_id, Api.current_revision_id == expected_revision_id)
+                .values(current_revision_id=new_revision_id)
+            ),
+        )
+        await session.flush()
+        return result.rowcount
+
+    @staticmethod
     async def apply_counts(
         session: AsyncSession,
         api_id: uuid.UUID,

--- a/src/jentic_one/registry/repos/catalog_update_check_repo.py
+++ b/src/jentic_one/registry/repos/catalog_update_check_repo.py
@@ -120,6 +120,7 @@ class CatalogUpdateCheckRepository:
         digest: str | None,
         checked_at: datetime,
         notified_digest: str | None = None,
+        notified_event_class: str | None = None,
         sync_notified: bool = False,
     ) -> CatalogUpdateCheck:
         """Insert or update the observation for ``local_api_id`` and return the row.
@@ -127,6 +128,13 @@ class CatalogUpdateCheckRepository:
         ``notified_digest`` is only written when non-``None`` — a probe that
         observes no change (or a ``304``) must not clear the digest that last
         produced an event, or the dedupe would re-fire on the next real change.
+
+        ``notified_event_class`` records *which* event class that digest fired under
+        (``catalog.update_available`` vs ``catalog.update_conflicts_overlay``). It is
+        written on the same branches as ``last_notified_digest`` (real notify or a
+        sync-revert) so the dedupe pair ``(last_notified_digest, last_notified_event_class)``
+        stays consistent — a digest that re-classifies between the two classes is not
+        wrongly deduped against the prior class.
 
         ``sync_notified`` is the one exception to that "never lower the digest"
         rule: when the caller observes that the *upstream is back in sync with the
@@ -159,6 +167,9 @@ class CatalogUpdateCheckRepository:
                 last_seen_etag=etag,
                 last_seen_digest=digest,
                 last_notified_digest=digest if sync_notified else notified_digest,
+                last_notified_event_class=(
+                    notified_event_class if (sync_notified or notified_digest is not None) else None
+                ),
                 last_checked_at=checked_at,
             )
             session.add(row)
@@ -172,8 +183,10 @@ class CatalogUpdateCheckRepository:
                 # Upstream is back in sync with the served revision: pin the notified
                 # digest to it so the outdated read surface clears (see docstring).
                 row.last_notified_digest = digest
+                row.last_notified_event_class = notified_event_class
             elif notified_digest is not None:
                 row.last_notified_digest = notified_digest
+                row.last_notified_event_class = notified_event_class
             row.last_checked_at = checked_at
         await session.flush()
         return row

--- a/src/jentic_one/registry/repos/overlay_repo.py
+++ b/src/jentic_one/registry/repos/overlay_repo.py
@@ -57,6 +57,60 @@ class OverlayRepository:
         return result.scalar_one_or_none()
 
     @staticmethod
+    async def get_live_confirmed_for_revision(
+        session: AsyncSession, api_id: uuid.UUID, revision_id: uuid.UUID
+    ) -> Overlay | None:
+        """The CONFIRMED overlay whose materialization *is* the given revision, if any.
+
+        Used by the re-import collision check (A4a): "does adopting an upstream change
+        for this API supersede a live operator overlay?" is answered by asking whether
+        the API's current revision was itself produced by confirming an overlay. We match
+        on ``confirmed_revision_id == revision_id`` (not merely ``status==CONFIRMED``) so a
+        stale/relinked CONFIRMED overlay that no longer backs the served revision is not
+        mistaken for the live one. At most one overlay can back a given revision (each
+        materialize produces a fresh revision), so this returns 0 or 1.
+        """
+        result = await session.execute(
+            select(Overlay).where(
+                Overlay.api_id == api_id,
+                Overlay.status == OverlayStatus.CONFIRMED,
+                Overlay.confirmed_revision_id == revision_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def get_live_confirmed_for_api(
+        session: AsyncSession, api_id: uuid.UUID
+    ) -> Overlay | None:
+        """The live CONFIRMED overlay for *api_id* (for actionable-event enrichment).
+
+        Used by the Flow-3 sweep: once an upstream change is *already* classified as
+        ``conflicts_overlay`` (the API's current revision is overlay-origin and carries an
+        ``overlay_base_digest``), this returns the overlay to deep-link for keep/rollback.
+
+        Deliberately keyed on ``(api_id, status==CONFIRMED)`` and **not** on
+        ``confirmed_revision_id == current_revision_id``: an overlay's
+        ``confirmed_revision_id`` is linked lazily by the materialize path (it can transiently
+        be NULL while the overlay revision is already served — see
+        ``get_live_confirmed_for_revision`` / the confirm→materialize seam), so requiring the
+        link here would drop the overlay id from a legitimately-fired conflict event. At most
+        one overlay per API is CONFIRMED at a time (rollback/supersede deprecate the prior
+        one before another can confirm), so this returns 0 or 1. If two ever raced, the
+        oldest-confirmed is returned deterministically.
+
+        This is enrichment only; the *authorization* decision (A4b) still uses the strict
+        revision-keyed :meth:`get_live_confirmed_for_revision`.
+        """
+        result = await session.execute(
+            select(Overlay)
+            .where(Overlay.api_id == api_id, Overlay.status == OverlayStatus.CONFIRMED)
+            .order_by(Overlay.confirmed_at.asc().nulls_last(), Overlay.id.asc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    @staticmethod
     async def list_page(
         session: AsyncSession,
         *,

--- a/src/jentic_one/registry/repos/overlay_repo.py
+++ b/src/jentic_one/registry/repos/overlay_repo.py
@@ -7,11 +7,12 @@ from datetime import datetime
 from enum import Enum, auto
 from typing import Any, cast
 
-from sqlalchemy import and_, or_, select, update
+from sqlalchemy import and_, case, or_, select, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import func
 
+from jentic_one.registry.core.schema.apis import Api
 from jentic_one.registry.core.schema.overlays import Overlay
 from jentic_one.shared.models import OverlayStatus
 
@@ -89,23 +90,42 @@ class OverlayRepository:
         ``conflicts_overlay`` (the API's current revision is overlay-origin and carries an
         ``overlay_base_digest``), this returns the overlay to deep-link for keep/rollback.
 
-        Deliberately keyed on ``(api_id, status==CONFIRMED)`` and **not** on
-        ``confirmed_revision_id == current_revision_id``: an overlay's
-        ``confirmed_revision_id`` is linked lazily by the materialize path (it can transiently
-        be NULL while the overlay revision is already served — see
-        ``get_live_confirmed_for_revision`` / the confirm→materialize seam), so requiring the
-        link here would drop the overlay id from a legitimately-fired conflict event. At most
-        one overlay per API is CONFIRMED at a time (rollback/supersede deprecate the prior
-        one before another can confirm), so this returns 0 or 1. If two ever raced, the
-        oldest-confirmed is returned deterministically.
+        Prefers the overlay whose ``confirmed_revision_id`` **is** the API's current served
+        revision — that is unambiguously the live one. Falls back to the newest-confirmed
+        overlay only when no CONFIRMED overlay is linked to the current revision yet, which
+        covers the lazy-link window: the materialize path promotes the overlay revision to
+        current *before* it stamps ``confirmed_revision_id``, so for a brief window the live
+        overlay is CONFIRMED with a NULL link while its revision is already served (dropping
+        the id here would blank the conflict event). ``confirmed_revision_id`` cannot be
+        keyed strictly (unlike :meth:`get_live_confirmed_for_revision`, the A4b *authorization*
+        path) for that reason.
+
+        Note the confirm path does not itself deprecate a prior CONFIRMED overlay, so two
+        CONFIRMED rows for one API are reachable (confirm A, then confirm B stacks B on A's
+        output and makes B current, leaving A CONFIRMED-but-superseded). The
+        current-revision-link preference returns **B** (the live one); newest-confirmed is the
+        correct fallback for the lazy-link window because the most recently materialized
+        overlay is the one now served. Returns 0 or 1.
 
         This is enrichment only; the *authorization* decision (A4b) still uses the strict
         revision-keyed :meth:`get_live_confirmed_for_revision`.
         """
+        # 0 when the overlay's confirmed_revision_id IS the current served revision (the
+        # unambiguous live overlay), 1 otherwise — sorts the linked-live overlay first, then
+        # newest-confirmed as the lazy-link fallback.
+        current_first = case(
+            (Overlay.confirmed_revision_id == Api.current_revision_id, 0),
+            else_=1,
+        )
         result = await session.execute(
             select(Overlay)
+            .join(Api, Api.id == Overlay.api_id)
             .where(Overlay.api_id == api_id, Overlay.status == OverlayStatus.CONFIRMED)
-            .order_by(Overlay.confirmed_at.asc().nulls_last(), Overlay.id.asc())
+            .order_by(
+                current_first,
+                Overlay.confirmed_at.desc().nulls_last(),
+                Overlay.id.desc(),
+            )
             .limit(1)
         )
         return result.scalar_one_or_none()

--- a/src/jentic_one/registry/repos/revision_repo.py
+++ b/src/jentic_one/registry/repos/revision_repo.py
@@ -31,6 +31,12 @@ class RegisteredSpec:
     #: for a manual import). The update-notify sweep uses it to decide whether the spec
     #: is upstream-tracked (see ``ORIGIN_CATALOG`` / ``ORIGIN_OVERLAY``).
     origin: str | None
+    #: For an overlay-origin current revision: the ``spec_digest`` of the base the
+    #: overlay was materialized over. The sweep compares the upstream digest against
+    #: this base to classify a change as a plain "update available" vs one that
+    #: "conflicts with the overlay". ``None`` for non-overlay revisions and for overlay
+    #: revisions materialized before A2 shipped the column (treated as "unknown base").
+    overlay_base_digest: str | None = None
 
 
 class ApiRevisionRepository:
@@ -76,6 +82,7 @@ class ApiRevisionRepository:
         source_filename: str | None = None,
         source_content_id: uuid.UUID | None = None,
         submitted_by: str | None = None,
+        overlay_base_digest: str | None = None,
         created_by: str,
     ) -> ApiRevision:
         revision = ApiRevision(
@@ -88,6 +95,7 @@ class ApiRevisionRepository:
             source_filename=source_filename,
             source_content_id=source_content_id,
             submitted_by=submitted_by,
+            overlay_base_digest=overlay_base_digest,
             promoted_at=datetime.now(UTC),
             created_by=created_by,
         )
@@ -200,6 +208,96 @@ class ApiRevisionRepository:
             .limit(1)
         )
         return result.scalar_one_or_none()
+
+    @staticmethod
+    async def current_revision_for_source_url(
+        session: AsyncSession, source_url: str
+    ) -> tuple[uuid.UUID, uuid.UUID] | None:
+        """The (api_id, current_revision_id) of a local API served from ``source_url``.
+
+        Resolves a catalog entry (identified by its upstream ``spec_url``) to the locally
+        registered API and its *current* revision, so the A4 collision check can ask
+        whether re-importing that upstream would supersede a live confirmed overlay. Keys
+        on the current revision's ``source_url`` — the same provenance the Flow-3 sweep
+        uses — and requires the API to actually have a current revision (a bare draft
+        import that was never promoted has none, so there's nothing to supersede).
+        Returns ``None`` when no such API is registered.
+        """
+        result = await session.execute(
+            select(Api.id, Api.current_revision_id)
+            .join(ApiRevision, ApiRevision.id == Api.current_revision_id)
+            .where(ApiRevision.source_url == source_url)
+            .limit(1)
+        )
+        row = result.first()
+        if row is None or row[1] is None:
+            return None
+        return (row[0], row[1])
+
+    @staticmethod
+    async def origin_of(session: AsyncSession, revision_id: uuid.UUID) -> str | None:
+        """The ``origin`` of a revision by id, or ``None`` if it doesn't exist.
+
+        A minimal single-column lookup used by the supersede-recovery path to decide
+        whether the served revision is the fresh upstream (non-overlay) — i.e. whether an
+        interrupted supersede's durable effect already landed — without materializing the
+        whole ORM row.
+        """
+        result = await session.execute(
+            select(ApiRevision.origin).where(ApiRevision.id == revision_id)
+        )
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def archive_one(session: AsyncSession, revision_id: uuid.UUID) -> int:
+        """Archive a single *active* revision by id (CAS on state). Returns rowcount.
+
+        Used by overlay rollback (A5b): the current overlay revision is archived in the
+        same txn as restoring the superseded one, guarded on ``state IN (published,
+        imported)`` so a concurrent transition that already archived it yields rowcount 0
+        (the caller aborts rather than double-acting).
+        """
+        result = cast(
+            "CursorResult[Any]",
+            await session.execute(
+                update(ApiRevision)
+                .where(
+                    ApiRevision.id == revision_id,
+                    ApiRevision.state.in_(
+                        [ApiRevisionState.PUBLISHED, ApiRevisionState.IMPORTED]
+                    ),
+                )
+                .values(state=ApiRevisionState.ARCHIVED, archived_at=datetime.now(UTC))
+                .execution_options(synchronize_session="fetch")
+            ),
+        )
+        await session.flush()
+        return result.rowcount
+
+    @staticmethod
+    async def restore_archived_to_imported(session: AsyncSession, revision_id: uuid.UUID) -> int:
+        """Un-archive a revision (ARCHIVED → IMPORTED), clearing ``archived_at``.
+
+        Rollback (A5b) restores the revision an overlay superseded so it can serve again.
+        CAS on ``state == ARCHIVED`` so only a genuinely archived revision is restored
+        (rowcount 0 otherwise). The caller archives the current overlay revision *first*
+        in the same txn, so the one-active partial unique index is never transiently
+        violated (never two active revisions at once).
+        """
+        result = cast(
+            "CursorResult[Any]",
+            await session.execute(
+                update(ApiRevision)
+                .where(
+                    ApiRevision.id == revision_id,
+                    ApiRevision.state == ApiRevisionState.ARCHIVED,
+                )
+                .values(state=ApiRevisionState.IMPORTED, archived_at=None)
+                .execution_options(synchronize_session="fetch")
+            ),
+        )
+        await session.flush()
+        return result.rowcount
 
     @staticmethod
     async def delete_replaceable_by_digest(
@@ -351,6 +449,7 @@ class ApiRevisionRepository:
                 ApiRevision.source_url,
                 ApiRevision.spec_digest,
                 ApiRevision.origin,
+                ApiRevision.overlay_base_digest,
                 Api.vendor,
                 Api.name,
                 Api.version,
@@ -367,7 +466,16 @@ class ApiRevisionRepository:
         )
         seen: set[uuid.UUID] = set()
         specs: list[RegisteredSpec] = []
-        for api_id, source_url, spec_digest, origin, vendor, name, version in result.all():
+        for (
+            api_id,
+            source_url,
+            spec_digest,
+            origin,
+            overlay_base_digest,
+            vendor,
+            name,
+            version,
+        ) in result.all():
             if api_id in seen:
                 continue
             seen.add(api_id)
@@ -380,6 +488,7 @@ class ApiRevisionRepository:
                     name=name,
                     version=version,
                     origin=origin,
+                    overlay_base_digest=overlay_base_digest,
                 )
             )
         return specs

--- a/src/jentic_one/registry/repos/revision_repo.py
+++ b/src/jentic_one/registry/repos/revision_repo.py
@@ -263,9 +263,7 @@ class ApiRevisionRepository:
                 update(ApiRevision)
                 .where(
                     ApiRevision.id == revision_id,
-                    ApiRevision.state.in_(
-                        [ApiRevisionState.PUBLISHED, ApiRevisionState.IMPORTED]
-                    ),
+                    ApiRevision.state.in_([ApiRevisionState.PUBLISHED, ApiRevisionState.IMPORTED]),
                 )
                 .values(state=ApiRevisionState.ARCHIVED, archived_at=datetime.now(UTC))
                 .execution_options(synchronize_session="fetch")

--- a/src/jentic_one/registry/services/catalog/fetch.py
+++ b/src/jentic_one/registry/services/catalog/fetch.py
@@ -18,6 +18,7 @@ from urllib.parse import urljoin
 import httpx
 
 from jentic_one.shared.config import IngestConfig
+from jentic_one.shared.egress import build_pinned_transport
 from jentic_one.shared.url_validation import validate_upstream_url
 
 
@@ -67,6 +68,7 @@ async def fetch_json(url: str, *, config: IngestConfig) -> dict[str, Any]:
         async with httpx.AsyncClient(
             timeout=config.fetch_timeout_s,
             follow_redirects=False,
+            transport=build_pinned_transport(config.egress),
         ) as client:
             resp = await client.get(validated_url, headers={"user-agent": _USER_AGENT})
             for _ in range(config.max_redirects):
@@ -140,6 +142,7 @@ async def fetch_bytes_conditional(
         async with httpx.AsyncClient(
             timeout=config.fetch_timeout_s,
             follow_redirects=False,
+            transport=build_pinned_transport(config.egress),
         ) as client:
             resp = await client.get(validated_url, headers=headers)
             for _ in range(config.max_redirects):

--- a/src/jentic_one/registry/services/catalog/service.py
+++ b/src/jentic_one/registry/services/catalog/service.py
@@ -26,6 +26,7 @@ import structlog
 
 from jentic_one.registry.repos.catalog_repo import CatalogRepository
 from jentic_one.registry.repos.catalog_update_check_repo import CatalogUpdateCheckRepository
+from jentic_one.registry.repos.overlay_repo import OverlayRepository
 from jentic_one.registry.repos.revision_repo import ApiRevisionRepository, RegisteredSpec
 from jentic_one.registry.services.catalog import manifest_builder as mb
 from jentic_one.registry.services.catalog.fetch import (
@@ -36,8 +37,10 @@ from jentic_one.registry.services.catalog.fetch import (
 from jentic_one.registry.services.errors import (
     CatalogEntryNotFoundError,
     CatalogUnavailableError,
+    OverlaySupersedeForbiddenError,
 )
 from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.auth.permissions import has_effective_permission
 from jentic_one.shared.context import Context
 from jentic_one.shared.db.utils import utcnow
 from jentic_one.shared.events import emit_event_best_effort
@@ -320,6 +323,36 @@ class CatalogService:
             duration_ms=int((asyncio.get_running_loop().time() - started) * 1000),
         )
 
+    def _classify_update(self, spec: RegisteredSpec, upstream_digest: str) -> str:
+        """Classify a detected upstream change as plain-update vs overlay-conflict.
+
+        The served revision carries an overlay only when it is overlay-origin. In that
+        case the overlay was materialized over a *base* whose digest we persist as
+        ``overlay_base_digest`` (A2). If the upstream now differs from that base, adopting
+        it would supersede the operator's overlay — an operator decision, not a routine
+        nudge — so we classify it as ``CATALOG_UPDATE_CONFLICTS_OVERLAY``.
+
+        Everything else is a plain ``CATALOG_UPDATE_AVAILABLE``:
+        - non-overlay revisions (catalog/manual imports) have no overlay to conflict with;
+        - overlay revisions materialized before A2 have a NULL base digest (unknown base):
+          we cannot prove a conflict, so we fall back to the safe, non-alarming class and
+          let the next re-materialize self-heal the column.
+        """
+        if (
+            spec.origin == ORIGIN_OVERLAY
+            and spec.overlay_base_digest is not None
+            and upstream_digest != spec.overlay_base_digest
+        ):
+            return EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY
+        return EventType.CATALOG_UPDATE_AVAILABLE
+
+    @staticmethod
+    def _update_summary(event_class: str, spec: RegisteredSpec) -> str:
+        who = f"{spec.vendor}/{spec.name} ({spec.version})"
+        if event_class == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY:
+            return f"Upstream spec changed under a confirmed overlay for {who}"
+        return f"Upstream spec updated for {who}"
+
     async def _probe_one(self, spec: RegisteredSpec, *, now: datetime, interval: int) -> None:
         """Conditionally fetch one registered spec and emit on a fresh change."""
         async with self._ctx.registry_db.session() as session:
@@ -349,14 +382,23 @@ class CatalogService:
 
         upstream_digest = result.digest
         last_notified = check.last_notified_digest if check is not None else None
+        last_notified_class = check.last_notified_event_class if check is not None else None
         # A change worth notifying: the upstream bytes differ from what backs the
         # registered revision, and we have not already notified for this exact
-        # upstream digest. Comparing against spec_digest (not just last_seen)
-        # means a spec that reverts to the registered content stops notifying.
+        # (upstream digest, event class) pair. Comparing against spec_digest (not just
+        # last_seen) means a spec that reverts to the registered content stops
+        # notifying. The event class is part of the dedupe key so a digest that
+        # re-classifies (e.g. an overlaid API whose upstream now collides with the
+        # overlay's base) still fires the new class exactly once.
         in_sync = upstream_digest == spec.spec_digest
-        changed = not in_sync and upstream_digest != last_notified
+        event_class = self._classify_update(spec, upstream_digest)
+        changed = not in_sync and (upstream_digest, event_class) != (
+            last_notified,
+            last_notified_class,
+        )
 
         notified_digest = upstream_digest if changed else None
+        notified_event_class = event_class if changed else None
         async with self._ctx.registry_db.transaction() as session:
             await CatalogUpdateCheckRepository.upsert(
                 session,
@@ -366,6 +408,7 @@ class CatalogService:
                 digest=upstream_digest,
                 checked_at=now,
                 notified_digest=notified_digest,
+                notified_event_class=notified_event_class,
                 # Upstream matches the served revision again (e.g. a bad publish was
                 # reverted): pin last_notified_digest to it so the outdated read surface
                 # clears. Otherwise a revert leaves the badge stuck lit with no operator
@@ -377,12 +420,25 @@ class CatalogService:
         if not changed:
             return
 
+        # For a conflict, resolve the live overlay's id so the actionable event can
+        # deep-link to the overlay to keep/rollback (parallel to the refuse path). The
+        # conflict class is only reached when the current revision *is* the live confirmed
+        # overlay, so this resolves to exactly that overlay (best-effort: None if a race
+        # already moved it — the event still carries api_id + event_class).
+        conflict_overlay_id: str | None = None
+        if event_class == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY:
+            async with self._ctx.registry_db.session() as session:
+                live_overlay = await OverlayRepository.get_live_confirmed_for_api(
+                    session, spec.api_id
+                )
+            conflict_overlay_id = live_overlay.id if live_overlay is not None else None
+
         async with self._ctx.admin_db.transaction() as session:
             await emit_event_best_effort(
                 session,
-                type=EventType.CATALOG_UPDATE_AVAILABLE,
+                type=event_class,
                 severity=EventSeverity.INFO,
-                summary=(f"Upstream spec updated for {spec.vendor}/{spec.name} ({spec.version})"),
+                summary=self._update_summary(event_class, spec),
                 # Actionable: an operator can resolve it by re-importing the upstream spec
                 # (one-click in the UI / `jentic catalog outdated` + import in the CLI),
                 # which the ImportHandler settles via ``settle_actionable_events`` keyed on
@@ -403,6 +459,11 @@ class CatalogService:
                     "current_digest": spec.spec_digest,
                     "upstream_digest": upstream_digest,
                     "spec_url": spec.source_url,
+                    "event_class": event_class,
+                    "overlay_base_digest": spec.overlay_base_digest,
+                    # Present only for conflicts_overlay so the inbox card can deep-link to
+                    # the overlay; None/absent for plain update_available.
+                    "overlay_id": conflict_overlay_id,
                 },
             )
 
@@ -605,17 +666,92 @@ class CatalogService:
             source["catalog_api_id"] = entry.api_id
         return source
 
+    async def _authorize_overlay_supersede(
+        self, entry: CatalogEntryView, identity: Identity
+    ) -> str | None:
+        """Gate a re-import that would supersede a live confirmed overlay (A4b).
+
+        Returns the overlay id to auto-deprecate when the caller is authorized to
+        supersede it (so the enqueued job can stamp ``supersede_overlay_id``), ``None``
+        when there is no live overlay to supersede (ordinary re-import), or raises
+        :class:`OverlaySupersedeForbiddenError` when a supersede is required but the
+        caller lacks ``overlays:confirm`` — re-emitting an operator-facing conflict event
+        so the fix is not silently discarded.
+
+        The check keys on the catalog entry's ``spec_url`` (the upstream provenance) to
+        find the locally-served current revision and asks whether that revision *is* a
+        confirmed overlay's materialization. Only that case is a supersede; a plain
+        catalog-origin current revision imports normally.
+        """
+        if not entry.spec_url:
+            return None
+        async with self._ctx.registry_db.session() as session:
+            current = await ApiRevisionRepository.current_revision_for_source_url(
+                session, entry.spec_url
+            )
+            if current is None:
+                return None
+            api_id, current_revision_id = current
+            overlay = await OverlayRepository.get_live_confirmed_for_revision(
+                session, api_id, current_revision_id
+            )
+        if overlay is None:
+            return None
+
+        if has_effective_permission(identity.permissions, "overlays:confirm"):
+            return overlay.id
+
+        # Refuse: do not enqueue a silent revert. Re-surface the conflict for an operator
+        # who can decide (confirm-scope holder), keyed on api_id so it settles on resolve.
+        # Intentionally NOT digest-deduped (unlike the sweep): each refused attempt is a
+        # distinct operator-relevant signal, and they all settle together on the eventual
+        # authorized import.
+        async with self._ctx.admin_db.transaction() as session:
+            await emit_event_best_effort(
+                session,
+                type=EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY,
+                severity=EventSeverity.INFO,
+                summary=(
+                    f"Re-import of {entry.api_id} was refused: adopting upstream would "
+                    f"supersede confirmed overlay {overlay.id} "
+                    "(needs catalog:import + overlays:confirm)"
+                ),
+                requires_action=True,
+                created_by=None,
+                data={
+                    "api_id": str(api_id),
+                    "overlay_id": overlay.id,
+                    "spec_url": entry.spec_url,
+                    "event_class": EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY,
+                    "refused_actor": identity.sub,
+                },
+            )
+        raise OverlaySupersedeForbiddenError(entry.api_id, overlay.id)
+
     async def import_entry(self, api_id: str, identity: Identity) -> str:
-        """Enqueue an async url-import for a catalog entry; return the job id."""
+        """Enqueue an async url-import for a catalog entry; return the job id.
+
+        If re-importing would supersede a live confirmed overlay, the caller must hold
+        ``overlays:confirm`` (A4b); an authorized supersede stamps ``supersede_overlay_id``
+        on the job so the worker auto-deprecates the overlay in the re-ingest transaction.
+        An unauthorized caller is refused (``OverlaySupersedeForbiddenError``) rather than
+        silently reverting the operator's fix.
+        """
         entry = await self.get(api_id)
+        supersede_overlay_id = await self._authorize_overlay_supersede(entry, identity)
         source = self._to_import_source(entry)
+        if supersede_overlay_id is not None:
+            source["supersede_active"] = "true"
+        payload: dict[str, Any] = {"sources": [source]}
+        if supersede_overlay_id is not None:
+            payload["supersede_overlay_id"] = supersede_overlay_id
         async with self._ctx.admin_db.transaction() as session:
             return await enqueue_job(
                 session,
                 JobKind.IMPORT,
                 created_by=identity.sub,
                 actor_type=identity.actor_type,
-                payload={"sources": [source]},
+                payload=payload,
             )
 
     async def ensure_imported(self, api_id: str, identity: Identity) -> str | None:

--- a/src/jentic_one/registry/services/catalog/service.py
+++ b/src/jentic_one/registry/services/catalog/service.py
@@ -347,10 +347,16 @@ class CatalogService:
         return EventType.CATALOG_UPDATE_AVAILABLE
 
     @staticmethod
-    def _update_summary(event_class: str, spec: RegisteredSpec) -> str:
+    def _update_summary(
+        event_class: str, spec: RegisteredSpec, overlay_id: str | None = None
+    ) -> str:
         who = f"{spec.vendor}/{spec.name} ({spec.version})"
         if event_class == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY:
-            return f"Upstream spec changed under a confirmed overlay for {who}"
+            ovl = f" {overlay_id}" if overlay_id else ""
+            return (
+                f"Upstream spec changed under confirmed overlay{ovl} for {who} — adopt "
+                "upstream (needs catalog:import + overlays:confirm) or keep the overlay"
+            )
         return f"Upstream spec updated for {who}"
 
     async def _probe_one(self, spec: RegisteredSpec, *, now: datetime, interval: int) -> None:
@@ -438,7 +444,7 @@ class CatalogService:
                 session,
                 type=event_class,
                 severity=EventSeverity.INFO,
-                summary=self._update_summary(event_class, spec),
+                summary=self._update_summary(event_class, spec, conflict_overlay_id),
                 # Actionable: an operator can resolve it by re-importing the upstream spec
                 # (one-click in the UI / `jentic catalog outdated` + import in the CLI),
                 # which the ImportHandler settles via ``settle_actionable_events`` keyed on
@@ -706,6 +712,17 @@ class CatalogService:
         # Intentionally NOT digest-deduped (unlike the sweep): each refused attempt is a
         # distinct operator-relevant signal, and they all settle together on the eventual
         # authorized import.
+        #
+        # The refusing actor is recorded via structlog (server-side, not exposed by the
+        # events API) rather than in the event ``data`` — event payloads are readable by any
+        # ``events:read`` holder, and the actor subject is attribution that belongs in logs/
+        # audit, not a broadly-readable notification.
+        logger.info(
+            "overlay_supersede_refused",
+            api_id=str(api_id),
+            overlay_id=overlay.id,
+            refused_actor=identity.sub,
+        )
         async with self._ctx.admin_db.transaction() as session:
             await emit_event_best_effort(
                 session,
@@ -723,7 +740,6 @@ class CatalogService:
                     "overlay_id": overlay.id,
                     "spec_url": entry.spec_url,
                     "event_class": EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY,
-                    "refused_actor": identity.sub,
                 },
             )
         raise OverlaySupersedeForbiddenError(entry.api_id, overlay.id)

--- a/src/jentic_one/registry/services/errors.py
+++ b/src/jentic_one/registry/services/errors.py
@@ -244,8 +244,10 @@ class OverlaySupersedeForbiddenError(RegistryServiceError):
 
     def __init__(self, api_id: str, overlay_id: str) -> None:
         super().__init__(
-            f"Re-importing '{api_id}' would supersede confirmed overlay '{overlay_id}'; "
-            "this requires the 'overlays:confirm' permission"
+            f"Re-importing '{api_id}' would supersede confirmed overlay '{overlay_id}', "
+            "which discards an operator's fix. This requires the 'overlays:confirm' "
+            "permission — ask an operator to run the re-import, or roll back the overlay "
+            "if the fix should be retired."
         )
         self.api_id = api_id
         self.overlay_id = overlay_id

--- a/src/jentic_one/registry/services/errors.py
+++ b/src/jentic_one/registry/services/errors.py
@@ -122,6 +122,23 @@ class OverlayStateConflictError(RegistryServiceError):
         self.action = action
 
 
+class OverlayRollbackTargetMissingError(RegistryServiceError):
+    """Raised when a confirmed overlay cannot be rolled back to a prior revision.
+
+    Rollback (A5b) promotes the overlay's ``superseded_revision_id`` back to current.
+    This is raised when that target is unknown (a first-ever materialize superseded
+    nothing, or a pre-A5a overlay never recorded it) or the target revision is no longer
+    restorable (deleted / not archived) — there is no deterministic revision to serve, so
+    the caller must resolve manually (e.g. re-import upstream) rather than the rollback
+    silently doing nothing.
+    """
+
+    def __init__(self, overlay_id: str, detail: str) -> None:
+        super().__init__(f"Cannot roll back overlay '{overlay_id}': {detail}")
+        self.overlay_id = overlay_id
+        self.detail = detail
+
+
 class OverlayApplyConflictError(RegistryServiceError):
     """Raised when a confirmed overlay cannot be materialized onto its base spec.
 
@@ -212,3 +229,23 @@ class CatalogUnavailableError(RegistryServiceError):
     def __init__(self, detail: str) -> None:
         super().__init__(detail)
         self.detail = detail
+
+
+class OverlaySupersedeForbiddenError(RegistryServiceError):
+    """Raised when a re-import would supersede a live overlay but the caller can't.
+
+    A4b (privilege-inversion guard): re-importing an upstream spec over an API whose
+    current revision is a live *confirmed* overlay would silently discard the operator's
+    materialized fix. That is an operator action, so it requires ``overlays:confirm``.
+    When the enqueuing caller lacks it, the import is refused (rather than silently
+    reverting the fix) and an operator-facing ``catalog.update_conflicts_overlay`` event
+    is re-emitted so a privileged operator can decide. The caller sees a 403.
+    """
+
+    def __init__(self, api_id: str, overlay_id: str) -> None:
+        super().__init__(
+            f"Re-importing '{api_id}' would supersede confirmed overlay '{overlay_id}'; "
+            "this requires the 'overlays:confirm' permission"
+        )
+        self.api_id = api_id
+        self.overlay_id = overlay_id

--- a/src/jentic_one/registry/services/import_service.py
+++ b/src/jentic_one/registry/services/import_service.py
@@ -337,9 +337,7 @@ class ImportHandler:
             return None
         try:
             async with self._ctx.registry_db.session() as session:
-                current = await ApiRevisionRepository.current_revision_for_source_url(
-                    session, url
-                )
+                current = await ApiRevisionRepository.current_revision_for_source_url(session, url)
                 if current is None:
                     return None
                 api_id, current_revision_id = current

--- a/src/jentic_one/registry/services/import_service.py
+++ b/src/jentic_one/registry/services/import_service.py
@@ -7,6 +7,7 @@ It fetches/parses OpenAPI/Arazzo sources and creates draft ApiRevisions.
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 from typing import Any
 
 import structlog
@@ -24,7 +25,7 @@ from jentic_one.shared.context import Context
 from jentic_one.shared.db.errors import DatabaseIntegrityError
 from jentic_one.shared.events import settle_actionable_events
 from jentic_one.shared.jobs.handlers import JobResultPayload
-from jentic_one.shared.models import ORIGIN_OVERLAY, ActorType
+from jentic_one.shared.models import ORIGIN_OVERLAY, ActorType, OverlayStatus
 from jentic_one.shared.models.events import EventType
 
 logger = structlog.get_logger(__name__)
@@ -70,6 +71,7 @@ class ImportHandler:
             payload = payload or {}
             sources = payload.get("sources", [])
             overlay_id = payload.get("overlay_id")
+            supersede_overlay_id = payload.get("supersede_overlay_id")
             resolved_actor_type = ActorType(actor_type) if actor_type else ActorType.USER
             revisions: list[dict[str, Any]] = []
             failures: list[str] = []
@@ -134,6 +136,37 @@ class ImportHandler:
             for rev in revisions:
                 await self._settle_update_available(job_id, created_by, rev["api"], session)
 
+            # A4b worker step: an authorized catalog re-import that supersedes a live
+            # confirmed overlay. The re-ingest archived the overlay's revision (the
+            # supersede_active stage archived *all* active revisions), so the served spec
+            # is now the fresh upstream. Auto-deprecate the overlay so its lifecycle
+            # reflects reality. Two cases reach a correct end state:
+            #   - clean first run: the fresh revision was created this attempt; deprecate.
+            #   - duplicate-on-retry: a prior attempt already committed the fresh revision
+            #     and made it current, then crashed *before* the (separate-transaction)
+            #     deprecate. The retry re-ingests identical content → DuplicateRevisionError
+            #     → no new revision, a failure. Without recovery the deprecate is skipped
+            #     and the job dead-letters, leaving the overlay stuck CONFIRMED over an
+            #     archived revision. So treat "served spec is already the fresh upstream"
+            #     as success and (idempotently, CAS on CONFIRMED) deprecate + settle.
+            recovered_supersede = False
+            if supersede_overlay_id:
+                if revisions and not failures:
+                    await self._deprecate_superseded_overlay(job_id, str(supersede_overlay_id))
+                elif not revisions and len(sources) == 1:
+                    recovered_api_id = await self._recover_supersede(
+                        job_id, str(supersede_overlay_id), sources[0]
+                    )
+                    recovered_supersede = recovered_api_id is not None
+                    if recovered_api_id is not None:
+                        # The served spec is already the fresh upstream; settle the Flow-3
+                        # prompts the (now-durable) adoption resolved, mirroring the clean
+                        # path. Keyed on the resolved api_id — the URL source carries no
+                        # version triple to re-resolve from.
+                        await self._settle_events_for_api_id(
+                            job_id, created_by, recovered_api_id, session
+                        )
+
             # Overlay materialization: link the confirmed overlay to the revision the
             # re-ingest just produced, so the served spec and the overlay agree on which
             # revision embodies the applied change. ``overlay_id`` is set only by
@@ -176,8 +209,15 @@ class ImportHandler:
             #
             # Exception: an overlay recovery job whose only failure was "identical
             # content already exists" *did* achieve its goal (the revision exists and
-            # we linked it above) — treat it as success, not a failed job.
-            if failures and not revisions and not recovered_overlay_link:
+            # we linked it above) — treat it as success, not a failed job. Same for a
+            # supersede re-import recovered on duplicate-retry (fresh upstream already
+            # served, overlay deprecated) — see _recover_supersede.
+            if (
+                failures
+                and not revisions
+                and not recovered_overlay_link
+                and not recovered_supersede
+            ):
                 raise IngestJobError(
                     f"all {len(sources)} import source(s) failed: " + "; ".join(failures)
                 )
@@ -235,16 +275,110 @@ class ImportHandler:
                 overlay_id=overlay_id,
             )
 
+    async def _deprecate_superseded_overlay(self, job_id: str, overlay_id: str) -> None:
+        """Auto-deprecate an overlay superseded by an authorized catalog re-import (A4b).
+
+        The re-ingest already archived the overlay's materialized revision and made the
+        fresh upstream the served spec; this only flips the overlay's own lifecycle to
+        DEPRECATED (CAS on it still being CONFIRMED) so status reflects reality. Runs in
+        its own registry_db transaction — a failure here does not undo the durable
+        re-ingest, so it is logged rather than raised (the served spec is already correct;
+        only the overlay's status label lags and can be repaired).
+        """
+        try:
+            async with self._ctx.registry_db.transaction() as session:
+                demoted = await OverlayRepository.set_status(
+                    session,
+                    overlay_id,
+                    OverlayStatus.DEPRECATED,
+                    deprecated_at=datetime.now(UTC),
+                    expected_status=OverlayStatus.CONFIRMED,
+                )
+            if demoted == 0:
+                logger.warning(
+                    "overlay_supersede_not_deprecated",
+                    job_id=job_id,
+                    overlay_id=overlay_id,
+                    reason="overlay_not_confirmed_or_missing",
+                )
+        except Exception:
+            logger.exception(
+                "overlay_supersede_deprecate_failed",
+                job_id=job_id,
+                overlay_id=overlay_id,
+            )
+
+    async def _recover_supersede(
+        self, job_id: str, overlay_id: str, source: Any
+    ) -> uuid.UUID | None:
+        """Recover an interrupted A4b supersede after a duplicate-on-retry re-ingest.
+
+        Mirrors ``_recover_overlay_link`` for the supersede path. A prior attempt already
+        committed the fresh upstream revision and made it current, then crashed before the
+        separate-transaction deprecate ran; the retry re-ingests identical content and
+        fails with ``DuplicateRevisionError`` (no new revision). Returns the resolved
+        ``api_id`` — so the caller completes the job (instead of dead-lettering) and settles
+        events — when the served revision is now a *non-overlay* (upstream) revision,
+        meaning the supersede's durable effect already landed. In that case it also
+        (idempotently, CAS on CONFIRMED) deprecates the overlay to finish the interrupted
+        step. Returns ``None`` for a genuine failure (served revision is still the overlay,
+        or identity can't be resolved).
+
+        Identity is resolved by the source's upstream ``url`` (the catalog ``spec_url``),
+        *not* the (vendor, name, version) triple: the production supersede source is a
+        ``type:"url"`` payload built by ``CatalogService._to_import_source`` that has no
+        ``version`` key (the version isn't known until the spec is fetched). Keying on the
+        served revision's ``source_url`` — the same provenance the enqueue-time gate uses
+        (``current_revision_for_source_url``) — is what lets this fire on the real path.
+        """
+        src = source if isinstance(source, dict) else {}
+        url = src.get("url")
+        if not isinstance(url, str):
+            return None
+        try:
+            async with self._ctx.registry_db.session() as session:
+                current = await ApiRevisionRepository.current_revision_for_source_url(
+                    session, url
+                )
+                if current is None:
+                    return None
+                api_id, current_revision_id = current
+                origin = await ApiRevisionRepository.origin_of(session, current_revision_id)
+                if origin is None:
+                    return None
+                # The supersede's durable effect is "served revision is the fresh upstream"
+                # (non-overlay). If the current revision is still the overlay, the prior
+                # attempt did not actually supersede — this is a real duplicate failure.
+                if origin == ORIGIN_OVERLAY:
+                    return None
+            logger.info(
+                "overlay_supersede_recovered_existing_revision",
+                job_id=job_id,
+                overlay_id=overlay_id,
+                revision_id=str(current_revision_id),
+            )
+        except Exception:
+            logger.exception(
+                "overlay_supersede_recovery_failed", job_id=job_id, overlay_id=overlay_id
+            )
+            return None
+        # Finish the interrupted deprecate (idempotent: CAS on CONFIRMED — a no-op if a
+        # prior attempt already demoted it).
+        await self._deprecate_superseded_overlay(job_id, overlay_id)
+        return api_id
+
     async def _settle_update_available(
         self, job_id: str, actor_id: str, api: dict[str, Any], session: Any
     ) -> None:
-        """Clear any outstanding ``catalog.update_available`` for the (re-)imported API.
+        """Clear outstanding Flow-3 update prompts for the (re-)imported API.
 
-        A successful import adopts the upstream spec, so the Flow-3 update prompt for that
-        API is resolved. Best-effort: resolve the local ``api_id`` from the spec triple,
-        then acknowledge matching actionable events (matched on the event payload's
-        ``api_id``). Never fails the import — the served spec is already correct; a missed
-        settle only leaves a stale inbox item that the next re-import clears.
+        A successful import adopts the upstream spec, so both the routine
+        ``catalog.update_available`` prompt **and** any ``catalog.update_conflicts_overlay``
+        prompt (A4c — the operator adopted upstream over an overlay) are resolved for that
+        API. Best-effort: resolve the local ``api_id`` from the spec triple, then
+        acknowledge matching actionable events of either class (matched on the event
+        payload's ``api_id``). Never fails the import — the served spec is already correct;
+        a missed settle only leaves a stale inbox item that the next re-import clears.
 
         ``session`` is the handler's own jobs/admin write session (events live in the admin
         DB). We deliberately reuse it rather than opening a second admin transaction: the
@@ -252,7 +386,7 @@ class ImportHandler:
         ``JobWorker._execute_handler``), and on SQLite's single writer a nested admin
         transaction would deadlock against that outer one — no retry can win because the
         blocker is our own call stack. Reusing the session also makes the ack atomic with
-        the import. The settle runs in a SAVEPOINT so a failure rolls back only itself,
+        the import. Each settle runs in a SAVEPOINT so a failure rolls back only itself,
         leaving the surrounding import (and its completion event) intact.
         """
         vendor, name, version = api.get("vendor"), api.get("name"), api.get("version")
@@ -265,23 +399,51 @@ class ImportHandler:
                 )
             if resolved is None:
                 return
-            async with session.begin_nested():
-                settled = await settle_actionable_events(
-                    session,
-                    event_type=EventType.CATALOG_UPDATE_AVAILABLE,
-                    acknowledged_by=actor_id,
-                    acknowledgement_note="Resolved by re-import of the upstream spec",
-                    data_match={"api_id": str(resolved.id)},
-                )
-            if settled:
-                logger.info(
-                    "catalog_update_available_settled",
-                    job_id=job_id,
-                    api_id=str(resolved.id),
-                    settled=settled,
-                )
         except Exception:
             logger.exception("catalog_update_available_settle_failed", job_id=job_id)
+            return
+        await self._settle_events_for_api_id(job_id, actor_id, resolved.id, session)
+
+    async def _settle_events_for_api_id(
+        self, job_id: str, actor_id: str, api_id: uuid.UUID, session: Any
+    ) -> None:
+        """Ack both Flow-3 update event classes for a resolved ``api_id``.
+
+        Split from ``_settle_update_available`` so callers that already hold the resolved
+        ``api_id`` (e.g. the supersede-recovery path, whose URL source carries no version
+        triple to re-resolve) can settle directly. Per-type isolation: settle each event
+        class in its own SAVEPOINT + try, so a failure settling one class (e.g. the plain
+        update) does not skip the other — for the A4c adopt-over-overlay case the conflict
+        event is the one that most matters, and it must be acked even if the plain-update
+        settle errors first.
+        """
+        for event_type in (
+            EventType.CATALOG_UPDATE_AVAILABLE,
+            EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY,
+        ):
+            try:
+                async with session.begin_nested():
+                    settled = await settle_actionable_events(
+                        session,
+                        event_type=event_type,
+                        acknowledged_by=actor_id,
+                        acknowledgement_note="Resolved by re-import of the upstream spec",
+                        data_match={"api_id": str(api_id)},
+                    )
+                if settled:
+                    logger.info(
+                        "catalog_update_event_settled",
+                        job_id=job_id,
+                        api_id=str(api_id),
+                        event_type=event_type,
+                        settled=settled,
+                    )
+            except Exception:
+                logger.exception(
+                    "catalog_update_event_settle_failed",
+                    job_id=job_id,
+                    event_type=event_type,
+                )
 
     async def _recover_overlay_link(self, job_id: str, overlay_id: str, source: Any) -> bool:
         """Link an overlay to its already-materialized revision after a duplicate re-ingest.

--- a/src/jentic_one/registry/services/overlay_service.py
+++ b/src/jentic_one/registry/services/overlay_service.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 from jentic_one.registry.core.schema.apis import Api
 from jentic_one.registry.repos.api_repo import ApiRepository
 from jentic_one.registry.repos.overlay_repo import OverlayRepository
+from jentic_one.registry.repos.revision_repo import ApiRevisionRepository
 from jentic_one.registry.repos.spec_file_repo import SpecFileRepository
 from jentic_one.registry.services.errors import (
     ApiNotFoundError,
@@ -24,6 +25,7 @@ from jentic_one.registry.services.errors import (
     NoCurrentRevisionError,
     OverlayApplyConflictError,
     OverlayNotFoundError,
+    OverlayRollbackTargetMissingError,
     OverlayStateConflictError,
     SpecFileMissingError,
 )
@@ -194,12 +196,14 @@ class OverlayService:
         version: str,
         overlay_id: str,
         target_revision_id: uuid.UUID | None = None,
-    ) -> tuple[dict[str, Any], str | None]:
-        """Load the base revision's spec content + source_url an overlay applies to.
+    ) -> tuple[dict[str, Any], str | None, str | None]:
+        """Load the base revision's spec content + source_url + digest an overlay applies to.
 
-        The base is the API's current (live) revision. Returns the parsed spec dict
-        and its ``source_url`` (so the materialized revision keeps the same catalog
-        provenance for Flow-3 update detection).
+        The base is the API's current (live) revision. Returns the parsed spec dict,
+        its ``source_url`` (so the materialized revision keeps the same catalog
+        provenance for Flow-3 update detection), and its ``spec_digest`` (persisted on
+        the materialized revision as ``overlay_base_digest`` so the sweep can diff
+        upstream against the overlay's base rather than the overlaid digest).
 
         NOTE: materialization always applies to the *current* revision, not to the
         overlay's ``target_revision_id`` (the base it was authored against). Structural
@@ -231,7 +235,8 @@ class OverlayService:
             if spec_file is None:
                 raise SpecFileMissingError(str(api.current_revision_id))
             source_url = api.current_revision.source_url if api.current_revision else None
-            return dict(spec_file.content), source_url
+            base_digest = api.current_revision.spec_digest if api.current_revision else None
+            return dict(spec_file.content), source_url, base_digest
 
     def _apply_and_validate(
         self, overlay_id: str, base_content: dict[str, Any], document: dict[str, Any]
@@ -280,6 +285,7 @@ class OverlayService:
         overlay_id: str,
         overlaid_spec: dict[str, Any],
         base_source_url: str | None,
+        base_digest: str | None,
         identity: Identity,
     ) -> None:
         """Enqueue the re-ingest that rewrites the served spec for a confirmed overlay."""
@@ -293,6 +299,7 @@ class OverlayService:
             "submitted_by": identity.sub,
             "origin": ORIGIN_OVERLAY,
             "source_url": base_source_url,
+            "overlay_base_digest": base_digest,
         }
         async with self._ctx.admin_db.transaction() as session:
             await enqueue_job(
@@ -592,7 +599,7 @@ class OverlayService:
         # Load the base spec + its provenance (source_url) and materialize BEFORE
         # flipping state, so a drifted/unsafe overlay is rejected while it is still
         # pending — no torn confirm, no orphaned ingest job.
-        base_content, base_source_url = await self._load_base_spec(
+        base_content, base_source_url, base_digest = await self._load_base_spec(
             vendor, name, version, overlay_id, target_revision_id
         )
         overlaid = self._apply_and_validate(overlay_id, base_content, document)
@@ -653,6 +660,7 @@ class OverlayService:
             overlay_id=overlay_id,
             overlaid_spec=overlaid,
             base_source_url=base_source_url,
+            base_digest=base_digest,
             identity=identity,
         )
 
@@ -697,5 +705,114 @@ class OverlayService:
             actor_type=identity.actor_type,
             actor_id=identity.sub,
             target_parent_id=str(api.id),
+            origin=identity.origin.value,
+        )
+
+    async def rollback(
+        self, vendor: str, name: str, version: str, overlay_id: str, *, identity: Identity
+    ) -> None:
+        """Un-confirm a materialized overlay: restore the revision it superseded (A5b).
+
+        Reverses a confirm. The overlay must be CONFIRMED and *currently live* (its
+        ``confirmed_revision_id`` is the API's current revision), and must carry a
+        ``superseded_revision_id`` (recorded at materialize time, A5a) that is still an
+        archived revision. In one registry transaction, guarded by compare-and-swaps so a
+        concurrent confirm/re-import can't double-flip:
+
+        1. archive the current overlay revision (CAS on it being active),
+        2. restore the superseded revision (ARCHIVED → IMPORTED),
+        3. flip ``current_revision_id`` overlay → superseded (CAS on the expected prior),
+        4. mark the overlay DEPRECATED (CAS on CONFIRMED).
+
+        Ordering archive-before-restore keeps the one-active partial unique index
+        satisfied throughout (never two active revisions). Any CAS returning 0 means
+        another transition raced us; we raise a state conflict and change nothing.
+        """
+        if not overlay_id.startswith("ovr_"):
+            raise OverlayNotFoundError(overlay_id, vendor, name, version)
+
+        api = await self._resolve_api(vendor, name, version)
+
+        async with self._ctx.registry_db.transaction() as session:
+            overlay = await OverlayRepository.get_for_api(session, api.id, overlay_id)
+            if overlay is None:
+                raise OverlayNotFoundError(overlay_id, vendor, name, version)
+            if overlay.status != OverlayStatus.CONFIRMED:
+                raise OverlayStateConflictError(
+                    overlay_id, overlay.status, [OverlayStatus.CONFIRMED], "rollback"
+                )
+
+            live = await ApiRepository.get_by_id(session, api.id)
+            overlay_revision_id = overlay.confirmed_revision_id
+            if (
+                overlay_revision_id is None
+                or live is None
+                or live.current_revision_id != overlay_revision_id
+            ):
+                # The overlay isn't the currently-served revision (already rolled back,
+                # re-imported, or never fully materialized) — nothing deterministic to
+                # reverse here.
+                raise OverlayStateConflictError(
+                    overlay_id, overlay.status, [OverlayStatus.CONFIRMED], "rollback"
+                )
+
+            superseded_id = overlay.superseded_revision_id
+            if superseded_id is None:
+                raise OverlayRollbackTargetMissingError(
+                    overlay_id,
+                    "no superseded revision was recorded (a first-ever materialize "
+                    "superseded nothing, or the overlay predates superseded-revision "
+                    "tracking) — resolve manually, e.g. by re-importing upstream",
+                )
+
+            # 1. Archive the current overlay revision (CAS on it being active).
+            if await ApiRevisionRepository.archive_one(session, overlay_revision_id) == 0:
+                raise OverlayStateConflictError(
+                    overlay_id, overlay.status, [OverlayStatus.CONFIRMED], "rollback"
+                )
+            # 2. Restore the superseded revision (must still be archived).
+            restored = await ApiRevisionRepository.restore_archived_to_imported(
+                session, superseded_id
+            )
+            if restored == 0:
+                raise OverlayRollbackTargetMissingError(
+                    overlay_id,
+                    f"superseded revision '{superseded_id}' is no longer restorable "
+                    "(deleted or not archived) — resolve manually",
+                )
+            # 3. Flip current overlay → superseded (CAS on the expected prior pointer).
+            flipped = await ApiRepository.compare_and_set_current_revision(
+                session,
+                api.id,
+                expected_revision_id=overlay_revision_id,
+                new_revision_id=superseded_id,
+            )
+            if flipped == 0:
+                raise OverlayStateConflictError(
+                    overlay_id, overlay.status, [OverlayStatus.CONFIRMED], "rollback"
+                )
+            # 4. Mark the overlay DEPRECATED (CAS on it still being CONFIRMED).
+            now = datetime.now(UTC)
+            demoted = await OverlayRepository.set_status(
+                session,
+                overlay_id,
+                OverlayStatus.DEPRECATED,
+                deprecated_at=now,
+                expected_status=OverlayStatus.CONFIRMED,
+            )
+            if demoted == 0:
+                raise OverlayStateConflictError(
+                    overlay_id, overlay.status, [OverlayStatus.CONFIRMED], "rollback"
+                )
+
+        await record_audit_best_effort(
+            self._ctx,
+            action=AuditAction.DEPRECATE,
+            target_type=AuditTargetType.OVERLAY,
+            target_id=overlay_id,
+            actor_type=identity.actor_type,
+            actor_id=identity.sub,
+            target_parent_id=str(api.id),
+            reason=f"rolled back; restored revision {overlay.superseded_revision_id}",
             origin=identity.origin.value,
         )

--- a/src/jentic_one/registry/web/errors.py
+++ b/src/jentic_one/registry/web/errors.py
@@ -21,7 +21,9 @@ from jentic_one.registry.services.errors import (
     OperationNotFoundError,
     OverlayApplyConflictError,
     OverlayNotFoundError,
+    OverlayRollbackTargetMissingError,
     OverlayStateConflictError,
+    OverlaySupersedeForbiddenError,
     RevisionNotFoundError,
     RevisionStateConflictError,
     SearchUnavailableError,
@@ -41,8 +43,17 @@ _ERROR_MAP: dict[type[Exception], tuple[int, str]] = {
     CatalogEntryNotFoundError: (404, "catalog_entry_not_found"),
     MethodNotAllowedError: (405, "method_not_allowed"),
     AmbiguousMatchError: (409, "ambiguous_match"),
+    # Refused overlay-superseding re-import (privilege inversion guard, A4b): the caller
+    # lacks overlays:confirm. 403 (not 409) — it's an authorization decision, and an
+    # operator-facing conflict event was re-emitted for someone who can resolve it.
+    OverlaySupersedeForbiddenError: (403, "overlay_supersede_forbidden"),
     OverlayStateConflictError: (409, "overlay_conflict"),
     OverlayApplyConflictError: (409, "overlay_apply_conflict"),
+    # Rollback asked for a prior revision that was never recorded or is no longer
+    # restorable — a precondition the operator must resolve (e.g. re-import upstream),
+    # not a transient conflict. 409 keeps it in the same family as the other overlay
+    # lifecycle conflicts while the distinct code lets surfaces message it precisely.
+    OverlayRollbackTargetMissingError: (409, "overlay_rollback_target_missing"),
     NotePreconditionFailedError: (412, "precondition_failed"),
     InvalidApiFilterError: (422, "invalid_api_filter"),
     ArchivedRevisionPinError: (422, "archived_revision_pin"),

--- a/src/jentic_one/registry/web/routers/overlays.py
+++ b/src/jentic_one/registry/web/routers/overlays.py
@@ -255,3 +255,27 @@ async def confirm_overlay(
 
     resp = _build_overlay_response(view, request)
     return JSONResponse(status_code=200, content=resp.model_dump(mode="json", by_alias=True))
+
+
+@router.post("/{overlay_id}:rollback", status_code=204)
+async def rollback_overlay(
+    vendor: str,
+    name: str,
+    version: str,
+    overlay_id: str,
+    identity: Identity = get_current_identity(required_permissions=["overlays:confirm"]),
+    ctx: Context = Depends(get_ctx),
+) -> Response:
+    """Un-confirm a materialized overlay, restoring the revision it superseded (A5b).
+
+    Requires ``overlays:confirm`` — the symmetric inverse of confirm. Rolling back
+    rewrites the API's served spec (it archives the overlay's materialized revision and
+    promotes the prior revision back to current), so it is the same operator action as
+    confirm, not a contributor one. The overlay must be CONFIRMED, currently live, and
+    carry a recorded superseded revision that is still restorable; otherwise a 409 is
+    returned (``overlay_conflict`` or ``overlay_rollback_target_missing``) and nothing
+    changes.
+    """
+    svc = OverlayService(ctx)
+    await svc.rollback(vendor, name, version, overlay_id, identity=identity)
+    return Response(status_code=204)

--- a/src/jentic_one/shared/auth/permissions.py
+++ b/src/jentic_one/shared/auth/permissions.py
@@ -1,0 +1,21 @@
+"""Shared permission-expansion helper.
+
+Wraps the admin implication map (``compute_effective``) so non-web callers — e.g. a
+service that must make an authorization decision *beyond* the route's declared scope —
+can ask "does this identity effectively hold permission X?" without importing the admin
+tier directly (which the module-boundary arch rules forbid for registry/broker/control).
+This mirrors the expansion the request guard applies in ``shared/web/deps.py``: grants
+are expanded through the static implication map (so ``org:admin`` implies everything and
+``*:write`` implies ``*:read``) before the membership test.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from jentic_one.admin.core.permissions import compute_effective
+
+
+def has_effective_permission(granted: Iterable[str], required: str) -> bool:
+    """True if *granted* (after implication-map expansion) includes *required*."""
+    return required in compute_effective(set(granted))

--- a/src/jentic_one/shared/egress.py
+++ b/src/jentic_one/shared/egress.py
@@ -1,0 +1,109 @@
+"""Shared egress safety: connection-time DNS-rebinding guard + pin (§08 E2).
+
+``validate_upstream_url`` (the pre-request check in ``shared/url_validation``)
+resolves the host and rejects a name that resolves into a blocked range. But that
+check runs *before* the request; the client's own ``httpx`` connection re-resolves
+the name at connect time, leaving a **TOCTOU rebind window** — a hostile resolver
+can answer "public" for the validation probe and "private" (``169.254.169.254``,
+``10.x``) for the real connection.
+
+:class:`DnsPinningTransport` closes that window: on every request it resolves the
+host **once**, re-validates each returned IP against the *same* egress policy
+(``assert_ip_allowed`` — identical block rules, metadata hard-deny, and allowlist
+exemptions), and **pins** the connection to the validated IP by rewriting the URL
+host to that IP while preserving the original ``Host`` header and TLS SNI. A second
+resolution can't swap in a private address because there is no second resolution.
+
+This lives in ``shared`` because *every* outbound-fetch site needs it, not just the
+broker's execution runtime: the Flow-3 catalog/ingest fetchers pull upstream specs
+on server-initiated schedules and are equally exposed to a rebind. ``build_client``
+(broker) and the registry fetchers both wrap their transports with this.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+
+import httpx
+
+from jentic_one.shared.config import EgressConfig
+from jentic_one.shared.url_validation import assert_ip_allowed
+
+_IpAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+
+def resolve_and_validate(host: str, egress: EgressConfig | None) -> _IpAddress:
+    """Resolve *host* and return the first IP that passes the egress policy.
+
+    Validates **every** resolved address against ``assert_ip_allowed`` so a
+    multi-record answer can't smuggle a blocked IP past the check, then returns
+    the first one to pin the connection to. Raises ``ValueError`` if the host
+    can't be resolved or any resolved IP is blocked (the rebind guard).
+    """
+    try:
+        results = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise ValueError(f"upstream host did not resolve: {host}") from exc
+
+    addrs = [ipaddress.ip_address(sockaddr[0]) for *_rest, sockaddr in results]
+    if not addrs:
+        raise ValueError(f"upstream host did not resolve: {host}")
+
+    for addr in addrs:
+        # A DNS name re-resolved here, so pass the hostname for the suffix
+        # exemption — matches the validation-time semantics.
+        assert_ip_allowed(addr, egress, hostname=host)
+    return addrs[0]
+
+
+class DnsPinningTransport(httpx.AsyncBaseTransport):
+    """Wraps a transport to resolve+validate+pin the host IP per request.
+
+    An IP-literal host is passed through unchanged (nothing to rebind). For a DNS
+    name the request URL host is rewritten to the validated IP, the original host
+    is preserved as the ``Host`` header, and ``sni_hostname`` is set so TLS still
+    validates against the real certificate name.
+    """
+
+    def __init__(self, inner: httpx.AsyncBaseTransport, egress: EgressConfig | None) -> None:
+        self._inner = inner
+        self._egress = egress
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        host = request.url.host
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            # A DNS name: resolve, validate (rebind guard), and pin.
+            pinned = resolve_and_validate(host, self._egress)
+            request = self._pin(request, host, pinned)
+        return await self._inner.handle_async_request(request)
+
+    @staticmethod
+    def _pin(request: httpx.Request, host: str, pinned: _IpAddress) -> httpx.Request:
+        """Rewrite *request* to connect to *pinned* while keeping Host + SNI as *host*."""
+        # Preserve the original authority for the Host header and TLS SNI.
+        if "host" not in (k.lower() for k in request.headers):
+            request.headers["Host"] = f"{host}:{request.url.port}" if request.url.port else host
+        # ip_address renders IPv6 bare; httpx.URL wants it bracketed in a netloc.
+        host_for_url = f"[{pinned}]" if pinned.version == 6 else str(pinned)
+        request.url = request.url.copy_with(host=host_for_url)
+        request.extensions = {**request.extensions, "sni_hostname": host}
+        return request
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+def build_pinned_transport(egress: EgressConfig | None) -> httpx.AsyncBaseTransport | None:
+    """Build a DNS-pinning transport for *egress*, or ``None`` if pinning is off.
+
+    Returns ``None`` when no egress policy is supplied or ``dns_pinning_enabled`` is
+    ``False`` — callers pass the result straight to ``httpx.AsyncClient(transport=...)``,
+    where ``None`` means "use httpx's default transport" (unchanged behaviour). This is
+    the one-liner the registry fetchers use so their SSRF guard survives a rebind.
+    """
+    if egress is None or not egress.dns_pinning_enabled:
+        return None
+    return DnsPinningTransport(httpx.AsyncHTTPTransport(), egress)

--- a/src/jentic_one/shared/models/events.py
+++ b/src/jentic_one/shared/models/events.py
@@ -37,6 +37,14 @@ class EventType:
     # settle_actionable_events. Deduped on the observed spec digest so it fires once
     # per real change, not every sweep.
     CATALOG_UPDATE_AVAILABLE = "catalog.update_available"
+    # A registered API's upstream spec changed AND that change collides with a
+    # confirmed overlay's *base* (the overlay was materialized over an older base;
+    # the upstream now differs from that base). Distinct from CATALOG_UPDATE_AVAILABLE
+    # because the resolution differs: adopting the upstream would *supersede* the
+    # operator's overlay, so this is an operator decision (re-import → auto-deprecate,
+    # gated) rather than a routine "update available" nudge. Emitted by the Flow-3
+    # sweep once per (digest, class) pair.
+    CATALOG_UPDATE_CONFLICTS_OVERLAY = "catalog.update_conflicts_overlay"
 
     # --- Product-telemetry event types (issue #446) ----------------------
     # These flow through emit_event (the single entry point) like any other
@@ -92,6 +100,7 @@ class EventType:
             JOB_FAILED_PERMANENTLY,
             UNAUTHORIZED_ACCESS_ATTEMPT,
             CATALOG_UPDATE_AVAILABLE,
+            CATALOG_UPDATE_CONFLICTS_OVERLAY,
             INSTANCE_INITIALIZED,
             INSTANCE_BOOTED,
             CREDENTIAL_STORED,

--- a/tests/arch/test_no_manual_commit.py
+++ b/tests/arch/test_no_manual_commit.py
@@ -20,6 +20,31 @@ ALLOWED_FILES = frozenset(
 
 MIGRATIONS_DIR = SRC_ROOT / "migrations"
 
+#: Receiver names that denote a DB session/connection — the objects whose bare
+#: ``commit()``/``rollback()`` this rule governs. Matched against the last attribute
+#: segment (``self.session`` → ``session``) or a plain variable name. In addition to
+#: these exact names, any receiver whose name ends in ``session``/``_session``/``_conn``
+#: is treated as a session (covers multi-DB handlers using ``admin_session``,
+#: ``control_session``, ``read_session``, ``audit_session``, etc.) so the invariant
+#: cannot be dodged by a differently-named session binding.
+_SESSION_RECEIVER_NAMES = frozenset({"session", "conn", "connection", "db_session", "sess"})
+
+
+def _is_session_receiver(node: ast.expr) -> bool:
+    """True if *node* names a DB session/connection (vs an arbitrary service object)."""
+    if isinstance(node, ast.Name):
+        name: str | None = node.id
+    elif isinstance(node, ast.Attribute):
+        name = node.attr
+    else:
+        return False
+    return (
+        name in _SESSION_RECEIVER_NAMES
+        or name.endswith("session")
+        or name.endswith("_conn")
+        or name == "conn"
+    )
+
 
 def _check_file(filepath: Path) -> list[str]:
     """Return violation messages if the file calls session.commit() or session.rollback().
@@ -47,6 +72,12 @@ def _check_file(filepath: Path) -> list[str]:
         if not isinstance(func, ast.Attribute):
             continue
         if func.attr in ("commit", "rollback"):
+            # Only flag calls on a *session/connection* receiver — the transaction
+            # primitives this rule governs. Domain services may legitimately expose a
+            # method named ``rollback`` (e.g. OverlayService.rollback un-confirms an
+            # overlay); that is not a raw session.rollback() and must not trip the rule.
+            if not _is_session_receiver(func.value):
+                continue
             line = source_lines[node.lineno - 1] if node.lineno <= len(source_lines) else ""
             if "# arch-allow: manual-commit" in line:
                 continue

--- a/tests/arch/test_no_manual_commit.py
+++ b/tests/arch/test_no_manual_commit.py
@@ -33,7 +33,7 @@ _SESSION_RECEIVER_NAMES = frozenset({"session", "conn", "connection", "db_sessio
 def _is_session_receiver(node: ast.expr) -> bool:
     """True if *node* names a DB session/connection (vs an arbitrary service object)."""
     if isinstance(node, ast.Name):
-        name: str | None = node.id
+        name: str = node.id
     elif isinstance(node, ast.Attribute):
         name = node.attr
     else:

--- a/tests/integration/registry/repos/test_catalog_update_check_repo.py
+++ b/tests/integration/registry/repos/test_catalog_update_check_repo.py
@@ -47,6 +47,7 @@ async def test_upsert_inserts_then_updates(registry_db: DatabaseSession, sample_
             digest="digest-2",
             checked_at=now,
             notified_digest="digest-2",
+            notified_event_class="catalog.update_conflicts_overlay",
         )
         await session.commit()
 
@@ -54,6 +55,8 @@ async def test_upsert_inserts_then_updates(registry_db: DatabaseSession, sample_
     assert again.last_seen_etag == '"v2"'
     assert again.last_seen_digest == "digest-2"
     assert again.last_notified_digest == "digest-2"
+    # The event class the digest fired under round-trips (part of the dedupe key).
+    assert again.last_notified_event_class == "catalog.update_conflicts_overlay"
 
 
 async def test_upsert_does_not_clear_notified_digest_on_none(
@@ -124,6 +127,38 @@ async def test_registered_specs_for_notify_joins_identity_and_excludes_archived(
     assert spec.vendor == sample_api.vendor
     assert spec.name == sample_api.name
     assert spec.version == sample_api.version
+    # Non-overlay revision → no overlay base digest.
+    assert spec.overlay_base_digest is None
+
+
+async def test_registered_specs_for_notify_threads_overlay_base_digest(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """An overlay-origin current revision surfaces its overlay_base_digest to the sweep.
+
+    A3 classifies an upstream change as a conflict by comparing the upstream digest to
+    the overlay's base — so the notify query must carry ``overlay_base_digest`` through.
+    """
+    async with registry_db.session() as session:
+        rev = ApiRevision(
+            api_id=sample_api.id,
+            state="published",
+            origin="overlay",
+            spec_digest="sha256:overlaid",
+            overlay_base_digest="sha256:base",
+            source_type="url",
+            source_url="https://example.com/openapi.json",
+        )
+        session.add(rev)
+        await session.commit()
+
+    async with registry_db.session() as session:
+        specs = await ApiRevisionRepository.registered_specs_for_notify(session)
+
+    mine = [s for s in specs if s.api_id == sample_api.id]
+    assert len(mine) == 1
+    assert mine[0].origin == "overlay"
+    assert mine[0].overlay_base_digest == "sha256:base"
 
 
 async def test_registered_specs_for_notify_picks_deterministic_revision(

--- a/tests/integration/registry/repos/test_overlay_repo.py
+++ b/tests/integration/registry/repos/test_overlay_repo.py
@@ -7,8 +7,9 @@ import uuid
 from datetime import UTC, datetime
 
 import pytest
-from sqlalchemy import delete
+from sqlalchemy import delete, update
 
+from jentic_one.registry.core.schema.api_revisions import ApiRevision
 from jentic_one.registry.core.schema.apis import Api
 from jentic_one.registry.repos.overlay_repo import OverlayRepository
 from jentic_one.shared.db.session import DatabaseSession
@@ -407,3 +408,54 @@ async def test_get_live_confirmed_for_api_ignores_link_lag(
 
     async with registry_db.session() as session:
         assert await OverlayRepository.get_live_confirmed_for_api(session, sample_api.id) is None
+
+
+async def test_get_live_confirmed_for_api_prefers_live_link_over_recency(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """With 2+ CONFIRMED overlays, prefer the one backing the current revision.
+
+    The confirm path does not deprecate a prior CONFIRMED overlay, so stacking confirm A
+    then confirm B leaves both CONFIRMED. The sweep's deep-link must point at the overlay
+    whose materialization *is* the served revision — keyed on
+    ``confirmed_revision_id == Api.current_revision_id`` — not merely the newest/oldest by
+    ``confirmed_at``. Here A is confirmed *later* but B backs the current revision, so B wins.
+    """
+    async with registry_db.session() as session:
+        rev_b = ApiRevision(
+            api_id=sample_api.id, state="imported", spec_digest="sha256:b", source_type="url"
+        )
+        session.add(rev_b)
+        await session.flush()
+        rev_b_id = rev_b.id
+        await session.execute(
+            update(Api).where(Api.id == sample_api.id).values(current_revision_id=rev_b_id)
+        )
+
+        overlay_a = await OverlayRepository.create(
+            session, api_id=sample_api.id, document={"a": 1}, created_by="usr_test"
+        )
+        overlay_b = await OverlayRepository.create(
+            session, api_id=sample_api.id, document={"b": 1}, created_by="usr_test"
+        )
+        # B backs the current revision but was confirmed EARLIER; A is confirmed LATER but is
+        # the superseded/stacked overlay. Newest-confirmed would wrongly pick A.
+        await OverlayRepository.set_status(
+            session,
+            overlay_b.id,
+            OverlayStatus.CONFIRMED,
+            confirmed_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        await OverlayRepository.set_confirmed_revision(session, overlay_b.id, rev_b_id)
+        await OverlayRepository.set_status(
+            session,
+            overlay_a.id,
+            OverlayStatus.CONFIRMED,
+            confirmed_at=datetime(2026, 6, 1, tzinfo=UTC),
+        )
+        await session.commit()
+        overlay_b_id = overlay_b.id
+
+    async with registry_db.session() as session:
+        found = await OverlayRepository.get_live_confirmed_for_api(session, sample_api.id)
+        assert found is not None and found.id == overlay_b_id

--- a/tests/integration/registry/repos/test_overlay_repo.py
+++ b/tests/integration/registry/repos/test_overlay_repo.py
@@ -369,3 +369,41 @@ async def test_cascade_delete(registry_db: DatabaseSession, sample_api: Api) -> 
         fetched = await OverlayRepository.get_for_api(session, sample_api.id, overlay_id)
 
     assert fetched is None
+
+
+async def test_get_live_confirmed_for_api_ignores_link_lag(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """get_live_confirmed_for_api returns the CONFIRMED overlay even with a NULL link.
+
+    Regression: the Flow-3 sweep enriches a ``conflicts_overlay`` event with the overlay
+    id via this lookup. ``confirmed_revision_id`` is linked *lazily* by the materialize
+    path, so it can be NULL while the overlay is already CONFIRMED and its revision served.
+    The lookup must key on ``(api_id, status==CONFIRMED)`` — not the revision link — or the
+    event drops the overlay id (caught by the manual flywheel E2E, missed by mocked units).
+    """
+    async with registry_db.session() as session:
+        overlay = await OverlayRepository.create(
+            session, api_id=sample_api.id, document={"x": 1}, created_by="usr_test"
+        )
+        # CONFIRMED but not yet linked to a materialized revision (the lazy-link window).
+        await OverlayRepository.set_status(
+            session, overlay.id, OverlayStatus.CONFIRMED, confirmed_at=datetime.now(UTC)
+        )
+        await session.commit()
+        overlay_id = overlay.id
+
+    async with registry_db.session() as session:
+        found = await OverlayRepository.get_live_confirmed_for_api(session, sample_api.id)
+        assert found is not None and found.id == overlay_id
+        assert found.confirmed_revision_id is None  # link still lagging
+
+    # A deprecated overlay is not "live".
+    async with registry_db.session() as session:
+        await OverlayRepository.set_status(
+            session, overlay_id, OverlayStatus.DEPRECATED, deprecated_at=datetime.now(UTC)
+        )
+        await session.commit()
+
+    async with registry_db.session() as session:
+        assert await OverlayRepository.get_live_confirmed_for_api(session, sample_api.id) is None

--- a/tests/integration/registry/services/test_import_handler.py
+++ b/tests/integration/registry/services/test_import_handler.py
@@ -19,7 +19,10 @@ from jentic_one.registry.core.schema.security_schemes import SecurityScheme, Sec
 from jentic_one.registry.core.schema.servers import Server, ServerVariable
 from jentic_one.registry.core.schema.spec_files import SpecFile
 from jentic_one.registry.ingest.exc import IngestJobError
+from jentic_one.registry.services.errors import OverlayStateConflictError
 from jentic_one.registry.services.import_service import ImportHandler
+from jentic_one.registry.services.overlay_service import OverlayService
+from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.context import Context
 from jentic_one.shared.db.session import DatabaseSession
 
@@ -386,6 +389,13 @@ async def test_overlay_materialization_rewrites_served_spec_and_links_revision(
     )
 
     async with registry_db.session() as session:
+        base_rev_pre = (
+            await session.execute(select(ApiRevision).where(ApiRevision.id == base_revision_id))
+        ).scalar_one()
+        base_digest = base_rev_pre.spec_digest
+    assert base_digest is not None
+
+    async with registry_db.session() as session:
         api = (await session.execute(select(Api).where(Api.vendor == "ovl-vendor"))).scalar_one()
         api_id = api.id
         overlay = Overlay(
@@ -424,6 +434,7 @@ async def test_overlay_materialization_rewrites_served_spec_and_links_revision(
                     "version": "1.0.0",
                     "origin": "overlay",
                     "source_url": "https://catalog.example.com/base.json",
+                    "overlay_base_digest": base_digest,
                 }
             ],
             "overlay_id": overlay_id,
@@ -451,6 +462,9 @@ async def test_overlay_materialization_rewrites_served_spec_and_links_revision(
         ).scalar_one()
         assert new_rev.origin == "overlay"
         assert new_rev.source_url == "https://catalog.example.com/base.json"
+        # A2: the base spec's digest is persisted on the materialized overlay revision
+        # so the Flow-3 sweep can diff upstream against the overlay's base.
+        assert new_rev.overlay_base_digest == base_digest
 
         spec_file = (
             await session.execute(select(SpecFile).where(SpecFile.revision_id == new_revision_id))
@@ -462,6 +476,347 @@ async def test_overlay_materialization_rewrites_served_spec_and_links_revision(
         ).scalar_one()
         assert overlay_row.confirmed_revision_id == new_revision_id
         assert overlay_row.superseded_revision_id == base_revision_id
+
+
+async def test_overlay_rollback_restores_superseded_revision(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    _clean_registry: None,
+) -> None:
+    """A5b: rollback un-confirms a live overlay and restores the revision it superseded.
+
+    Sets up the committed post-materialize state (base archived, overlay revision current
+    and CONFIRMED with confirmed_/superseded_revision_id linked), then rolls back via
+    OverlayService. The served revision must revert to the base (un-archived, current),
+    the overlay revision must be archived, and the overlay must be DEPRECATED.
+    """
+    handler = ImportHandler(integration_context)
+    base_revision_id = await _import_base(
+        handler, vendor="rb-vendor", name="rb-api", version="1.0.0", origin="catalog"
+    )
+
+    async with registry_db.session() as session:
+        api = (await session.execute(select(Api).where(Api.vendor == "rb-vendor"))).scalar_one()
+        api_id = api.id
+        overlay = Overlay(
+            api_id=api_id, document=_OVERLAY_DOC, status="pending", created_by="usr_test"
+        )
+        session.add(overlay)
+        await session.commit()
+        overlay_id = overlay.id
+
+    # Materialize the overlay (the job the confirm would enqueue).
+    result = await handler.execute(
+        job_id=str(uuid.uuid4()),
+        session=None,
+        payload={
+            "sources": [
+                {
+                    "type": "inline",
+                    "content": json.dumps(
+                        {
+                            "openapi": "3.1.0",
+                            "info": {"title": "RB", "version": "1.0.0"},
+                            "servers": [{"url": "https://new.example.com"}],
+                            "paths": {
+                                "/items": {
+                                    "get": {
+                                        "operationId": "listItems",
+                                        "responses": {"200": {"description": "OK"}},
+                                    }
+                                }
+                            },
+                        }
+                    ),
+                    "filename": "openapi.json",
+                    "vendor": "rb-vendor",
+                    "api_name": "rb-api",
+                    "version": "1.0.0",
+                    "origin": "overlay",
+                    "source_url": "https://catalog.example.com/base.json",
+                }
+            ],
+            "overlay_id": overlay_id,
+        },
+        created_by="usr_test",
+    )
+    overlay_revision_id = uuid.UUID(result.body["revisions"][0]["revision_id"])
+
+    # Flip the overlay to CONFIRMED (the confirm service does this via CAS; the raw
+    # materialize job only links the revision). Rollback requires CONFIRMED.
+    async with registry_db.session() as session:
+        await session.execute(
+            update(Overlay).where(Overlay.id == overlay_id).values(status="confirmed")
+        )
+        await session.commit()
+
+    identity = Identity(
+        sub="usr_operator", email="op@test.local", permissions=["overlays:confirm"]
+    )
+    await OverlayService(integration_context).rollback(
+        "rb-vendor", "rb-api", "1.0.0", overlay_id, identity=identity
+    )
+
+    async with registry_db.session() as session:
+        api = (await session.execute(select(Api).where(Api.id == api_id))).scalar_one()
+        # Served revision reverted to the base.
+        assert api.current_revision_id == base_revision_id
+
+        base_rev = (
+            await session.execute(select(ApiRevision).where(ApiRevision.id == base_revision_id))
+        ).scalar_one()
+        assert base_rev.state == "imported"  # restored (un-archived)
+        assert base_rev.archived_at is None
+
+        overlay_rev = (
+            await session.execute(
+                select(ApiRevision).where(ApiRevision.id == overlay_revision_id)
+            )
+        ).scalar_one()
+        assert overlay_rev.state == "archived"  # the overlay's revision is retired
+
+        overlay_row = (
+            await session.execute(select(Overlay).where(Overlay.id == overlay_id))
+        ).scalar_one()
+        assert overlay_row.status == "deprecated"
+        assert overlay_row.deprecated_at is not None
+
+
+async def test_overlay_rollback_conflict_when_not_live(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    _clean_registry: None,
+) -> None:
+    """Rollback of an overlay that isn't the currently-served revision is a 409 no-op.
+
+    A CONFIRMED overlay whose confirmed_revision_id is not the API's current revision
+    (already superseded/rolled back) must raise a state conflict and change nothing.
+    """
+    handler = ImportHandler(integration_context)
+    base_revision_id = await _import_base(
+        handler, vendor="rb2-vendor", name="rb2-api", version="1.0.0", origin="catalog"
+    )
+
+    async with registry_db.session() as session:
+        api = (await session.execute(select(Api).where(Api.vendor == "rb2-vendor"))).scalar_one()
+        api_id = api.id
+        # A CONFIRMED overlay that points at some *other* (not current) revision.
+        overlay = Overlay(
+            api_id=api_id,
+            document=_OVERLAY_DOC,
+            status="confirmed",
+            confirmed_revision_id=uuid.uuid4(),
+            superseded_revision_id=base_revision_id,
+            created_by="usr_test",
+        )
+        session.add(overlay)
+        await session.commit()
+        overlay_id = overlay.id
+
+    identity = Identity(
+        sub="usr_operator", email="op@test.local", permissions=["overlays:confirm"]
+    )
+    with pytest.raises(OverlayStateConflictError):
+        await OverlayService(integration_context).rollback(
+            "rb2-vendor", "rb2-api", "1.0.0", overlay_id, identity=identity
+        )
+
+    async with registry_db.session() as session:
+        api = (await session.execute(select(Api).where(Api.id == api_id))).scalar_one()
+        # Unchanged: base is still current, nothing rolled.
+        assert api.current_revision_id == base_revision_id
+
+
+async def test_authorized_supersede_reimport_deprecates_overlay(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    _clean_registry: None,
+) -> None:
+    """A4b: an authorized catalog re-import over a live confirmed overlay supersedes it.
+
+    Sets up a live confirmed overlay (its materialized revision is current), then runs
+    the catalog re-import job the scope-checked enqueue path would produce — carrying
+    ``supersede_active`` on the source and ``supersede_overlay_id`` on the payload. The
+    fresh catalog revision must become current (the overlay revision archived) and the
+    overlay must be auto-DEPRECATED in the same job.
+    """
+    handler = ImportHandler(integration_context)
+    await _import_base(
+        handler, vendor="sup-vendor", name="sup-api", version="1.0.0", origin="catalog"
+    )
+
+    async with registry_db.session() as session:
+        api = (await session.execute(select(Api).where(Api.vendor == "sup-vendor"))).scalar_one()
+        api_id = api.id
+        overlay = Overlay(
+            api_id=api_id, document=_OVERLAY_DOC, status="pending", created_by="usr_test"
+        )
+        session.add(overlay)
+        await session.commit()
+        overlay_id = overlay.id
+
+    # Materialize + confirm the overlay so it is the live served revision.
+    result = await handler.execute(
+        job_id=str(uuid.uuid4()),
+        session=None,
+        payload={
+            "sources": [
+                {
+                    "type": "inline",
+                    "content": json.dumps(
+                        {
+                            "openapi": "3.1.0",
+                            "info": {"title": "SUP", "version": "1.0.0"},
+                            "servers": [{"url": "https://overlaid.example.com"}],
+                            "paths": {
+                                "/items": {
+                                    "get": {
+                                        "operationId": "listItems",
+                                        "responses": {"200": {"description": "OK"}},
+                                    }
+                                }
+                            },
+                        }
+                    ),
+                    "filename": "openapi.json",
+                    "vendor": "sup-vendor",
+                    "api_name": "sup-api",
+                    "version": "1.0.0",
+                    "origin": "overlay",
+                    "source_url": "https://catalog.example.com/base.json",
+                }
+            ],
+            "overlay_id": overlay_id,
+        },
+        created_by="usr_test",
+    )
+    overlay_revision_id = uuid.UUID(result.body["revisions"][0]["revision_id"])
+    async with registry_db.session() as session:
+        await session.execute(
+            update(Overlay).where(Overlay.id == overlay_id).values(status="confirmed")
+        )
+        await session.commit()
+
+    # The scope-checked enqueue path stamps supersede_active + supersede_overlay_id.
+    reimport = await handler.execute(
+        job_id=str(uuid.uuid4()),
+        session=None,
+        payload={
+            "sources": [
+                {
+                    "type": "inline",
+                    "content": json.dumps(
+                        {
+                            "openapi": "3.1.0",
+                            "info": {"title": "SUP", "version": "1.0.0"},
+                            "servers": [{"url": "https://upstream-fresh.example.com"}],
+                            "paths": {
+                                "/items": {
+                                    "get": {
+                                        "operationId": "listItems",
+                                        "responses": {"200": {"description": "OK"}},
+                                    }
+                                }
+                            },
+                        }
+                    ),
+                    "filename": "openapi.json",
+                    "vendor": "sup-vendor",
+                    "api_name": "sup-api",
+                    "version": "1.0.0",
+                    "origin": "catalog",
+                    "source_url": "https://catalog.example.com/base.json",
+                    "supersede_active": "true",
+                }
+            ],
+            "supersede_overlay_id": overlay_id,
+        },
+        created_by="usr_operator",
+    )
+    new_revision_id = uuid.UUID(reimport.body["revisions"][0]["revision_id"])
+    assert new_revision_id != overlay_revision_id
+
+    async with registry_db.session() as session:
+        api = (await session.execute(select(Api).where(Api.id == api_id))).scalar_one()
+        # The fresh catalog revision is now served.
+        assert api.current_revision_id == new_revision_id
+
+        overlay_rev = (
+            await session.execute(select(ApiRevision).where(ApiRevision.id == overlay_revision_id))
+        ).scalar_one()
+        assert overlay_rev.state == "archived"
+
+        overlay_row = (
+            await session.execute(select(Overlay).where(Overlay.id == overlay_id))
+        ).scalar_one()
+        assert overlay_row.status == "deprecated"
+        assert overlay_row.deprecated_at is not None
+
+    # --- Simulate a crash between the committed re-ingest and the separate-transaction
+    # deprecate: reset the overlay to CONFIRMED (as if the deprecate never committed) and
+    # re-run the *identical* supersede job. The re-ingest now hits DuplicateRevisionError
+    # (fresh revision already exists + is current), so there are no new revisions and a
+    # failure — the retry must RECOVER (not dead-letter): served spec is already the fresh
+    # upstream, so _recover_supersede completes the job and re-deprecates the overlay.
+    async with registry_db.session() as session:
+        await session.execute(
+            update(Overlay).where(Overlay.id == overlay_id).values(status="confirmed")
+        )
+        await session.commit()
+
+    retry = await handler.execute(
+        job_id=str(uuid.uuid4()),
+        session=None,
+        payload={
+            "sources": [
+                {
+                    "type": "inline",
+                    "content": json.dumps(
+                        {
+                            "openapi": "3.1.0",
+                            "info": {"title": "SUP", "version": "1.0.0"},
+                            "servers": [{"url": "https://upstream-fresh.example.com"}],
+                            "paths": {
+                                "/items": {
+                                    "get": {
+                                        "operationId": "listItems",
+                                        "responses": {"200": {"description": "OK"}},
+                                    }
+                                }
+                            },
+                        }
+                    ),
+                    "filename": "openapi.json",
+                    "vendor": "sup-vendor",
+                    "api_name": "sup-api",
+                    # NB: NO "version" key, and a "url" that equals the served revision's
+                    # source_url — deliberately mirroring the PRODUCTION supersede source
+                    # (CatalogService._to_import_source builds a type:"url" payload with no
+                    # version). This proves _recover_supersede resolves identity by url
+                    # (current_revision_for_source_url), not by the vendor/name/version
+                    # triple the real path never carries.
+                    "url": "https://catalog.example.com/base.json",
+                    "origin": "catalog",
+                    "source_url": "https://catalog.example.com/base.json",
+                    "supersede_active": "true",
+                }
+            ],
+            "supersede_overlay_id": overlay_id,
+        },
+        created_by="usr_operator",
+    )
+    # The job completed (did not raise / dead-letter) with no new revision.
+    assert retry.body["revisions"] == []
+
+    async with registry_db.session() as session:
+        api = (await session.execute(select(Api).where(Api.id == api_id))).scalar_one()
+        # Served spec unchanged: still the fresh upstream from the first pass.
+        assert api.current_revision_id == new_revision_id
+        overlay_row = (
+            await session.execute(select(Overlay).where(Overlay.id == overlay_id))
+        ).scalar_one()
+        # Recovery re-ran the idempotent CAS deprecate.
+        assert overlay_row.status == "deprecated"
 
 
 async def test_overlay_materialization_archives_active_revision_of_other_origin(

--- a/tests/integration/registry/services/test_import_handler.py
+++ b/tests/integration/registry/services/test_import_handler.py
@@ -550,9 +550,7 @@ async def test_overlay_rollback_restores_superseded_revision(
         )
         await session.commit()
 
-    identity = Identity(
-        sub="usr_operator", email="op@test.local", permissions=["overlays:confirm"]
-    )
+    identity = Identity(sub="usr_operator", email="op@test.local", permissions=["overlays:confirm"])
     await OverlayService(integration_context).rollback(
         "rb-vendor", "rb-api", "1.0.0", overlay_id, identity=identity
     )
@@ -569,9 +567,7 @@ async def test_overlay_rollback_restores_superseded_revision(
         assert base_rev.archived_at is None
 
         overlay_rev = (
-            await session.execute(
-                select(ApiRevision).where(ApiRevision.id == overlay_revision_id)
-            )
+            await session.execute(select(ApiRevision).where(ApiRevision.id == overlay_revision_id))
         ).scalar_one()
         assert overlay_rev.state == "archived"  # the overlay's revision is retired
 
@@ -613,9 +609,7 @@ async def test_overlay_rollback_conflict_when_not_live(
         await session.commit()
         overlay_id = overlay.id
 
-    identity = Identity(
-        sub="usr_operator", email="op@test.local", permissions=["overlays:confirm"]
-    )
+    identity = Identity(sub="usr_operator", email="op@test.local", permissions=["overlays:confirm"])
     with pytest.raises(OverlayStateConflictError):
         await OverlayService(integration_context).rollback(
             "rb2-vendor", "rb2-api", "1.0.0", overlay_id, identity=identity
@@ -785,9 +779,7 @@ async def test_authorized_supersede_reimport_deprecates_overlay(
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
 
-    with patch(
-        "jentic_one.registry.ingest.fetch.httpx.AsyncClient", return_value=mock_client
-    ):
+    with patch("jentic_one.registry.ingest.fetch.httpx.AsyncClient", return_value=mock_client):
         retry = await handler.execute(
             job_id=str(uuid.uuid4()),
             session=None,

--- a/tests/integration/registry/services/test_import_handler.py
+++ b/tests/integration/registry/services/test_import_handler.py
@@ -697,6 +697,24 @@ async def test_authorized_supersede_reimport_deprecates_overlay(
         )
         await session.commit()
 
+    # The fresh upstream content the catalog re-import adopts. Reused verbatim by the retry's
+    # mocked fetch below so the retry re-ingests identical bytes → DuplicateRevisionError.
+    fresh_upstream = json.dumps(
+        {
+            "openapi": "3.1.0",
+            "info": {"title": "SUP", "version": "1.0.0"},
+            "servers": [{"url": "https://upstream-fresh.example.com"}],
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "listItems",
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+
     # The scope-checked enqueue path stamps supersede_active + supersede_overlay_id.
     reimport = await handler.execute(
         job_id=str(uuid.uuid4()),
@@ -705,21 +723,7 @@ async def test_authorized_supersede_reimport_deprecates_overlay(
             "sources": [
                 {
                     "type": "inline",
-                    "content": json.dumps(
-                        {
-                            "openapi": "3.1.0",
-                            "info": {"title": "SUP", "version": "1.0.0"},
-                            "servers": [{"url": "https://upstream-fresh.example.com"}],
-                            "paths": {
-                                "/items": {
-                                    "get": {
-                                        "operationId": "listItems",
-                                        "responses": {"200": {"description": "OK"}},
-                                    }
-                                }
-                            },
-                        }
-                    ),
+                    "content": fresh_upstream,
                     "filename": "openapi.json",
                     "vendor": "sup-vendor",
                     "api_name": "sup-api",
@@ -764,47 +768,45 @@ async def test_authorized_supersede_reimport_deprecates_overlay(
         )
         await session.commit()
 
-    retry = await handler.execute(
-        job_id=str(uuid.uuid4()),
-        session=None,
-        payload={
-            "sources": [
-                {
-                    "type": "inline",
-                    "content": json.dumps(
-                        {
-                            "openapi": "3.1.0",
-                            "info": {"title": "SUP", "version": "1.0.0"},
-                            "servers": [{"url": "https://upstream-fresh.example.com"}],
-                            "paths": {
-                                "/items": {
-                                    "get": {
-                                        "operationId": "listItems",
-                                        "responses": {"200": {"description": "OK"}},
-                                    }
-                                }
-                            },
-                        }
-                    ),
-                    "filename": "openapi.json",
-                    "vendor": "sup-vendor",
-                    "api_name": "sup-api",
-                    # NB: NO "version" key, and a "url" that equals the served revision's
-                    # source_url — deliberately mirroring the PRODUCTION supersede source
-                    # (CatalogService._to_import_source builds a type:"url" payload with no
-                    # version). This proves _recover_supersede resolves identity by url
-                    # (current_revision_for_source_url), not by the vendor/name/version
-                    # triple the real path never carries.
-                    "url": "https://catalog.example.com/base.json",
-                    "origin": "catalog",
-                    "source_url": "https://catalog.example.com/base.json",
-                    "supersede_active": "true",
-                }
-            ],
-            "supersede_overlay_id": overlay_id,
-        },
-        created_by="usr_operator",
-    )
+    # Faithfully mirror the PRODUCTION supersede source: a ``type:"url"`` payload with NO
+    # version key (CatalogService._to_import_source builds exactly this — the version isn't
+    # known until the spec is fetched). Mock the HTTP fetch to return the *identical* fresh
+    # upstream bytes so the re-ingest actually runs through load_specification/Ingestor and
+    # raises DuplicateRevisionError — the real trigger _recover_supersede handles. This proves
+    # _recover_supersede resolves identity by url (current_revision_for_source_url), not by a
+    # vendor/name/version triple the real path never carries.
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.text = fresh_upstream
+    mock_response.content = fresh_upstream.encode()
+    mock_response.headers = {"content-length": str(len(fresh_upstream.encode()))}
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "jentic_one.registry.ingest.fetch.httpx.AsyncClient", return_value=mock_client
+    ):
+        retry = await handler.execute(
+            job_id=str(uuid.uuid4()),
+            session=None,
+            payload={
+                "sources": [
+                    {
+                        "type": "url",
+                        "url": "https://catalog.example.com/base.json",
+                        "vendor": "sup-vendor",
+                        "api_name": "sup-api",
+                        "origin": "catalog",
+                        "source_url": "https://catalog.example.com/base.json",
+                        "supersede_active": "true",
+                    }
+                ],
+                "supersede_overlay_id": overlay_id,
+            },
+            created_by="usr_operator",
+        )
     # The job completed (did not raise / dead-letter) with no new revision.
     assert retry.body["revisions"] == []
 

--- a/tests/unit/registry/ingest/test_fetch_inline.py
+++ b/tests/unit/registry/ingest/test_fetch_inline.py
@@ -1,6 +1,7 @@
 """Tests for inline spec loading via load_specification."""
 
 import hashlib
+from typing import Any
 
 import pytest
 import yaml
@@ -10,9 +11,7 @@ from jentic_one.registry.ingest.fetch import InlineSource, load_specification
 from jentic_one.shared.config import IngestConfig
 
 
-def _make_inline(
-    content: str, filename: str = "openapi.yaml", **kwargs: str | None
-) -> InlineSource:
+def _make_inline(content: str, filename: str = "openapi.yaml", **kwargs: Any) -> InlineSource:
     return InlineSource(type="inline", content=content, filename=filename, **kwargs)
 
 

--- a/tests/unit/registry/ingest/test_fetch_url.py
+++ b/tests/unit/registry/ingest/test_fetch_url.py
@@ -19,9 +19,7 @@ _SPEC: dict[str, Any] = {
 _SPEC_BYTES = json.dumps(_SPEC).encode()
 
 
-def _url_source(
-    url: str = "https://example.com/specs/openapi.json", **kwargs: str | None
-) -> UrlSource:
+def _url_source(url: str = "https://example.com/specs/openapi.json", **kwargs: Any) -> UrlSource:
     return UrlSource(type="url", url=url, **kwargs)
 
 

--- a/tests/unit/registry/services/test_catalog_fetch.py
+++ b/tests/unit/registry/services/test_catalog_fetch.py
@@ -20,6 +20,7 @@ from jentic_one.registry.services.catalog.fetch import (
     fetch_json,
 )
 from jentic_one.shared.config import IngestConfig
+from jentic_one.shared.egress import DnsPinningTransport
 
 _SPEC: dict[str, Any] = {"openapi": "3.1.0", "info": {"title": "Big API", "version": "1.0.0"}}
 _SPEC_BYTES = json.dumps(_SPEC).encode()
@@ -283,3 +284,48 @@ async def test_conditional_304_propagates_refreshed_etag() -> None:
         )
     assert result.not_modified is True
     assert result.etag == '"v1-refreshed"'
+
+
+@pytest.mark.asyncio
+async def test_fetch_wires_dns_pinning_transport_by_default() -> None:
+    """L5: the catalog fetchers pin DNS at connect time, closing the rebind window.
+
+    ``validate_upstream_url`` resolves+checks before the request, but httpx re-resolves
+    at connect time — a rebind window. The fetchers must build the client with a
+    :class:`DnsPinningTransport` so the connection is pinned to a validated IP. Assert
+    on the ``transport`` kwarg passed to ``httpx.AsyncClient`` (the constructor is
+    mocked in these tests, so the transport isn't otherwise exercised here).
+    """
+    captured: dict[str, Any] = {}
+    stub = _mock_conditional_client()  # built before patching to avoid recursion
+
+    def _capturing_client(*_args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        captured["transport"] = kwargs.get("transport")
+        return stub
+
+    with patch(
+        "jentic_one.registry.services.catalog.fetch.httpx.AsyncClient",
+        side_effect=_capturing_client,
+    ):
+        await fetch_bytes_conditional("https://example.com/openapi.json", config=IngestConfig())
+    assert isinstance(captured["transport"], DnsPinningTransport)
+
+
+@pytest.mark.asyncio
+async def test_fetch_no_pinning_transport_when_disabled() -> None:
+    """With pinning disabled the client uses httpx's default transport (None)."""
+    captured: dict[str, Any] = {}
+    stub = _mock_conditional_client()  # built before patching to avoid recursion
+
+    def _capturing_client(*_args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        captured["transport"] = kwargs.get("transport")
+        return stub
+
+    cfg = IngestConfig()
+    cfg.egress.dns_pinning_enabled = False
+    with patch(
+        "jentic_one.registry.services.catalog.fetch.httpx.AsyncClient",
+        side_effect=_capturing_client,
+    ):
+        await fetch_bytes_conditional("https://example.com/openapi.json", config=cfg)
+    assert captured["transport"] is None

--- a/tests/unit/registry/services/test_catalog_supersede_gate.py
+++ b/tests/unit/registry/services/test_catalog_supersede_gate.py
@@ -1,0 +1,204 @@
+"""Unit tests for the A4b overlay-supersede gate on catalog re-import.
+
+Covers ``CatalogService._authorize_overlay_supersede`` / ``import_entry``:
+- no local API / no live confirmed overlay → ordinary import (no stamp, no refusal);
+- collision + caller holds ``overlays:confirm`` → authorized supersede stamps the job;
+- collision + caller lacks the scope → refused (403) and an operator-facing
+  ``catalog.update_conflicts_overlay`` event is re-emitted (privilege-inversion guard).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from jentic_one.registry.services.catalog.service import CatalogService
+from jentic_one.registry.services.errors import OverlaySupersedeForbiddenError
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.models.events import EventType
+
+_SVC = "jentic_one.registry.services.catalog.service"
+_API_ID = uuid.uuid4()
+_REV_ID = uuid.uuid4()
+
+
+def _make_ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.update_sweep_lock = asyncio.Lock()
+    session = AsyncMock()
+    for db in (ctx.registry_db, ctx.admin_db):
+        db.transaction.return_value.__aenter__ = AsyncMock(return_value=session)
+        db.transaction.return_value.__aexit__ = AsyncMock(return_value=False)
+        db.session.return_value.__aenter__ = AsyncMock(return_value=session)
+        db.session.return_value.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+def _entry() -> MagicMock:
+    entry = MagicMock()
+    entry.spec_url = "https://raw.githubusercontent.com/x/y/main/openapi.json"
+    entry.vendor = "acme"
+    entry.api_id = "acme.com/widgets/1.0.0"
+    return entry
+
+
+def _identity(perms: list[str]) -> Identity:
+    return Identity(sub="usr_x", email="x@test.local", permissions=perms)
+
+
+@pytest.mark.asyncio
+async def test_no_local_api_is_ordinary_import() -> None:
+    """No registered API for the spec_url → nothing to supersede, plain import."""
+    svc = CatalogService(_make_ctx())
+    with patch(
+        f"{_SVC}.ApiRevisionRepository.current_revision_for_source_url",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        result = await svc._authorize_overlay_supersede(_entry(), _identity(["catalog:import"]))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_no_live_overlay_is_ordinary_import() -> None:
+    """Current revision is not an overlay's materialization → plain import."""
+    svc = CatalogService(_make_ctx())
+    with (
+        patch(
+            f"{_SVC}.ApiRevisionRepository.current_revision_for_source_url",
+            new_callable=AsyncMock,
+            return_value=(_API_ID, _REV_ID),
+        ),
+        patch(
+            f"{_SVC}.OverlayRepository.get_live_confirmed_for_revision",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        result = await svc._authorize_overlay_supersede(_entry(), _identity(["catalog:import"]))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_collision_with_confirm_scope_authorizes_supersede() -> None:
+    """A confirm-scope holder may supersede: returns the overlay id to stamp."""
+    svc = CatalogService(_make_ctx())
+    overlay = MagicMock()
+    overlay.id = "ovr_abc"
+    with (
+        patch(
+            f"{_SVC}.ApiRevisionRepository.current_revision_for_source_url",
+            new_callable=AsyncMock,
+            return_value=(_API_ID, _REV_ID),
+        ),
+        patch(
+            f"{_SVC}.OverlayRepository.get_live_confirmed_for_revision",
+            new_callable=AsyncMock,
+            return_value=overlay,
+        ),
+        patch(f"{_SVC}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+    ):
+        result = await svc._authorize_overlay_supersede(
+            _entry(), _identity(["overlays:confirm"])
+        )
+    assert result == "ovr_abc"
+    emit.assert_not_awaited()  # authorized: no operator-facing refusal event
+
+
+@pytest.mark.asyncio
+async def test_collision_via_org_admin_authorizes_supersede() -> None:
+    """org:admin expands to overlays:confirm, so an admin may supersede too."""
+    svc = CatalogService(_make_ctx())
+    overlay = MagicMock()
+    overlay.id = "ovr_admin"
+    with (
+        patch(
+            f"{_SVC}.ApiRevisionRepository.current_revision_for_source_url",
+            new_callable=AsyncMock,
+            return_value=(_API_ID, _REV_ID),
+        ),
+        patch(
+            f"{_SVC}.OverlayRepository.get_live_confirmed_for_revision",
+            new_callable=AsyncMock,
+            return_value=overlay,
+        ),
+    ):
+        result = await svc._authorize_overlay_supersede(_entry(), _identity(["org:admin"]))
+    assert result == "ovr_admin"
+
+
+@pytest.mark.asyncio
+async def test_collision_without_scope_refuses_and_reemits() -> None:
+    """Low-privilege caller: refuse the silent revert and re-emit a conflict event."""
+    svc = CatalogService(_make_ctx())
+    overlay = MagicMock()
+    overlay.id = "ovr_xyz"
+    with (
+        patch(
+            f"{_SVC}.ApiRevisionRepository.current_revision_for_source_url",
+            new_callable=AsyncMock,
+            return_value=(_API_ID, _REV_ID),
+        ),
+        patch(
+            f"{_SVC}.OverlayRepository.get_live_confirmed_for_revision",
+            new_callable=AsyncMock,
+            return_value=overlay,
+        ),
+        patch(f"{_SVC}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+        pytest.raises(OverlaySupersedeForbiddenError),
+    ):
+        await svc._authorize_overlay_supersede(_entry(), _identity(["catalog:import"]))
+    emit.assert_awaited_once()
+    kwargs = emit.await_args.kwargs if emit.await_args else {}
+    assert kwargs["type"] == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY
+    assert kwargs["requires_action"] is True
+    assert kwargs["data"]["overlay_id"] == "ovr_xyz"
+    assert kwargs["data"]["event_class"] == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY
+
+
+@pytest.mark.asyncio
+async def test_import_entry_stamps_supersede_when_authorized() -> None:
+    """import_entry threads supersede_overlay_id + supersede_active into the job payload."""
+    svc = CatalogService(_make_ctx())
+    with (
+        patch.object(svc, "get", new_callable=AsyncMock, return_value=_entry()),
+        patch.object(
+            svc, "_authorize_overlay_supersede", new_callable=AsyncMock, return_value="ovr_1"
+        ),
+        patch.object(
+            svc,
+            "_to_import_source",
+            return_value={"type": "url", "url": "https://u", "origin": "catalog"},
+        ),
+        patch(f"{_SVC}.enqueue_job", new_callable=AsyncMock, return_value="job_1") as enqueue,
+    ):
+        job_id = await svc.import_entry("acme.com/widgets/1.0.0", _identity(["overlays:confirm"]))
+    assert job_id == "job_1"
+    payload = enqueue.await_args.kwargs["payload"]
+    assert payload["supersede_overlay_id"] == "ovr_1"
+    assert payload["sources"][0]["supersede_active"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_import_entry_ordinary_when_no_collision() -> None:
+    """No supersede → payload carries no supersede markers."""
+    svc = CatalogService(_make_ctx())
+    with (
+        patch.object(svc, "get", new_callable=AsyncMock, return_value=_entry()),
+        patch.object(
+            svc, "_authorize_overlay_supersede", new_callable=AsyncMock, return_value=None
+        ),
+        patch.object(
+            svc,
+            "_to_import_source",
+            return_value={"type": "url", "url": "https://u", "origin": "catalog"},
+        ),
+        patch(f"{_SVC}.enqueue_job", new_callable=AsyncMock, return_value="job_2") as enqueue,
+    ):
+        await svc.import_entry("acme.com/widgets/1.0.0", _identity(["catalog:import"]))
+    payload = enqueue.await_args.kwargs["payload"]
+    assert "supersede_overlay_id" not in payload
+    assert "supersede_active" not in payload["sources"][0]

--- a/tests/unit/registry/services/test_catalog_supersede_gate.py
+++ b/tests/unit/registry/services/test_catalog_supersede_gate.py
@@ -101,9 +101,7 @@ async def test_collision_with_confirm_scope_authorizes_supersede() -> None:
         ),
         patch(f"{_SVC}.emit_event_best_effort", new_callable=AsyncMock) as emit,
     ):
-        result = await svc._authorize_overlay_supersede(
-            _entry(), _identity(["overlays:confirm"])
-        )
+        result = await svc._authorize_overlay_supersede(_entry(), _identity(["overlays:confirm"]))
     assert result == "ovr_abc"
     emit.assert_not_awaited()  # authorized: no operator-facing refusal event
 
@@ -177,6 +175,7 @@ async def test_import_entry_stamps_supersede_when_authorized() -> None:
     ):
         job_id = await svc.import_entry("acme.com/widgets/1.0.0", _identity(["overlays:confirm"]))
     assert job_id == "job_1"
+    assert enqueue.await_args is not None
     payload = enqueue.await_args.kwargs["payload"]
     assert payload["supersede_overlay_id"] == "ovr_1"
     assert payload["sources"][0]["supersede_active"] == "true"
@@ -199,6 +198,7 @@ async def test_import_entry_ordinary_when_no_collision() -> None:
         patch(f"{_SVC}.enqueue_job", new_callable=AsyncMock, return_value="job_2") as enqueue,
     ):
         await svc.import_entry("acme.com/widgets/1.0.0", _identity(["catalog:import"]))
+    assert enqueue.await_args is not None
     payload = enqueue.await_args.kwargs["payload"]
     assert "supersede_overlay_id" not in payload
     assert "supersede_active" not in payload["sources"][0]

--- a/tests/unit/registry/services/test_catalog_update_notify.py
+++ b/tests/unit/registry/services/test_catalog_update_notify.py
@@ -42,7 +42,12 @@ def _make_ctx(*, interval: int = 86400) -> MagicMock:
     return ctx
 
 
-def _spec(digest: str | None = "local-digest", *, origin: str | None = "catalog") -> RegisteredSpec:
+def _spec(
+    digest: str | None = "local-digest",
+    *,
+    origin: str | None = "catalog",
+    overlay_base_digest: str | None = None,
+) -> RegisteredSpec:
     return RegisteredSpec(
         api_id=_API_ID,
         source_url="https://raw.githubusercontent.com/x/y/main/openapi.json",
@@ -51,16 +56,25 @@ def _spec(digest: str | None = "local-digest", *, origin: str | None = "catalog"
         name="widgets",
         version="1.0.0",
         origin=origin,
+        overlay_base_digest=overlay_base_digest,
     )
 
 
 def _check(
-    *, last_checked_at: datetime | None, etag: str | None, notified: str | None
+    *,
+    last_checked_at: datetime | None,
+    etag: str | None,
+    notified: str | None,
+    notified_class: str | None = EventType.CATALOG_UPDATE_AVAILABLE,
 ) -> MagicMock:
     row = MagicMock()
     row.last_checked_at = last_checked_at
     row.last_seen_etag = etag
     row.last_notified_digest = notified
+    # Default to the plain-update class so a "already notified this digest" row dedupes
+    # against a plain update (the common case). Tests exercising the overlay-conflict
+    # class pass notified_class explicitly.
+    row.last_notified_event_class = notified_class if notified is not None else None
     return row
 
 
@@ -219,6 +233,161 @@ async def test_probe_upstream_matches_registered_is_noop() -> None:
 
 
 @pytest.mark.asyncio
+async def test_probe_overlay_conflict_emits_conflict_class() -> None:
+    """Overlay-origin served revision + upstream ≠ overlay base → conflict class.
+
+    The served spec was produced by materializing an overlay over a base whose digest
+    we recorded (``overlay_base_digest``). When upstream now differs from that base,
+    adopting it would supersede the overlay, so the sweep classifies the change as
+    ``CATALOG_UPDATE_CONFLICTS_OVERLAY`` (an operator decision), not a routine update.
+    """
+    svc = CatalogService(_make_ctx())
+    overlay = MagicMock()
+    overlay.id = "ovr_live"
+    with (
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.get", new_callable=AsyncMock, return_value=None
+        ),
+        patch(
+            f"{_SWEEP}.fetch_bytes_conditional",
+            new_callable=AsyncMock,
+            return_value=ConditionalFetch(
+                not_modified=False, etag='"v2"', content=b"{}", digest="upstream-new"
+            ),
+        ),
+        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock) as upsert,
+        patch(
+            f"{_SWEEP}.OverlayRepository.get_live_confirmed_for_api",
+            new_callable=AsyncMock,
+            return_value=overlay,
+        ),
+        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+    ):
+        # Overlaid served digest is "overlaid"; the base it was built over is "base-old".
+        spec = _spec(digest="overlaid", origin="overlay", overlay_base_digest="base-old")
+        await svc._probe_one(spec, now=datetime.now(UTC), interval=86400)
+        emit.assert_awaited_once()
+        emit_kwargs = emit.await_args.kwargs if emit.await_args else {}
+        assert emit_kwargs["type"] == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY
+        assert emit_kwargs["data"]["event_class"] == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY
+        assert emit_kwargs["data"]["overlay_base_digest"] == "base-old"
+        # The conflict event deep-links to the live overlay so a UI/CLI can keep/rollback.
+        assert emit_kwargs["data"]["overlay_id"] == "ovr_live"
+        upsert_kwargs = upsert.await_args.kwargs if upsert.await_args else {}
+        assert upsert_kwargs["notified_event_class"] == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY
+
+
+@pytest.mark.asyncio
+async def test_probe_overlay_upstream_matches_base_is_plain_noop() -> None:
+    """Overlay-origin, but upstream still equals the overlay's base → no conflict.
+
+    If upstream matches the base the overlay was built on, the operator's fix is still
+    valid against the current upstream — there's nothing to reconcile. (Here upstream
+    also equals the served digest, so it's a full no-op; the point is that base-equality
+    never yields the conflict class.)
+    """
+    svc = CatalogService(_make_ctx())
+    with (
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.get", new_callable=AsyncMock, return_value=None
+        ),
+        patch(
+            f"{_SWEEP}.fetch_bytes_conditional",
+            new_callable=AsyncMock,
+            return_value=ConditionalFetch(
+                not_modified=False, etag='"v1"', content=b"{}", digest="base-old"
+            ),
+        ),
+        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
+        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+    ):
+        spec = _spec(digest="overlaid", origin="overlay", overlay_base_digest="base-old")
+        await svc._probe_one(spec, now=datetime.now(UTC), interval=86400)
+        # Upstream == base != served("overlaid"); classified plain-update, and it emits
+        # once (a genuine change vs the served spec) — never the conflict class.
+        emit.assert_awaited_once()
+        emit_kwargs = emit.await_args.kwargs if emit.await_args else {}
+        assert emit_kwargs["type"] == EventType.CATALOG_UPDATE_AVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_probe_overlay_unknown_base_falls_back_to_plain() -> None:
+    """A pre-A2 overlay revision (NULL base digest) can't prove a conflict → plain class.
+
+    We can't assert the upstream collides with the overlay's base when we never recorded
+    that base, so the safe fallback is the non-alarming plain-update class. The column
+    self-heals on the next re-materialize.
+    """
+    svc = CatalogService(_make_ctx())
+    with (
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.get", new_callable=AsyncMock, return_value=None
+        ),
+        patch(
+            f"{_SWEEP}.fetch_bytes_conditional",
+            new_callable=AsyncMock,
+            return_value=ConditionalFetch(
+                not_modified=False, etag='"v2"', content=b"{}", digest="upstream-new"
+            ),
+        ),
+        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
+        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+    ):
+        spec = _spec(digest="overlaid", origin="overlay", overlay_base_digest=None)
+        await svc._probe_one(spec, now=datetime.now(UTC), interval=86400)
+        emit.assert_awaited_once()
+        emit_kwargs = emit.await_args.kwargs if emit.await_args else {}
+        assert emit_kwargs["type"] == EventType.CATALOG_UPDATE_AVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_probe_reclassified_digest_re_emits_once() -> None:
+    """Same digest, different class → the widened dedupe key re-fires exactly once.
+
+    A digest previously notified as a plain update can later re-classify (e.g. the served
+    revision becomes an overlay whose base the upstream now collides with). Deduping on
+    the digest alone would wrongly swallow the conflict; deduping on
+    ``(digest, event_class)`` lets the new class fire once.
+    """
+    svc = CatalogService(_make_ctx())
+    with (
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.get",
+            new_callable=AsyncMock,
+            # Already notified this exact digest, but under the plain-update class.
+            return_value=_check(
+                last_checked_at=None,
+                etag=None,
+                notified="upstream-new",
+                notified_class=EventType.CATALOG_UPDATE_AVAILABLE,
+            ),
+        ),
+        patch(
+            f"{_SWEEP}.fetch_bytes_conditional",
+            new_callable=AsyncMock,
+            return_value=ConditionalFetch(
+                not_modified=False, etag='"v2"', content=b"{}", digest="upstream-new"
+            ),
+        ),
+        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock) as upsert,
+        patch(
+            f"{_SWEEP}.OverlayRepository.get_live_confirmed_for_api",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+    ):
+        # Now overlay-origin with a base the upstream digest differs from → conflict class.
+        spec = _spec(digest="overlaid", origin="overlay", overlay_base_digest="base-old")
+        await svc._probe_one(spec, now=datetime.now(UTC), interval=86400)
+        emit.assert_awaited_once()
+        emit_kwargs = emit.await_args.kwargs if emit.await_args else {}
+        assert emit_kwargs["type"] == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY
+        upsert_kwargs = upsert.await_args.kwargs if upsert.await_args else {}
+        assert upsert_kwargs["notified_event_class"] == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY
+
+
+@pytest.mark.asyncio
 async def test_sweep_isolates_per_api_failures() -> None:
     """A probe that raises for one API does not abort the rest of the sweep."""
     svc = CatalogService(_make_ctx())
@@ -238,6 +407,7 @@ async def test_sweep_isolates_per_api_failures() -> None:
 
 def test_catalog_update_event_in_all_frozenset() -> None:
     assert EventType.CATALOG_UPDATE_AVAILABLE in EventType.ALL
+    assert EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY in EventType.ALL
 
 
 @pytest.mark.asyncio

--- a/tests/unit/shared/auth/test_permissions.py
+++ b/tests/unit/shared/auth/test_permissions.py
@@ -1,0 +1,22 @@
+"""Unit tests for the shared permission-expansion helper."""
+
+from __future__ import annotations
+
+from jentic_one.shared.auth.permissions import has_effective_permission
+
+
+def test_direct_grant_matches() -> None:
+    assert has_effective_permission(["overlays:confirm"], "overlays:confirm") is True
+
+
+def test_missing_grant_does_not_match() -> None:
+    assert has_effective_permission(["catalog:import"], "overlays:confirm") is False
+
+
+def test_org_admin_expands_to_confirm() -> None:
+    # org:admin implies overlays:confirm via the implication map.
+    assert has_effective_permission(["org:admin"], "overlays:confirm") is True
+
+
+def test_empty_grants() -> None:
+    assert has_effective_permission([], "overlays:confirm") is False

--- a/tests/unit/shared/test_egress.py
+++ b/tests/unit/shared/test_egress.py
@@ -1,0 +1,33 @@
+"""Unit tests for the shared egress helper ``build_pinned_transport``.
+
+The DNS-pinning transport itself is exercised in ``tests/unit/broker/test_dns_pin.py``
+(via the broker re-export). These pin the shared ``build_pinned_transport`` contract
+that the registry fetchers rely on: enabled → a pinning transport, disabled/None → the
+default (``None``) so httpx behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+from jentic_one.broker.adapters import egress as broker_egress
+from jentic_one.shared.config import EgressConfig
+from jentic_one.shared.egress import DnsPinningTransport, build_pinned_transport
+
+
+def test_build_pinned_transport_enabled_returns_pinning_transport() -> None:
+    transport = build_pinned_transport(EgressConfig(dns_pinning_enabled=True))
+    assert isinstance(transport, DnsPinningTransport)
+
+
+def test_build_pinned_transport_disabled_returns_none() -> None:
+    assert build_pinned_transport(EgressConfig(dns_pinning_enabled=False)) is None
+
+
+def test_build_pinned_transport_none_egress_returns_none() -> None:
+    # No egress policy → no pin (httpx default transport), unchanged behaviour.
+    assert build_pinned_transport(None) is None
+
+
+def test_broker_reexport_is_the_same_object() -> None:
+    """The broker adapter must re-export the shared symbols (single implementation)."""
+    assert broker_egress.DnsPinningTransport is DnsPinningTransport
+    assert broker_egress.build_pinned_transport is build_pinned_transport

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -15102,6 +15102,172 @@
         ]
       }
     },
+    "/apis/{vendor}/{name}/{version}/overlays/{overlay_id}:rollback": {
+      "post": {
+        "description": "Un-confirm a materialized overlay, restoring the revision it superseded (A5b).\n\nRequires ``overlays:confirm`` — the symmetric inverse of confirm. Rolling back\nrewrites the API's served spec (it archives the overlay's materialized revision and\npromotes the prior revision back to current), so it is the same operator action as\nconfirm, not a contributor one. The overlay must be CONFIRMED, currently live, and\ncarry a recorded superseded revision that is still restorable; otherwise a 409 is\nreturned (``overlay_conflict`` or ``overlay_rollback_target_missing``) and nothing\nchanges.",
+        "operationId": "rollbackOverlay",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vendor",
+            "required": true,
+            "schema": {
+              "title": "Vendor",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "title": "Version",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "overlay_id",
+            "required": true,
+            "schema": {
+              "title": "Overlay Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The request was malformed or failed a precondition.",
+                  "instance": "/example/path",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "type": "bad_request"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Authentication is required or the bearer token is invalid.",
+                  "instance": "/example/path",
+                  "status": 401,
+                  "title": "Unauthorized",
+                  "type": "unauthorized"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The authenticated principal lacks the required permission.",
+                  "instance": "/example/path",
+                  "status": 403,
+                  "title": "Forbidden",
+                  "type": "forbidden"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Request validation failed; see errors[] for details.",
+                  "errors": [
+                    {
+                      "detail": "Field 'name' must not be blank.",
+                      "pointer": "#/name"
+                    }
+                  ],
+                  "instance": "/example/path",
+                  "status": 422,
+                  "title": "Unprocessable Entity",
+                  "type": "validation_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "An unexpected error occurred.",
+                  "instance": "/example/path",
+                  "status": 500,
+                  "title": "Internal Server Error",
+                  "type": "server_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The database is temporarily unavailable; please retry.",
+                  "instance": "/example/path",
+                  "status": 503,
+                  "title": "Service Unavailable",
+                  "type": "database_unavailable"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Rollback Overlay",
+        "tags": [
+          "Overlays"
+        ]
+      }
+    },
     "/apis/{vendor}/{name}/{version}/revisions": {
       "get": {
         "description": "List revisions for an API with optional state filter and cursor pagination.",

--- a/ui/src/shared/api/generated/services/OverlaysService.ts
+++ b/ui/src/shared/api/generated/services/OverlaysService.ts
@@ -252,4 +252,48 @@ export class OverlaysService {
             },
         });
     }
+    /**
+     * Rollback Overlay
+     * Un-confirm a materialized overlay, restoring the revision it superseded (A5b).
+     *
+     * Requires ``overlays:confirm`` — the symmetric inverse of confirm. Rolling back
+     * rewrites the API's served spec (it archives the overlay's materialized revision and
+     * promotes the prior revision back to current), so it is the same operator action as
+     * confirm, not a contributor one. The overlay must be CONFIRMED, currently live, and
+     * carry a recorded superseded revision that is still restorable; otherwise a 409 is
+     * returned (``overlay_conflict`` or ``overlay_rollback_target_missing``) and nothing
+     * changes.
+     * @returns void
+     * @throws ApiError
+     */
+    public static rollbackOverlay({
+        vendor,
+        name,
+        version,
+        overlayId,
+    }: {
+        vendor: string,
+        name: string,
+        version: string,
+        overlayId: string,
+    }): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/apis/{vendor}/{name}/{version}/overlays/{overlay_id}:rollback',
+            path: {
+                'vendor': vendor,
+                'name': name,
+                'version': version,
+                'overlay_id': overlayId,
+            },
+            errors: {
+                400: `Bad Request`,
+                401: `Unauthorized`,
+                403: `Forbidden`,
+                422: `Unprocessable Entity`,
+                500: `Internal Server Error`,
+                503: `Service Unavailable`,
+            },
+        });
+    }
 }


### PR DESCRIPTION
## Summary

Finishes the Flow-3 / overlay loop end-to-end. **The loop:** an operator/agent contributes a spec fix as an **overlay** → it **materializes** onto the served spec → later the **upstream spec changes** → the system **detects it, reports it truthfully, and lets someone reconcile it** — without silently destroying the fix or misreporting served state.

The forward half + detection already merged (#904 materialization · #912 scanner + "update available" surfaces · #916 `overlays:confirm` gate · #918 `superseded_revision_id`). This PR lands the **must-haves** that make the *reconciliation* half correct, safe, and discoverable. Should-/nice-to-haves are filed as issues under epic #919 for a follow-up PR.

```mermaid
flowchart TD
    A[Agent/operator submits overlay] --> B[Confirm → materialize onto served spec]
    B --> C[Scanner re-fetches upstream on a schedule]
    C --> D{Upstream vs overlay BASE digest}
    D -- unchanged --> E[No event: served fix still valid]
    D -- changed --> F[Emit catalog.update_conflicts_overlay w/ overlay_id]
    F --> G{Reconcile}
    G -- keep fix --> H[Rollback stays / ignore upstream]
    G -- adopt upstream --> I{Caller holds overlays:confirm?}
    I -- no --> J[403 refuse + re-emit conflict for an operator]
    I -- yes --> K[Re-import supersedes: auto-deprecate overlay via CAS, settle event]
    K --> L[Served spec = fresh upstream]
    H --> M[Rollback restores superseded revision under CAS]
```

## What & why (each is must-have — without it the loop is incorrect, unsafe, or undiscoverable)

- **A2 — base-digest column + widened dedupe key.** An overlaid revision inherits the base `source_url`, so the scanner was comparing upstream against the **overlaid** digest and couldn't distinguish "no real change" from "a real conflict". Persists nullable `overlay_base_digest` on the materialized `api_revisions` row, read column-directly in the sweep's single query (no *extra* join to fetch the base digest — the served revision row already carries it), and widens the sweep dedupe key `last_notified_digest` → `(last_notified_digest, event_class)`.
- **A3 — scanner classification.** Threads `overlay_base_digest` into `RegisteredSpec`; `_probe_one` branches on `origin == ORIGIN_OVERLAY` to diff upstream vs **base**. Overlaid + unchanged-vs-base ⇒ no event; changed-vs-base ⇒ one `catalog.update_conflicts_overlay` carrying the `overlay_id` for deep-linking.
- **L5 — DNS-pin the scanner/ingest fetchers.** A3 adds a *recurring* re-fetch of overlay-origin URLs, widening the DNS-rebind TOCTOU surface. Promotes `DnsPinningTransport` to a shared module and pins both registry fetch paths.
- **A4a/b/c — re-import reconciliation (the security-critical item, privilege inversion).** `catalog:import` is a *default agent scope*, so a low-priv re-import could silently revert an operator's security-fix overlay. An overlay-**superseding** re-import now requires `overlays:confirm`; if the caller lacks it we **refuse and re-emit `conflicts_overlay`** for an operator. On an authorized supersede we auto-deprecate the overlay via CAS in the re-ingest txn and settle the actionable event best-effort (reconcile-from-committed-state; crash-recovery keyed on the source URL).
- **A5b — CAS-guarded un-confirm / rollback.** Restores the `superseded_revision_id` back to current under a CAS on `Api.current_revision_id` + `ix_api_revisions_one_active`, so an auto-deprecate can never strand the served spec.
- **SKILL — teach agents the loop.** Extends `contribute-spec-fix` with the update/conflict-reaction section (submit overlay, what `overlays:confirm` means, react to `update_available` vs `conflicts_overlay`).

Also adds `shared/auth/permissions.has_effective_permission` so the registry checks effective permissions without importing `admin` directly (respects the module boundary).

## Migration

One registry migration (`b3c4d5e6f7a8`) chained onto the merged head: adds nullable `api_revisions.overlay_base_digest` and `catalog_update_checks.last_notified_event_class`. Nullable, **no backfill** — NULL preserves current behaviour and self-heals on the next re-materialize / sweep.

## Test plan

- [x] `ruff` + `mypy` clean; **266 arch tests** pass (incl. the tightened no-manual-commit rule).
- [x] **654 registry unit + integration tests** pass on SQLite (1 Postgres-only skip).
- [x] New coverage: supersede gate, DNS-pin egress, effective-permission helper, supersede crash-recovery (URL-keyed), sweep `overlay_id` enrichment, and a repo regression test for the lazy `confirmed_revision_id` link window.
- [x] **Manual end-to-end flywheel** against a live app (SQLite) + a local upstream host — **0 failures** across the full loop: import → `update_available` detect/adopt/settle → overlay submit+confirm+materialize → upstream diverges → `conflicts_overlay` fires with `overlay_id` → low-scope adopt refused (`403 overlay_supersede_forbidden`, fix preserved) → rollback restores the superseded revision. This caught a real bug (the sweep dropped `overlay_id` because the lookup keyed on the lazily-linked `confirmed_revision_id`; now keyed on `(api_id, status==CONFIRMED)`).

## Related

- Second half of the two-PR plan: should-/nice-to-haves are tracked under epic #919 (children #920–#929) for a follow-up PR.
- Builds on #904 · #912 · #916 · #918.

Made with [Cursor](https://cursor.com)
