### PR TITLE
fix(cli): gate the stack update on its own recorded ref

### DIFF
--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -74,6 +74,12 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 	fmt.Fprint(a.Out, a.brandHeader(opts.baseURL, cliVersion))
 	fmt.Fprintln(a.Out)
 	fmt.Fprintln(a.Out, theme.Field("cli", cliLine(cliVersion, installed)))
+	// Surface the stack's own recorded build separately from the CLI's. They
+	// advance independently, and a silent divergence is exactly what left users
+	// on a stale stack with no visible cause (#943).
+	if stackRef := manifest.ResolvedStackRef(); stackRef != "" {
+		fmt.Fprintln(a.Out, theme.Field("stack", stackRef))
+	}
 	if !found {
 		fmt.Fprintln(a.Out, theme.Dim.Render("  (no install manifest; using build-time metadata)"))
 	}
@@ -127,7 +133,7 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 	// stack may lag behind, so the stack half must not key off the CLI binary.
 	// A --ref override always proceeds (the user asked for a specific build);
 	// re-run with --ref to force a rebuild at a pinned version.
-	stackVersion := firstNonEmpty(manifest.Ref, cliVersion)
+	stackVersion := firstNonEmpty(manifest.ResolvedStackRef(), cliVersion)
 	if !pinned && latestKnown && !updateNeeded(doCLI, doStack, cliVersion, stackVersion, latest) {
 		fmt.Fprintln(a.Out)
 		fmt.Fprintln(a.Out, theme.Successf("Already up to date (%s); nothing to rebuild.", latest))
@@ -166,8 +172,26 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 		if err := a.updateStack(manifest.Mode); err != nil {
 			return err
 		}
+		// Only now is the stack genuinely at `ref`. Recording it earlier (or
+		// alongside the CLI half) is what let a failed/skipped stack rebuild
+		// advertise itself as current and wedge every later update (#943).
+		a.recordStackBuild(ref)
 	}
 	return nil
+}
+
+// recordStackBuild persists the ref the stack was just built from, so the next
+// `update` gates the stack half on what was actually built. Best-effort: the
+// rebuild already succeeded, so a manifest write failure must not fail the
+// command — it only costs a redundant rebuild next time.
+func (a *App) recordStackBuild(ref string) {
+	m, _, err := config.LoadManifest(a.Paths)
+	if err != nil {
+		return
+	}
+	if err := m.RecordStackBuild(a.Paths, ref); err != nil {
+		fmt.Fprintln(a.Out, theme.Warnf("warning: could not record stack version: %v", err))
+	}
 }
 
 // brewUpgradeCLI refreshes a Homebrew-managed CLI by delegating to

--- a/cli/internal/cmd/update_test.go
+++ b/cli/internal/cmd/update_test.go
@@ -39,6 +39,34 @@ func TestUpdateNeeded(t *testing.T) {
 	}
 }
 
+// TestUpdateNeededStackRefGatesIndependently is the regression test for #943:
+// a CLI-only version bump must not make a stale stack look current. The stack
+// half is gated on the manifest's stack_ref, so when the CLI reached the latest
+// release but the stack never rebuilt, `update` must still offer the rebuild.
+func TestUpdateNeededStackRefGatesIndependently(t *testing.T) {
+	const latest = "v0.25.0"
+	// The wedge: CLI swapped to v0.25.0, stack still on the v0.24.0 build.
+	wedged := &config.Manifest{Ref: latest, StackRef: "v0.24.0", CLIVersion: latest}
+	stackVersion := firstNonEmpty(wedged.ResolvedStackRef(), wedged.CLIVersion)
+	if !updateNeeded(false, true, wedged.CLIVersion, stackVersion, latest) {
+		t.Error("stale stack with a current CLI reported nothing to rebuild (#943 regression)")
+	}
+
+	// Once the stack rebuild is recorded, the same invocation is a no-op.
+	rebuilt := &config.Manifest{Ref: latest, StackRef: latest, CLIVersion: latest}
+	stackVersion = firstNonEmpty(rebuilt.ResolvedStackRef(), rebuilt.CLIVersion)
+	if updateNeeded(false, true, rebuilt.CLIVersion, stackVersion, latest) {
+		t.Error("fully-updated install still offered a rebuild")
+	}
+
+	// A legacy manifest (no stack_ref) keeps its previous meaning via Ref.
+	legacy := &config.Manifest{Ref: "v0.24.0", CLIVersion: latest}
+	stackVersion = firstNonEmpty(legacy.ResolvedStackRef(), legacy.CLIVersion)
+	if !updateNeeded(false, true, legacy.CLIVersion, stackVersion, latest) {
+		t.Error("legacy manifest with a stale ref reported nothing to rebuild")
+	}
+}
+
 // TestResolveCtlTargetResolvesManifestSymlink covers the manifest branch: a
 // recorded BinaryPath that is a PATH symlink (what `jenticctl install` records
 // under a linked install) must resolve to the real file so the update swaps

--- a/cli/internal/config/manifest.go
+++ b/cli/internal/config/manifest.go
@@ -28,6 +28,14 @@ type Manifest struct {
 	Repo string `json:"repo,omitempty"`
 	// Ref is the git branch, tag, or commit the install tracks.
 	Ref string `json:"ref,omitempty"`
+	// StackRef is the ref the *stack* (venv or Docker images) was last
+	// successfully built from. It is tracked separately from Ref because the two
+	// halves of `jentic update` advance independently: a Homebrew-managed CLI is
+	// refreshed out-of-band, and a CLI swap that is not followed by a successful
+	// stack rebuild must not advertise the stack as current. Empty on installs
+	// written before this field existed; ResolvedStackRef falls back to Ref so
+	// those keep their previous behaviour.
+	StackRef string `json:"stack_ref,omitempty"`
 	// Commit is the short SHA that was built.
 	Commit string `json:"commit,omitempty"`
 	// CLIVersion is the version stamped into the installed binary.
@@ -52,6 +60,28 @@ func (m *Manifest) ResolvedRepo() string {
 		return m.Repo
 	}
 	return DefaultRepo
+}
+
+// ResolvedStackRef returns the ref the stack was last built from, falling back
+// to Ref for installs written before StackRef existed. Callers gating a stack
+// rebuild must use this rather than Ref, so a CLI-only version bump can never
+// make a stale stack look current (#943).
+func (m *Manifest) ResolvedStackRef() string {
+	if m.StackRef != "" {
+		return m.StackRef
+	}
+	return m.Ref
+}
+
+// RecordStackBuild persists the ref the stack was just built from. Call it only
+// after a stack rebuild has actually succeeded: StackRef is what gates the next
+// `jentic update`, so writing it early is what wedges a user on a stale stack.
+func (m *Manifest) RecordStackBuild(paths Paths, ref string) error {
+	if ref == "" {
+		return nil
+	}
+	m.StackRef = ref
+	return m.Save(paths)
 }
 
 // LoadManifest reads <paths>/install.json. A missing file is not an error: it
@@ -96,6 +126,10 @@ func (m *Manifest) Save(paths Paths) error {
 // installer recorded, then saves. This is what `jentic install` calls so a
 // re-install keeps any CLI fields written by tools/install.sh while refreshing
 // the rest.
+//
+// `install` only reaches this point after the stack was built, so it also
+// advances StackRef — an install is the baseline the next `update` compares
+// against.
 func (m *Manifest) MergeStack(paths Paths, mode, db, brokerPort, ref, commit, cliVersion string) error {
 	m.Mode = mode
 	m.DB = db
@@ -104,6 +138,7 @@ func (m *Manifest) MergeStack(paths Paths, mode, db, brokerPort, ref, commit, cl
 	}
 	if ref != "" {
 		m.Ref = ref
+		m.StackRef = ref
 	}
 	if commit != "" {
 		m.Commit = commit

--- a/cli/internal/config/manifest_test.go
+++ b/cli/internal/config/manifest_test.go
@@ -74,3 +74,79 @@ func TestMergeStackPreservesCLIFields(t *testing.T) {
 		t.Errorf("BinaryPath = %q, want preserved /tmp/jentic", got.BinaryPath)
 	}
 }
+
+// TestMergeStackRecordsStackRef: `install` builds the stack, so it establishes
+// the StackRef baseline the next update compares against.
+func TestMergeStackRecordsStackRef(t *testing.T) {
+	paths := Paths{Root: t.TempDir()}
+	m := &Manifest{Repo: "jentic/jentic-one"}
+	if err := m.MergeStack(paths, ModeDocker, "postgres", "8100", "v0.25.0", "abc1234", "v0.25.0"); err != nil {
+		t.Fatalf("MergeStack: %v", err)
+	}
+	got, _, err := LoadManifest(paths)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.StackRef != "v0.25.0" {
+		t.Errorf("StackRef = %q, want v0.25.0", got.StackRef)
+	}
+}
+
+// TestResolvedStackRefFallsBackToRef: installs written before stack_ref existed
+// have no value, and must keep behaving as they did (gated on Ref) rather than
+// reporting an empty stack version.
+func TestResolvedStackRefFallsBackToRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest Manifest
+		want     string
+	}{
+		{"stack_ref set wins", Manifest{Ref: "v0.26.0", StackRef: "v0.25.0"}, "v0.25.0"},
+		{"legacy manifest falls back to ref", Manifest{Ref: "v0.25.0"}, "v0.25.0"},
+		{"empty manifest is empty", Manifest{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.manifest.ResolvedStackRef(); got != tt.want {
+				t.Errorf("ResolvedStackRef() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRecordStackBuildPersistsRef: a successful stack rebuild advances StackRef
+// without disturbing the CLI's own Ref (the two halves move independently).
+func TestRecordStackBuildPersistsRef(t *testing.T) {
+	paths := Paths{Root: t.TempDir()}
+	m := &Manifest{Repo: "jentic/jentic-one", Ref: "v0.26.0", StackRef: "v0.25.0", CLIVersion: "v0.26.0"}
+	if err := m.Save(paths); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := m.RecordStackBuild(paths, "v0.26.0"); err != nil {
+		t.Fatalf("RecordStackBuild: %v", err)
+	}
+
+	got, _, err := LoadManifest(paths)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.StackRef != "v0.26.0" {
+		t.Errorf("StackRef = %q, want v0.26.0", got.StackRef)
+	}
+	if got.Ref != "v0.26.0" || got.CLIVersion != "v0.26.0" {
+		t.Errorf("CLI fields disturbed: ref=%q cli_version=%q", got.Ref, got.CLIVersion)
+	}
+}
+
+// TestRecordStackBuildIgnoresEmptyRef: never blank out a known-good StackRef
+// when the caller could not resolve a ref.
+func TestRecordStackBuildIgnoresEmptyRef(t *testing.T) {
+	paths := Paths{Root: t.TempDir()}
+	m := &Manifest{StackRef: "v0.25.0"}
+	if err := m.RecordStackBuild(paths, ""); err != nil {
+		t.Fatalf("RecordStackBuild: %v", err)
+	}
+	if m.StackRef != "v0.25.0" {
+		t.Errorf("StackRef = %q, want preserved v0.25.0", m.StackRef)
+	}
+}

--- a/tests/tools/install_test.sh
+++ b/tests/tools/install_test.sh
@@ -170,6 +170,52 @@ else
   pass "detect_platform: unsupported arch exits non-zero"
 fi
 
+# --- write_manifest preserves stack-owned fields across a CLI-only run ---
+# This script only ever builds the CLI binaries. `stack_ref` records what the
+# *stack* was last built from, so dropping it would let a CLI update advertise a
+# stale stack as current and wedge later updates (jentic-one#943). mode/db/
+# broker_port are likewise owned by `jenticctl install`.
+tmp_home="$(mktemp -d "${TMPDIR:-/tmp}/jentic-test-home.XXXXXX")"
+cat > "$tmp_home/install.json" <<'EOF'
+{
+  "repo": "jentic/jentic-one",
+  "ref": "v0.24.0",
+  "stack_ref": "v0.24.0",
+  "commit": "aaaaaaa",
+  "cli_version": "v0.24.0",
+  "binary_path": "/opt/homebrew/bin/jenticctl",
+  "mode": "docker",
+  "db": "postgres",
+  "broker_port": "8100",
+  "installed_at": "2026-01-01T00:00:00Z"
+}
+EOF
+(
+  export JENTIC_HOME="$tmp_home"
+  JENTIC_REPO="jentic/jentic-one" JENTIC_REF="v0.25.0" \
+    BUILT_COMMIT="bbbbbbb" INSTALLED_PATH="/opt/homebrew/bin/jenticctl" \
+    write_manifest >/dev/null 2>&1
+)
+manifest_out="$(cat "$tmp_home/install.json")"
+assert_contains "write_manifest: advances ref to the new CLI build" "$manifest_out" '"ref": "v0.25.0"'
+assert_contains "write_manifest: preserves stack_ref (#943)" "$manifest_out" '"stack_ref": "v0.24.0"'
+assert_contains "write_manifest: preserves mode" "$manifest_out" '"mode": "docker"'
+assert_contains "write_manifest: preserves db" "$manifest_out" '"db": "postgres"'
+assert_contains "write_manifest: preserves broker_port" "$manifest_out" '"broker_port": "8100"'
+
+# A fresh install (no prior manifest) must not emit an empty stack_ref: the
+# stack has not been built yet, and `""` would parse as a real (bogus) value.
+rm -f "$tmp_home/install.json"
+(
+  export JENTIC_HOME="$tmp_home"
+  JENTIC_REPO="jentic/jentic-one" JENTIC_REF="v0.25.0" \
+    BUILT_COMMIT="bbbbbbb" INSTALLED_PATH="/opt/homebrew/bin/jenticctl" \
+    write_manifest >/dev/null 2>&1
+)
+manifest_out="$(cat "$tmp_home/install.json")"
+assert_not_contains "write_manifest: fresh install omits stack_ref" "$manifest_out" 'stack_ref'
+rm -rf "$tmp_home"
+
 # --- highest_release_tag: latest canonical release tag from ls-remote output ---
 # Mirrors the Go highestReleaseTag (cli/internal/update/version.go): keep only
 # clean vX.Y.Z tags; ignore cli/v* noise, pre-releases, and peeled "^{}" lines.

--- a/tests/tools/install_test.sh
+++ b/tests/tools/install_test.sh
@@ -216,6 +216,61 @@ manifest_out="$(cat "$tmp_home/install.json")"
 assert_not_contains "write_manifest: fresh install omits stack_ref" "$manifest_out" 'stack_ref'
 rm -rf "$tmp_home"
 
+# --- write_manifest: backfill stack_ref for pre-stack_ref manifests ------------
+# Every manifest written before stack_ref existed records the stack's build only
+# in `ref` — the field a CLI-only re-install overwrites. Losing it makes
+# ResolvedStackRef() fall back to the *new* `ref`, so a stale stack reports
+# itself current: #943, re-created on the first CLI-only re-install, which is
+# precisely when the wedge occurs. `mode` is written by `jenticctl install`, so
+# its presence is what says "a stack was built at this ref".
+tmp_home="$(mktemp -d "${TMPDIR:-/tmp}/jentic-test-home.XXXXXX")"
+cat > "$tmp_home/install.json" <<'EOF'
+{
+  "repo": "jentic/jentic-one",
+  "ref": "v0.25.0",
+  "commit": "f4cb196",
+  "cli_version": "v0.25.0",
+  "binary_path": "/opt/homebrew/bin/jenticctl",
+  "mode": "docker",
+  "db": "postgres",
+  "installed_at": "2026-08-04T10:42:27Z"
+}
+EOF
+(
+  export JENTIC_HOME="$tmp_home"
+  JENTIC_REPO="jentic/jentic-one" JENTIC_REF="v0.26.0" \
+    BUILT_COMMIT="ccccccc" INSTALLED_PATH="/opt/homebrew/bin/jenticctl" \
+    write_manifest >/dev/null 2>&1
+)
+manifest_out="$(cat "$tmp_home/install.json")"
+assert_contains "write_manifest: legacy manifest advances ref" "$manifest_out" '"ref": "v0.26.0"'
+assert_contains "write_manifest: backfills stack_ref from the old ref (#943)" \
+  "$manifest_out" '"stack_ref": "v0.25.0"'
+
+# A legacy manifest with no `mode` never had a stack built, so there is nothing
+# to backfill — inventing a stack_ref would claim a stack that does not exist.
+rm -f "$tmp_home/install.json"
+cat > "$tmp_home/install.json" <<'EOF'
+{
+  "repo": "jentic/jentic-one",
+  "ref": "v0.25.0",
+  "commit": "f4cb196",
+  "cli_version": "v0.25.0",
+  "binary_path": "/opt/homebrew/bin/jenticctl",
+  "installed_at": "2026-08-04T10:42:27Z"
+}
+EOF
+(
+  export JENTIC_HOME="$tmp_home"
+  JENTIC_REPO="jentic/jentic-one" JENTIC_REF="v0.26.0" \
+    BUILT_COMMIT="ccccccc" INSTALLED_PATH="/opt/homebrew/bin/jenticctl" \
+    write_manifest >/dev/null 2>&1
+)
+manifest_out="$(cat "$tmp_home/install.json")"
+assert_not_contains "write_manifest: CLI-only legacy manifest omits stack_ref" \
+  "$manifest_out" 'stack_ref'
+rm -rf "$tmp_home"
+
 # --- highest_release_tag: latest canonical release tag from ls-remote output ---
 # Mirrors the Go highestReleaseTag (cli/internal/update/version.go): keep only
 # clean vX.Y.Z tags; ignore cli/v* noise, pre-releases, and peeled "^{}" lines.

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -653,18 +653,26 @@ print_path_hint() {
 # which repo/ref/commit to track. We write the CLI fields here; `jenticctl install`
 # fills in the stack fields (mode, db). binary_path records the primary
 # (jenticctl) binary; the sibling jentic binary is co-located in the same dir.
-# Preserve any previously recorded mode/db so a CLI-only re-install doesn't wipe
-# the stack metadata.
+# Preserve any previously recorded stack-owned fields (mode/db/broker_port and
+# stack_ref) so a CLI-only re-install doesn't wipe the stack metadata.
 write_manifest() {
-  local home_dir manifest now prev_mode prev_db
+  local home_dir manifest now prev_mode prev_db prev_broker_port prev_stack_ref
   home_dir="${JENTIC_HOME:-$HOME/.jentic}"
   manifest="$home_dir/install.json"
   now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   prev_mode=""
   prev_db=""
+  prev_broker_port=""
+  prev_stack_ref=""
   if [ -f "$manifest" ]; then
-    prev_mode="$(sed -n 's/.*"mode"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest" | head -n1)"
-    prev_db="$(sed -n 's/.*"db"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest" | head -n1)"
+    prev_mode="$(manifest_field "$manifest" mode)"
+    prev_db="$(manifest_field "$manifest" db)"
+    prev_broker_port="$(manifest_field "$manifest" broker_port)"
+    # stack_ref records what the *stack* was last built from. This script only
+    # ever builds the CLI binaries, so carrying it over is what stops a CLI
+    # update from advertising the stack as current (jentic-one#943). Losing it
+    # would silently re-wedge users on a stale stack.
+    prev_stack_ref="$(manifest_field "$manifest" stack_ref)"
   fi
 
   mkdir -p "$home_dir"
@@ -672,16 +680,24 @@ write_manifest() {
     printf '{\n'
     printf '  "repo": "%s",\n' "$JENTIC_REPO"
     printf '  "ref": "%s",\n' "$JENTIC_REF"
+    if [ -n "$prev_stack_ref" ]; then printf '  "stack_ref": "%s",\n' "$prev_stack_ref"; fi
     printf '  "commit": "%s",\n' "${BUILT_COMMIT:-none}"
     printf '  "cli_version": "%s",\n' "$JENTIC_REF"
     printf '  "binary_path": "%s",\n' "$INSTALLED_PATH"
     if [ -n "$prev_mode" ]; then printf '  "mode": "%s",\n' "$prev_mode"; fi
     if [ -n "$prev_db" ]; then printf '  "db": "%s",\n' "$prev_db"; fi
+    if [ -n "$prev_broker_port" ]; then printf '  "broker_port": "%s",\n' "$prev_broker_port"; fi
     printf '  "installed_at": "%s"\n' "$now"
     printf '}\n'
   } > "$manifest"
   chmod 0600 "$manifest" 2>/dev/null || true
   ok "Recorded manifest ${C_DIM}->${C_RESET} ${manifest}"
+}
+
+# manifest_field extracts a top-level string value from the install manifest by
+# key. Kept to sed so the installer stays dependency-free (no jq).
+manifest_field() {
+  sed -n 's/.*"'"$2"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$1" | head -n1
 }
 
 # --- verify -----------------------------------------------------------------

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -673,6 +673,17 @@ write_manifest() {
     # update from advertising the stack as current (jentic-one#943). Losing it
     # would silently re-wedge users on a stale stack.
     prev_stack_ref="$(manifest_field "$manifest" stack_ref)"
+    # Backfill for manifests written before stack_ref existed. Such a manifest
+    # records the stack's build only in `ref`, which we are about to overwrite
+    # with the newly installed CLI ref. Without this, the old value is lost and
+    # ResolvedStackRef() falls back to the *new* `ref`, so a stale stack reports
+    # itself current — re-creating #943 on the very first CLI-only re-install,
+    # which is exactly when it bites. `mode` is written by `jenticctl install`,
+    # so its presence is what distinguishes "a stack was installed at this ref"
+    # from a CLI-only install that never built one.
+    if [ -z "$prev_stack_ref" ] && [ -n "$prev_mode" ]; then
+      prev_stack_ref="$(manifest_field "$manifest" ref)"
+    fi
   fi
 
   mkdir -p "$home_dir"


### PR DESCRIPTION
Closes #943

## Summary

`jenticctl update` kept a single `ref` in `~/.jentic/install.json` shared by **both** update halves (CLI binaries and the stack). When the CLI half succeeded but the stack half did not actually rebuild, the manifest still advertised the new version — so every later `jenticctl update` short-circuited with *"Already up to date (vX.Y.Z); nothing to rebuild"* with no non-`--ref` way out. The stack stayed stale indefinitely.

Because the SPA bundle is baked into the app image (the `ui-builder` stage of `deploy/docker/python-base.Dockerfile`), the user-visible symptom was **"I updated but the UI is still the old one"** — which reads as a UI bug, not an update bug. That misdirection is most of the cost of this one.

Found on a real `mode: docker` install: CLI and manifest both read `v0.25.0` while the running `jentic-one/app:jentic-cli` image was 7 days old.

## Root cause

The comment above `updateNeeded` already stated the intended contract — *"Each requested half is gated on its own recorded version"* — but both halves read the same `manifest.Ref`, so the intent was never realised. `updateStack` also never wrote back on success, so nothing distinguished "stack rebuilt to N+1" from "CLI moved to N+1 while the stack sat at N".

## Changes

- **`config.Manifest`**: new `stack_ref` field recording what the stack was last built from. `ResolvedStackRef()` falls back to `ref` when absent, so installs written before this field migrate transparently with no behaviour change.
- **Gate + write-back**: the stack half is gated on `stack_ref`, and `stack_ref` is written **only after** `updateStack` returns successfully. A failed or skipped rebuild can no longer mark itself current. The write is best-effort — the rebuild already succeeded, so a manifest failure costs at most one redundant rebuild rather than failing the command.
- **Visibility**: `update` now reports the stack's recorded build next to the CLI's, so a divergence between the halves is visible instead of silent.
- **`tools/install.sh`**: `write_manifest` runs on every update (only `chain_install` is skipped), and it rewrote the manifest from scratch — it would have dropped `stack_ref` and silently re-wedged users. It now carries `stack_ref` over, plus `broker_port`, which was being lost the same way. Field extraction is factored into a `manifest_field` helper, still sed-based so the installer stays dependency-free.

## Not in this PR

Two adjacent bugs found in the same investigation, kept separate to stay reviewable:

- **`--ref` is ignored by the stack half.** `BuildPlan.fetchSource` does `git reset --hard origin/<default-branch>`, so `--ref v0.25.0` builds `main`. Worth noting this also means the natural workaround for the bug fixed here silently builds the wrong ref — so operator guidance should not recommend `--ref` until it is fixed.
- **The SPA shell is served with an `ETag` but no `Cache-Control`**, so browsers heuristically cache `index.html` and keep rendering the previous UI even after a fully correct update.

## Test plan

Both new tests were verified to **fail** against the pre-fix behaviour, not just pass after it:

- Reverting `ResolvedStackRef()` to return `Ref` only → `TestUpdateNeededStackRefGatesIndependently` fails with *"stale stack with a current CLI reported nothing to rebuild (#943 regression)"*.
- Removing the `stack_ref` line from `write_manifest` → `not ok 15 - write_manifest: preserves stack_ref (#943)`.

Coverage added:
- [x] `TestUpdateNeededStackRefGatesIndependently` — the wedge scenario (current CLI + stale stack must still rebuild), the rebuilt case (no-op), and a legacy manifest with no `stack_ref`.
- [x] `TestResolvedStackRefFallsBackToRef` — `stack_ref` wins, legacy falls back to `ref`, empty stays empty.
- [x] `TestRecordStackBuildPersistsRef` / `...IgnoresEmptyRef` — advances `stack_ref` without disturbing CLI fields; never blanks a known-good value.
- [x] `TestMergeStackRecordsStackRef` — `install` establishes the baseline.
- [x] Installer: `stack_ref`/`mode`/`db`/`broker_port` preserved across a CLI-only run; a fresh install omits `stack_ref` rather than emitting an empty string.

Verification run:
- [x] `go build ./...`, `go vet ./...`, `go test ./...` (all packages) pass
- [x] `make lint` → 0 issues
- [x] `bash tests/tools/install_test.sh` → all 33 checks pass
- [x] Committed CLI reference is not drifted by this change

Please **squash merge**.

Made with [Cursor](https://cursor.com)