### PR TITLE
fix(cli): stop `start` coming up on an unmigrated database

### DIFF
--- a/cli/internal/cmd/start.go
+++ b/cli/internal/cmd/start.go
@@ -159,7 +159,7 @@ func (a *App) startDocker(composePath string) error {
 // An undeterminable state never blocks the start: refusing because a diagnostic
 // failed would be a worse regression than the bug being fixed.
 func (a *App) ensureDockerSchema(composePath string) error {
-	switch install.ComposeSchemaState(composePath) {
+	switch install.ComposeSchemaState(a.Out, composePath) {
 	case install.SchemaUnknown, install.SchemaCurrent:
 		return nil
 

--- a/cli/internal/cmd/start.go
+++ b/cli/internal/cmd/start.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -158,22 +159,22 @@ func (a *App) startDocker(composePath string) error {
 // An undeterminable state never blocks the start: refusing because a diagnostic
 // failed would be a worse regression than the bug being fixed.
 func (a *App) ensureDockerSchema(composePath string) error {
-	state, err := install.ComposeSchemaState(composePath)
-	if err != nil || state == install.SchemaUnknown || state == install.SchemaCurrent {
+	switch install.ComposeSchemaState(composePath) {
+	case install.SchemaUnknown, install.SchemaCurrent:
 		return nil
-	}
 
-	if state == install.SchemaPending {
-		return fmt.Errorf("database schema is behind this build — start aborted.\n" +
+	case install.SchemaPending:
+		return errors.New("database schema is behind this build — start aborted.\n" +
 			"  Back up your data, then apply migrations:\n" +
 			"    jenticctl update --stack-only\n" +
 			"  (starting now would run the app against a schema it does not match)")
-	}
 
-	fmt.Fprintln(a.Out, theme.Warn.Render("Database has no schema (new or wiped volume) — creating it before start"))
-	if err := install.RunComposeMigrations(a.Out, composePath); err != nil {
-		return fmt.Errorf("could not initialize the database schema: %w", err)
+	case install.SchemaUninitialized:
+		fmt.Fprintln(a.Out, theme.Warn.Render("Database has no schema (new or wiped volume) — creating it before start"))
+		if err := install.RunComposeMigrations(a.Out, composePath); err != nil {
+			return fmt.Errorf("could not initialize the database schema: %w", err)
+		}
+		fmt.Fprintln(a.Out, theme.Successf("Schema created."))
 	}
-	fmt.Fprintln(a.Out, theme.Successf("Schema created."))
 	return nil
 }

--- a/cli/internal/cmd/start.go
+++ b/cli/internal/cmd/start.go
@@ -124,6 +124,10 @@ func brokerPortFromManifest(a *App) string {
 
 // startDocker brings the generated docker-compose stack up in detached mode.
 func (a *App) startDocker(composePath string) error {
+	if err := a.ensureDockerSchema(composePath); err != nil {
+		return err
+	}
+
 	fmt.Fprintln(a.Out, theme.Infof("Starting Docker stack ..."))
 	if err := install.ComposeUp(a.Out, composePath); err != nil {
 		return fmt.Errorf("docker compose up: %w", err)
@@ -131,5 +135,45 @@ func (a *App) startDocker(composePath string) error {
 	fmt.Fprintln(a.Out, theme.Successf("Stack started."))
 	fmt.Fprintln(a.Out, theme.Dimf("  logs: docker compose -f %s logs -f", composePath))
 	fmt.Fprintln(a.Out, theme.Dim.Render("  stop: jenticctl stop"))
+	return nil
+}
+
+// ensureDockerSchema stops `start` from bringing the stack up on a database that
+// has no schema.
+//
+// `start` only ever ran `compose up`; migrations belong to `install` and
+// `update`. So after a `stop --volumes` (or any wiped volume), `start` reported
+// "Stack started." over an empty, unmigrated database — the app comes up, the
+// login fails or the UI is inexplicably blank, and nothing in the output points
+// at the schema. That is the failure this guards (#951).
+//
+// The two non-current states get deliberately different treatment:
+//
+//   - uninitialized: no schema, therefore no data to lose. Creating it is safe,
+//     so we do it automatically — exactly what `install` would have done.
+//   - pending: a schema WITH data that forward-only migrations would rewrite.
+//     That is the operator's decision to make with a backup in hand, so we
+//     refuse and name the command, rather than silently migrating on a `start`.
+//
+// An undeterminable state never blocks the start: refusing because a diagnostic
+// failed would be a worse regression than the bug being fixed.
+func (a *App) ensureDockerSchema(composePath string) error {
+	state, err := install.ComposeSchemaState(composePath)
+	if err != nil || state == install.SchemaUnknown || state == install.SchemaCurrent {
+		return nil
+	}
+
+	if state == install.SchemaPending {
+		return fmt.Errorf("database schema is behind this build — start aborted.\n" +
+			"  Back up your data, then apply migrations:\n" +
+			"    jenticctl update --stack-only\n" +
+			"  (starting now would run the app against a schema it does not match)")
+	}
+
+	fmt.Fprintln(a.Out, theme.Warn.Render("Database has no schema (new or wiped volume) — creating it before start"))
+	if err := install.RunComposeMigrations(a.Out, composePath); err != nil {
+		return fmt.Errorf("could not initialize the database schema: %w", err)
+	}
+	fmt.Fprintln(a.Out, theme.Successf("Schema created."))
 	return nil
 }

--- a/cli/internal/cmd/stop.go
+++ b/cli/internal/cmd/stop.go
@@ -140,6 +140,12 @@ func (a *App) stopDocker(opts *stopOptions, composePath string) error {
 		return fmt.Errorf("docker compose down -v: %w", err)
 	}
 	fmt.Fprintln(a.Out, theme.Successf("Stopped Docker stack and removed its data volumes."))
+	// The database is gone, so the next `start` comes up on an empty volume.
+	// `start` now creates the schema itself, but say so here too: this is the
+	// moment the operator loses their data, and it is where they will look when
+	// their login stops working.
+	fmt.Fprintln(a.Out, theme.Dim.Render("  the database was deleted; `jenticctl start` will recreate an empty schema"))
+	fmt.Fprintln(a.Out, theme.Dim.Render("  you will need to create the admin user again"))
 	return nil
 }
 

--- a/cli/internal/install/compose.go
+++ b/cli/internal/install/compose.go
@@ -534,10 +534,17 @@ const (
 // to SchemaUnknown, because a caller cannot act on a non-answer: blocking a
 // start because a diagnostic broke would be worse than the problem being
 // diagnosed. Only a verdict the runner actually printed is authoritative.
-func ComposeSchemaState(composePath string) SchemaState {
+//
+// w receives progress and, when no verdict could be read, the check's own output.
+// The probe pulls/starts a database container, so it is not instant; without a
+// line explaining the pause `start` looks hung. And silently swallowing the
+// output would make the one case that needs explaining — "why did it not
+// notice?" — undiagnosable.
+func ComposeSchemaState(w io.Writer, composePath string) SchemaState {
 	if _, err := exec.LookPath("docker"); err != nil {
 		return SchemaUnknown
 	}
+	fmt.Fprintln(w, mutedStyle.Render("Checking database schema ..."))
 	//nolint:gosec // composePath is CLI-managed under JENTIC_HOME.
 	out, _ := exec.Command("docker", migrateCheckArgs(composePath)...).CombinedOutput()
 
@@ -545,8 +552,24 @@ func ComposeSchemaState(composePath string) SchemaState {
 	// design* when migrations are needed, so the printed verdict — not the exit
 	// code — is what carries the answer. No verdict (an old image without
 	// `--check`, no daemon, an unreachable database) means undeterminable.
-	state, _ := parseSchemaVerdict(string(out))
+	state, ok := parseSchemaVerdict(string(out))
+	if !ok {
+		fmt.Fprintln(w, mutedStyle.Render("  could not determine schema state; continuing"))
+		if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+			fmt.Fprintln(w, mutedStyle.Render(indentLines(trimmed, "  ")))
+		}
+	}
 	return state
+}
+
+// indentLines prefixes every line of s, so borrowed subprocess output stays
+// visually subordinate to the CLI's own messages.
+func indentLines(s, prefix string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = prefix + line
+	}
+	return strings.Join(lines, "\n")
 }
 
 // parseSchemaVerdict extracts the OVERALL line that `migrations.run --check`

--- a/cli/internal/install/compose.go
+++ b/cli/internal/install/compose.go
@@ -527,37 +527,26 @@ const (
 	SchemaPending
 )
 
-// checkExitNeedsMigration is the exit code `migrations.run --check` uses for
-// "not at head". Kept distinct from 1 so a genuine failure of the check (bad
-// config, database unreachable) is not misread as a schema verdict.
-const checkExitNeedsMigration = 3
-
 // ComposeSchemaState reports whether the stack's databases are migrated, without
 // modifying them. It runs `migrations.run --check` in a one-shot app container.
 //
-// Any failure to *obtain* an answer yields SchemaUnknown with a nil error: the
-// caller cannot act on a non-answer, and blocking a start on a broken
-// diagnostic would be worse than the problem being diagnosed. Only the schema
-// verdict itself is authoritative.
-func ComposeSchemaState(composePath string) (SchemaState, error) {
+// It deliberately returns no error. Any failure to *obtain* an answer collapses
+// to SchemaUnknown, because a caller cannot act on a non-answer: blocking a
+// start because a diagnostic broke would be worse than the problem being
+// diagnosed. Only a verdict the runner actually printed is authoritative.
+func ComposeSchemaState(composePath string) SchemaState {
 	if _, err := exec.LookPath("docker"); err != nil {
-		return SchemaUnknown, nil
+		return SchemaUnknown
 	}
 	//nolint:gosec // composePath is CLI-managed under JENTIC_HOME.
-	out, err := exec.Command("docker", migrateCheckArgs(composePath)...).CombinedOutput()
-	text := string(out)
+	out, _ := exec.Command("docker", migrateCheckArgs(composePath)...).CombinedOutput()
 
-	// Parse the verdict first: it is the authoritative signal, and `--check`
-	// exits non-zero *by design* when migrations are needed.
-	if state, ok := parseSchemaVerdict(text); ok {
-		return state, nil
-	}
-	if err != nil {
-		// No verdict and a failure: an old image without `--check` (argparse
-		// exits 2), no docker daemon, an unreachable database. Undeterminable.
-		return SchemaUnknown, nil
-	}
-	return SchemaUnknown, nil
+	// The exit status is intentionally ignored: `--check` exits non-zero *by
+	// design* when migrations are needed, so the printed verdict — not the exit
+	// code — is what carries the answer. No verdict (an old image without
+	// `--check`, no daemon, an unreachable database) means undeterminable.
+	state, _ := parseSchemaVerdict(string(out))
+	return state
 }
 
 // parseSchemaVerdict extracts the OVERALL line that `migrations.run --check`

--- a/cli/internal/install/compose.go
+++ b/cli/internal/install/compose.go
@@ -505,6 +505,89 @@ func RunComposeMigrations(w io.Writer, composePath string) error {
 	return run(w, "docker", migrateArgs(composePath)...)
 }
 
+// SchemaState is the migration state of the stack's databases.
+type SchemaState int
+
+const (
+	// SchemaUnknown means the state could not be determined — the check could
+	// not run at all (no docker, an app image predating `--check`, an
+	// unreachable database). Callers must treat it as "carry on": refusing to
+	// start because a *diagnostic* failed would be a worse regression than the
+	// bug the check exists to catch.
+	SchemaUnknown SchemaState = iota
+	// SchemaCurrent means every database is at head.
+	SchemaCurrent
+	// SchemaUninitialized means at least one database has no schema at all
+	// (no Alembic version table). A wiped or brand-new volume. There is no data
+	// to protect, so creating the schema is safe and needs no confirmation.
+	SchemaUninitialized
+	// SchemaPending means at least one database has a schema but is behind
+	// head. It holds data that forward-only migrations will rewrite, so this is
+	// the operator's call to make with a backup in hand — never automatic.
+	SchemaPending
+)
+
+// checkExitNeedsMigration is the exit code `migrations.run --check` uses for
+// "not at head". Kept distinct from 1 so a genuine failure of the check (bad
+// config, database unreachable) is not misread as a schema verdict.
+const checkExitNeedsMigration = 3
+
+// ComposeSchemaState reports whether the stack's databases are migrated, without
+// modifying them. It runs `migrations.run --check` in a one-shot app container.
+//
+// Any failure to *obtain* an answer yields SchemaUnknown with a nil error: the
+// caller cannot act on a non-answer, and blocking a start on a broken
+// diagnostic would be worse than the problem being diagnosed. Only the schema
+// verdict itself is authoritative.
+func ComposeSchemaState(composePath string) (SchemaState, error) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		return SchemaUnknown, nil
+	}
+	//nolint:gosec // composePath is CLI-managed under JENTIC_HOME.
+	out, err := exec.Command("docker", migrateCheckArgs(composePath)...).CombinedOutput()
+	text := string(out)
+
+	// Parse the verdict first: it is the authoritative signal, and `--check`
+	// exits non-zero *by design* when migrations are needed.
+	if state, ok := parseSchemaVerdict(text); ok {
+		return state, nil
+	}
+	if err != nil {
+		// No verdict and a failure: an old image without `--check` (argparse
+		// exits 2), no docker daemon, an unreachable database. Undeterminable.
+		return SchemaUnknown, nil
+	}
+	return SchemaUnknown, nil
+}
+
+// parseSchemaVerdict extracts the OVERALL line that `migrations.run --check`
+// prints last. Reported as a verdict only when explicitly found, so garbled or
+// truncated output degrades to "unknown" rather than to a wrong answer.
+func parseSchemaVerdict(out string) (SchemaState, bool) {
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) != 2 || fields[0] != "OVERALL" {
+			continue
+		}
+		switch fields[1] {
+		case "current":
+			return SchemaCurrent, true
+		case "uninitialized":
+			return SchemaUninitialized, true
+		case "pending":
+			return SchemaPending, true
+		}
+	}
+	return SchemaUnknown, false
+}
+
+// migrateCheckArgs builds the read-only schema probe. It reuses migrateArgs so
+// the check always runs the same entrypoint, in the same one-shot container, as
+// the migration it gates.
+func migrateCheckArgs(composePath string) []string {
+	return append(migrateArgs(composePath), "--check")
+}
+
 // migrateArgs builds the `docker compose run` invocation that applies
 // migrations via a one-shot app container. -T disables pseudo-TTY allocation:
 // the run is non-interactive and CLI-driven, so without it `docker compose run`

--- a/cli/internal/install/compose_schema_test.go
+++ b/cli/internal/install/compose_schema_test.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,7 +73,7 @@ func TestComposeSchemaStateReadsVerdict(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			stubDocker(t, tc.stdout, tc.exit, filepath.Join(t.TempDir(), "args"))
-			if got := ComposeSchemaState("/tmp/compose.yaml"); got != tc.want {
+			if got := ComposeSchemaState(io.Discard, "/tmp/compose.yaml"); got != tc.want {
 				t.Errorf("state = %v, want %v", got, tc.want)
 			}
 		})
@@ -98,7 +99,7 @@ func TestComposeSchemaStateUnknownWhenUndeterminable(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			stubDocker(t, tc.stdout, tc.exit, filepath.Join(t.TempDir(), "args"))
-			if got := ComposeSchemaState("/tmp/compose.yaml"); got != SchemaUnknown {
+			if got := ComposeSchemaState(io.Discard, "/tmp/compose.yaml"); got != SchemaUnknown {
 				t.Errorf("state = %v, want SchemaUnknown", got)
 			}
 		})
@@ -113,7 +114,7 @@ func TestComposeSchemaStateProbeIsReadOnly(t *testing.T) {
 	argsFile := filepath.Join(t.TempDir(), "args")
 	stubDocker(t, "OVERALL current", 0, argsFile)
 
-	ComposeSchemaState("/tmp/compose.yaml")
+	ComposeSchemaState(io.Discard, "/tmp/compose.yaml")
 	raw, err := os.ReadFile(argsFile)
 	if err != nil {
 		t.Fatalf("read recorded args: %v", err)
@@ -133,11 +134,55 @@ func TestComposeSchemaStateProbeIsReadOnly(t *testing.T) {
 	}
 }
 
+// TestComposeSchemaStateSurfacesAnUndeterminableProbe: when the check cannot
+// produce a verdict, `start` carries on by design — so the operator's only clue
+// that the safety net was skipped is what gets printed. Swallowing the output
+// would make the one case that needs explaining ("why did it not notice?")
+// undiagnosable. The probe also pulls/starts a database container, so it must
+// announce itself or `start` looks hung.
+func TestComposeSchemaStateSurfacesAnUndeterminableProbe(t *testing.T) {
+	stubDocker(t, "Cannot connect to the Docker daemon at unix:///var/run/docker.sock", 1,
+		filepath.Join(t.TempDir(), "args"))
+
+	var out strings.Builder
+	if got := ComposeSchemaState(&out, "/tmp/compose.yaml"); got != SchemaUnknown {
+		t.Fatalf("state = %v, want SchemaUnknown", got)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Checking database schema") {
+		t.Errorf("probe must announce itself (it is slow):\n%s", got)
+	}
+	if !strings.Contains(got, "could not determine") {
+		t.Errorf("an undeterminable probe must say so:\n%s", got)
+	}
+	if !strings.Contains(got, "Cannot connect to the Docker daemon") {
+		t.Errorf("the check's own output is the only diagnostic; it must not be swallowed:\n%s", got)
+	}
+}
+
+// TestComposeSchemaStateQuietOnASuccessfulVerdict: the failure diagnostics above
+// must not turn every ordinary `start` into a wall of subprocess output.
+func TestComposeSchemaStateQuietOnASuccessfulVerdict(t *testing.T) {
+	stubDocker(t, "STATUS jentic current current=abc head=abc\nOVERALL current", 0,
+		filepath.Join(t.TempDir(), "args"))
+
+	var out strings.Builder
+	if got := ComposeSchemaState(&out, "/tmp/compose.yaml"); got != SchemaCurrent {
+		t.Fatalf("state = %v, want SchemaCurrent", got)
+	}
+	if strings.Contains(out.String(), "could not determine") {
+		t.Errorf("a clean verdict must not warn:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "STATUS jentic") {
+		t.Errorf("per-database detail is for the failure path only:\n%s", out.String())
+	}
+}
+
 // TestComposeSchemaStateUnknownWithoutDocker: no docker at all is undeterminable
 // rather than an error, so a local-mode or docker-less environment is unaffected.
 func TestComposeSchemaStateUnknownWithoutDocker(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
-	if got := ComposeSchemaState("/tmp/compose.yaml"); got != SchemaUnknown {
+	if got := ComposeSchemaState(io.Discard, "/tmp/compose.yaml"); got != SchemaUnknown {
 		t.Errorf("state = %v, want SchemaUnknown", got)
 	}
 }

--- a/cli/internal/install/compose_schema_test.go
+++ b/cli/internal/install/compose_schema_test.go
@@ -72,11 +72,7 @@ func TestComposeSchemaStateReadsVerdict(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			stubDocker(t, tc.stdout, tc.exit, filepath.Join(t.TempDir(), "args"))
-			got, err := ComposeSchemaState("/tmp/compose.yaml")
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if got != tc.want {
+			if got := ComposeSchemaState("/tmp/compose.yaml"); got != tc.want {
 				t.Errorf("state = %v, want %v", got, tc.want)
 			}
 		})
@@ -102,11 +98,7 @@ func TestComposeSchemaStateUnknownWhenUndeterminable(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			stubDocker(t, tc.stdout, tc.exit, filepath.Join(t.TempDir(), "args"))
-			got, err := ComposeSchemaState("/tmp/compose.yaml")
-			if err != nil {
-				t.Fatalf("an undeterminable probe must not error, got: %v", err)
-			}
-			if got != SchemaUnknown {
+			if got := ComposeSchemaState("/tmp/compose.yaml"); got != SchemaUnknown {
 				t.Errorf("state = %v, want SchemaUnknown", got)
 			}
 		})
@@ -121,9 +113,7 @@ func TestComposeSchemaStateProbeIsReadOnly(t *testing.T) {
 	argsFile := filepath.Join(t.TempDir(), "args")
 	stubDocker(t, "OVERALL current", 0, argsFile)
 
-	if _, err := ComposeSchemaState("/tmp/compose.yaml"); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	ComposeSchemaState("/tmp/compose.yaml")
 	raw, err := os.ReadFile(argsFile)
 	if err != nil {
 		t.Fatalf("read recorded args: %v", err)
@@ -147,11 +137,7 @@ func TestComposeSchemaStateProbeIsReadOnly(t *testing.T) {
 // rather than an error, so a local-mode or docker-less environment is unaffected.
 func TestComposeSchemaStateUnknownWithoutDocker(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
-	got, err := ComposeSchemaState("/tmp/compose.yaml")
-	if err != nil {
-		t.Fatalf("missing docker must not error, got: %v", err)
-	}
-	if got != SchemaUnknown {
+	if got := ComposeSchemaState("/tmp/compose.yaml"); got != SchemaUnknown {
 		t.Errorf("state = %v, want SchemaUnknown", got)
 	}
 }

--- a/cli/internal/install/compose_schema_test.go
+++ b/cli/internal/install/compose_schema_test.go
@@ -1,0 +1,178 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These cover the schema probe that stops `start` bringing the stack up on an
+// unmigrated database (#951). The docker binary is stubbed so the probe's
+// contract — how it reads a verdict, and what it does when it can't get one —
+// is pinned without needing a real daemon.
+
+// stubDocker installs a fake `docker` on PATH that prints stdout and exits with
+// code. args of the last invocation are recorded to argsFile.
+func stubDocker(t *testing.T, stdout string, exit int, argsFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> '" + argsFile + "'\n" +
+		"cat <<'STUBEOF'\n" + stdout + "\nSTUBEOF\n" +
+		"exit " + itoa(exit) + "\n"
+	path := filepath.Join(dir, "docker")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+n%10)) + digits
+		n /= 10
+	}
+	return digits
+}
+
+// TestComposeSchemaStateReadsVerdict pins the mapping from the runner's OVERALL
+// line to a state. `--check` exits 3 by design for the two non-current states,
+// so the verdict must be read even though the command "failed".
+func TestComposeSchemaStateReadsVerdict(t *testing.T) {
+	cases := []struct {
+		name   string
+		stdout string
+		exit   int
+		want   SchemaState
+	}{
+		{
+			name:   "uninitialized after a wiped volume",
+			stdout: "STATUS admin uninitialized current=- head=abc\nOVERALL uninitialized",
+			exit:   3,
+			want:   SchemaUninitialized,
+		},
+		{
+			name:   "pending when behind head",
+			stdout: "STATUS admin pending current=aaa head=bbb\nOVERALL pending",
+			exit:   3,
+			want:   SchemaPending,
+		},
+		{
+			name:   "current when at head",
+			stdout: "STATUS admin current current=bbb head=bbb\nOVERALL current",
+			exit:   0,
+			want:   SchemaCurrent,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stubDocker(t, tc.stdout, tc.exit, filepath.Join(t.TempDir(), "args"))
+			got, err := ComposeSchemaState("/tmp/compose.yaml")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("state = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestComposeSchemaStateUnknownWhenUndeterminable is the safety property: a
+// probe that cannot answer must NOT be reported as a schema problem. An app
+// image predating --check exits 2 from argparse; a dead daemon prints noise.
+// Blocking a start on either would be a worse regression than the bug the check
+// exists to catch.
+func TestComposeSchemaStateUnknownWhenUndeterminable(t *testing.T) {
+	cases := []struct {
+		name   string
+		stdout string
+		exit   int
+	}{
+		{"old image without --check", "unrecognized arguments: --check", 2},
+		{"daemon unreachable", "Cannot connect to the Docker daemon", 1},
+		{"garbled output", "OVERALL", 0},
+		{"unrecognised verdict word", "OVERALL sideways", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stubDocker(t, tc.stdout, tc.exit, filepath.Join(t.TempDir(), "args"))
+			got, err := ComposeSchemaState("/tmp/compose.yaml")
+			if err != nil {
+				t.Fatalf("an undeterminable probe must not error, got: %v", err)
+			}
+			if got != SchemaUnknown {
+				t.Errorf("state = %v, want SchemaUnknown", got)
+			}
+		})
+	}
+}
+
+// TestComposeSchemaStateProbeIsReadOnly pins that the probe runs the migration
+// entrypoint with --check appended. Without that flag this same argv would
+// *apply* migrations, so the flag's presence is a correctness property, not a
+// formatting detail.
+func TestComposeSchemaStateProbeIsReadOnly(t *testing.T) {
+	argsFile := filepath.Join(t.TempDir(), "args")
+	stubDocker(t, "OVERALL current", 0, argsFile)
+
+	if _, err := ComposeSchemaState("/tmp/compose.yaml"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	raw, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read recorded args: %v", err)
+	}
+	got := string(raw)
+	if !strings.Contains(got, "--check") {
+		t.Errorf("probe must pass --check or it would apply migrations:\n%s", got)
+	}
+	if !strings.Contains(got, "jentic_one.migrations.run") {
+		t.Errorf("probe must use the migration entrypoint:\n%s", got)
+	}
+	// One-shot container, removed after, non-interactive — same as the migrate run.
+	for _, want := range []string{"run", "--rm", "-T"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("probe args missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestComposeSchemaStateUnknownWithoutDocker: no docker at all is undeterminable
+// rather than an error, so a local-mode or docker-less environment is unaffected.
+func TestComposeSchemaStateUnknownWithoutDocker(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	got, err := ComposeSchemaState("/tmp/compose.yaml")
+	if err != nil {
+		t.Fatalf("missing docker must not error, got: %v", err)
+	}
+	if got != SchemaUnknown {
+		t.Errorf("state = %v, want SchemaUnknown", got)
+	}
+}
+
+// TestParseSchemaVerdictIgnoresStatusLines makes sure the per-database STATUS
+// lines (which contain the same words) never get mistaken for the overall
+// verdict — only the explicit OVERALL line counts.
+func TestParseSchemaVerdictIgnoresStatusLines(t *testing.T) {
+	out := "STATUS registry current current=x head=x\n" +
+		"STATUS control current current=y head=y\n" +
+		"STATUS admin pending current=a head=b\n" +
+		"OVERALL pending"
+	got, ok := parseSchemaVerdict(out)
+	if !ok {
+		t.Fatal("expected a verdict")
+	}
+	if got != SchemaPending {
+		t.Errorf("state = %v, want SchemaPending (the OVERALL line, not the first STATUS)", got)
+	}
+
+	if _, ok := parseSchemaVerdict("STATUS admin current current=x head=x"); ok {
+		t.Error("STATUS lines alone must not yield a verdict")
+	}
+}

--- a/src/jentic_one/migrations/env.py
+++ b/src/jentic_one/migrations/env.py
@@ -195,6 +195,18 @@ def do_run_migrations(connection: Connection) -> None:
         # etc.) only commit their own work, never a sibling's.
         transaction_per_migration=True,
     )
+    # Read-only status probe (``migrations.run --check``): the caller stashed a
+    # dict to be filled with the revisions this database is actually stamped at.
+    #
+    # Safety here comes from the *caller* invoking ``alembic current`` rather
+    # than ``upgrade``: that runs this env under ``dont_mutate=True`` with a
+    # no-op migration function, so nothing can be applied. Returning early is a
+    # belt-and-braces guard that also skips opening a pointless transaction — it
+    # is not the thing that makes the probe safe.
+    probe = config.attributes.get("status_probe")
+    if probe is not None:
+        probe["current"] = sorted(context.get_context().get_current_heads())
+        return
     with context.begin_transaction():
         context.run_migrations()
 

--- a/src/jentic_one/migrations/run.py
+++ b/src/jentic_one/migrations/run.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
+from alembic.script import ScriptDirectory
 
 from jentic_one.migrations.targets import DB_TARGETS
 
@@ -57,6 +58,73 @@ def downgrade(db_name: str, target: str) -> None:
     command.downgrade(_build_config(db_name), target)
 
 
+# Schema states reported by ``status`` / ``--check``, in ascending severity.
+STATE_CURRENT = "current"
+STATE_PENDING = "pending"
+STATE_UNINITIALIZED = "uninitialized"
+
+# Exit code for ``--check`` when at least one database is not at head. Distinct
+# from 1 so a caller can tell "the schema needs work" apart from "the check
+# itself failed" (bad config, database unreachable) and not act on a non-answer.
+CHECK_EXIT_NEEDS_MIGRATION = 3
+
+
+def status(db_name: str) -> tuple[str, list[str], list[str]]:
+    """Report a database's schema state without modifying it.
+
+    Returns ``(state, current_revisions, head_revisions)`` where state is one of
+    :data:`STATE_CURRENT`, :data:`STATE_PENDING`, :data:`STATE_UNINITIALIZED`.
+
+    ``uninitialized`` (no Alembic version table at all) is deliberately distinct
+    from ``pending`` (stamped, but behind head). They call for opposite
+    responses: an uninitialized database holds no data, so creating the schema is
+    safe and unattended; a pending one holds data that forward-only migrations
+    will rewrite, which is a decision for the operator with a backup in hand.
+
+    Implemented via ``alembic current``, which runs ``env.py`` (so URL/schema
+    resolution stays in one place) under ``dont_mutate=True`` and with a no-op
+    migration function. That is what makes the probe read-only: no migration can
+    be applied, and no version table is created on an untouched database.
+    """
+    if db_name not in DB_TARGETS:
+        raise ValueError(f"Unknown database {db_name!r}; expected one of {_valid_dbs()}")
+    cfg = _build_config(db_name)
+    probe: dict[str, list[str]] = {}
+    cfg.attributes["status_probe"] = probe
+    command.current(cfg)
+
+    current = probe.get("current", [])
+    heads = sorted(ScriptDirectory.from_config(cfg).get_heads())
+    if not current:
+        return STATE_UNINITIALIZED, current, heads
+    if set(current) == set(heads):
+        return STATE_CURRENT, current, heads
+    return STATE_PENDING, current, heads
+
+
+def _run_check(order: list[str]) -> int:
+    """Print each database's schema state and return the process exit code.
+
+    The output is line-oriented and stable because `jenticctl` parses it to
+    decide whether starting the stack is safe.
+    """
+    # The overall verdict is the most severe per-database state: one lagging
+    # database makes the whole stack unsafe to start.
+    severity = {STATE_CURRENT: 0, STATE_PENDING: 1, STATE_UNINITIALIZED: 2}
+    worst = STATE_CURRENT
+    for db_name in order:
+        state, current, heads = status(db_name)
+        print(
+            f"STATUS {db_name} {state} current={','.join(current) or '-'} "
+            f"head={','.join(heads) or '-'}",
+            flush=True,
+        )
+        if severity[state] > severity[worst]:
+            worst = state
+    print(f"OVERALL {worst}", flush=True)
+    return 0 if worst == STATE_CURRENT else CHECK_EXIT_NEEDS_MIGRATION
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Apply Alembic migrations.")
     parser.add_argument(
@@ -78,9 +146,17 @@ def main(argv: list[str] | None = None) -> int:
         "The down default of '-1' is applied per --db, so a bare "
         "'--db a --db b down' steps each database back one revision.",
     )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Report each database's schema state and exit without changing "
+        f"anything. Exits {CHECK_EXIT_NEEDS_MIGRATION} if any database is not at head.",
+    )
     args = parser.parse_args(argv)
 
     order = args.db or list(_valid_dbs())
+    if args.check:
+        return _run_check(order)
     if args.direction == "down":
         # Rollback reverses registration order so a dependent schema tears down
         # before the schema it FKs into. Critical for FK safety.

--- a/src/jentic_one/migrations/run.py
+++ b/src/jentic_one/migrations/run.py
@@ -108,10 +108,18 @@ def _run_check(order: list[str]) -> int:
     The output is line-oriented and stable because `jenticctl` parses it to
     decide whether starting the stack is safe.
     """
-    # The overall verdict is the most severe per-database state: one lagging
-    # database makes the whole stack unsafe to start.
-    severity = {STATE_CURRENT: 0, STATE_PENDING: 1, STATE_UNINITIALIZED: 2}
-    worst = STATE_CURRENT
+    # The overall verdict is the state demanding the most caution, which is
+    # ``pending`` — NOT the "worst-looking" one. The caller responds to these
+    # states in opposite ways: ``uninitialized`` is migrated unattended (nothing
+    # to lose), while ``pending`` aborts so the operator can take a backup.
+    #
+    # So a mixed stack — say a newly added database target with no version table
+    # alongside an existing one behind head — must report ``pending``. Ranking
+    # ``uninitialized`` higher would let the "no data to lose" path run
+    # forward-only migrations across every database, including the ones holding
+    # data, silently bypassing the very safeguard this check exists to provide.
+    caution = {STATE_CURRENT: 0, STATE_UNINITIALIZED: 1, STATE_PENDING: 2}
+    verdict = STATE_CURRENT
     for db_name in order:
         state, current, heads = status(db_name)
         print(
@@ -119,10 +127,10 @@ def _run_check(order: list[str]) -> int:
             f"head={','.join(heads) or '-'}",
             flush=True,
         )
-        if severity[state] > severity[worst]:
-            worst = state
-    print(f"OVERALL {worst}", flush=True)
-    return 0 if worst == STATE_CURRENT else CHECK_EXIT_NEEDS_MIGRATION
+        if caution[state] > caution[verdict]:
+            verdict = state
+    print(f"OVERALL {verdict}", flush=True)
+    return 0 if verdict == STATE_CURRENT else CHECK_EXIT_NEEDS_MIGRATION
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/unit/test_migration_status.py
+++ b/tests/unit/test_migration_status.py
@@ -1,0 +1,150 @@
+"""Tests for the read-only migration status check (``migrations.run --check``).
+
+The check is what lets ``jenticctl start`` refuse to bring the stack up on a
+database that has no schema, or one that is behind the code (#951). Two
+properties matter and are pinned here against real SQLite databases:
+
+* it **distinguishes** uninitialized (no data — safe to create) from pending
+  (has data — the operator's call), because those warrant opposite responses;
+* it is genuinely **read-only** — a status probe that migrated as a side effect
+  would be worse than no probe at all.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jentic_one.migrations import run as run_mod
+from jentic_one.migrations.run import (
+    CHECK_EXIT_NEEDS_MIGRATION,
+    STATE_CURRENT,
+    STATE_PENDING,
+    STATE_UNINITIALIZED,
+    status,
+)
+
+# One database is enough to pin the semantics and keeps the suite fast; the
+# per-database loop is exercised by the CLI-facing --check tests below.
+_DB = "admin"
+
+
+@pytest.fixture
+def sqlite_stack(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point config at fresh, empty per-database SQLite files."""
+    cfg = tmp_path / "jentic-one.yaml"
+    lines = ["databases:"]
+    for name in ("admin", "control", "registry"):
+        lines += [f"  {name}:", "    backend: sqlite", f"    path: {tmp_path / f'{name}.db'}"]
+    cfg.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    monkeypatch.setenv("JENTIC_CONFIG_FILE", str(cfg))
+    return tmp_path
+
+
+def _tables(db_path: Path) -> set[str]:
+    if not db_path.exists():
+        return set()
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    return {name for (name,) in rows}
+
+
+def test_status_reports_uninitialized_for_a_wiped_database(sqlite_stack: Path) -> None:
+    """A wiped/new volume has no version table — the #951 scenario.
+
+    This must NOT be reported as ``pending``: there is no data at risk, so the
+    caller is free to create the schema unattended.
+    """
+    state, current, heads = status(_DB)
+    assert state == STATE_UNINITIALIZED
+    assert current == []
+    assert heads, "the packaged migrations must have a head revision"
+
+
+def test_status_probe_does_not_create_a_schema(sqlite_stack: Path) -> None:
+    """The probe must not migrate as a side effect.
+
+    Asserting on the state alone would not catch a probe that answered
+    correctly *and* mutated the database, so check the tables directly.
+    """
+    status(_DB)
+    assert _tables(sqlite_stack / f"{_DB}.db") == set()
+
+
+def test_status_reports_current_after_migrating(sqlite_stack: Path) -> None:
+    run_mod.upgrade(_DB)
+    state, current, heads = status(_DB)
+    assert state == STATE_CURRENT
+    assert current == heads
+
+
+def test_status_reports_pending_when_behind_head(sqlite_stack: Path) -> None:
+    """A populated schema behind head is ``pending``, not ``current``.
+
+    This is the state where forward-only migrations would rewrite existing data,
+    so it must be distinguishable from both other states.
+    """
+    run_mod.upgrade(_DB)
+    run_mod.downgrade(_DB, "-1")
+
+    state, current, heads = status(_DB)
+    assert state == STATE_PENDING
+    assert current and current != heads
+
+
+def test_status_rejects_an_unknown_database() -> None:
+    with pytest.raises(ValueError, match="Unknown database"):
+        status("not-a-database")
+
+
+def test_check_exits_nonzero_and_reports_uninitialized(
+    sqlite_stack: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The CLI contract `jenticctl` depends on: verdict line + exit code.
+
+    The exit code is deliberately not 1, so a caller can tell "migrations are
+    needed" apart from "the check itself failed" and never act on a non-answer.
+    """
+    code = run_mod.main(["--check"])
+    out = capsys.readouterr().out
+
+    assert code == CHECK_EXIT_NEEDS_MIGRATION
+    assert "OVERALL uninitialized" in out
+    # Per-database detail is present for diagnosis, one line each.
+    for name in ("admin", "control", "registry"):
+        assert f"STATUS {name} uninitialized" in out
+
+
+def test_check_exits_zero_when_all_databases_are_current(
+    sqlite_stack: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert run_mod.main([]) == 0
+    capsys.readouterr()
+
+    assert run_mod.main(["--check"]) == 0
+    assert "OVERALL current" in capsys.readouterr().out
+
+
+def test_check_reports_pending_when_any_database_is_behind(
+    sqlite_stack: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """One lagging database is enough to make the whole stack unsafe to start."""
+    run_mod.main([])
+    run_mod.downgrade(_DB, "-1")
+    capsys.readouterr()
+
+    code = run_mod.main(["--check"])
+    out = capsys.readouterr().out
+
+    assert code == CHECK_EXIT_NEEDS_MIGRATION
+    assert "OVERALL pending" in out
+    assert f"STATUS {_DB} pending" in out
+
+
+def test_check_does_not_migrate(sqlite_stack: Path) -> None:
+    """End-to-end read-only guarantee for the CLI entrypoint."""
+    assert run_mod.main(["--check"]) == CHECK_EXIT_NEEDS_MIGRATION
+    for name in ("admin", "control", "registry"):
+        assert _tables(sqlite_stack / f"{name}.db") == set(), f"{name} was modified by --check"

--- a/tests/unit/test_migration_status.py
+++ b/tests/unit/test_migration_status.py
@@ -143,6 +143,41 @@ def test_check_reports_pending_when_any_database_is_behind(
     assert f"STATUS {_DB} pending" in out
 
 
+def test_check_reports_pending_when_one_database_is_behind_and_another_is_wiped(
+    sqlite_stack: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A mixed stack must report ``pending`` — the state demanding most caution.
+
+    The two states get opposite responses from the caller: ``uninitialized`` is
+    migrated unattended (nothing to lose), while ``pending`` aborts the start so
+    the operator can take a backup first. So the overall verdict cannot be the
+    "worst-looking" state; it has to be the most cautious one.
+
+    Ranking ``uninitialized`` higher would let the "no data to lose" path run
+    forward-only migrations across *every* database, including the one holding
+    data that is behind head — silently bypassing the safeguard this check
+    exists to provide. Realistic trigger: a newly added database target
+    alongside existing ones, or a partially wiped volume set.
+
+    The wiped database is deliberately the last one checked, so a verdict that
+    merely reflects iteration order cannot pass.
+    """
+    order = list(run_mod._valid_dbs())
+    behind, wiped_db = order[0], order[-1]
+    run_mod.main([])
+    run_mod.downgrade(behind, "-1")
+    (sqlite_stack / f"{wiped_db}.db").unlink()
+    capsys.readouterr()
+
+    code = run_mod.main(["--check"])
+    out = capsys.readouterr().out
+
+    assert f"STATUS {behind} pending" in out
+    assert f"STATUS {wiped_db} uninitialized" in out
+    assert "OVERALL pending" in out, f"a mixed stack must not auto-migrate:\n{out}"
+    assert code == CHECK_EXIT_NEEDS_MIGRATION
+
+
 def test_check_does_not_migrate(sqlite_stack: Path) -> None:
     """End-to-end read-only guarantee for the CLI entrypoint."""
     assert run_mod.main(["--check"]) == CHECK_EXIT_NEEDS_MIGRATION


### PR DESCRIPTION
Closes #951

## Summary

`start` only ran `compose up`; migrations belong to `install`/`update`, so nothing on the start path ever looked at the schema. After a `stop --volumes` (or any wiped volume), `start` brought the app up against a **completely empty database** and reported `Stack started.` The app boots, login fails, and nothing in the output mentions the schema.

The cost of this one is misdirection: a reporter hit it right after an unrelated update problem and reasonably blamed the update, which sent the investigation down the wrong path entirely.

## Changes

**`migrations.run --check`** — a read-only status mode (none existed; the runner could only *apply* migrations).

It reports `uninitialized` **separately from** `pending`, which is the design decision worth reviewing. They look similar but warrant opposite responses:

| State | Meaning | `start` does |
| --- | --- | --- |
| `uninitialized` | No Alembic version table — new or wiped volume | **Creates the schema.** No data exists to lose, so this is safe and unattended, exactly what `install` would do. |
| `pending` | Schema present but behind head | **Refuses**, and names the command. There *is* data, and forward-only migrations will rewrite it — an operator decision, with a backup, not a side effect of `start`. |
| `current` | At head | Starts normally. |

Two details that are correctness properties rather than polish:

- **Exit `3`, not `1`, when migrations are needed.** A caller must be able to distinguish "the schema needs work" from "the check itself failed" (bad config, database unreachable) and never act on a non-answer.
- **An undeterminable state never blocks the start.** No docker, an app image predating `--check` (argparse exits 2), a dead daemon → `SchemaUnknown`, and `start` proceeds. Refusing because a *diagnostic* failed would be a worse regression than the bug being fixed.

**`stop --volumes`** now states that the database is gone and the admin user needs recreating. The prompt already confirms the deletion, but nothing set expectations for the next `start` — and that is where the operator looks when their login breaks.

## Read-only guarantee

The probe runs through `alembic current`, which uses `dont_mutate=True` and a no-op migration function, so no migration can be applied and no version table is created on an untouched database. `env.py` also returns before `run_migrations` as a second, independent guard.

I verified the read-only assertion is **meaningful** rather than trivially true: against real SQLite databases, the probe leaves **0** tables while a real upgrade creates **23**, so `_tables(...) == set()` genuinely discriminates.

## Test plan

Python (real SQLite databases, all three states):
- [x] Wiped database → `uninitialized`; probe creates no tables
- [x] After migrating → `current`
- [x] Stepped back one revision → `pending` (not `current`, not `uninitialized`)
- [x] `--check` prints `OVERALL <state>` + per-database `STATUS` lines, exits 3 / 0 correctly
- [x] One lagging database makes the whole stack `pending`
- [x] `--check` end-to-end creates no tables in any database
- [x] Unknown database name rejected

Go (stubbed `docker`, so no daemon needed):
- [x] Each `OVERALL` verdict maps to the right state, *including* when `--check` exits 3 by design
- [x] Old image / dead daemon / garbled / unrecognised verdict → `SchemaUnknown`, no error
- [x] Missing `docker` → `SchemaUnknown`, no error
- [x] Probe argv contains `--check` (without it, this same argv would **apply** migrations) and uses `run --rm -T` with the migration entrypoint
- [x] Per-database `STATUS` lines are never mistaken for the `OVERALL` verdict

Suites: `pytest tests/unit/test_migration_status.py tests/unit/test_migrations.py tests/arch` → 301 passed · `go test ./...` green · `ruff`/`mypy`/`gofmt`/`go vet` clean.

## Reviewer notes

- The `--check` output is a **parsed contract** between the Python runner and the Go CLI. It is deliberately line-oriented and boring; changing those strings breaks the gate.
- Only the Docker path is gated. The local path already fails loudly on a missing venv/config, and `install`/`update` migrate it — worth a follow-up if we want parity.

Please **squash merge**.

Made with [Cursor](https://cursor.com)