### PR TITLE
feat(cli): guard docker runtime commands against a stopped daemon

### DIFF
--- a/cli/internal/cmd/docker_guard.go
+++ b/cli/internal/cmd/docker_guard.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/jentic/jentic-one/cli/internal/install"
+	"github.com/jentic/jentic-one/cli/internal/theme"
+)
+
+// requireDockerDaemon guards the Docker-backed commands (`start`, `stop`,
+// `update`, `setup`, `reset-password`) against a stopped daemon, surfacing
+// actionable recovery guidance instead of a raw `docker compose` transport
+// error. It is a package-level seam so tests can simulate an up/down daemon
+// without a real Docker (#783, jentic-api-scorecard#224).
+//
+// It can block up to ~30s while the underlying probe waits out a cold-starting
+// daemon, so callers must announce the check first (via announceDaemonCheck)
+// or the command looks like it hung. Tests that swap this global must not run
+// with t.Parallel().
+var requireDockerDaemon = install.RequireDockerDaemon
+
+// composeUp / composeDown / composeDownVolumes are package-level seams over the
+// install package's docker-compose helpers so the Docker-backed commands can be
+// tested (guard pass-through, output) without shelling out to a real Docker.
+// Tests that swap these globals must not run with t.Parallel().
+var (
+	composeUp          = install.ComposeUp
+	composeDown        = install.ComposeDown
+	composeDownVolumes = install.ComposeDownVolumes
+)
+
+// daemonCheckMsg is the single announce line every Docker-backed command prints
+// before requireDockerDaemon, so the ~30s cold-start wait doesn't look like a
+// hang. Kept in one place so the wording (and the advertised window) can't
+// drift between commands.
+const daemonCheckMsg = "Checking the Docker daemon (waiting up to ~30s if it is still starting) ..."
+
+// announceDaemonCheck prints daemonCheckMsg. Call it immediately before
+// requireDockerDaemon on any command that probes the daemon.
+func announceDaemonCheck(w io.Writer) {
+	fmt.Fprintln(w, theme.Infof(daemonCheckMsg))
+}

--- a/cli/internal/cmd/doctor.go
+++ b/cli/internal/cmd/doctor.go
@@ -215,7 +215,7 @@ func (d *doctor) checkDeploy(section string) {
 		// than inferred from a cryptic `docker compose ps` error (#783).
 		if detail, healthy := dockerDaemonProbe(); !healthy {
 			d.add(section, "docker daemon", statusFail, detail,
-				"start Docker Desktop (or your docker daemon), then `jenticctl start`")
+				"start it with `docker desktop start` (or open Docker Desktop), then `jenticctl start`")
 			return
 		}
 		out, err := install.ComposePs(composePath)

--- a/cli/internal/cmd/doctor.go
+++ b/cli/internal/cmd/doctor.go
@@ -198,9 +198,26 @@ func (d *doctor) checkServer() {
 	d.checkDeploy(section)
 }
 
+// dockerDaemonProbe is the seam doctor's deploy check runs through so tests can
+// simulate a stopped daemon without a real Docker. It returns a short reason
+// (empty when healthy) and whether the daemon answered. It is a fast,
+// single-round-trip probe: doctor is read-only and must not block for the full
+// cold-start polling window when the daemon is simply down.
+var dockerDaemonProbe = func() (string, bool) {
+	return install.DockerDaemonResponsiveQuick(2 * time.Second)
+}
+
 func (d *doctor) checkDeploy(section string) {
 	composePath := d.app.Paths.ComposePath()
 	if proc.FileExists(composePath) {
+		// A compose install needs a live daemon. Probe it directly so a stopped
+		// Docker Desktop is reported as an explicit, actionable failure rather
+		// than inferred from a cryptic `docker compose ps` error (#783).
+		if detail, healthy := dockerDaemonProbe(); !healthy {
+			d.add(section, "docker daemon", statusFail, detail,
+				"start Docker Desktop (or your docker daemon), then `jenticctl start`")
+			return
+		}
 		out, err := install.ComposePs(composePath)
 		if err != nil {
 			d.add(section, "deploy", statusWarn, "docker compose ps failed: "+err.Error(), "is the Docker daemon running?")

--- a/cli/internal/cmd/doctor.go
+++ b/cli/internal/cmd/doctor.go
@@ -198,12 +198,13 @@ func (d *doctor) checkServer() {
 	d.checkDeploy(section)
 }
 
-// dockerDaemonProbe is the seam doctor's deploy check runs through so tests can
+// doctorDockerProbe is the seam doctor's deploy check runs through so tests can
 // simulate a stopped daemon without a real Docker. It returns a short reason
 // (empty when healthy) and whether the daemon answered. It is a fast,
-// single-round-trip probe: doctor is read-only and must not block for the full
-// cold-start polling window when the daemon is simply down.
-var dockerDaemonProbe = func() (string, bool) {
+// single-round-trip probe (distinct from install's ~30s polling probe): doctor
+// is read-only and must not block for the full cold-start window when the daemon
+// is simply down.
+var doctorDockerProbe = func() (string, bool) {
 	return install.DockerDaemonResponsiveQuick(2 * time.Second)
 }
 
@@ -211,11 +212,14 @@ func (d *doctor) checkDeploy(section string) {
 	composePath := d.app.Paths.ComposePath()
 	if proc.FileExists(composePath) {
 		// A compose install needs a live daemon. Probe it directly so a stopped
-		// Docker Desktop is reported as an explicit, actionable failure rather
-		// than inferred from a cryptic `docker compose ps` error (#783).
-		if detail, healthy := dockerDaemonProbe(); !healthy {
-			d.add(section, "docker daemon", statusFail, detail,
-				"start it with `docker desktop start` (or open Docker Desktop), then `jenticctl start`")
+		// daemon is reported explicitly rather than inferred from a cryptic
+		// `docker compose ps` error (#783). Keep it a warning, not a fail: doctor
+		// is documented as safe to wire into CI ("warnings keep a zero exit"),
+		// and the sibling `control`/`compose ps` checks also warn on a
+		// not-running dependency — a down daemon shouldn't flip the exit code.
+		if detail, healthy := doctorDockerProbe(); !healthy {
+			d.add(section, "docker daemon", statusWarn, detail,
+				install.DockerDaemonRecoveryHint()+", then `jenticctl start`")
 			return
 		}
 		out, err := install.ComposePs(composePath)

--- a/cli/internal/cmd/doctor.go
+++ b/cli/internal/cmd/doctor.go
@@ -224,7 +224,8 @@ func (d *doctor) checkDeploy(section string) {
 		}
 		out, err := install.ComposePs(composePath)
 		if err != nil {
-			d.add(section, "deploy", statusWarn, "docker compose ps failed: "+err.Error(), "is the Docker daemon running?")
+			d.add(section, "deploy", statusWarn, "docker compose ps failed: "+err.Error(),
+				install.DockerDaemonRecoveryHint())
 			return
 		}
 		d.add(section, "deploy", statusPass, "docker compose ("+composeSummary(out)+")", "")

--- a/cli/internal/cmd/doctor_test.go
+++ b/cli/internal/cmd/doctor_test.go
@@ -127,7 +127,7 @@ func TestDoctorReportsDockerDaemonDown(t *testing.T) {
 	_ = app.doctorE(context.Background(), offlineOpts())
 
 	got := app.Out.(*bytes.Buffer).String()
-	for _, want := range []string{"docker daemon", "Cannot connect to the Docker daemon", "start Docker Desktop"} {
+	for _, want := range []string{"docker daemon", "Cannot connect to the Docker daemon", "docker desktop start"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("doctor output missing %q\n---\n%s", want, got)
 		}

--- a/cli/internal/cmd/doctor_test.go
+++ b/cli/internal/cmd/doctor_test.go
@@ -112,24 +112,34 @@ func TestDotFor(t *testing.T) {
 }
 
 // With a compose install and a stopped daemon, doctor reports an explicit,
-// actionable "docker daemon" failure rather than inferring it from a cryptic
-// `docker compose ps` error (#783).
+// actionable "docker daemon" warning rather than inferring it from a cryptic
+// `docker compose ps` error (#783). It stays a warning (not a fail) so doctor
+// keeps a zero exit — safe to wire into CI — and it returns before touching real
+// `docker compose ps`.
 func TestDoctorReportsDockerDaemonDown(t *testing.T) {
-	orig := dockerDaemonProbe
-	t.Cleanup(func() { dockerDaemonProbe = orig })
-	dockerDaemonProbe = func() (string, bool) { return "Cannot connect to the Docker daemon", false }
+	orig := doctorDockerProbe
+	t.Cleanup(func() { doctorDockerProbe = orig })
+	doctorDockerProbe = func() (string, bool) { return "Cannot connect to the Docker daemon", false }
 
 	app := testApp(t)
 	if err := os.WriteFile(app.Paths.ComposePath(), []byte("services: {}\n"), 0o600); err != nil {
 		t.Fatalf("write compose: %v", err)
 	}
-	// A failing check makes doctor exit non-zero; the error is expected here.
-	_ = app.doctorE(context.Background(), offlineOpts())
+	// A down daemon is a warning, not a failure, so doctor must still exit zero.
+	if err := app.doctorE(context.Background(), offlineOpts()); err != nil {
+		t.Fatalf("a down daemon should warn, not fail doctor; got error: %v", err)
+	}
 
 	got := app.Out.(*bytes.Buffer).String()
-	for _, want := range []string{"docker daemon", "Cannot connect to the Docker daemon", "docker desktop start"} {
+	for _, want := range []string{"docker daemon", "Cannot connect to the Docker daemon", "docker desktop start", "colima start"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("doctor output missing %q\n---\n%s", want, got)
+		}
+	}
+	// The check must return early, never falling through to real `docker compose ps`.
+	for _, absent := range []string{"docker compose ps failed", "docker compose ("} {
+		if strings.Contains(got, absent) {
+			t.Errorf("doctor should not reach `docker compose ps` when the daemon is down; saw %q\n---\n%s", absent, got)
 		}
 	}
 }

--- a/cli/internal/cmd/doctor_test.go
+++ b/cli/internal/cmd/doctor_test.go
@@ -111,11 +111,12 @@ func TestDotFor(t *testing.T) {
 	}
 }
 
-// With a compose install and a stopped daemon, doctor reports an explicit,
-// actionable "docker daemon" warning rather than inferring it from a cryptic
-// `docker compose ps` error (#783). It stays a warning (not a fail) so doctor
-// keeps a zero exit — safe to wire into CI — and it returns before touching real
-// `docker compose ps`.
+// With a compose install and a stopped daemon, the deploy check records an
+// explicit, actionable "docker daemon" WARNING (not a fail) rather than
+// inferring it from a cryptic `docker compose ps` error (#783). Keeping it a
+// warning is what lets doctor stay a zero-exit, CI-safe diagnostic. We assert on
+// the specific check rather than doctor's aggregate exit, since other checks'
+// severity varies by environment (e.g. CI vs a dev box).
 func TestDoctorReportsDockerDaemonDown(t *testing.T) {
 	orig := doctorDockerProbe
 	t.Cleanup(func() { doctorDockerProbe = orig })
@@ -125,21 +126,35 @@ func TestDoctorReportsDockerDaemonDown(t *testing.T) {
 	if err := os.WriteFile(app.Paths.ComposePath(), []byte("services: {}\n"), 0o600); err != nil {
 		t.Fatalf("write compose: %v", err)
 	}
-	// A down daemon is a warning, not a failure, so doctor must still exit zero.
-	if err := app.doctorE(context.Background(), offlineOpts()); err != nil {
-		t.Fatalf("a down daemon should warn, not fail doctor; got error: %v", err)
-	}
 
-	got := app.Out.(*bytes.Buffer).String()
-	for _, want := range []string{"docker daemon", "Cannot connect to the Docker daemon", "docker desktop start", "colima start"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("doctor output missing %q\n---\n%s", want, got)
+	d := &doctor{app: app}
+	d.checkDeploy("Server")
+
+	var daemon *check
+	for i := range d.checks {
+		if d.checks[i].name == "docker daemon" {
+			daemon = &d.checks[i]
+			break
+		}
+	}
+	if daemon == nil {
+		t.Fatalf("deploy check did not record a `docker daemon` row: %+v", d.checks)
+	}
+	if daemon.status != statusWarn {
+		t.Errorf("down daemon should be statusWarn (CI-safe, zero exit), got %v", daemon.status)
+	}
+	if !strings.Contains(daemon.detail, "Cannot connect to the Docker daemon") {
+		t.Errorf("daemon detail = %q, want the probe's reason", daemon.detail)
+	}
+	for _, want := range []string{"docker desktop start", "colima start"} {
+		if !strings.Contains(daemon.hint, want) {
+			t.Errorf("daemon hint missing %q: %q", want, daemon.hint)
 		}
 	}
 	// The check must return early, never falling through to real `docker compose ps`.
-	for _, absent := range []string{"docker compose ps failed", "docker compose ("} {
-		if strings.Contains(got, absent) {
-			t.Errorf("doctor should not reach `docker compose ps` when the daemon is down; saw %q\n---\n%s", absent, got)
+	for i := range d.checks {
+		if d.checks[i].name == "deploy" {
+			t.Errorf("deploy check should return early on a down daemon, not record a `deploy` row: %+v", d.checks[i])
 		}
 	}
 }

--- a/cli/internal/cmd/doctor_test.go
+++ b/cli/internal/cmd/doctor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -107,6 +108,29 @@ func TestDotFor(t *testing.T) {
 	}
 	if dotFor(statusFail) != dotFail() {
 		t.Error("statusFail should map to dotFail")
+	}
+}
+
+// With a compose install and a stopped daemon, doctor reports an explicit,
+// actionable "docker daemon" failure rather than inferring it from a cryptic
+// `docker compose ps` error (#783).
+func TestDoctorReportsDockerDaemonDown(t *testing.T) {
+	orig := dockerDaemonProbe
+	t.Cleanup(func() { dockerDaemonProbe = orig })
+	dockerDaemonProbe = func() (string, bool) { return "Cannot connect to the Docker daemon", false }
+
+	app := testApp(t)
+	if err := os.WriteFile(app.Paths.ComposePath(), []byte("services: {}\n"), 0o600); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	// A failing check makes doctor exit non-zero; the error is expected here.
+	_ = app.doctorE(context.Background(), offlineOpts())
+
+	got := app.Out.(*bytes.Buffer).String()
+	for _, want := range []string{"docker daemon", "Cannot connect to the Docker daemon", "start Docker Desktop"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("doctor output missing %q\n---\n%s", want, got)
+		}
 	}
 }
 

--- a/cli/internal/cmd/reset-password.go
+++ b/cli/internal/cmd/reset-password.go
@@ -45,6 +45,20 @@ func newResetPasswordCmd(app *App) *cobra.Command {
 }
 
 func (a *App) resetPasswordE(opts *resetPasswordOptions) error {
+	// A generated compose file marks a Docker install: the reset runs in a
+	// one-shot app container. Probe the daemon up front — before prompting for
+	// credentials — so a user on a stopped daemon isn't asked to type an email
+	// and password only to be told the daemon is down afterwards. The probe may
+	// poll (~30s) for a cold-starting daemon, so announce it (see start.go).
+	composePath := a.Paths.ComposePath()
+	dockerInstall := proc.FileExists(composePath)
+	if dockerInstall {
+		announceDaemonCheck(a.Out)
+		if err := requireDockerDaemon("jenticctl reset-password"); err != nil {
+			return err
+		}
+	}
+
 	prompt := credentialPrompt{
 		heading:       "Reset a user's password",
 		subheading:    "Set a one-time temporary password. The user must change it at next sign-in.",
@@ -68,17 +82,7 @@ func (a *App) resetPasswordE(opts *resetPasswordOptions) error {
 
 	fmt.Fprintln(a.Out, theme.Infof("Setting a temporary password for %s ...", opts.email))
 
-	// A generated compose file marks a Docker install: reset inside a one-shot
-	// app container. Otherwise drive the local venv directly.
-	composePath := a.Paths.ComposePath()
-	if proc.FileExists(composePath) {
-		// The reset runs in a one-shot app container, so a stopped daemon would
-		// otherwise surface a raw compose error. Announce the probe first since
-		// it may poll (~30s) for a cold-starting daemon (see start.go).
-		fmt.Fprintln(a.Out, theme.Infof("Checking the Docker daemon (waiting up to ~30s if it is still starting) ..."))
-		if err := requireDockerDaemon("jenticctl reset-password"); err != nil {
-			return err
-		}
+	if dockerInstall {
 		if err := install.ComposeResetPassword(a.Out, composePath, opts.email, opts.password); err != nil {
 			return fmt.Errorf("reset password (docker): %w", err)
 		}

--- a/cli/internal/cmd/reset-password.go
+++ b/cli/internal/cmd/reset-password.go
@@ -72,6 +72,13 @@ func (a *App) resetPasswordE(opts *resetPasswordOptions) error {
 	// app container. Otherwise drive the local venv directly.
 	composePath := a.Paths.ComposePath()
 	if proc.FileExists(composePath) {
+		// The reset runs in a one-shot app container, so a stopped daemon would
+		// otherwise surface a raw compose error. Announce the probe first since
+		// it may poll (~30s) for a cold-starting daemon (see start.go).
+		fmt.Fprintln(a.Out, theme.Infof("Checking the Docker daemon (waiting up to ~30s if it is still starting) ..."))
+		if err := requireDockerDaemon("jenticctl reset-password"); err != nil {
+			return err
+		}
 		if err := install.ComposeResetPassword(a.Out, composePath, opts.email, opts.password); err != nil {
 			return fmt.Errorf("reset password (docker): %w", err)
 		}

--- a/cli/internal/cmd/reset-password_test.go
+++ b/cli/internal/cmd/reset-password_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"bytes"
+	"errors"
+	"os"
 	"strings"
 	"testing"
 )
@@ -53,5 +56,28 @@ func TestResetPasswordRequiresInstall(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "install") {
 		t.Errorf("error = %q, want it to point at `jenticctl install`", err.Error())
+	}
+}
+
+// A Docker install (compose file present) with a stopped daemon must fail fast
+// with the guard's actionable error, before the one-shot reset container is
+// started (which would otherwise surface a raw compose transport error).
+func TestResetPasswordDockerFailsFastWhenDaemonDown(t *testing.T) {
+	app := testApp(t)
+	if err := os.WriteFile(app.Paths.ComposePath(), []byte("services: {}\n"), 0o600); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	sentinel := stubDaemonDown(t)
+
+	err := app.resetPasswordE(&resetPasswordOptions{
+		yes:      true,
+		email:    "user@example.com",
+		password: "a-strong-password",
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("reset-password should surface the daemon guard error, got %v", err)
+	}
+	if got := app.Out.(*bytes.Buffer).String(); strings.Contains(got, "Temporary password set") {
+		t.Errorf("reset-password ran past the guard when the daemon was down:\n%s", got)
 	}
 }

--- a/cli/internal/cmd/setup.go
+++ b/cli/internal/cmd/setup.go
@@ -47,6 +47,20 @@ func newSetupCmd(app *App) *cobra.Command {
 }
 
 func (a *App) setupE(opts *setupOptions) error {
+	// A generated compose file marks a Docker install: the admin is created in a
+	// one-shot app container. Probe the daemon up front — before prompting for
+	// credentials — so a user on a stopped daemon isn't asked to type an email
+	// and password only to be told the daemon is down afterwards. The probe may
+	// poll (~30s) for a cold-starting daemon, so announce it (see start.go).
+	composePath := a.Paths.ComposePath()
+	dockerInstall := proc.FileExists(composePath)
+	if dockerInstall {
+		announceDaemonCheck(a.Out)
+		if err := requireDockerDaemon("jenticctl setup"); err != nil {
+			return err
+		}
+	}
+
 	prompt := credentialPrompt{
 		heading:       "First-run setup",
 		subheading:    "Create the first administrator. This runs once; afterwards manage users in the UI.",
@@ -70,17 +84,7 @@ func (a *App) setupE(opts *setupOptions) error {
 
 	fmt.Fprintln(a.Out, theme.Infof("Creating the first admin account ..."))
 
-	// A generated compose file marks a Docker install: create the admin in a
-	// one-shot app container. Otherwise drive the local venv directly.
-	composePath := a.Paths.ComposePath()
-	if proc.FileExists(composePath) {
-		// The admin is created in a one-shot app container, so a stopped daemon
-		// would otherwise surface a raw compose error. Announce the probe first
-		// since it may poll (~30s) for a cold-starting daemon (see start.go).
-		fmt.Fprintln(a.Out, theme.Infof("Checking the Docker daemon (waiting up to ~30s if it is still starting) ..."))
-		if err := requireDockerDaemon("jenticctl setup"); err != nil {
-			return err
-		}
+	if dockerInstall {
 		if err := install.ComposeCreateAdmin(a.Out, composePath, opts.email, opts.password); err != nil {
 			return fmt.Errorf("create admin (docker): %w", err)
 		}

--- a/cli/internal/cmd/setup.go
+++ b/cli/internal/cmd/setup.go
@@ -74,6 +74,13 @@ func (a *App) setupE(opts *setupOptions) error {
 	// one-shot app container. Otherwise drive the local venv directly.
 	composePath := a.Paths.ComposePath()
 	if proc.FileExists(composePath) {
+		// The admin is created in a one-shot app container, so a stopped daemon
+		// would otherwise surface a raw compose error. Announce the probe first
+		// since it may poll (~30s) for a cold-starting daemon (see start.go).
+		fmt.Fprintln(a.Out, theme.Infof("Checking the Docker daemon (waiting up to ~30s if it is still starting) ..."))
+		if err := requireDockerDaemon("jenticctl setup"); err != nil {
+			return err
+		}
 		if err := install.ComposeCreateAdmin(a.Out, composePath, opts.email, opts.password); err != nil {
 			return fmt.Errorf("create admin (docker): %w", err)
 		}

--- a/cli/internal/cmd/setup_test.go
+++ b/cli/internal/cmd/setup_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"bytes"
+	"errors"
+	"os"
 	"strings"
 	"testing"
 )
@@ -53,5 +56,30 @@ func TestSetupRequiresInstall(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "install") {
 		t.Errorf("error = %q, want it to point at `jenticctl install`", err.Error())
+	}
+}
+
+// A Docker install (compose file present) with a stopped daemon must fail fast
+// with the guard's actionable error, before the one-shot admin container is
+// started (which would otherwise surface a raw compose transport error).
+func TestSetupDockerFailsFastWhenDaemonDown(t *testing.T) {
+	app := testApp(t)
+	if err := os.WriteFile(app.Paths.ComposePath(), []byte("services: {}\n"), 0o600); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	sentinel := stubDaemonDown(t)
+
+	err := app.setupE(&setupOptions{
+		yes:      true,
+		email:    "admin@example.com",
+		password: "a-strong-password",
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("setup should surface the daemon guard error, got %v", err)
+	}
+	// The guard runs after the "Creating ..." banner but before the container
+	// runs; the success line must never appear when the daemon is down.
+	if got := app.Out.(*bytes.Buffer).String(); strings.Contains(got, "Admin account created") {
+		t.Errorf("setup ran past the guard when the daemon was down:\n%s", got)
 	}
 }

--- a/cli/internal/cmd/start.go
+++ b/cli/internal/cmd/start.go
@@ -16,15 +16,15 @@ type startOptions struct {
 	config string
 }
 
-// requireDockerDaemon guards the Docker runtime commands (`start`/`stop`)
-// against a stopped daemon, surfacing actionable recovery guidance instead of a
-// raw `docker compose` transport error. It is a package-level seam so tests can
-// simulate an up/down daemon without a real Docker (#783,
-// jentic-api-scorecard#224).
+// requireDockerDaemon guards the Docker-backed commands (`start`, `stop`,
+// `update`, `setup`, `reset-password`) against a stopped daemon, surfacing
+// actionable recovery guidance instead of a raw `docker compose` transport
+// error. It is a package-level seam so tests can simulate an up/down daemon
+// without a real Docker (#783, jentic-api-scorecard#224).
 //
 // It can block up to ~30s while the underlying probe waits out a cold-starting
-// daemon, so callers must announce the check first (see startDocker/stopDocker)
-// or the command looks like it hung.
+// daemon, so callers must announce the check first (see e.g.
+// startDocker/stopDocker) or the command looks like it hung.
 var requireDockerDaemon = install.RequireDockerDaemon
 
 // composeUp / composeDown / composeDownVolumes are package-level seams over the

--- a/cli/internal/cmd/start.go
+++ b/cli/internal/cmd/start.go
@@ -17,11 +17,24 @@ type startOptions struct {
 }
 
 // requireDockerDaemon guards the Docker runtime commands (`start`/`stop`)
-// against a stopped daemon, surfacing the installer's actionable "start Docker
-// Desktop" guidance instead of a raw `docker compose` transport error. It is a
-// package-level seam so tests can simulate an up/down daemon without a real
-// Docker (#783, jentic-api-scorecard#224).
+// against a stopped daemon, surfacing actionable recovery guidance instead of a
+// raw `docker compose` transport error. It is a package-level seam so tests can
+// simulate an up/down daemon without a real Docker (#783,
+// jentic-api-scorecard#224).
+//
+// It can block up to ~30s while the underlying probe waits out a cold-starting
+// daemon, so callers must announce the check first (see startDocker/stopDocker)
+// or the command looks like it hung.
 var requireDockerDaemon = install.RequireDockerDaemon
+
+// composeUp / composeDown / composeDownVolumes are package-level seams over the
+// install package's docker-compose helpers so the runtime commands can be
+// tested (guard pass-through, output) without shelling out to a real Docker.
+var (
+	composeUp          = install.ComposeUp
+	composeDown        = install.ComposeDown
+	composeDownVolumes = install.ComposeDownVolumes
+)
 
 func newStartCmd(app *App) *cobra.Command {
 	opts := &startOptions{}
@@ -132,15 +145,17 @@ func brokerPortFromManifest(a *App) string {
 // startDocker brings the generated docker-compose stack up in detached mode.
 func (a *App) startDocker(composePath string) error {
 	// The compose file proves a Docker install, but not that the daemon is up:
-	// with Docker Desktop closed (common after a reboot) `docker compose up`
-	// fails with a raw "Cannot connect to the Docker daemon" error. Probe first
-	// so we surface the same actionable "start Docker Desktop" guidance the
-	// installer does (#783, jentic-api-scorecard#224).
+	// with the daemon down (e.g. Docker Desktop closed after a reboot) `docker
+	// compose up` fails with a raw "Cannot connect to the Docker daemon" error.
+	// Probe first so we surface actionable recovery guidance (#783,
+	// jentic-api-scorecard#224). The probe can wait out a cold-starting daemon
+	// (~30s), so announce it — otherwise the command looks hung.
+	fmt.Fprintln(a.Out, theme.Infof("Checking the Docker daemon (waiting up to ~30s if it is still starting) ..."))
 	if err := requireDockerDaemon("jenticctl start"); err != nil {
 		return err
 	}
 	fmt.Fprintln(a.Out, theme.Infof("Starting Docker stack ..."))
-	if err := install.ComposeUp(a.Out, composePath); err != nil {
+	if err := composeUp(a.Out, composePath); err != nil {
 		return fmt.Errorf("docker compose up: %w", err)
 	}
 	fmt.Fprintln(a.Out, theme.Successf("Stack started."))

--- a/cli/internal/cmd/start.go
+++ b/cli/internal/cmd/start.go
@@ -16,26 +16,6 @@ type startOptions struct {
 	config string
 }
 
-// requireDockerDaemon guards the Docker-backed commands (`start`, `stop`,
-// `update`, `setup`, `reset-password`) against a stopped daemon, surfacing
-// actionable recovery guidance instead of a raw `docker compose` transport
-// error. It is a package-level seam so tests can simulate an up/down daemon
-// without a real Docker (#783, jentic-api-scorecard#224).
-//
-// It can block up to ~30s while the underlying probe waits out a cold-starting
-// daemon, so callers must announce the check first (see e.g.
-// startDocker/stopDocker) or the command looks like it hung.
-var requireDockerDaemon = install.RequireDockerDaemon
-
-// composeUp / composeDown / composeDownVolumes are package-level seams over the
-// install package's docker-compose helpers so the runtime commands can be
-// tested (guard pass-through, output) without shelling out to a real Docker.
-var (
-	composeUp          = install.ComposeUp
-	composeDown        = install.ComposeDown
-	composeDownVolumes = install.ComposeDownVolumes
-)
-
 func newStartCmd(app *App) *cobra.Command {
 	opts := &startOptions{}
 	cmd := &cobra.Command{
@@ -150,7 +130,7 @@ func (a *App) startDocker(composePath string) error {
 	// Probe first so we surface actionable recovery guidance (#783,
 	// jentic-api-scorecard#224). The probe can wait out a cold-starting daemon
 	// (~30s), so announce it — otherwise the command looks hung.
-	fmt.Fprintln(a.Out, theme.Infof("Checking the Docker daemon (waiting up to ~30s if it is still starting) ..."))
+	announceDaemonCheck(a.Out)
 	if err := requireDockerDaemon("jenticctl start"); err != nil {
 		return err
 	}

--- a/cli/internal/cmd/start.go
+++ b/cli/internal/cmd/start.go
@@ -16,6 +16,13 @@ type startOptions struct {
 	config string
 }
 
+// requireDockerDaemon guards the Docker runtime commands (`start`/`stop`)
+// against a stopped daemon, surfacing the installer's actionable "start Docker
+// Desktop" guidance instead of a raw `docker compose` transport error. It is a
+// package-level seam so tests can simulate an up/down daemon without a real
+// Docker (#783, jentic-api-scorecard#224).
+var requireDockerDaemon = install.RequireDockerDaemon
+
 func newStartCmd(app *App) *cobra.Command {
 	opts := &startOptions{}
 	cmd := &cobra.Command{
@@ -124,6 +131,14 @@ func brokerPortFromManifest(a *App) string {
 
 // startDocker brings the generated docker-compose stack up in detached mode.
 func (a *App) startDocker(composePath string) error {
+	// The compose file proves a Docker install, but not that the daemon is up:
+	// with Docker Desktop closed (common after a reboot) `docker compose up`
+	// fails with a raw "Cannot connect to the Docker daemon" error. Probe first
+	// so we surface the same actionable "start Docker Desktop" guidance the
+	// installer does (#783, jentic-api-scorecard#224).
+	if err := requireDockerDaemon("jenticctl start"); err != nil {
+		return err
+	}
 	fmt.Fprintln(a.Out, theme.Infof("Starting Docker stack ..."))
 	if err := install.ComposeUp(a.Out, composePath); err != nil {
 		return fmt.Errorf("docker compose up: %w", err)

--- a/cli/internal/cmd/start_test.go
+++ b/cli/internal/cmd/start_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -20,6 +21,15 @@ func stubDaemonDown(t *testing.T) error {
 	return sentinel
 }
 
+// stubDaemonUp replaces the runtime daemon guard with one that reports the
+// daemon healthy (nil error), so tests can exercise the pass-through path.
+func stubDaemonUp(t *testing.T) {
+	t.Helper()
+	orig := requireDockerDaemon
+	t.Cleanup(func() { requireDockerDaemon = orig })
+	requireDockerDaemon = func(string) error { return nil }
+}
+
 // A Docker install (compose file present) with a stopped daemon must fail fast
 // with the guard's actionable error, before any `docker compose up` is run.
 func TestStartDockerFailsFastWhenDaemonDown(t *testing.T) {
@@ -29,6 +39,14 @@ func TestStartDockerFailsFastWhenDaemonDown(t *testing.T) {
 	}
 	sentinel := stubDaemonDown(t)
 
+	// Fail the test if the guard is bypassed and compose is actually invoked.
+	origUp := composeUp
+	t.Cleanup(func() { composeUp = origUp })
+	composeUp = func(io.Writer, string) error {
+		t.Fatal("composeUp must not run when the daemon is down")
+		return nil
+	}
+
 	err := app.startE(&startOptions{})
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("start should surface the daemon guard error, got %v", err)
@@ -36,5 +54,38 @@ func TestStartDockerFailsFastWhenDaemonDown(t *testing.T) {
 	// The guard short-circuits before announcing the stack start.
 	if got := app.Out.(*bytes.Buffer).String(); strings.Contains(got, "Starting Docker stack") {
 		t.Errorf("startDocker ran past the guard when the daemon was down:\n%s", got)
+	}
+}
+
+// With the daemon healthy, the guard passes through and startDocker proceeds to
+// bring the stack up. A compose seam stub keeps this off a real Docker.
+func TestStartDockerProceedsWhenDaemonUp(t *testing.T) {
+	app := testApp(t)
+	if err := os.WriteFile(app.Paths.ComposePath(), []byte("services: {}\n"), 0o600); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	stubDaemonUp(t)
+
+	var upCalls int
+	var gotPath string
+	origUp := composeUp
+	t.Cleanup(func() { composeUp = origUp })
+	composeUp = func(_ io.Writer, path string) error {
+		upCalls++
+		gotPath = path
+		return nil
+	}
+
+	if err := app.startE(&startOptions{}); err != nil {
+		t.Fatalf("start with a healthy daemon should succeed, got %v", err)
+	}
+	if upCalls != 1 {
+		t.Errorf("composeUp called %d times, want 1", upCalls)
+	}
+	if gotPath != app.Paths.ComposePath() {
+		t.Errorf("composeUp path = %q, want %q", gotPath, app.Paths.ComposePath())
+	}
+	if got := app.Out.(*bytes.Buffer).String(); !strings.Contains(got, "Starting Docker stack") {
+		t.Errorf("expected startDocker to announce the stack start, got:\n%s", got)
 	}
 }

--- a/cli/internal/cmd/start_test.go
+++ b/cli/internal/cmd/start_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// stubDaemonDown replaces the runtime daemon guard with one that reports the
+// daemon down, and restores it after the test. It returns the sentinel error
+// the stub yields so callers can assert it propagated unchanged.
+func stubDaemonDown(t *testing.T) error {
+	t.Helper()
+	orig := requireDockerDaemon
+	t.Cleanup(func() { requireDockerDaemon = orig })
+	sentinel := errors.New("docker daemon is not responding: start Docker Desktop")
+	requireDockerDaemon = func(string) error { return sentinel }
+	return sentinel
+}
+
+// A Docker install (compose file present) with a stopped daemon must fail fast
+// with the guard's actionable error, before any `docker compose up` is run.
+func TestStartDockerFailsFastWhenDaemonDown(t *testing.T) {
+	app := testApp(t)
+	if err := os.WriteFile(app.Paths.ComposePath(), []byte("services: {}\n"), 0o600); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	sentinel := stubDaemonDown(t)
+
+	err := app.startE(&startOptions{})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("start should surface the daemon guard error, got %v", err)
+	}
+	// The guard short-circuits before announcing the stack start.
+	if got := app.Out.(*bytes.Buffer).String(); strings.Contains(got, "Starting Docker stack") {
+		t.Errorf("startDocker ran past the guard when the daemon was down:\n%s", got)
+	}
+}

--- a/cli/internal/cmd/stop.go
+++ b/cli/internal/cmd/stop.go
@@ -115,6 +115,12 @@ func (a *App) stopProcess(pidPath, label string, timeout time.Duration) error {
 // stack's data volumes (`down -v`), which destroys the database; it confirms
 // first unless --yes is set.
 func (a *App) stopDocker(opts *stopOptions, composePath string) error {
+	// `docker compose down` needs a live daemon; with Docker Desktop closed it
+	// fails with a raw transport error. Probe first so a stopped daemon yields
+	// the actionable "start Docker Desktop" guidance instead (#783).
+	if err := requireDockerDaemon("jenticctl stop"); err != nil {
+		return err
+	}
 	if !opts.volumes {
 		fmt.Fprintln(a.Out, theme.Infof("Stopping Docker stack ..."))
 		if err := install.ComposeDown(a.Out, composePath); err != nil {

--- a/cli/internal/cmd/stop.go
+++ b/cli/internal/cmd/stop.go
@@ -115,15 +115,18 @@ func (a *App) stopProcess(pidPath, label string, timeout time.Duration) error {
 // stack's data volumes (`down -v`), which destroys the database; it confirms
 // first unless --yes is set.
 func (a *App) stopDocker(opts *stopOptions, composePath string) error {
-	// `docker compose down` needs a live daemon; with Docker Desktop closed it
-	// fails with a raw transport error. Probe first so a stopped daemon yields
-	// the actionable "start Docker Desktop" guidance instead (#783).
+	// `docker compose down` needs a live daemon; with the daemon down it fails
+	// with a raw transport error. Probe first (before the destructive --volumes
+	// confirmation prompt) so a stopped daemon yields actionable recovery
+	// guidance instead (#783). The probe can wait out a cold-starting daemon
+	// (~30s), so announce it — otherwise the command looks hung.
+	fmt.Fprintln(a.Out, theme.Infof("Checking the Docker daemon (waiting up to ~30s if it is still starting) ..."))
 	if err := requireDockerDaemon("jenticctl stop"); err != nil {
 		return err
 	}
 	if !opts.volumes {
 		fmt.Fprintln(a.Out, theme.Infof("Stopping Docker stack ..."))
-		if err := install.ComposeDown(a.Out, composePath); err != nil {
+		if err := composeDown(a.Out, composePath); err != nil {
 			return fmt.Errorf("docker compose down: %w", err)
 		}
 		fmt.Fprintln(a.Out, theme.Successf("Stopped Docker stack."))
@@ -142,7 +145,7 @@ func (a *App) stopDocker(opts *stopOptions, composePath string) error {
 	}
 
 	fmt.Fprintln(a.Out, theme.Infof("Stopping Docker stack and removing volumes ..."))
-	if err := install.ComposeDownVolumes(a.Out, composePath); err != nil {
+	if err := composeDownVolumes(a.Out, composePath); err != nil {
 		return fmt.Errorf("docker compose down -v: %w", err)
 	}
 	fmt.Fprintln(a.Out, theme.Successf("Stopped Docker stack and removed its data volumes."))

--- a/cli/internal/cmd/stop.go
+++ b/cli/internal/cmd/stop.go
@@ -120,7 +120,7 @@ func (a *App) stopDocker(opts *stopOptions, composePath string) error {
 	// confirmation prompt) so a stopped daemon yields actionable recovery
 	// guidance instead (#783). The probe can wait out a cold-starting daemon
 	// (~30s), so announce it — otherwise the command looks hung.
-	fmt.Fprintln(a.Out, theme.Infof("Checking the Docker daemon (waiting up to ~30s if it is still starting) ..."))
+	announceDaemonCheck(a.Out)
 	if err := requireDockerDaemon("jenticctl stop"); err != nil {
 		return err
 	}

--- a/cli/internal/cmd/stop_test.go
+++ b/cli/internal/cmd/stop_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"io"
 	"os"
 	"testing"
 )
@@ -15,23 +16,40 @@ func TestStopDockerFailsFastWhenDaemonDown(t *testing.T) {
 	}
 	sentinel := stubDaemonDown(t)
 
+	origDown := composeDown
+	t.Cleanup(func() { composeDown = origDown })
+	composeDown = func(io.Writer, string) error {
+		t.Fatal("composeDown must not run when the daemon is down")
+		return nil
+	}
+
 	err := app.stopE(&stopOptions{})
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("stop should surface the daemon guard error, got %v", err)
 	}
 }
 
-// The guard applies to the destructive --volumes path too (the confirmation
-// prompt is downstream of the guard, so a down daemon fails before prompting).
-func TestStopDockerVolumesFailsFastWhenDaemonDown(t *testing.T) {
+// The guard must run BEFORE the destructive --volumes confirmation prompt.
+// Deliberately omit `yes: true`: if the guard is correctly first, a down daemon
+// returns the sentinel and the interactive `huh` confirm is never reached (so
+// the test doesn't block on stdin). A regression that moved the guard below the
+// prompt would hang here instead of returning — proving the ordering.
+func TestStopDockerVolumesFailsFastBeforeConfirm(t *testing.T) {
 	app := testApp(t)
 	if err := os.WriteFile(app.Paths.ComposePath(), []byte("services: {}\n"), 0o600); err != nil {
 		t.Fatalf("write compose: %v", err)
 	}
 	sentinel := stubDaemonDown(t)
 
-	err := app.stopE(&stopOptions{volumes: true, yes: true})
+	origDownV := composeDownVolumes
+	t.Cleanup(func() { composeDownVolumes = origDownV })
+	composeDownVolumes = func(io.Writer, string) error {
+		t.Fatal("composeDownVolumes must not run when the daemon is down")
+		return nil
+	}
+
+	err := app.stopE(&stopOptions{volumes: true})
 	if !errors.Is(err, sentinel) {
-		t.Fatalf("stop --volumes should surface the daemon guard error, got %v", err)
+		t.Fatalf("stop --volumes should surface the daemon guard error before confirming, got %v", err)
 	}
 }

--- a/cli/internal/cmd/stop_test.go
+++ b/cli/internal/cmd/stop_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+// A Docker install with a stopped daemon must fail fast on `stop` with the
+// guard's actionable error rather than a raw `docker compose down` failure.
+func TestStopDockerFailsFastWhenDaemonDown(t *testing.T) {
+	app := testApp(t)
+	if err := os.WriteFile(app.Paths.ComposePath(), []byte("services: {}\n"), 0o600); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	sentinel := stubDaemonDown(t)
+
+	err := app.stopE(&stopOptions{})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("stop should surface the daemon guard error, got %v", err)
+	}
+}
+
+// The guard applies to the destructive --volumes path too (the confirmation
+// prompt is downstream of the guard, so a down daemon fails before prompting).
+func TestStopDockerVolumesFailsFastWhenDaemonDown(t *testing.T) {
+	app := testApp(t)
+	if err := os.WriteFile(app.Paths.ComposePath(), []byte("services: {}\n"), 0o600); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	sentinel := stubDaemonDown(t)
+
+	err := app.stopE(&stopOptions{volumes: true, yes: true})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("stop --volumes should surface the daemon guard error, got %v", err)
+	}
+}

--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -421,7 +421,7 @@ func (a *App) updateStackDocker() error {
 	// long image build — otherwise the build/migrations/up sequence surfaces a
 	// raw compose transport error deep into the run. The probe may poll (~30s)
 	// for a cold-starting daemon, so announce it first (see start.go/stop.go).
-	fmt.Fprintln(a.Out, theme.Infof("Checking the Docker daemon (waiting up to ~30s if it is still starting) ..."))
+	announceDaemonCheck(a.Out)
 	if err := requireDockerDaemon("jenticctl update"); err != nil {
 		return err
 	}

--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -417,6 +417,15 @@ func (a *App) updateStackDocker() error {
 		return fmt.Errorf("no compose stack at %s — run `jenticctl install` first", composePath)
 	}
 
+	// Fail fast with an actionable message when the daemon is down, before the
+	// long image build — otherwise the build/migrations/up sequence surfaces a
+	// raw compose transport error deep into the run. The probe may poll (~30s)
+	// for a cold-starting daemon, so announce it first (see start.go/stop.go).
+	fmt.Fprintln(a.Out, theme.Infof("Checking the Docker daemon (waiting up to ~30s if it is still starting) ..."))
+	if err := requireDockerDaemon("jenticctl update"); err != nil {
+		return err
+	}
+
 	plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath())
 	fmt.Fprintln(a.Out)
 	fmt.Fprint(a.Out, plan.RenderDockerBuildHeader())

--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -153,6 +153,21 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 		}
 	}
 
+	// In a *combined* docker-mode run, probe the daemon here — before updateCLI
+	// swaps the binaries — so a stopped daemon fails fast instead of leaving new
+	// binaries against an old, un-rebuilt stack. Scoped to doCLI so we don't
+	// probe/announce twice on the stack-only path (updateStackDocker guards
+	// itself); the daemonChecked flag then tells the stack step to skip its own
+	// probe here. The probe may poll (~30s) for a cold-starting daemon.
+	daemonChecked := false
+	if doCLI && doStack && manifest.Mode == config.ModeDocker && proc.FileExists(a.Paths.ComposePath()) {
+		announceDaemonCheck(a.Out)
+		if err := requireDockerDaemon("jenticctl update"); err != nil {
+			return err
+		}
+		daemonChecked = true
+	}
+
 	if doCLI {
 		if brewManaged {
 			if err := a.brewUpgradeCLI(ctx, latest, latestKnown); err != nil {
@@ -163,7 +178,7 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 		}
 	}
 	if doStack {
-		if err := a.updateStack(manifest.Mode); err != nil {
+		if err := a.updateStack(manifest.Mode, daemonChecked); err != nil {
 			return err
 		}
 	}
@@ -371,13 +386,13 @@ func binaryVersion(path string) (string, error) {
 // updateStack rebuilds and restarts the installed server in place, reusing the
 // existing jentic-one.yaml (no wizard). It dispatches on the recorded deploy
 // mode; an empty/unknown mode is treated as a local install.
-func (a *App) updateStack(mode string) error {
+func (a *App) updateStack(mode string, daemonChecked bool) error {
 	fmt.Fprintln(a.Out)
 	fmt.Fprintln(a.Out, theme.Warn.Render("Stack update runs forward-only migrations — back up your data first"))
 	fmt.Fprintln(a.Out, theme.Dim.Render("  SQLite: copy ~/.jentic/data/*.db · Postgres: pg_dump your database"))
 
 	if mode == config.ModeDocker {
-		return a.updateStackDocker()
+		return a.updateStackDocker(daemonChecked)
 	}
 	return a.updateStackLocal()
 }
@@ -410,8 +425,11 @@ func (a *App) updateStackLocal() error {
 }
 
 // updateStackDocker rebuilds the app image, applies migrations in a one-shot
-// container, and recreates the running stack with the new image.
-func (a *App) updateStackDocker() error {
+// container, and recreates the running stack with the new image. daemonChecked
+// is true when updateE already probed the daemon up front (combined run), so we
+// skip a redundant second probe/announce; a standalone/stack-only call passes
+// false and probes here.
+func (a *App) updateStackDocker(daemonChecked bool) error {
 	composePath := a.Paths.ComposePath()
 	if !proc.FileExists(composePath) {
 		return fmt.Errorf("no compose stack at %s — run `jenticctl install` first", composePath)
@@ -421,9 +439,11 @@ func (a *App) updateStackDocker() error {
 	// long image build — otherwise the build/migrations/up sequence surfaces a
 	// raw compose transport error deep into the run. The probe may poll (~30s)
 	// for a cold-starting daemon, so announce it first (see start.go/stop.go).
-	announceDaemonCheck(a.Out)
-	if err := requireDockerDaemon("jenticctl update"); err != nil {
-		return err
+	if !daemonChecked {
+		announceDaemonCheck(a.Out)
+		if err := requireDockerDaemon("jenticctl update"); err != nil {
+			return err
+		}
 	}
 
 	plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath())
@@ -442,7 +462,7 @@ func (a *App) updateStackDocker() error {
 
 	fmt.Fprintln(a.Out)
 	fmt.Fprintln(a.Out, install.RenderStartHeader())
-	if err := install.ComposeUp(a.Out, composePath); err != nil {
+	if err := composeUp(a.Out, composePath); err != nil {
 		return fmt.Errorf("docker compose up: %w", err)
 	}
 	fmt.Fprintln(a.Out, theme.Successf("Stack updated (docker)."))

--- a/cli/internal/cmd/update_test.go
+++ b/cli/internal/cmd/update_test.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/jentic/jentic-one/cli/internal/config"
@@ -123,5 +126,25 @@ func TestApplyPromptTitle(t *testing.T) {
 				t.Errorf("applyPromptTitle(%v, %v, %v) = %q, want %q", tt.doCLI, tt.doStack, tt.brew, got, tt.want)
 			}
 		})
+	}
+}
+
+// A Docker install (compose file present) with a stopped daemon must fail fast
+// with the guard's actionable error, before the long image build / migrations
+// / compose up sequence surfaces a raw compose transport error.
+func TestUpdateStackDockerFailsFastWhenDaemonDown(t *testing.T) {
+	app := testApp(t)
+	if err := os.WriteFile(app.Paths.ComposePath(), []byte("services: {}\n"), 0o600); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	sentinel := stubDaemonDown(t)
+
+	err := app.updateStackDocker()
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("update should surface the daemon guard error, got %v", err)
+	}
+	// The guard short-circuits before the image build header is rendered.
+	if got := app.Out.(*bytes.Buffer).String(); strings.Contains(got, "Build (Docker images)") {
+		t.Errorf("updateStackDocker ran past the guard when the daemon was down:\n%s", got)
 	}
 }

--- a/cli/internal/cmd/update_test.go
+++ b/cli/internal/cmd/update_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -139,7 +140,16 @@ func TestUpdateStackDockerFailsFastWhenDaemonDown(t *testing.T) {
 	}
 	sentinel := stubDaemonDown(t)
 
-	err := app.updateStackDocker()
+	// The stack bring-up routes through the composeUp seam; a bypassed guard
+	// would reach it and fail loudly (mirrors start/stop).
+	origUp := composeUp
+	t.Cleanup(func() { composeUp = origUp })
+	composeUp = func(io.Writer, string) error {
+		t.Fatal("composeUp must not run when the daemon is down")
+		return nil
+	}
+
+	err := app.updateStackDocker(false)
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("update should surface the daemon guard error, got %v", err)
 	}

--- a/cli/internal/cmd/update_test.go
+++ b/cli/internal/cmd/update_test.go
@@ -143,7 +143,8 @@ func TestUpdateStackDockerFailsFastWhenDaemonDown(t *testing.T) {
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("update should surface the daemon guard error, got %v", err)
 	}
-	// The guard short-circuits before the image build header is rendered.
+	// The guard short-circuits before the image build header is rendered, so the
+	// build/migrations/compose-up sequence never starts (no real Docker call).
 	if got := app.Out.(*bytes.Buffer).String(); strings.Contains(got, "Build (Docker images)") {
 		t.Errorf("updateStackDocker ran past the guard when the daemon was down:\n%s", got)
 	}

--- a/cli/internal/install/preflight.go
+++ b/cli/internal/install/preflight.go
@@ -215,12 +215,18 @@ func DaemonError(check CheckResult) error {
 }
 
 // RequireDockerDaemon fails fast with an actionable error when the Docker daemon
-// is not responding, so runtime commands (`start`/`stop`) surface the same
-// "start Docker Desktop" guidance as install instead of a raw `docker compose`
-// transport error when Docker Desktop is closed (e.g. after a reboot). The
-// referenced command names the caller (e.g. "jenticctl start") so the recovery
-// path points back at what the operator ran. It returns nil when the daemon
-// answers. See jentic-one#783 and jentic-api-scorecard#224.
+// is not responding, so runtime commands (`start`/`stop`) surface a clear
+// recovery path when Docker Desktop is closed (e.g. after a reboot) instead of a
+// raw `docker compose` transport error. The referenced command names the caller
+// (e.g. "jenticctl start") so the recovery path points back at what the operator
+// ran. It returns nil when the daemon answers. See jentic-one#783 and
+// jentic-api-scorecard#224.
+//
+// It only reports the problem; it deliberately does NOT start Docker itself.
+// Client CLIs across the ecosystem (Testcontainers, act, Dagger) fail fast here
+// rather than silently launching the daemon, since Docker Desktop is packaged as
+// a user app, not a managed service. The message points at `docker desktop
+// start` (Docker Desktop 4.37+) so the operator has the one-liner to hand.
 func RequireDockerDaemon(command string) error {
 	detail, healthy := dockerDaemonHealth()
 	if healthy {
@@ -230,8 +236,8 @@ func RequireDockerDaemon(command string) error {
 		detail = "the Docker daemon is not reachable"
 	}
 	return fmt.Errorf("docker is installed but its daemon is not responding: %s — "+
-		"start Docker Desktop (or your docker daemon), wait for it to report healthy, "+
-		"then re-run `%s`", detail, command)
+		"start it with `docker desktop start` (or open Docker Desktop / start your docker daemon), "+
+		"wait for it to report healthy, then re-run `%s`", detail, command)
 }
 
 // DockerDaemonResponsiveQuick is a single-round-trip daemon probe for callers

--- a/cli/internal/install/preflight.go
+++ b/cli/internal/install/preflight.go
@@ -133,6 +133,16 @@ func dockerDaemonHealth() (detail string, healthy bool) {
 	return dockerDaemonProbe()
 }
 
+// daemonProbeBackoff is the pause between daemon probe attempts. Kept named so
+// the "~30s total" arithmetic in defaultDockerDaemonProbe stays self-documenting
+// (4 × 6s timeout + 3 × daemonProbeBackoff).
+const daemonProbeBackoff = 2 * time.Second
+
+// daemonUnreachableFallback is the generic reason used when a probe can't
+// extract a more specific one from Docker's output. Shared so every daemon-down
+// message reads the same when there's nothing more precise to show.
+const daemonUnreachableFallback = "the Docker daemon is not reachable"
+
 // defaultDockerDaemonProbe checks whether the Docker daemon answers a
 // server-side request. A LookPath-present client whose daemon is stopped/wedged
 // returns a non-zero exit with "Cannot connect to the Docker daemon" / "Is the
@@ -155,7 +165,7 @@ func defaultDockerDaemonProbe() (string, bool) {
 		}
 		lastDetail = detail
 		if i < attempts-1 {
-			time.Sleep(2 * time.Second)
+			time.Sleep(daemonProbeBackoff)
 		}
 	}
 	if lastDetail == "" {
@@ -190,7 +200,7 @@ func firstLine(s string) string {
 			return t
 		}
 	}
-	return "the Docker daemon is not reachable"
+	return daemonUnreachableFallback
 }
 
 // UnhealthyDaemon returns the docker check whose daemon probe failed, if any.
@@ -220,7 +230,7 @@ const dockerDaemonRecoveryHint = "start your Docker daemon " +
 func DaemonError(check CheckResult) error {
 	detail := check.DaemonDetail
 	if detail == "" {
-		detail = "the Docker daemon is not reachable"
+		detail = daemonUnreachableFallback
 	}
 	return fmt.Errorf("docker is installed but its daemon is not responding: %s — %s, "+
 		"wait until `docker info` succeeds, then re-run `jenticctl install`", detail, dockerDaemonRecoveryHint)
@@ -251,7 +261,7 @@ func RequireDockerDaemon(command string) error {
 		return nil
 	}
 	if detail == "" {
-		detail = "the Docker daemon is not reachable"
+		detail = daemonUnreachableFallback
 	}
 	return fmt.Errorf("docker is installed but its daemon is not responding: %s — %s, "+
 		"wait until `docker info` succeeds, then re-run `%s`", detail, dockerDaemonRecoveryHint, command)
@@ -269,8 +279,7 @@ func DockerDaemonRecoveryHint() string { return dockerDaemonRecoveryHint }
 // Desktop; it answers within `timeout`. It returns a short human reason (empty
 // when healthy) and whether the daemon answered.
 func DockerDaemonResponsiveQuick(timeout time.Duration) (detail string, healthy bool) {
-	detail, ok := dockerInfoOnce(timeout)
-	return detail, ok
+	return dockerInfoOnce(timeout)
 }
 
 // RenderPreflight returns a styled checklist of the probe results.
@@ -316,7 +325,7 @@ func MissingError(missing []CheckResult) error {
 		} else if r.DaemonChecked && !r.Healthy {
 			detail := r.DaemonDetail
 			if detail == "" {
-				detail = "the Docker daemon is not reachable"
+				detail = daemonUnreachableFallback
 			}
 			fmt.Fprintf(&hints, "\n  docker daemon: %s — %s, then re-run", detail, dockerDaemonRecoveryHint)
 		}

--- a/cli/internal/install/preflight.go
+++ b/cli/internal/install/preflight.go
@@ -202,6 +202,17 @@ func UnhealthyDaemon(results []CheckResult) (CheckResult, bool) {
 	return CheckResult{}, false
 }
 
+// dockerDaemonRecoveryHint is the one canonical "how to bring the daemon back"
+// phrase, reused by every daemon-down message (install, start/stop, doctor) so
+// the guidance can't drift between touch points. It leads with the
+// runtime-agnostic instruction so Colima / Linux dockerd / Podman / Rancher
+// users aren't sent down a Docker-Desktop-only path, then offers the
+// Docker-Desktop convenience (the `docker desktop start` CLI needs Docker
+// Desktop 4.37+, hence the version caveat inline).
+const dockerDaemonRecoveryHint = "start your Docker daemon " +
+	"(Docker Desktop users: open it, or run `docker desktop start` on 4.37+; " +
+	"Linux: `sudo systemctl start docker`; Colima: `colima start`)"
+
 // DaemonError builds an actionable error for a present-but-unresponsive Docker
 // daemon, so the install fails fast here instead of crashing mid-build.
 func DaemonError(check CheckResult) error {
@@ -209,24 +220,29 @@ func DaemonError(check CheckResult) error {
 	if detail == "" {
 		detail = "the Docker daemon is not reachable"
 	}
-	return fmt.Errorf("docker is installed but its daemon is not responding: %s — "+
-		"start Docker Desktop (or your docker daemon), wait for it to report healthy, "+
-		"then re-run `jenticctl install`", detail)
+	return fmt.Errorf("docker is installed but its daemon is not responding: %s — %s, "+
+		"wait until `docker info` succeeds, then re-run `jenticctl install`", detail, dockerDaemonRecoveryHint)
 }
 
 // RequireDockerDaemon fails fast with an actionable error when the Docker daemon
 // is not responding, so runtime commands (`start`/`stop`) surface a clear
-// recovery path when Docker Desktop is closed (e.g. after a reboot) instead of a
-// raw `docker compose` transport error. The referenced command names the caller
-// (e.g. "jenticctl start") so the recovery path points back at what the operator
-// ran. It returns nil when the daemon answers. See jentic-one#783 and
-// jentic-api-scorecard#224.
+// recovery path when the daemon is down (e.g. Docker Desktop closed after a
+// reboot) instead of a raw `docker compose` transport error. The referenced
+// command names the caller (e.g. "jenticctl start") so the recovery path points
+// back at what the operator ran. It returns nil when the daemon answers. See
+// jentic-one#783 and jentic-api-scorecard#224.
 //
 // It only reports the problem; it deliberately does NOT start Docker itself.
 // Client CLIs across the ecosystem (Testcontainers, act, Dagger) fail fast here
 // rather than silently launching the daemon, since Docker Desktop is packaged as
-// a user app, not a managed service. The message points at `docker desktop
-// start` (Docker Desktop 4.37+) so the operator has the one-liner to hand.
+// a user app, not a managed service. The recovery hint (dockerDaemonRecoveryHint)
+// leads with a runtime-agnostic instruction so non-Docker-Desktop users aren't
+// misled.
+//
+// The probe (dockerDaemonHealth) polls for up to ~30s to tolerate a
+// cold-starting daemon, so callers should announce the check before invoking
+// this — otherwise the command appears to hang. See the callers in
+// internal/cmd/start.go and stop.go.
 func RequireDockerDaemon(command string) error {
 	detail, healthy := dockerDaemonHealth()
 	if healthy {
@@ -235,10 +251,14 @@ func RequireDockerDaemon(command string) error {
 	if detail == "" {
 		detail = "the Docker daemon is not reachable"
 	}
-	return fmt.Errorf("docker is installed but its daemon is not responding: %s — "+
-		"start it with `docker desktop start` (or open Docker Desktop / start your docker daemon), "+
-		"wait for it to report healthy, then re-run `%s`", detail, command)
+	return fmt.Errorf("docker is installed but its daemon is not responding: %s — %s, "+
+		"wait until `docker info` succeeds, then re-run `%s`", detail, dockerDaemonRecoveryHint, command)
 }
+
+// DockerDaemonRecoveryHint returns the canonical "how to start the Docker
+// daemon" guidance so callers outside this package (e.g. the doctor deploy
+// check) render the exact same advice as the fail-fast errors.
+func DockerDaemonRecoveryHint() string { return dockerDaemonRecoveryHint }
 
 // DockerDaemonResponsiveQuick is a single-round-trip daemon probe for callers
 // that must stay fast and non-blocking — `doctor` is read-only and should not
@@ -296,7 +316,7 @@ func MissingError(missing []CheckResult) error {
 			if detail == "" {
 				detail = "the Docker daemon is not reachable"
 			}
-			fmt.Fprintf(&hints, "\n  docker daemon: %s — start Docker Desktop and re-run", detail)
+			fmt.Fprintf(&hints, "\n  docker daemon: %s — %s, then re-run", detail, dockerDaemonRecoveryHint)
 		}
 	}
 	return fmt.Errorf("missing required tool(s) or daemons down: %s — install/start and re-run:%s",

--- a/cli/internal/install/preflight.go
+++ b/cli/internal/install/preflight.go
@@ -214,6 +214,37 @@ func DaemonError(check CheckResult) error {
 		"then re-run `jenticctl install`", detail)
 }
 
+// RequireDockerDaemon fails fast with an actionable error when the Docker daemon
+// is not responding, so runtime commands (`start`/`stop`) surface the same
+// "start Docker Desktop" guidance as install instead of a raw `docker compose`
+// transport error when Docker Desktop is closed (e.g. after a reboot). The
+// referenced command names the caller (e.g. "jenticctl start") so the recovery
+// path points back at what the operator ran. It returns nil when the daemon
+// answers. See jentic-one#783 and jentic-api-scorecard#224.
+func RequireDockerDaemon(command string) error {
+	detail, healthy := dockerDaemonHealth()
+	if healthy {
+		return nil
+	}
+	if detail == "" {
+		detail = "the Docker daemon is not reachable"
+	}
+	return fmt.Errorf("docker is installed but its daemon is not responding: %s — "+
+		"start Docker Desktop (or your docker daemon), wait for it to report healthy, "+
+		"then re-run `%s`", detail, command)
+}
+
+// DockerDaemonResponsiveQuick is a single-round-trip daemon probe for callers
+// that must stay fast and non-blocking — `doctor` is read-only and should not
+// hang for the full cold-start polling window when the daemon is simply down.
+// Unlike RequireDockerDaemon it does not tolerate a cold-starting Docker
+// Desktop; it answers within `timeout`. It returns a short human reason (empty
+// when healthy) and whether the daemon answered.
+func DockerDaemonResponsiveQuick(timeout time.Duration) (detail string, healthy bool) {
+	detail, ok := dockerInfoOnce(timeout)
+	return detail, ok
+}
+
 // RenderPreflight returns a styled checklist of the probe results.
 func RenderPreflight(results []CheckResult) string {
 	var b strings.Builder

--- a/cli/internal/install/preflight.go
+++ b/cli/internal/install/preflight.go
@@ -141,8 +141,10 @@ func dockerDaemonHealth() (detail string, healthy bool) {
 // launch, so we poll a few times before declaring it down rather than failing
 // on a single short timeout and sending the operator down a false "wedged" path.
 func defaultDockerDaemonProbe() (string, bool) {
-	// Up to ~24s total: a snappy daemon answers on the first try in well under a
-	// second; a cold-starting one usually comes up within this window.
+	// Up to ~30s total (4 attempts × 6s timeout + 3 × 2s backoff): a snappy
+	// daemon answers on the first try in well under a second; a cold-starting
+	// one usually comes up within this window. Matches the "~30s" the callers
+	// advertise before probing.
 	const attempts = 4
 	const perAttempt = 6 * time.Second
 	var lastDetail string

--- a/cli/internal/install/preflight_test.go
+++ b/cli/internal/install/preflight_test.go
@@ -126,7 +126,7 @@ func TestRequireDockerDaemon(t *testing.T) {
 		t.Fatal("stopped daemon should return an error")
 	}
 	msg := err.Error()
-	for _, want := range []string{"daemon is not responding", "Cannot connect to the Docker daemon", "start Docker Desktop", "jenticctl start"} {
+	for _, want := range []string{"daemon is not responding", "Cannot connect to the Docker daemon", "docker desktop start", "jenticctl start"} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("error missing %q: %q", want, msg)
 		}

--- a/cli/internal/install/preflight_test.go
+++ b/cli/internal/install/preflight_test.go
@@ -109,6 +109,38 @@ func TestDaemonError(t *testing.T) {
 	}
 }
 
+func TestRequireDockerDaemon(t *testing.T) {
+	orig := dockerDaemonProbe
+	t.Cleanup(func() { dockerDaemonProbe = orig })
+
+	// Healthy daemon → no error, so `start`/`stop` proceed.
+	dockerDaemonProbe = func() (string, bool) { return "", true }
+	if err := RequireDockerDaemon("jenticctl start"); err != nil {
+		t.Errorf("healthy daemon should not error, got %v", err)
+	}
+
+	// Stopped daemon → actionable error naming the caller's command.
+	dockerDaemonProbe = func() (string, bool) { return "Cannot connect to the Docker daemon", false }
+	err := RequireDockerDaemon("jenticctl start")
+	if err == nil {
+		t.Fatal("stopped daemon should return an error")
+	}
+	msg := err.Error()
+	for _, want := range []string{"daemon is not responding", "Cannot connect to the Docker daemon", "start Docker Desktop", "jenticctl start"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error missing %q: %q", want, msg)
+		}
+	}
+
+	// A down daemon with no detail still yields a usable fallback reason.
+	dockerDaemonProbe = func() (string, bool) { return "", false }
+	if err := RequireDockerDaemon("jenticctl stop"); err == nil ||
+		!strings.Contains(err.Error(), "not reachable") ||
+		!strings.Contains(err.Error(), "jenticctl stop") {
+		t.Errorf("empty-detail down daemon: %v", err)
+	}
+}
+
 func TestPreflightDaemonProbeSeam(t *testing.T) {
 	// Stub a `docker` on PATH so Preflight's LookPath succeeds (and the daemon
 	// branch is reached) regardless of whether the host has Docker installed,

--- a/cli/internal/install/preflight_test.go
+++ b/cli/internal/install/preflight_test.go
@@ -103,7 +103,7 @@ func TestDaemonError(t *testing.T) {
 	}
 	msg := err.Error()
 	if !strings.Contains(msg, "daemon is not responding") ||
-		!strings.Contains(msg, "start Docker Desktop") ||
+		!strings.Contains(msg, "docker desktop start") ||
 		!strings.Contains(msg, "Is the docker daemon running?") {
 		t.Errorf("daemon error not actionable: %q", msg)
 	}
@@ -119,25 +119,43 @@ func TestRequireDockerDaemon(t *testing.T) {
 		t.Errorf("healthy daemon should not error, got %v", err)
 	}
 
-	// Stopped daemon → actionable error naming the caller's command.
-	dockerDaemonProbe = func() (string, bool) { return "Cannot connect to the Docker daemon", false }
-	err := RequireDockerDaemon("jenticctl start")
-	if err == nil {
-		t.Fatal("stopped daemon should return an error")
-	}
-	msg := err.Error()
-	for _, want := range []string{"daemon is not responding", "Cannot connect to the Docker daemon", "docker desktop start", "jenticctl start"} {
-		if !strings.Contains(msg, want) {
-			t.Errorf("error missing %q: %q", want, msg)
-		}
-	}
-
-	// A down daemon with no detail still yields a usable fallback reason.
-	dockerDaemonProbe = func() (string, bool) { return "", false }
-	if err := RequireDockerDaemon("jenticctl stop"); err == nil ||
-		!strings.Contains(err.Error(), "not reachable") ||
-		!strings.Contains(err.Error(), "jenticctl stop") {
-		t.Errorf("empty-detail down daemon: %v", err)
+	for _, tc := range []struct {
+		name    string
+		probe   func() (string, bool)
+		command string
+		want    []string
+	}{
+		{
+			name:    "down with detail names the caller and stays runtime-agnostic",
+			probe:   func() (string, bool) { return "Cannot connect to the Docker daemon", false },
+			command: "jenticctl start",
+			// Leads with the generic instruction, then Docker Desktop / Linux /
+			// Colima specifics, and names the command the operator ran.
+			want: []string{
+				"daemon is not responding", "Cannot connect to the Docker daemon",
+				"start your Docker daemon", "docker desktop start", "colima start", "jenticctl start",
+			},
+		},
+		{
+			name:    "down with empty detail falls back to a usable reason",
+			probe:   func() (string, bool) { return "", false },
+			command: "jenticctl stop",
+			want:    []string{"not reachable", "jenticctl stop"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dockerDaemonProbe = tc.probe
+			err := RequireDockerDaemon(tc.command)
+			if err == nil {
+				t.Fatal("stopped daemon should return an error")
+			}
+			msg := err.Error()
+			for _, want := range tc.want {
+				if !strings.Contains(msg, want) {
+					t.Errorf("error missing %q: %q", want, msg)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What's this about?

If you're running Jentic One on Docker and Docker Desktop happens to be closed (super common after a reboot), the CLI used to be pretty unhelpful about it. `jenticctl start` would just dump a raw `docker compose ... Cannot connect to the Docker daemon` error at you, and `doctor` would only hint at the problem sideways through a confusing `docker compose ps` failure. You'd have to already know that the real fix was "oh, Docker isn't running."

The interesting part: our **installer** already handles this really nicely — it probes the daemon, waits patiently for a cold-starting Docker Desktop, and tells you exactly what to do. The runtime commands just never got the same love. This PR closes that gap so **every** Docker-backed command behaves consistently.

## What changed

Every `jenticctl` command that shells out to `docker compose` now checks the daemon is actually up first, and — if it isn't — fails fast with a clear, actionable message instead of a cryptic transport error:

- **`start` / `stop`** — probe before `docker compose up` / `down`. For `stop --volumes`, the check runs *before* the destructive confirmation prompt, so you fail fast rather than confirm-then-fail.
- **`update`** — probe before the (potentially multi-minute) image build, so you're not left staring at a build that was doomed from the start.
- **`setup` / `reset-password`** — probe *before* prompting for credentials on a Docker install, so you're not asked to type an email + password only to be told the daemon is down afterwards.
- **`doctor`** — reports a proper `docker daemon` warning with a fix-it hint, using a fast single-shot check so the diagnostic stays snappy and CI-safe (a down daemon is a warning, not a hard fail).

Under the hood we reuse the installer's existing probe, which politely waits (~30s) for a cold-starting Docker Desktop rather than giving up on the first ping. All five action commands print a single shared "Checking the Docker daemon ..." line first, so the wait never looks like a hang.

**The message points you at the fix**: it leads with a runtime-agnostic "start your Docker daemon", then offers the Docker Desktop 4.37+ `docker desktop start` one-liner (with the version caveat) and `colima start`, so Linux/Colima/Rancher users aren't misled.

### Deliberately left alone

- **`install`** already gates on this via the wizard's preflight (`Preflight` → `UnhealthyDaemon` → `DaemonError`), so it needs nothing here.
- **`uninstall`** is intentionally lenient: it treats compose failures as non-fatal and prints manual `docker volume rm` hints, so it can still tear down your filesystem state with the daemon down. A hard guard there would *break* graceful teardown.
- **`status`** does no Docker I/O (it's a `FileExists` check), so there's nothing to guard.

## Why fail fast instead of auto-starting Docker?

I did a bit of a survey of how the ecosystem handles this. The consistent pattern for client CLIs (Testcontainers, `act`, Dagger) is to **fail fast with a clear message** — none of them silently launch Docker for you, because on Mac/Windows it's a user app, not a managed service. Auto-starting behind your back is considered too invasive. The one thing everyone *does* do is tolerate a slow-to-wake daemon with a bounded wait, which is exactly what our reused probe does. So this PR deliberately stays in the "tell you clearly, hand you the one-liner" camp rather than starting Docker itself.

## Context

These closed issues describe the same rough edge, so linking them for the trail (not auto-closing):
- jentic-one#783 — instance stopped / Docker not running fails silently
- jentic-api-scorecard#224 — "fails if Docker is installed but not running"
- jentic-one-internal#653 — the installer hardening this mirrors on the runtime side

## Review

Reviewed by a multi-agent pass (Go correctness, tests, UX, architecture, completeness audit, Bugbot, security) — **zero blockers**. Non-blocking findings were folded in (shared announce helper to prevent wording drift, seams moved to a neutral `docker_guard.go`, daemon-probe-before-credential-prompt, consistent doctor fallthrough hint). Two deeper pre-existing probe improvements were split out as follow-ups: #953 (Ctrl-C cancellation of the ~30s wait) and #954 (distinguish "docker not installed" from "daemon down").

## Test plan

- [x] `cd cli && go build ./...`
- [x] `cd cli && go vet ./internal/cmd/... ./internal/install/...`
- [x] `cd cli && go test -race ./...` (whole module green)
- [x] New tests cover start (down + up), stop (incl. `--volumes` ordering), update, setup, reset-password, doctor, and the `install` helper
- [x] Manual sanity check: quit Docker Desktop, ran `jenticctl start` / `stop` / `stop --volumes` / `doctor` on a Docker install — all surface the friendly message (no raw compose error); `start`/`stop` exit 1, `doctor` warns and exits 0

_Heads up: please **squash + merge** to keep `main` tidy._