### PR TITLE
fix(web): revalidate the SPA shell and cache hashed assets immutably

### DIFF
--- a/src/jentic_one/shared/web/static.py
+++ b/src/jentic_one/shared/web/static.py
@@ -37,6 +37,12 @@ collide). The serving layer is the only component that knows which mode it's
 in, so it exposes that path to the SPA via a tiny JSON config endpoint
 (``GET /app-config.json``) the SPA fetches on boot — replacing the older
 ``index.html`` HTML-rewrite. The bundle is served byte-for-byte as built.
+
+Cache policy is applied by :class:`SPACacheHeadersMiddleware`: the unversioned
+shell is revalidated on every navigation while Vite's content-hashed assets are
+cached immutably. Without it a browser can serve a stale ``index.html`` that
+names the *previous* build's assets, so a correctly-upgraded server still
+renders the old UI (#945).
 """
 
 from __future__ import annotations
@@ -48,6 +54,7 @@ from pathlib import Path
 import structlog
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse, RedirectResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 _logger = structlog.get_logger(__name__)
 
@@ -56,6 +63,25 @@ _logger = structlog.get_logger(__name__)
 # is a true 404. Kept in lockstep with the UI's Vite ``base`` and React Router
 # ``basename`` (both ``/app`` — see ``ui/vite.config.ts`` / ``ui/src/main.tsx``).
 SPA_MOUNT_PATH = "/app"
+
+# Subpath under the SPA mount holding Vite's content-hashed build output
+# (``/app/assets/index-<hash>.js``). A new build emits new filenames, so these
+# URLs are immutable and safe to cache forever — see :data:`_IMMUTABLE_CACHE`.
+_ASSETS_PREFIX = f"{SPA_MOUNT_PATH}/assets/"
+
+# Cache policy for content-hashed assets: the hash *is* the version, so a URL's
+# bytes never change and the client need never revalidate. One year is the
+# conventional maximum (RFC 9111 caps practical freshness lifetimes there).
+_IMMUTABLE_CACHE = "public, max-age=31536000, immutable"
+
+# Cache policy for the SPA shell (``index.html``) and every deep-link URL that
+# falls back to it. The filename is *not* versioned, so a cached shell keeps
+# referencing the previous build's hashed assets and the app renders stale
+# indefinitely after an upgrade. ``no-cache`` does not mean "don't store" — it
+# means "always revalidate before reuse", so the existing ``ETag`` still yields
+# a cheap 304 when the build is unchanged, but a new build is picked up on the
+# next navigation without a manual hard reload (#945).
+_REVALIDATE_CACHE = "no-cache"
 
 # Fixed, mode-independent path the SPA fetches on boot to learn deploy-mode
 # facts (currently just the admin health path). Served at the site root (NOT
@@ -137,6 +163,77 @@ def _resolve_static_dir() -> Path | None:
     return _resolve_dev_static_dir()
 
 
+def _cache_control_for(path: str) -> str:
+    """Return the ``Cache-Control`` value for an SPA path.
+
+    Content-hashed assets are immutable; everything else under the mount is (or
+    falls back to) the unversioned shell and must be revalidated.
+    """
+    if path.startswith(_ASSETS_PREFIX):
+        return _IMMUTABLE_CACHE
+    return _REVALIDATE_CACHE
+
+
+class SPACacheHeadersMiddleware:
+    """Stamp cache policy on SPA responses so an upgrade is picked up.
+
+    ``app.frontend()`` serves the bundle with an ``ETag`` but no
+    ``Cache-Control``, and it exposes no hook to add one. Without an explicit
+    directive a browser applies *heuristic* freshness to ``index.html`` and may
+    reuse it for a long time without revalidating. Since the shell names the
+    hashed asset files, a stale shell keeps loading the previous build's JS/CSS
+    and the app renders the old UI indefinitely after a correct server-side
+    upgrade — indistinguishable, from the operator's seat, from a broken
+    update (#945).
+
+    So the shell (and every deep-link path that falls back to it) is served
+    ``no-cache``: still cached, but always revalidated, which the existing
+    ``ETag`` turns into a cheap 304 when nothing changed. The hashed assets
+    under ``/app/assets/`` go the other way and are cached immutably — their URL
+    changes whenever their bytes do, so revalidating them is pure waste.
+
+    Implemented as **pure ASGI middleware** (not ``BaseHTTPMiddleware``) for the
+    same reason as ``RequestIDMiddleware``: it operates on ``scope``/``send``
+    without materialising a Starlette ``Response`` or wrapping the downstream
+    app in a cancel scope (#627).
+
+    Only responses under :data:`SPA_MOUNT_PATH` are touched, and an explicit
+    ``Cache-Control`` already set by a route is never overwritten — the
+    middleware fills a gap, it does not impose policy on API responses.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or not self._owns(scope.get("path", "")):
+            await self._app(scope, receive, send)
+            return
+        await self._app(scope, receive, self._with_cache_control(send, scope["path"]))
+
+    @staticmethod
+    def _owns(path: str) -> bool:
+        """Whether path is the SPA mount itself or lives under it.
+
+        Guards against a sibling prefix (``/apple-touch-icon.png``,
+        ``/application/...``) matching on a bare ``startswith``.
+        """
+        return path == SPA_MOUNT_PATH or path.startswith(f"{SPA_MOUNT_PATH}/")
+
+    @staticmethod
+    def _with_cache_control(send: Send, path: str) -> Send:
+        directive = _cache_control_for(path).encode("latin-1")
+
+        async def wrapped(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = message.get("headers", [])
+                if not any(name.lower() == b"cache-control" for name, _ in headers):
+                    message = {**message, "headers": [*headers, (b"cache-control", directive)]}
+            await send(message)
+
+        return wrapped
+
+
 def mount_spa(app: FastAPI, *, health_path: str = "/health") -> bool:
     """Serve the built SPA on ``app`` if a bundle is packaged.
 
@@ -203,6 +300,12 @@ def mount_spa(app: FastAPI, *, health_path: str = "/health") -> bool:
     # routes never live under /app anyway, so this only governs unknown /app/*
     # subpaths (always SPA routes in practice).
     app.frontend(SPA_MOUNT_PATH, directory=str(static_dir), fallback="auto")
+
+    # Cache policy for the bundle. ``app.frontend()`` sets an ETag but no
+    # Cache-Control, which lets browsers heuristically cache the unversioned
+    # shell and keep rendering a previous build's assets after an upgrade
+    # (#945). See :class:`SPACacheHeadersMiddleware`.
+    app.add_middleware(SPACacheHeadersMiddleware)
 
     # Flag consumed by the shared 401 handler (app_factory): only when an SPA
     # is actually mounted does an anonymous HTML navigation that 401s get

--- a/src/jentic_one/shared/web/static.py
+++ b/src/jentic_one/shared/web/static.py
@@ -163,13 +163,23 @@ def _resolve_static_dir() -> Path | None:
     return _resolve_dev_static_dir()
 
 
-def _cache_control_for(path: str) -> str:
-    """Return the ``Cache-Control`` value for an SPA path.
+def _cache_control_for(path: str, status: int) -> str:
+    """Return the ``Cache-Control`` value for an SPA response.
 
     Content-hashed assets are immutable; everything else under the mount is (or
     falls back to) the unversioned shell and must be revalidated.
+
+    ``status`` gates the immutable directive because "this URL's bytes never
+    change" is only true of a response that actually *served* those bytes. A
+    ``404`` for a hashed asset is transient — a client that loaded a new shell
+    while a replica still served the old build, or a partially-synced deploy —
+    and caching it for a year would pin a broken UI that no later deploy could
+    repair. Negative and error responses therefore revalidate.
+
+    ``304 Not Modified`` counts as success: it is the cache *working*, and the
+    directive has to survive on it or the client has nothing to apply next time.
     """
-    if path.startswith(_ASSETS_PREFIX):
+    if path.startswith(_ASSETS_PREFIX) and (200 <= status < 300 or status == 304):
         return _IMMUTABLE_CACHE
     return _REVALIDATE_CACHE
 
@@ -190,7 +200,10 @@ class SPACacheHeadersMiddleware:
     ``no-cache``: still cached, but always revalidated, which the existing
     ``ETag`` turns into a cheap 304 when nothing changed. The hashed assets
     under ``/app/assets/`` go the other way and are cached immutably — their URL
-    changes whenever their bytes do, so revalidating them is pure waste.
+    changes whenever their bytes do, so revalidating them is pure waste. The
+    immutable directive is applied only to a *successful* asset response: a
+    transient 404 (mid-deploy skew) cached for a year would pin a broken UI that
+    no later deploy could repair.
 
     Implemented as **pure ASGI middleware** (not ``BaseHTTPMiddleware``) for the
     same reason as ``RequestIDMiddleware``: it operates on ``scope``/``send``
@@ -222,12 +235,11 @@ class SPACacheHeadersMiddleware:
 
     @staticmethod
     def _with_cache_control(send: Send, path: str) -> Send:
-        directive = _cache_control_for(path).encode("latin-1")
-
         async def wrapped(message: Message) -> None:
             if message["type"] == "http.response.start":
                 headers = message.get("headers", [])
                 if not any(name.lower() == b"cache-control" for name, _ in headers):
+                    directive = _cache_control_for(path, message["status"]).encode("latin-1")
                     message = {**message, "headers": [*headers, (b"cache-control", directive)]}
             await send(message)
 

--- a/tests/unit/shared/test_static_spa.py
+++ b/tests/unit/shared/test_static_spa.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import pytest
 from fastapi import APIRouter, FastAPI
+from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
 import jentic_one.shared.web.static as static_mod
@@ -246,6 +247,119 @@ def test_app_config_endpoint_is_not_shadowed_by_frontend(
     resp = client.get(APP_CONFIG_PATH, headers=_HTML_HEADERS)
     assert resp.status_code == 200
     assert resp.json() == {"healthPath": "/health"}
+
+
+def test_shell_is_revalidated_and_hashed_assets_are_immutable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for #945: the shell must not be heuristically cacheable.
+
+    ``app.frontend()`` sets an ETag but no Cache-Control. With no directive a
+    browser may reuse ``index.html`` without revalidating, and since the shell
+    names the hashed asset files it keeps loading the *previous* build — the app
+    renders the old UI after a correct server-side upgrade.
+
+    So the shell revalidates (``no-cache``) while the content-hashed assets,
+    whose URL changes whenever their bytes do, are cached immutably.
+    """
+    static_dir = _make_static_bundle(tmp_path)
+    monkeypatch.setattr(static_mod, "_resolve_static_dir", lambda: static_dir)
+
+    app = FastAPI()
+    mount_spa(app)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    # The shell, at the mount root and via a deep-link fallback.
+    for path in (f"{SPA_MOUNT_PATH}/", f"{SPA_MOUNT_PATH}/agents/some-id/settings"):
+        resp = client.get(path, headers=_HTML_HEADERS)
+        assert resp.status_code == 200, path
+        assert resp.headers["cache-control"] == "no-cache", path
+
+    # A hashed asset is immutable: cached forever, never revalidated.
+    asset = client.get(f"{SPA_MOUNT_PATH}/assets/app.js")
+    assert asset.status_code == 200
+    assert asset.headers["cache-control"] == "public, max-age=31536000, immutable"
+
+
+def test_shell_revalidation_still_yields_304_when_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``no-cache`` must stay cheap: revalidation, not re-download.
+
+    The point of ``no-cache`` (rather than ``no-store``) is that the shell is
+    still cached — the client just has to ask first. The ETag turns that ask
+    into a 304 with no body while the build is unchanged, so the correctness fix
+    does not cost a full shell fetch per navigation.
+    """
+    static_dir = _make_static_bundle(tmp_path)
+    monkeypatch.setattr(static_mod, "_resolve_static_dir", lambda: static_dir)
+
+    app = FastAPI()
+    mount_spa(app)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    first = client.get(f"{SPA_MOUNT_PATH}/", headers=_HTML_HEADERS)
+    etag = first.headers["etag"]
+
+    revalidated = client.get(f"{SPA_MOUNT_PATH}/", headers={**_HTML_HEADERS, "If-None-Match": etag})
+    assert revalidated.status_code == 304
+    assert not revalidated.content
+    # The directive must be present on the 304 too, or the client has nothing to
+    # apply for the *next* navigation.
+    assert revalidated.headers["cache-control"] == "no-cache"
+
+
+def test_cache_headers_do_not_leak_outside_the_spa_mount(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The middleware owns /app only; API responses keep their own policy.
+
+    Also pins the prefix boundary: a sibling path that merely *starts with*
+    ``/app`` (``/app-config.json``, ``/apple-touch-icon.png``) is not the SPA
+    and must not be stamped.
+    """
+    static_dir = _make_static_bundle(tmp_path)
+    monkeypatch.setattr(static_mod, "_resolve_static_dir", lambda: static_dir)
+
+    app = FastAPI()
+    router = APIRouter()
+
+    @router.get("/users")
+    def _users() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    app.include_router(router)
+    mount_spa(app)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    assert "cache-control" not in client.get("/users").headers
+    # /app-config.json is a real route outside the mount despite the prefix.
+    assert "cache-control" not in client.get(APP_CONFIG_PATH).headers
+
+
+def test_explicit_cache_control_is_not_overwritten(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The middleware fills a gap; it never overrides a deliberate policy.
+
+    A route under the mount that sets its own Cache-Control keeps it, so this
+    stays a default rather than an imposition.
+    """
+    static_dir = _make_static_bundle(tmp_path)
+    monkeypatch.setattr(static_mod, "_resolve_static_dir", lambda: static_dir)
+
+    app = FastAPI()
+
+    @app.get(f"{SPA_MOUNT_PATH}/live-thing", include_in_schema=False)
+    async def _live() -> JSONResponse:
+        return JSONResponse({"v": 1}, headers={"Cache-Control": "no-store"})
+
+    mount_spa(app)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get(f"{SPA_MOUNT_PATH}/live-thing")
+    assert resp.status_code == 200
+    assert resp.headers["cache-control"] == "no-store"
 
 
 def _make_source_checkout(tmp_path: Path, *, with_bundle: bool) -> Path:

--- a/tests/unit/shared/test_static_spa.py
+++ b/tests/unit/shared/test_static_spa.py
@@ -362,6 +362,59 @@ def test_explicit_cache_control_is_not_overwritten(
     assert resp.headers["cache-control"] == "no-store"
 
 
+def test_missing_hashed_asset_is_not_cached_immutably(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 404 for a hashed asset must NOT be cached for a year.
+
+    "This URL is immutable" is only true of a response that served the bytes. A
+    404 under ``/app/assets/`` is transient — a client on a freshly-loaded shell
+    requesting an asset from a replica still serving the previous build, or a
+    partially-synced deploy. Pinning that for a year would leave a permanently
+    broken UI that no *later* deploy could repair, which is the same class of
+    failure this middleware exists to prevent.
+    """
+    static_dir = _make_static_bundle(tmp_path)
+    monkeypatch.setattr(static_mod, "_resolve_static_dir", lambda: static_dir)
+
+    app = FastAPI()
+    mount_spa(app)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    missing = client.get(f"{SPA_MOUNT_PATH}/assets/index-DOESNOTEXIST.js")
+    assert missing.status_code == 404
+    assert "immutable" not in missing.headers.get("cache-control", "")
+    assert missing.headers["cache-control"] == "no-cache"
+
+    # The successful case still gets the immutable treatment.
+    present = client.get(f"{SPA_MOUNT_PATH}/assets/app.js")
+    assert present.status_code == 200
+    assert present.headers["cache-control"] == "public, max-age=31536000, immutable"
+
+
+def test_asset_304_keeps_the_immutable_directive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 304 is the cache working, so it must keep the immutable directive.
+
+    Excluding non-200s must not accidentally sweep up 304s: dropping the
+    directive there would leave the client with nothing to apply next time.
+    """
+    static_dir = _make_static_bundle(tmp_path)
+    monkeypatch.setattr(static_mod, "_resolve_static_dir", lambda: static_dir)
+
+    app = FastAPI()
+    mount_spa(app)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    first = client.get(f"{SPA_MOUNT_PATH}/assets/app.js")
+    revalidated = client.get(
+        f"{SPA_MOUNT_PATH}/assets/app.js", headers={"If-None-Match": first.headers["etag"]}
+    )
+    assert revalidated.status_code == 304
+    assert revalidated.headers["cache-control"] == "public, max-age=31536000, immutable"
+
+
 def _make_source_checkout(tmp_path: Path, *, with_bundle: bool) -> Path:
     """Simulate a source checkout: a repo root with pyproject.toml and ui/dist."""
     tmp_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Closes #945

## Summary

The SPA bundle was served with an `ETag` but **no `Cache-Control`**, so browsers applied *heuristic* freshness to `index.html`. Because the shell names the content-hashed asset files, a cached shell kept loading the **previous build's** JS/CSS — a correctly-upgraded server still rendered the old UI until the user knew to hard-reload.

The real cost of this one is misdirection: it turns any successful upgrade into an apparent UI regression, sending people to look at the frontend or the update command instead of cache policy. It materially slowed down diagnosing an unrelated update bug (#943).

Observed live, right after a verified-correct image rebuild:

```
$ curl -sI http://127.0.0.1:8000/app/
HTTP/1.1 200 OK
last-modified: Tue, 04 Aug 2026 11:03:32 GMT
etag: "2e2a197c66817017b7a4b0da2b228da9"
        <-- no cache-control
```

## Changes

Two directives, opposite in intent, both derived from whether the URL is versioned:

| Path | Policy | Why |
| --- | --- | --- |
| Shell — `/app/`, `/app/<deep-link>` | `no-cache` | Filename is unversioned, so it must be revalidated or it pins the old build. `no-cache` still *caches* — it just requires an ask first, which the existing `ETag` answers with a cheap `304`. |
| `/app/assets/*` | `public, max-age=31536000, immutable` | The content hash *is* the version; the bytes at a URL never change, so revalidating is pure waste. Previously these got the same heuristic treatment as the shell. |

`FastAPI.frontend()` exposes no header or cache hook (checked against `fastapi==0.138.0`), so this is a small ASGI middleware. Three deliberate constraints:

- **Pure ASGI, not `BaseHTTPMiddleware`** — same reason documented on `RequestIDMiddleware`: `BaseHTTPMiddleware` wraps the downstream app in a cancel scope, which is the SSE-disconnect connection-leak interaction from #627.
- **Scoped to the mount** — `_owns()` matches `/app` exactly or `/app/`-prefixed, so a sibling path like `/app-config.json` or `/apple-touch-icon.png` is untouched. A bare `startswith("/app")` would have caught both.
- **Never overwrites an existing `Cache-Control`** — this is a default for the static bundle, not a policy imposed on responses that set their own.

## Test plan

Verified the new tests **fail** without the fix, not merely pass with it — disabling the `add_middleware` call fails `test_shell_is_revalidated_and_hashed_assets_are_immutable` and `test_shell_revalidation_still_yields_304_when_unchanged`.

Coverage added:
- [x] Shell revalidates at both the mount root and via a deep-link fallback; hashed assets are immutable.
- [x] `no-cache` stays *cheap*: an `If-None-Match` revalidation returns `304` with no body, and the directive is present on the `304` too (or the client has nothing to apply for the next navigation).
- [x] No leakage outside the mount — an API route and `/app-config.json` keep no `Cache-Control`, pinning the prefix boundary.
- [x] An explicit `Cache-Control` set by a route under the mount is preserved.

Verification run:
- [x] `pytest tests/unit/shared tests/arch` → 637 passed
- [x] `ruff check`, `ruff format`, `mypy` clean on changed files
- [x] Manual check against a bundle laid out like a real Vite build:

```
shell (mount root)     200  cache-control: 'no-cache'                              etag: yes
deep link refresh      200  cache-control: 'no-cache'                              etag: yes
hashed asset           200  cache-control: 'public, max-age=31536000, immutable'   etag: yes
```

## Note for reviewers

Existing users with an already-poisoned cache will still need one hard reload to pick up the first shell that carries the new header — after that, upgrades are seamless. Worth a line in the release notes.

Please **squash merge**.

Made with [Cursor](https://cursor.com)