### PR TITLE
fix(cli): honor --ref when building the stack

### DIFF
--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -120,6 +120,20 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 		return errors.New("--ref cannot pin a Homebrew-managed CLI (brew only ships the latest release); use --stack-only, or reinstall from source via tools/install.sh")
 	}
 
+	// A pinned ref cannot be applied to a local checkout: the stack builds from
+	// the operator's own working tree (cwd walk or $JENTIC_SRC), and syncing that
+	// to a ref would clobber their work. Refuse rather than build something other
+	// than what was asked for — silently ignoring the pin is the bug being fixed
+	// here (#949).
+	if doStack && pinned {
+		if plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath()).AtRef(ref); plan.PinnedRefIgnored() {
+			return fmt.Errorf("--ref %s cannot be applied: the stack builds from the local checkout at %s, "+
+				"so the ref would be ignored. Check out %s there yourself and re-run without --ref, "+
+				"or unset %s to build from a managed clone",
+				ref, plan.SourceDir, ref, install.SrcEnv)
+		}
+	}
+
 	// When the latest release is not newer than what's installed there's
 	// nothing to rebuild. Each requested half is gated on its own recorded
 	// version (see updateNeeded): they normally move in lockstep, but a
@@ -163,7 +177,7 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 		}
 	}
 	if doStack {
-		if err := a.updateStack(manifest.Mode); err != nil {
+		if err := a.updateStack(manifest.Mode, ref); err != nil {
 			return err
 		}
 	}
@@ -370,28 +384,30 @@ func binaryVersion(path string) (string, error) {
 
 // updateStack rebuilds and restarts the installed server in place, reusing the
 // existing jentic-one.yaml (no wizard). It dispatches on the recorded deploy
-// mode; an empty/unknown mode is treated as a local install.
-func (a *App) updateStack(mode string) error {
+// mode; an empty/unknown mode is treated as a local install. ref is the git ref
+// the stack is built from — the same one the CLI half targets, so the two halves
+// stay in lockstep.
+func (a *App) updateStack(mode, ref string) error {
 	fmt.Fprintln(a.Out)
 	fmt.Fprintln(a.Out, theme.Warn.Render("Stack update runs forward-only migrations — back up your data first"))
 	fmt.Fprintln(a.Out, theme.Dim.Render("  SQLite: copy ~/.jentic/data/*.db · Postgres: pg_dump your database"))
 
 	if mode == config.ModeDocker {
-		return a.updateStackDocker()
+		return a.updateStackDocker(ref)
 	}
-	return a.updateStackLocal()
+	return a.updateStackLocal(ref)
 }
 
 // updateStackLocal pulls the source, reinstalls into the existing venv, applies
 // migrations, and restarts the app if it was running.
-func (a *App) updateStackLocal() error {
+func (a *App) updateStackLocal(ref string) error {
 	configPath := a.Paths.InstallConfigPath()
 	if !proc.FileExists(configPath) {
 		return fmt.Errorf("not configured: %s not found — run `jenticctl install` first", configPath)
 	}
 
 	install.EnsureUv(a.Out)
-	plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath())
+	plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath()).AtRef(ref)
 	fmt.Fprintln(a.Out)
 	fmt.Fprint(a.Out, plan.RenderHeader())
 	if err := plan.Execute(a.Out); err != nil {
@@ -411,13 +427,13 @@ func (a *App) updateStackLocal() error {
 
 // updateStackDocker rebuilds the app image, applies migrations in a one-shot
 // container, and recreates the running stack with the new image.
-func (a *App) updateStackDocker() error {
+func (a *App) updateStackDocker(ref string) error {
 	composePath := a.Paths.ComposePath()
 	if !proc.FileExists(composePath) {
 		return fmt.Errorf("no compose stack at %s — run `jenticctl install` first", composePath)
 	}
 
-	plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath())
+	plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath()).AtRef(ref)
 	fmt.Fprintln(a.Out)
 	fmt.Fprint(a.Out, plan.RenderDockerBuildHeader())
 	if err := plan.BuildImages(a.Out); err != nil {

--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -126,7 +126,7 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 	// than what was asked for — silently ignoring the pin is the bug being fixed
 	// here (#949).
 	if doStack && pinned {
-		if plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath()).AtRef(ref); plan.PinnedRefIgnored() {
+		if plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath()).AtRef(ref, pinned); plan.PinnedRefIgnored() {
 			return fmt.Errorf("--ref %s cannot be applied: the stack builds from the local checkout at %s, "+
 				"so the ref would be ignored. Check out %s there yourself and re-run without --ref, "+
 				"or unset %s to build from a managed clone",
@@ -177,7 +177,7 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 		}
 	}
 	if doStack {
-		if err := a.updateStack(manifest.Mode, ref); err != nil {
+		if err := a.updateStack(manifest.Mode, ref, pinned); err != nil {
 			return err
 		}
 	}
@@ -387,27 +387,27 @@ func binaryVersion(path string) (string, error) {
 // mode; an empty/unknown mode is treated as a local install. ref is the git ref
 // the stack is built from — the same one the CLI half targets, so the two halves
 // stay in lockstep.
-func (a *App) updateStack(mode, ref string) error {
+func (a *App) updateStack(mode, ref string, pinned bool) error {
 	fmt.Fprintln(a.Out)
 	fmt.Fprintln(a.Out, theme.Warn.Render("Stack update runs forward-only migrations — back up your data first"))
 	fmt.Fprintln(a.Out, theme.Dim.Render("  SQLite: copy ~/.jentic/data/*.db · Postgres: pg_dump your database"))
 
 	if mode == config.ModeDocker {
-		return a.updateStackDocker(ref)
+		return a.updateStackDocker(ref, pinned)
 	}
-	return a.updateStackLocal(ref)
+	return a.updateStackLocal(ref, pinned)
 }
 
 // updateStackLocal pulls the source, reinstalls into the existing venv, applies
 // migrations, and restarts the app if it was running.
-func (a *App) updateStackLocal(ref string) error {
+func (a *App) updateStackLocal(ref string, pinned bool) error {
 	configPath := a.Paths.InstallConfigPath()
 	if !proc.FileExists(configPath) {
 		return fmt.Errorf("not configured: %s not found — run `jenticctl install` first", configPath)
 	}
 
 	install.EnsureUv(a.Out)
-	plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath()).AtRef(ref)
+	plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath()).AtRef(ref, pinned)
 	fmt.Fprintln(a.Out)
 	fmt.Fprint(a.Out, plan.RenderHeader())
 	if err := plan.Execute(a.Out); err != nil {
@@ -427,13 +427,13 @@ func (a *App) updateStackLocal(ref string) error {
 
 // updateStackDocker rebuilds the app image, applies migrations in a one-shot
 // container, and recreates the running stack with the new image.
-func (a *App) updateStackDocker(ref string) error {
+func (a *App) updateStackDocker(ref string, pinned bool) error {
 	composePath := a.Paths.ComposePath()
 	if !proc.FileExists(composePath) {
 		return fmt.Errorf("no compose stack at %s — run `jenticctl install` first", composePath)
 	}
 
-	plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath()).AtRef(ref)
+	plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath()).AtRef(ref, pinned)
 	fmt.Fprintln(a.Out)
 	fmt.Fprint(a.Out, plan.RenderDockerBuildHeader())
 	if err := plan.BuildImages(a.Out); err != nil {

--- a/cli/internal/install/build.go
+++ b/cli/internal/install/build.go
@@ -77,12 +77,16 @@ type BuildPlan struct {
 	// GitURL is the clone source (set when FromGit is true).
 	GitURL string
 	// Ref pins the git ref (tag, branch, or commit) the source is synced to
-	// before building. Empty means "track the remote's default branch", which is
-	// the right default for `install` and an unpinned `update`. When set, the
-	// build MUST land on exactly this ref or fail — silently building something
-	// else is how `update --ref vX.Y.Z` used to produce a stack built from main
-	// (#949).
+	// before building. Empty means "track the remote's default branch". When set,
+	// the build MUST land on exactly this ref or fail — silently building
+	// something else is how `update --ref vX.Y.Z` used to produce a stack built
+	// from main (#949).
 	Ref string
+	// RefPinned records that Ref came from an explicit `--ref`, rather than being
+	// the release tag `update` resolves on its own. Only an operator's explicit
+	// pin is worth reporting as "ignored" when it cannot be applied; saying that
+	// about a ref they never typed reads as if their input was discarded.
+	RefPinned bool
 }
 
 // PlanLocalBuild decides whether to build from a local checkout or to clone the
@@ -94,19 +98,21 @@ func PlanLocalBuild(venvDir, cloneDir string) BuildPlan {
 	return BuildPlan{SourceDir: cloneDir, VenvDir: venvDir, FromGit: true, GitURL: GitURL}
 }
 
-// AtRef returns a copy of the plan pinned to ref. An empty ref is a no-op, so
-// callers can pass through whatever they resolved without branching.
-func (p BuildPlan) AtRef(ref string) BuildPlan {
+// AtRef returns a copy of the plan targeting ref. pinned distinguishes an
+// explicit `--ref` from a ref the caller resolved itself. An empty ref is a
+// no-op, so callers can pass through whatever they resolved without branching.
+func (p BuildPlan) AtRef(ref string, pinned bool) BuildPlan {
 	p.Ref = ref
+	p.RefPinned = pinned && ref != ""
 	return p
 }
 
-// PinnedRefIgnored reports whether a caller-requested ref cannot be honoured
+// PinnedRefIgnored reports whether an explicitly requested ref cannot be honoured
 // because the build reads a local checkout rather than a managed clone. The
 // working tree belongs to the operator, so syncing it to a ref would clobber
 // their work; the caller must surface this instead of implying the ref was used.
 func (p BuildPlan) PinnedRefIgnored() bool {
-	return p.Ref != "" && !p.FromGit
+	return p.RefPinned && !p.FromGit
 }
 
 // VenvPython returns the python interpreter path inside the given venv dir.
@@ -137,7 +143,7 @@ func (p BuildPlan) writeSourceLine(b *strings.Builder) {
 		return
 	}
 	b.WriteString("  source: " + commandStyle.Render(p.SourceDir) + " (local checkout)\n")
-	if p.Ref != "" {
+	if p.PinnedRefIgnored() {
 		b.WriteString(warnStyle.Render("  note:   --ref "+p.Ref+
 			" does not apply to a local checkout; building it as-is") + "\n")
 	}
@@ -254,24 +260,8 @@ func (p BuildPlan) fetchSource(w io.Writer) error {
 		// the published repo. $SourceDir is a throwaway build checkout under
 		// ~/.jentic (never a tree the user edits), so matching the requested
 		// target exactly is the correct, always-succeeding sync.
-		//
-		// A shallow clone (`--depth 1`) only has the default branch's tip, so an
-		// explicit ref must be fetched before it can be resolved — otherwise a
-		// pinned tag looks "missing" in an existing build checkout.
-		fetch := append(append([]string{}, common...), "fetch", "--prune", "--tags", "origin")
-		if p.Ref != "" {
-			fetch = append(fetch, p.Ref)
-		}
-		if err := runGit(w, p.SourceDir, fetch...); err != nil {
-			return fmt.Errorf("fetch source: %w", err)
-		}
-		target, err := p.resetTarget(p.SourceDir)
-		if err != nil {
+		if err := p.syncTo(w, common); err != nil {
 			return err
-		}
-		reset := append(append([]string{}, common...), "reset", "--hard", target)
-		if err := runGit(w, p.SourceDir, reset...); err != nil {
-			return fmt.Errorf("sync source to %s: %w", target, err)
 		}
 		return nil
 	}
@@ -279,56 +269,54 @@ func (p BuildPlan) fetchSource(w io.Writer) error {
 		return fmt.Errorf("create source parent: %w", err)
 	}
 
-	args := append(append([]string{}, common...), "clone", "--depth", "1")
-	// `clone --branch` accepts a tag or a branch (not a bare commit), which
-	// covers the release tags `update` pins by default. A ref it cannot resolve
-	// this way still lands via the fetch+reset path below.
-	if p.Ref != "" {
-		args = append(args, "--branch", p.Ref)
-	}
-	args = append(args, p.GitURL, p.SourceDir)
+	// Clone the default branch even when a ref is requested, then move onto the
+	// ref below. `clone --branch <tag>` would be one step shorter but implies
+	// --single-branch, which rewrites remote.origin.fetch to just that tag and
+	// leaves no origin/<default-branch>. A later *unpinned* build could then
+	// never reset, so pinning once would permanently wedge the managed checkout
+	// (found reviewing #949). Cloning unpinned keeps the refspec general, and
+	// makes one code path serve tags, branches and bare commit SHAs alike.
+	args := append(append([]string{}, common...), "clone", "--depth", "1", p.GitURL, p.SourceDir)
 	if err := runGit(w, "", args...); err != nil {
-		// A commit SHA (or a ref this git can't --branch) fails the pinned clone.
-		// Fall back to a plain clone plus an explicit fetch+reset, which resolves
-		// anything the remote will serve.
-		if p.Ref != "" {
-			if fallbackErr := p.clonePinnedFallback(w, common); fallbackErr == nil {
-				return nil
-			}
-		}
 		if os.Getenv("GITHUB_TOKEN") == "" {
 			return fmt.Errorf("clone failed — %s is likely private. To build from a local "+
 				"checkout instead (no token needed), set %s=/path/to/jentic-one and re-run; "+
 				"or set a token with 'repo' read scope: GITHUB_TOKEN=ghp_xxx jenticctl install: %w",
 				p.GitURL, SrcEnv, err)
 		}
-		return fmt.Errorf("clone failed (check the ref and your token's access): %w", err)
+		return fmt.Errorf("clone failed (check your token's access): %w", err)
 	}
-	return nil
+	return p.syncTo(w, common)
 }
 
-// clonePinnedFallback handles a Ref that `clone --branch` cannot resolve (most
-// notably a bare commit SHA): clone the default branch, then fetch and hard
-// reset onto the requested ref.
-func (p BuildPlan) clonePinnedFallback(w io.Writer, common []string) error {
-	// The failed attempt may have left a partial directory behind.
-	if err := os.RemoveAll(p.SourceDir); err != nil {
-		return err
+// syncTo points the build checkout at the requested target: the pinned Ref, or
+// origin's default branch when unpinned. Shared by the fresh-clone and
+// existing-checkout paths so both resolve a ref identically.
+func (p BuildPlan) syncTo(w io.Writer, common []string) error {
+	// --force is required, not cosmetic: since git 2.20 a fetch will not move an
+	// existing tag, and exits non-zero with "would clobber existing tag". Any
+	// upstream tag that gets re-pointed (a re-cut release, the OSS re-baseline
+	// this fetch+reset design exists to survive) would otherwise break every
+	// later install/update against ~/.jentic/src until it was deleted by hand.
+	//
+	// A shallow clone only carries the default branch's tip, so a pinned ref has
+	// to be named explicitly here or it cannot be resolved at all.
+	fetch := append(append([]string{}, common...), "fetch", "--prune", "--tags", "--force", "origin")
+	if p.Ref != "" {
+		fetch = append(fetch, p.Ref)
 	}
-	clone := append(append([]string{}, common...), "clone", p.GitURL, p.SourceDir)
-	if err := runGit(w, "", clone...); err != nil {
-		return err
-	}
-	fetch := append(append([]string{}, common...), "fetch", "--tags", "origin", p.Ref)
 	if err := runGit(w, p.SourceDir, fetch...); err != nil {
-		return err
+		return fmt.Errorf("fetch source: %w", err)
 	}
 	target, err := p.resetTarget(p.SourceDir)
 	if err != nil {
 		return err
 	}
 	reset := append(append([]string{}, common...), "reset", "--hard", target)
-	return runGit(w, p.SourceDir, reset...)
+	if err := runGit(w, p.SourceDir, reset...); err != nil {
+		return fmt.Errorf("sync source to %s: %w", target, err)
+	}
+	return nil
 }
 
 // resetTarget resolves what `git reset --hard` should land on. With no Ref that

--- a/cli/internal/install/build.go
+++ b/cli/internal/install/build.go
@@ -76,6 +76,13 @@ type BuildPlan struct {
 	FromGit bool
 	// GitURL is the clone source (set when FromGit is true).
 	GitURL string
+	// Ref pins the git ref (tag, branch, or commit) the source is synced to
+	// before building. Empty means "track the remote's default branch", which is
+	// the right default for `install` and an unpinned `update`. When set, the
+	// build MUST land on exactly this ref or fail — silently building something
+	// else is how `update --ref vX.Y.Z` used to produce a stack built from main
+	// (#949).
+	Ref string
 }
 
 // PlanLocalBuild decides whether to build from a local checkout or to clone the
@@ -85,6 +92,21 @@ func PlanLocalBuild(venvDir, cloneDir string) BuildPlan {
 		return BuildPlan{SourceDir: root, VenvDir: venvDir}
 	}
 	return BuildPlan{SourceDir: cloneDir, VenvDir: venvDir, FromGit: true, GitURL: GitURL}
+}
+
+// AtRef returns a copy of the plan pinned to ref. An empty ref is a no-op, so
+// callers can pass through whatever they resolved without branching.
+func (p BuildPlan) AtRef(ref string) BuildPlan {
+	p.Ref = ref
+	return p
+}
+
+// PinnedRefIgnored reports whether a caller-requested ref cannot be honoured
+// because the build reads a local checkout rather than a managed clone. The
+// working tree belongs to the operator, so syncing it to a ref would clobber
+// their work; the caller must surface this instead of implying the ref was used.
+func (p BuildPlan) PinnedRefIgnored() bool {
+	return p.Ref != "" && !p.FromGit
 }
 
 // VenvPython returns the python interpreter path inside the given venv dir.
@@ -101,13 +123,23 @@ func (p BuildPlan) VenvPython() string {
 }
 
 // writeSourceLine appends the "source:" row shared by the local and Docker
-// build headers: either a git clone target or the local checkout path.
+// build headers: either a git clone target or the local checkout path. A pinned
+// ref is named so the operator can see which build they are getting — and, for
+// a local checkout, that the pin does not apply.
 func (p BuildPlan) writeSourceLine(b *strings.Builder) {
 	if p.FromGit {
-		b.WriteString("  source: " + commandStyle.Render("git clone "+p.GitURL) +
+		src := "git clone " + p.GitURL
+		if p.Ref != "" {
+			src += " @ " + p.Ref
+		}
+		b.WriteString("  source: " + commandStyle.Render(src) +
 			" -> " + p.SourceDir + "\n")
-	} else {
-		b.WriteString("  source: " + commandStyle.Render(p.SourceDir) + " (local checkout)\n")
+		return
+	}
+	b.WriteString("  source: " + commandStyle.Render(p.SourceDir) + " (local checkout)\n")
+	if p.Ref != "" {
+		b.WriteString(warnStyle.Render("  note:   --ref "+p.Ref+
+			" does not apply to a local checkout; building it as-is") + "\n")
 	}
 }
 
@@ -216,20 +248,30 @@ func (p BuildPlan) fetchSource(w io.Writer) error {
 	common := append([]string{"-c", "credential.helper="}, gitAuthArgs()...)
 
 	if isGitRepo(p.SourceDir) {
-		// Sync to the remote's default branch by fetch + hard reset rather than
-		// `pull --ff-only`. A fast-forward pull dead-ends ("Not possible to
-		// fast-forward") whenever upstream history was rewritten/force-pushed —
-		// e.g. after an OSS re-baseline of the published repo. $SourceDir is a
-		// throwaway build checkout under ~/.jentic (never a tree the user edits),
-		// so matching the remote exactly is the correct, always-succeeding sync.
-		fetch := append(append([]string{}, common...), "fetch", "--prune", "origin")
+		// Sync by fetch + hard reset rather than `pull --ff-only`. A fast-forward
+		// pull dead-ends ("Not possible to fast-forward") whenever upstream
+		// history was rewritten/force-pushed — e.g. after an OSS re-baseline of
+		// the published repo. $SourceDir is a throwaway build checkout under
+		// ~/.jentic (never a tree the user edits), so matching the requested
+		// target exactly is the correct, always-succeeding sync.
+		//
+		// A shallow clone (`--depth 1`) only has the default branch's tip, so an
+		// explicit ref must be fetched before it can be resolved — otherwise a
+		// pinned tag looks "missing" in an existing build checkout.
+		fetch := append(append([]string{}, common...), "fetch", "--prune", "--tags", "origin")
+		if p.Ref != "" {
+			fetch = append(fetch, p.Ref)
+		}
 		if err := runGit(w, p.SourceDir, fetch...); err != nil {
 			return fmt.Errorf("fetch source: %w", err)
 		}
-		branch := remoteDefaultBranch(p.SourceDir)
-		reset := append(append([]string{}, common...), "reset", "--hard", "origin/"+branch)
+		target, err := p.resetTarget(p.SourceDir)
+		if err != nil {
+			return err
+		}
+		reset := append(append([]string{}, common...), "reset", "--hard", target)
 		if err := runGit(w, p.SourceDir, reset...); err != nil {
-			return fmt.Errorf("sync source to origin/%s: %w", branch, err)
+			return fmt.Errorf("sync source to %s: %w", target, err)
 		}
 		return nil
 	}
@@ -237,8 +279,23 @@ func (p BuildPlan) fetchSource(w io.Writer) error {
 		return fmt.Errorf("create source parent: %w", err)
 	}
 
-	args := append(append([]string{}, common...), "clone", "--depth", "1", p.GitURL, p.SourceDir)
+	args := append(append([]string{}, common...), "clone", "--depth", "1")
+	// `clone --branch` accepts a tag or a branch (not a bare commit), which
+	// covers the release tags `update` pins by default. A ref it cannot resolve
+	// this way still lands via the fetch+reset path below.
+	if p.Ref != "" {
+		args = append(args, "--branch", p.Ref)
+	}
+	args = append(args, p.GitURL, p.SourceDir)
 	if err := runGit(w, "", args...); err != nil {
+		// A commit SHA (or a ref this git can't --branch) fails the pinned clone.
+		// Fall back to a plain clone plus an explicit fetch+reset, which resolves
+		// anything the remote will serve.
+		if p.Ref != "" {
+			if fallbackErr := p.clonePinnedFallback(w, common); fallbackErr == nil {
+				return nil
+			}
+		}
 		if os.Getenv("GITHUB_TOKEN") == "" {
 			return fmt.Errorf("clone failed — %s is likely private. To build from a local "+
 				"checkout instead (no token needed), set %s=/path/to/jentic-one and re-run; "+
@@ -248,6 +305,58 @@ func (p BuildPlan) fetchSource(w io.Writer) error {
 		return fmt.Errorf("clone failed (check the ref and your token's access): %w", err)
 	}
 	return nil
+}
+
+// clonePinnedFallback handles a Ref that `clone --branch` cannot resolve (most
+// notably a bare commit SHA): clone the default branch, then fetch and hard
+// reset onto the requested ref.
+func (p BuildPlan) clonePinnedFallback(w io.Writer, common []string) error {
+	// The failed attempt may have left a partial directory behind.
+	if err := os.RemoveAll(p.SourceDir); err != nil {
+		return err
+	}
+	clone := append(append([]string{}, common...), "clone", p.GitURL, p.SourceDir)
+	if err := runGit(w, "", clone...); err != nil {
+		return err
+	}
+	fetch := append(append([]string{}, common...), "fetch", "--tags", "origin", p.Ref)
+	if err := runGit(w, p.SourceDir, fetch...); err != nil {
+		return err
+	}
+	target, err := p.resetTarget(p.SourceDir)
+	if err != nil {
+		return err
+	}
+	reset := append(append([]string{}, common...), "reset", "--hard", target)
+	return runGit(w, p.SourceDir, reset...)
+}
+
+// resetTarget resolves what `git reset --hard` should land on. With no Ref that
+// is origin's default branch (track upstream). With a Ref it is the ref itself,
+// verified to exist first so a typo fails loudly here rather than silently
+// building whatever the checkout happened to be on (#949).
+//
+// FETCH_HEAD is preferred when the ref resolves to it: the preceding fetch
+// pulled exactly the requested ref, and a shallow checkout may not have a local
+// branch/tag for it yet.
+func (p BuildPlan) resetTarget(dir string) (string, error) {
+	if p.Ref == "" {
+		return "origin/" + remoteDefaultBranch(dir), nil
+	}
+	for _, candidate := range []string{"origin/" + p.Ref, p.Ref, "FETCH_HEAD"} {
+		if gitRevParseSucceeds(dir, candidate) {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"ref %q not found in %s after fetch (check the tag/branch/commit exists)", p.Ref, p.GitURL)
+}
+
+// gitRevParseSucceeds reports whether rev names something this checkout can
+// resolve to a commit.
+func gitRevParseSucceeds(dir, rev string) bool {
+	//nolint:gosec // dir is a CLI-internal build checkout; rev is a CLI-resolved ref.
+	return exec.Command("git", "-C", dir, "rev-parse", "--verify", "--quiet", rev+"^{commit}").Run() == nil
 }
 
 // remoteDefaultBranch returns origin's default branch name (e.g. "main"),

--- a/cli/internal/install/build_ref_test.go
+++ b/cli/internal/install/build_ref_test.go
@@ -1,0 +1,180 @@
+package install
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests drive a real `git` against a local "remote" on disk. The bug they
+// guard (#949) was that fetchSource hard-reset to origin's default branch and
+// ignored the requested ref entirely, so a pinned `update --ref vX.Y.Z` built
+// main. Only a real git round-trip proves the checkout genuinely lands on the
+// requested commit — asserting on the argv we would have run cannot.
+
+// gitRun runs a git command in dir, failing the test on error.
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(cmd.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t",
+		"GIT_COMMITTER_EMAIL=t@t", "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s in %s: %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// makeUpstream builds a local repo with two commits on the default branch and a
+// `v1.0.0` tag on the FIRST one, so "the tag" and "the default branch tip" are
+// different commits. That difference is what makes the assertions meaningful.
+func makeUpstream(t *testing.T) (dir, tagCommit, headCommit string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir = t.TempDir()
+	gitRun(t, dir, "init", "--initial-branch=main", ".")
+	writeFile(t, filepath.Join(dir, "marker.txt"), "release")
+	gitRun(t, dir, "add", ".")
+	gitRun(t, dir, "commit", "-m", "release commit")
+	tagCommit = gitRun(t, dir, "rev-parse", "HEAD")
+	gitRun(t, dir, "tag", "v1.0.0")
+
+	writeFile(t, filepath.Join(dir, "marker.txt"), "main-moved-on")
+	gitRun(t, dir, "add", ".")
+	gitRun(t, dir, "commit", "-m", "later main commit")
+	headCommit = gitRun(t, dir, "rev-parse", "HEAD")
+	return dir, tagCommit, headCommit
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestFetchSourceClonesAtPinnedRef: a fresh clone pinned to a tag must land on
+// the tag's commit, not the default branch tip.
+func TestFetchSourceClonesAtPinnedRef(t *testing.T) {
+	upstream, tagCommit, headCommit := makeUpstream(t)
+	dest := filepath.Join(t.TempDir(), "src")
+
+	p := BuildPlan{SourceDir: dest, FromGit: true, GitURL: upstream, Ref: "v1.0.0"}
+	if err := p.fetchSource(&strings.Builder{}); err != nil {
+		t.Fatalf("fetchSource: %v", err)
+	}
+
+	got := gitRun(t, dest, "rev-parse", "HEAD")
+	if got != tagCommit {
+		t.Errorf("checkout is at %s, want the v1.0.0 commit %s", got, tagCommit)
+	}
+	if got == headCommit {
+		t.Error("checkout landed on the default-branch tip — the pinned ref was ignored (#949)")
+	}
+}
+
+// TestFetchSourceResyncsExistingCheckoutToPinnedRef is the exact update path:
+// ~/.jentic/src already exists (from a previous install) and a pinned update
+// must move it onto the requested ref rather than resetting to origin's default.
+func TestFetchSourceResyncsExistingCheckoutToPinnedRef(t *testing.T) {
+	upstream, tagCommit, headCommit := makeUpstream(t)
+	dest := filepath.Join(t.TempDir(), "src")
+
+	// First sync with no pin: lands on the default branch tip, as before.
+	unpinned := BuildPlan{SourceDir: dest, FromGit: true, GitURL: upstream}
+	if err := unpinned.fetchSource(&strings.Builder{}); err != nil {
+		t.Fatalf("initial fetchSource: %v", err)
+	}
+	if got := gitRun(t, dest, "rev-parse", "HEAD"); got != headCommit {
+		t.Fatalf("unpinned sync landed at %s, want default-branch tip %s", got, headCommit)
+	}
+
+	// Now re-sync the SAME checkout with a pin.
+	pinned := unpinned.AtRef("v1.0.0")
+	if err := pinned.fetchSource(&strings.Builder{}); err != nil {
+		t.Fatalf("pinned fetchSource: %v", err)
+	}
+	if got := gitRun(t, dest, "rev-parse", "HEAD"); got != tagCommit {
+		t.Errorf("existing checkout is at %s, want the v1.0.0 commit %s (#949)", got, tagCommit)
+	}
+}
+
+// TestFetchSourceHonoursPinnedCommitSHA: a bare commit SHA cannot be used with
+// `clone --branch`, so it exercises the fetch+reset fallback.
+func TestFetchSourceHonoursPinnedCommitSHA(t *testing.T) {
+	upstream, tagCommit, _ := makeUpstream(t)
+	dest := filepath.Join(t.TempDir(), "src")
+
+	p := BuildPlan{SourceDir: dest, FromGit: true, GitURL: upstream, Ref: tagCommit}
+	if err := p.fetchSource(&strings.Builder{}); err != nil {
+		t.Fatalf("fetchSource with a commit SHA: %v", err)
+	}
+	if got := gitRun(t, dest, "rev-parse", "HEAD"); got != tagCommit {
+		t.Errorf("checkout is at %s, want the pinned commit %s", got, tagCommit)
+	}
+}
+
+// TestFetchSourceUnpinnedTracksDefaultBranch: the default path is unchanged —
+// no ref means "follow origin's default branch", including after a force-push.
+func TestFetchSourceUnpinnedTracksDefaultBranch(t *testing.T) {
+	upstream, _, headCommit := makeUpstream(t)
+	dest := filepath.Join(t.TempDir(), "src")
+
+	p := BuildPlan{SourceDir: dest, FromGit: true, GitURL: upstream}
+	if err := p.fetchSource(&strings.Builder{}); err != nil {
+		t.Fatalf("fetchSource: %v", err)
+	}
+	if got := gitRun(t, dest, "rev-parse", "HEAD"); got != headCommit {
+		t.Errorf("checkout is at %s, want default-branch tip %s", got, headCommit)
+	}
+}
+
+// TestFetchSourceUnknownRefFailsLoudly: a typo'd ref must be an error, not a
+// silent build of whatever the checkout happened to be on.
+func TestFetchSourceUnknownRefFailsLoudly(t *testing.T) {
+	upstream, _, _ := makeUpstream(t)
+	dest := filepath.Join(t.TempDir(), "src")
+
+	p := BuildPlan{SourceDir: dest, FromGit: true, GitURL: upstream, Ref: "v9.9.9-does-not-exist"}
+	if err := p.fetchSource(&strings.Builder{}); err == nil {
+		t.Fatal("a nonexistent ref must fail rather than silently building something else")
+	}
+}
+
+// TestPinnedRefIgnoredOnlyForLocalCheckout: the caller-facing guard. A pin is
+// meaningful for a managed clone and impossible for the operator's own tree.
+func TestPinnedRefIgnoredOnlyForLocalCheckout(t *testing.T) {
+	local := BuildPlan{SourceDir: "/repo"}.AtRef("v1.0.0")
+	if !local.PinnedRefIgnored() {
+		t.Error("a pinned ref against a local checkout must be reported as ignored")
+	}
+	if (BuildPlan{SourceDir: "/repo"}).PinnedRefIgnored() {
+		t.Error("no ref means nothing is ignored")
+	}
+	cloned := BuildPlan{SourceDir: "/clone", FromGit: true}.AtRef("v1.0.0")
+	if cloned.PinnedRefIgnored() {
+		t.Error("a pinned ref against a managed clone is honoured, not ignored")
+	}
+}
+
+// TestRenderHeaderNamesPinnedRef: the operator must be able to see which build
+// they are getting, and be told when a pin does not apply.
+func TestRenderHeaderNamesPinnedRef(t *testing.T) {
+	cloned := BuildPlan{SourceDir: "/clone", FromGit: true, GitURL: "https://x/y.git"}.AtRef("v1.0.0")
+	if out := cloned.RenderHeader(); !strings.Contains(out, "v1.0.0") {
+		t.Errorf("clone header does not name the pinned ref:\n%s", out)
+	}
+
+	localPinned := BuildPlan{SourceDir: "/repo"}.AtRef("v1.0.0")
+	out := localPinned.RenderHeader()
+	if !strings.Contains(out, "does not apply") {
+		t.Errorf("local-checkout header must flag the ignored pin:\n%s", out)
+	}
+}

--- a/cli/internal/install/build_ref_test.go
+++ b/cli/internal/install/build_ref_test.go
@@ -97,7 +97,7 @@ func TestFetchSourceResyncsExistingCheckoutToPinnedRef(t *testing.T) {
 	}
 
 	// Now re-sync the SAME checkout with a pin.
-	pinned := unpinned.AtRef("v1.0.0")
+	pinned := unpinned.AtRef("v1.0.0", true)
 	if err := pinned.fetchSource(&strings.Builder{}); err != nil {
 		t.Fatalf("pinned fetchSource: %v", err)
 	}
@@ -148,33 +148,129 @@ func TestFetchSourceUnknownRefFailsLoudly(t *testing.T) {
 	}
 }
 
+// TestPinnedThenUnpinnedSyncStillWorks is the regression for the wedge found
+// reviewing #949: `clone --branch <tag>` implies --single-branch, which rewrites
+// remote.origin.fetch to only that tag and leaves no origin/<default-branch>.
+// A later UNPINNED build could then never reset, so pinning once permanently
+// broke the managed checkout until it was deleted by hand.
+//
+// Every earlier test used a fresh clone, which is exactly why they all passed
+// while this sequence — pin to roll back, then resume normal updates — did not.
+func TestPinnedThenUnpinnedSyncStillWorks(t *testing.T) {
+	upstream, tagCommit, headCommit := makeUpstream(t)
+	dest := filepath.Join(t.TempDir(), "src")
+
+	pinned := BuildPlan{SourceDir: dest, FromGit: true, GitURL: upstream, Ref: "v1.0.0"}
+	if err := pinned.fetchSource(&strings.Builder{}); err != nil {
+		t.Fatalf("pinned fetchSource: %v", err)
+	}
+	if got := gitRun(t, dest, "rev-parse", "HEAD"); got != tagCommit {
+		t.Fatalf("pinned checkout at %s, want %s", got, tagCommit)
+	}
+
+	// The operator resumes normal updates. This must not be wedged.
+	unpinned := BuildPlan{SourceDir: dest, FromGit: true, GitURL: upstream}
+	if err := unpinned.fetchSource(&strings.Builder{}); err != nil {
+		t.Fatalf("unpinned sync after a pinned build must work, got: %v", err)
+	}
+	if got := gitRun(t, dest, "rev-parse", "HEAD"); got != headCommit {
+		t.Errorf("unpinned sync landed at %s, want default-branch tip %s", got, headCommit)
+	}
+}
+
+// TestSyncSurvivesAMovedUpstreamTag: since git 2.20 a fetch refuses to move an
+// existing tag ("would clobber existing tag") and exits non-zero. A re-pointed
+// tag — a re-cut release, or the history rewrite this fetch+reset design exists
+// to survive — would otherwise break every later install/update against the
+// managed checkout until it was deleted by hand.
+func TestSyncSurvivesAMovedUpstreamTag(t *testing.T) {
+	upstream, _, _ := makeUpstream(t)
+	dest := filepath.Join(t.TempDir(), "src")
+
+	plan := BuildPlan{SourceDir: dest, FromGit: true, GitURL: upstream, Ref: "v1.0.0"}
+	if err := plan.fetchSource(&strings.Builder{}); err != nil {
+		t.Fatalf("initial pinned fetchSource: %v", err)
+	}
+
+	// Upstream re-points the tag at a different commit.
+	writeFile(t, filepath.Join(upstream, "marker.txt"), "re-cut release")
+	gitRun(t, upstream, "add", ".")
+	gitRun(t, upstream, "commit", "-m", "re-cut")
+	gitRun(t, upstream, "tag", "-f", "v1.0.0")
+	moved := gitRun(t, upstream, "rev-parse", "v1.0.0^{commit}")
+
+	if err := plan.fetchSource(&strings.Builder{}); err != nil {
+		t.Fatalf("a moved upstream tag must not break the sync, got: %v", err)
+	}
+	if got := gitRun(t, dest, "rev-parse", "HEAD"); got != moved {
+		t.Errorf("checkout at %s, want the tag's new commit %s", got, moved)
+	}
+}
+
+// TestUnpinnedFreshCloneIsNotSingleBranch pins the property underlying the wedge
+// directly: a fresh clone must keep a general refspec, so any later sync can
+// resolve origin's default branch.
+func TestUnpinnedFreshCloneIsNotSingleBranch(t *testing.T) {
+	upstream, _, _ := makeUpstream(t)
+	dest := filepath.Join(t.TempDir(), "src")
+
+	plan := BuildPlan{SourceDir: dest, FromGit: true, GitURL: upstream, Ref: "v1.0.0"}
+	if err := plan.fetchSource(&strings.Builder{}); err != nil {
+		t.Fatalf("fetchSource: %v", err)
+	}
+
+	refspec := gitRun(t, dest, "config", "remote.origin.fetch")
+	if !strings.Contains(refspec, "refs/heads/") {
+		t.Errorf("refspec %q does not cover branches; a later unpinned sync cannot resolve "+
+			"origin/<default-branch>", refspec)
+	}
+	if !gitRevParseSucceeds(dest, "origin/main") {
+		t.Error("origin/main must be resolvable after a pinned clone, or unpinned syncs wedge")
+	}
+}
+
 // TestPinnedRefIgnoredOnlyForLocalCheckout: the caller-facing guard. A pin is
 // meaningful for a managed clone and impossible for the operator's own tree.
 func TestPinnedRefIgnoredOnlyForLocalCheckout(t *testing.T) {
-	local := BuildPlan{SourceDir: "/repo"}.AtRef("v1.0.0")
+	local := BuildPlan{SourceDir: "/repo"}.AtRef("v1.0.0", true)
 	if !local.PinnedRefIgnored() {
 		t.Error("a pinned ref against a local checkout must be reported as ignored")
 	}
 	if (BuildPlan{SourceDir: "/repo"}).PinnedRefIgnored() {
 		t.Error("no ref means nothing is ignored")
 	}
-	cloned := BuildPlan{SourceDir: "/clone", FromGit: true}.AtRef("v1.0.0")
+	cloned := BuildPlan{SourceDir: "/clone", FromGit: true}.AtRef("v1.0.0", true)
 	if cloned.PinnedRefIgnored() {
 		t.Error("a pinned ref against a managed clone is honoured, not ignored")
+	}
+	// A ref the CLI resolved itself (the latest release tag on a plain `update`)
+	// is not an operator pin, so claiming it was "ignored" would read as though
+	// their input had been discarded.
+	resolved := BuildPlan{SourceDir: "/repo"}.AtRef("v1.0.0", false)
+	if resolved.PinnedRefIgnored() {
+		t.Error("a self-resolved ref must not be reported as an ignored --ref")
 	}
 }
 
 // TestRenderHeaderNamesPinnedRef: the operator must be able to see which build
 // they are getting, and be told when a pin does not apply.
 func TestRenderHeaderNamesPinnedRef(t *testing.T) {
-	cloned := BuildPlan{SourceDir: "/clone", FromGit: true, GitURL: "https://x/y.git"}.AtRef("v1.0.0")
+	cloned := BuildPlan{SourceDir: "/clone", FromGit: true, GitURL: "https://x/y.git"}.AtRef("v1.0.0", true)
 	if out := cloned.RenderHeader(); !strings.Contains(out, "v1.0.0") {
 		t.Errorf("clone header does not name the pinned ref:\n%s", out)
 	}
 
-	localPinned := BuildPlan{SourceDir: "/repo"}.AtRef("v1.0.0")
+	localPinned := BuildPlan{SourceDir: "/repo"}.AtRef("v1.0.0", true)
 	out := localPinned.RenderHeader()
 	if !strings.Contains(out, "does not apply") {
 		t.Errorf("local-checkout header must flag the ignored pin:\n%s", out)
+	}
+
+	// A plain `jenticctl update` resolves the latest release tag itself and passes
+	// it through. The operator never typed --ref, so the header must not claim
+	// their flag was ignored.
+	localResolved := BuildPlan{SourceDir: "/repo"}.AtRef("v1.0.0", false)
+	if out := localResolved.RenderHeader(); strings.Contains(out, "does not apply") {
+		t.Errorf("unpinned update must not warn about a --ref the user never passed:\n%s", out)
 	}
 }


### PR DESCRIPTION
Closes #949

## Summary

`update --ref <tag>` pinned the CLI half, but the stack half ignored the ref entirely and built the remote's default branch. `fetchSource` hard-reset to `origin/<default-branch>`, and `BuildPlan` had no `Ref` field at all — there was nothing to honour.

Verified against the live repo, this is not theoretical:

```
upstream v0.25.0 : f4cb196424e9b159c6071a90f42fb602c66587b7
main tip         : d24dcd79674991016b3459e73f470f4d3aee5784
clone HEAD       : f4cb196424e9b159c6071a90f42fb602c66587b7   <- with this PR
```

Before this change, `clone HEAD` was `d24dcd7` — and the command reported success, with no output naming the commit it actually built.

Both uses of the flag were broken. **Pinning** builds the wrong version. **Rollback** is worse than a no-op: it moves the operator *forward* to the default-branch tip while they believe they returned to a known-good build — possibly the exact build they were escaping.

## Changes

- `BuildPlan.Ref` (+ `AtRef`), threaded from `updateStack` through both the local and Docker paths.
- Sync to the requested ref:
  - fresh clone → `clone --branch <ref>` (covers tags and branches);
  - bare commit SHA → falls back to clone + `fetch` + `reset --hard`, since `--branch` cannot take a SHA;
  - existing `~/.jentic/src` → fetches the ref **explicitly** before resolving it, because the shallow clone from a prior install only has the default branch's tip and would otherwise report a valid tag as missing.
- **Unresolvable ref now fails loudly.** Silently building something other than what was asked for is the actual defect; a typo'd tag must be an error, not a surprise build.
- **A pin that cannot apply is refused, not ignored.** When the stack builds from the operator's own working tree (cwd walk or `$JENTIC_SRC`), syncing to a ref would clobber their work — so the command explains that instead of quietly disregarding the flag.
- The pinned ref is named in the build header.

Unpinned behaviour is unchanged: still tracks the default branch, and still by fetch + hard reset, preserving the force-push/re-baseline resilience that reset was there for (a `pull --ff-only` would dead-end).

## Test plan

New tests drive **real `git`** against a local on-disk remote. Asserting on the argv we'd have run cannot prove a checkout lands on the right commit, so the fixture builds two commits with `v1.0.0` tagged on the *first* — making "the tag" and "the default branch tip" genuinely different commits.

Confirmed the tests **reproduce the bug**: reinstating the ref-ignoring behaviour fails 4 of them with the wrong SHA, rather than passing vacuously.

- [x] Pinned fresh clone lands on the tag's commit, and explicitly *not* on the default-branch tip
- [x] Pinned re-sync of an **existing** checkout moves it onto the ref (the real `update` path)
- [x] Pinned bare commit SHA works (fallback path)
- [x] Unpinned still tracks the default branch
- [x] Unknown ref returns an error
- [x] `PinnedRefIgnored` is true only for a local checkout, and the header flags it
- [x] `go test ./...`, `go vet`, `gofmt` clean
- [x] End-to-end check against the real repo (output above)

Please **squash merge**.

Made with [Cursor](https://cursor.com)