### PR TITLE
feat(seams): add register_pipeline_stage — ingest pipeline extension seam

### DIFF
--- a/docs/development/extending-jentic-one.md
+++ b/docs/development/extending-jentic-one.md
@@ -65,10 +65,12 @@ Read your validated config back with `AppConfig.extension("my_ext")`, which
 returns your model instance (or `None` if the section is absent).
 
 You can also append **ingest pipeline stages**. Registered stages run after
-every built-in stage (in registration order), see the full context bag the
-built-ins produced (`operation_ids`, `revision_id`, …), and share the ingest
-transaction — a failing extension stage rolls back the whole ingest. Gate
-yourself on your own config section; the registry is config-blind:
+every built-in stage (in registration order; when several packages register
+stages, cross-package order is their import order — register from one place if
+relative order matters), see the full context bag the built-ins produced
+(`operation_ids`, `revision_id`, …), and share the ingest transaction — a
+failing extension stage rolls back the whole ingest. Gate yourself on your own
+config section; the registry is config-blind:
 
 ```python
 import uuid
@@ -78,11 +80,10 @@ from jentic_one.registry.ingest.pipeline import (
     PipelineStageSpec,
     register_pipeline_stage,
 )
-from jentic_one.registry.ingest.stages.base import BasePipelineStage
+from jentic_one.registry.ingest.stages import BasePipelineStage
 
 
 class EmbedOperationsStage(BasePipelineStage):
-    name = "EmbedOperationsStage"
     _requires = {"operation_ids": set, "revision_id": uuid.UUID}
 
     async def _run(self, ctx: PipelineContext) -> None:

--- a/docs/development/extending-jentic-one.md
+++ b/docs/development/extending-jentic-one.md
@@ -17,6 +17,8 @@ definition — this page links them into one workflow.
 | `register_config` | `jentic_one.shared.config` | Add a top-level config section validated by your own pydantic model. |
 | `register_target` | `jentic_one.migrations.targets` | Add an isolated migration target to the ordered upgrade/rollback sequence. |
 | `register_telemetry_event` | `jentic_one.shared.telemetry.events` | Forward extra telemetry events without editing the closed enum. |
+| `register_strategy` | `jentic_one.registry.repos.search.registry` | Register a `SearchStrategy` under a new `(dialect, search_mode)` pair. |
+| `register_pipeline_stage` | `jentic_one.registry.ingest.pipeline.stage_registry` | Append extra ingest stages that run after the built-in pipeline, inside the same transaction. |
 | `jentic_one.testing` | `jentic_one.testing` | Compliance base classes that prove your implementations honor the seam contracts. |
 | `pkg/core.AppContainer` | `cli/pkg/core` (Go) | Compose your own CLI binary with extra command groups. |
 
@@ -61,6 +63,39 @@ register_telemetry_event("my_ext.thing_happened", "thing_happened")
 
 Read your validated config back with `AppConfig.extension("my_ext")`, which
 returns your model instance (or `None` if the section is absent).
+
+You can also append **ingest pipeline stages**. Registered stages run after
+every built-in stage (in registration order), see the full context bag the
+built-ins produced (`operation_ids`, `revision_id`, …), and share the ingest
+transaction — a failing extension stage rolls back the whole ingest. Gate
+yourself on your own config section; the registry is config-blind:
+
+```python
+import uuid
+
+from jentic_one.registry.ingest.pipeline import (
+    PipelineContext,
+    PipelineStageSpec,
+    register_pipeline_stage,
+)
+from jentic_one.registry.ingest.stages.base import BasePipelineStage
+
+
+class EmbedOperationsStage(BasePipelineStage):
+    name = "EmbedOperationsStage"
+    _requires = {"operation_ids": set, "revision_id": uuid.UUID}
+
+    async def _run(self, ctx: PipelineContext) -> None:
+        cfg = ctx.config.extension("my_ext") if ctx.config else None
+        if cfg is None or not cfg.enabled:
+            return  # feature-gated: registered unconditionally, no-op when off
+        ...  # embed ctx.require("operation_ids", set) on ctx.session
+
+
+register_pipeline_stage(
+    PipelineStageSpec(name="my_ext.embed_operations", factory=EmbedOperationsStage)
+)
+```
 
 ### 2. Build an `AppContainer` and compose the app
 

--- a/src/jentic_one/registry/ingest/__init__.py
+++ b/src/jentic_one/registry/ingest/__init__.py
@@ -3,7 +3,14 @@
 from jentic_one.registry.ingest.fetch import InlineSource, UrlSource, load_specification
 from jentic_one.registry.ingest.ingestor import Ingestor
 from jentic_one.registry.ingest.models import ApiIdentifier, IngestSpecification, SpecType
-from jentic_one.registry.ingest.pipeline import Pipeline, PipelineContext, PipelineFactory
+from jentic_one.registry.ingest.pipeline import (
+    Pipeline,
+    PipelineContext,
+    PipelineFactory,
+    PipelineStageSpec,
+    register_pipeline_stage,
+    registered_pipeline_stage_specs,
+)
 from jentic_one.registry.ingest.schemas import IngestResult
 
 __all__ = [
@@ -15,7 +22,10 @@ __all__ = [
     "Pipeline",
     "PipelineContext",
     "PipelineFactory",
+    "PipelineStageSpec",
     "SpecType",
     "UrlSource",
     "load_specification",
+    "register_pipeline_stage",
+    "registered_pipeline_stage_specs",
 ]

--- a/src/jentic_one/registry/ingest/ingestor.py
+++ b/src/jentic_one/registry/ingest/ingestor.py
@@ -53,7 +53,10 @@ class Ingestor:
 
                 async with self._ctx.registry_db.transaction() as session:
                     pipeline_ctx = PipelineContext(
-                        session=session, specification=spec, created_by=created_by
+                        session=session,
+                        specification=spec,
+                        created_by=created_by,
+                        config=self._ctx.config,
                     )
                     pipeline = PipelineFactory.from_specification(
                         spec, include_search_text=include_search_text

--- a/src/jentic_one/registry/ingest/pipeline/__init__.py
+++ b/src/jentic_one/registry/ingest/pipeline/__init__.py
@@ -5,6 +5,7 @@ from jentic_one.registry.ingest.pipeline.pipeline import BasePipeline, Pipeline,
 from jentic_one.registry.ingest.pipeline.stage_registry import (
     PipelineStageSpec,
     register_pipeline_stage,
+    registered_pipeline_stage_specs,
     registered_pipeline_stages,
 )
 
@@ -15,5 +16,6 @@ __all__ = [
     "PipelineFactory",
     "PipelineStageSpec",
     "register_pipeline_stage",
+    "registered_pipeline_stage_specs",
     "registered_pipeline_stages",
 ]

--- a/src/jentic_one/registry/ingest/pipeline/__init__.py
+++ b/src/jentic_one/registry/ingest/pipeline/__init__.py
@@ -2,10 +2,18 @@
 
 from jentic_one.registry.ingest.pipeline.ctx import PipelineContext
 from jentic_one.registry.ingest.pipeline.pipeline import BasePipeline, Pipeline, PipelineFactory
+from jentic_one.registry.ingest.pipeline.stage_registry import (
+    PipelineStageSpec,
+    register_pipeline_stage,
+    registered_pipeline_stages,
+)
 
 __all__ = [
     "BasePipeline",
     "Pipeline",
     "PipelineContext",
     "PipelineFactory",
+    "PipelineStageSpec",
+    "register_pipeline_stage",
+    "registered_pipeline_stages",
 ]

--- a/src/jentic_one/registry/ingest/pipeline/ctx.py
+++ b/src/jentic_one/registry/ingest/pipeline/ctx.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from jentic_one.registry.ingest._typecheck import check_type
 from jentic_one.registry.ingest.exc import (
@@ -12,6 +12,9 @@ from jentic_one.registry.ingest.exc import (
     WrongTypeRequiredError,
 )
 from jentic_one.registry.ingest.models import IngestSpecification
+
+if TYPE_CHECKING:
+    from jentic_one.shared.config import AppConfig
 
 
 class PipelineContext:
@@ -23,7 +26,7 @@ class PipelineContext:
         session: Any,
         specification: IngestSpecification,
         created_by: str,
-        config: Any | None = None,
+        config: AppConfig | None = None,
     ) -> None:
         self.session: Any = session
         self.specification = specification
@@ -33,7 +36,7 @@ class PipelineContext:
         #: ``ctx.config.extension("<name>")`` to gate themselves — built-in
         #: stages must keep taking feature flags explicitly (like
         #: include_search_text) rather than growing implicit config reads.
-        self.config: Any | None = config
+        self.config: AppConfig | None = config
         self._data: dict[str, Any] = {}
 
     def produce(self, key: str, value: Any, expected_type: type) -> None:

--- a/src/jentic_one/registry/ingest/pipeline/ctx.py
+++ b/src/jentic_one/registry/ingest/pipeline/ctx.py
@@ -18,11 +18,22 @@ class PipelineContext:
     """Carries session, specification, and a typed data bag between pipeline stages."""
 
     def __init__(
-        self, *, session: Any, specification: IngestSpecification, created_by: str
+        self,
+        *,
+        session: Any,
+        specification: IngestSpecification,
+        created_by: str,
+        config: Any | None = None,
     ) -> None:
         self.session: Any = session
         self.specification = specification
         self.created_by = created_by
+        #: The loaded AppConfig, when the caller provides it (the ingestor
+        #: does). Registered extension stages read their own config section via
+        #: ``ctx.config.extension("<name>")`` to gate themselves — built-in
+        #: stages must keep taking feature flags explicitly (like
+        #: include_search_text) rather than growing implicit config reads.
+        self.config: Any | None = config
         self._data: dict[str, Any] = {}
 
     def produce(self, key: str, value: Any, expected_type: type) -> None:

--- a/src/jentic_one/registry/ingest/pipeline/pipeline.py
+++ b/src/jentic_one/registry/ingest/pipeline/pipeline.py
@@ -9,6 +9,7 @@ from jentic_one.registry.ingest.exc import IngestPipelineError, IngestStageError
 from jentic_one.registry.ingest.models import IngestSpecification, SpecType
 from jentic_one.registry.ingest.observability import tracer
 from jentic_one.registry.ingest.pipeline.ctx import PipelineContext
+from jentic_one.registry.ingest.pipeline.stage_registry import registered_pipeline_stages
 from jentic_one.registry.ingest.stages.base import BasePipelineStage
 from jentic_one.registry.ingest.stages.extract_api import CreateDraftRevisionStage, ResolveApiStage
 from jentic_one.registry.ingest.stages.extract_operations import ExtractOperationsStage
@@ -72,6 +73,10 @@ class PipelineFactory:
             ]
             if include_search_text:
                 stages.append(BuildSearchTextForOperationsStage())
+            # Extension stages (register_pipeline_stage) always run last, in
+            # registration order, so they can consume the built-ins' products
+            # (operation_ids, revision_id, ...) within the same transaction.
+            stages.extend(registered_pipeline_stages(spec.spec_type))
             return Pipeline(stages)
         msg = f"Unsupported spec type: {spec.spec_type}"
         raise ValueError(msg)

--- a/src/jentic_one/registry/ingest/pipeline/stage_registry.py
+++ b/src/jentic_one/registry/ingest/pipeline/stage_registry.py
@@ -1,10 +1,11 @@
 """Extension seam: registered ingest pipeline stages.
 
 Overlays append extra stages to the built-in ingest pipeline without editing
-it — e.g. an enterprise embed-at-import stage for semantic search. Mirrors the
-search-strategy registry (``jentic_one.registry.repos.search.registry``):
-process-global, populated at import time, with the collision guards the config
-and telemetry seams use.
+it — e.g. an embed-at-import stage registered by a downstream package. Mirrors
+the search-strategy registry (``jentic_one.registry.repos.search.registry``):
+process-global, populated at import time, with the same conflict-guard posture
+as the config and telemetry seams (idempotent for an identical
+re-registration, loud on a conflicting one).
 
 Contract:
 
@@ -13,8 +14,15 @@ Contract:
   see the full built-in context bag (``operation_ids``, ``revision_id``, …)
   and run inside the same ingest transaction — a failing registered stage
   rolls back the whole ingest, exactly like a built-in one.
+- When several packages register stages, cross-package order is their import
+  order; register all your stages from one place if relative order matters.
 - ``factory`` must return a **fresh** :class:`BasePipelineStage` per call
-  (pipelines are built per ingest; stages may carry per-run state).
+  (pipelines are built per ingest; stages may carry per-run state) and must
+  not raise — a raising factory fails pipeline *construction*, bypassing the
+  per-stage error taxonomy.
+- The stage class's ``name`` ClassVar is the key logs, spans, and the
+  ``stages_total``/``stage_duration`` metrics are labelled with — keep it as
+  unique as the registration name.
 - Feature gating is the stage's own job: read your registered config section
   from ``ctx.config`` (see :class:`PipelineContext`) and return early when
   disabled. The factory seam stays config-blind on purpose — it keeps
@@ -24,7 +32,7 @@ Contract:
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from jentic_one.registry.ingest.models import SpecType
 from jentic_one.registry.ingest.stages.base import BasePipelineStage
@@ -34,29 +42,44 @@ from jentic_one.registry.ingest.stages.base import BasePipelineStage
 class PipelineStageSpec:
     """A registered extension stage: unique name, factory, spec-type filter."""
 
-    #: Unique registration key; collisions are rejected loudly (typo safety).
+    #: Unique registration key; conflicting re-use is rejected loudly.
     name: str
     #: Zero-arg factory returning a fresh stage instance per pipeline build.
     factory: Callable[[], BasePipelineStage]
     #: Spec types the stage applies to. ``None`` (default) means every type.
-    spec_types: frozenset[SpecType] | None = field(default=None)
+    #: An empty set is rejected at registration (it could only mean "never
+    #: runs", which is always a bug).
+    spec_types: frozenset[SpecType] | None = None
 
 
 _REGISTERED_STAGES: dict[str, PipelineStageSpec] = {}
 
 
-def register_pipeline_stage(spec: PipelineStageSpec) -> PipelineStageSpec:
+def register_pipeline_stage(spec: PipelineStageSpec) -> None:
     """Register an extension stage. Call at import time, before ingest runs.
 
-    Raises ``ValueError`` on a duplicate name so two extensions (or a re-import
-    bug) can't silently fight over one slot — same posture as
-    ``register_config`` / ``register_telemetry_event``.
+    Idempotent for an identical re-registration (same frozen spec — safe under
+    double import); raises ``ValueError`` when the name is already bound to a
+    *different* spec, so two extensions can't silently fight over one slot.
+    Same posture as ``register_config`` / ``register_telemetry_event``.
     """
-    if spec.name in _REGISTERED_STAGES:
-        msg = f"Pipeline stage {spec.name!r} is already registered"
+    if spec.spec_types is not None and not spec.spec_types:
+        msg = f"Pipeline stage {spec.name!r} has an empty spec_types filter (would never run)"
+        raise ValueError(msg)
+    existing = _REGISTERED_STAGES.get(spec.name)
+    if existing is not None and existing != spec:
+        msg = f"Pipeline stage {spec.name!r} is already registered to a different spec"
         raise ValueError(msg)
     _REGISTERED_STAGES[spec.name] = spec
-    return spec
+
+
+def registered_pipeline_stage_specs() -> tuple[PipelineStageSpec, ...]:
+    """Snapshot of the registered specs, in registration order.
+
+    Public introspection for integrators' own tests (mirrors the config seam's
+    ``registered_config_models``) — don't reach into the private dict.
+    """
+    return tuple(_REGISTERED_STAGES.values())
 
 
 def registered_pipeline_stages(spec_type: SpecType) -> list[BasePipelineStage]:

--- a/src/jentic_one/registry/ingest/pipeline/stage_registry.py
+++ b/src/jentic_one/registry/ingest/pipeline/stage_registry.py
@@ -1,0 +1,71 @@
+"""Extension seam: registered ingest pipeline stages.
+
+Overlays append extra stages to the built-in ingest pipeline without editing
+it — e.g. an enterprise embed-at-import stage for semantic search. Mirrors the
+search-strategy registry (``jentic_one.registry.repos.search.registry``):
+process-global, populated at import time, with the collision guards the config
+and telemetry seams use.
+
+Contract:
+
+- Registered stages run **after every built-in stage** (including the
+  search-text stage when enabled), in **registration order**. They therefore
+  see the full built-in context bag (``operation_ids``, ``revision_id``, …)
+  and run inside the same ingest transaction — a failing registered stage
+  rolls back the whole ingest, exactly like a built-in one.
+- ``factory`` must return a **fresh** :class:`BasePipelineStage` per call
+  (pipelines are built per ingest; stages may carry per-run state).
+- Feature gating is the stage's own job: read your registered config section
+  from ``ctx.config`` (see :class:`PipelineContext`) and return early when
+  disabled. The factory seam stays config-blind on purpose — it keeps
+  registration a pure import-time side effect.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from jentic_one.registry.ingest.models import SpecType
+from jentic_one.registry.ingest.stages.base import BasePipelineStage
+
+
+@dataclass(frozen=True)
+class PipelineStageSpec:
+    """A registered extension stage: unique name, factory, spec-type filter."""
+
+    #: Unique registration key; collisions are rejected loudly (typo safety).
+    name: str
+    #: Zero-arg factory returning a fresh stage instance per pipeline build.
+    factory: Callable[[], BasePipelineStage]
+    #: Spec types the stage applies to. ``None`` (default) means every type.
+    spec_types: frozenset[SpecType] | None = field(default=None)
+
+
+_REGISTERED_STAGES: dict[str, PipelineStageSpec] = {}
+
+
+def register_pipeline_stage(spec: PipelineStageSpec) -> PipelineStageSpec:
+    """Register an extension stage. Call at import time, before ingest runs.
+
+    Raises ``ValueError`` on a duplicate name so two extensions (or a re-import
+    bug) can't silently fight over one slot — same posture as
+    ``register_config`` / ``register_telemetry_event``.
+    """
+    if spec.name in _REGISTERED_STAGES:
+        msg = f"Pipeline stage {spec.name!r} is already registered"
+        raise ValueError(msg)
+    _REGISTERED_STAGES[spec.name] = spec
+    return spec
+
+
+def registered_pipeline_stages(spec_type: SpecType) -> list[BasePipelineStage]:
+    """Fresh instances of every registered stage applicable to *spec_type*.
+
+    Registration order is the execution order (dicts preserve insertion order).
+    """
+    return [
+        spec.factory()
+        for spec in _REGISTERED_STAGES.values()
+        if spec.spec_types is None or spec_type in spec.spec_types
+    ]

--- a/tests/integration/registry/ingest/test_ingestor_openapi.py
+++ b/tests/integration/registry/ingest/test_ingestor_openapi.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import uuid
+from collections.abc import Iterator
+from typing import ClassVar
+
 import pytest
 import structlog
 from sqlalchemy import select
@@ -16,6 +20,13 @@ from jentic_one.registry.core.schema.spec_files import SpecFile
 from jentic_one.registry.ingest.exc import IngestPipelineError
 from jentic_one.registry.ingest.ingestor import Ingestor
 from jentic_one.registry.ingest.models import ApiIdentifier, IngestSpecification, SpecType
+from jentic_one.registry.ingest.pipeline.ctx import PipelineContext
+from jentic_one.registry.ingest.pipeline.stage_registry import (
+    _REGISTERED_STAGES,
+    PipelineStageSpec,
+    register_pipeline_stage,
+)
+from jentic_one.registry.ingest.stages.base import BasePipelineStage
 from jentic_one.shared.context import Context
 from jentic_one.shared.db.session import DatabaseSession
 from jentic_one.shared.models import ApiRevisionSourceType
@@ -261,3 +272,79 @@ def _reimport_spec() -> IngestSpecification:
     spec = _build_spec(sha="same_digest_xyz")
     spec.origin = "catalog"
     return spec
+
+
+# ── register_pipeline_stage seam: registered stages run inside the ingest ────
+
+
+@pytest.fixture()
+def _isolated_stage_registry() -> Iterator[None]:
+    """Snapshot/restore the process-global stage registry around a test."""
+    before = dict(_REGISTERED_STAGES)
+    _REGISTERED_STAGES.clear()
+    try:
+        yield
+    finally:
+        _REGISTERED_STAGES.clear()
+        _REGISTERED_STAGES.update(before)
+
+
+class _CaptureStage(BasePipelineStage):
+    """Extension stage that records what it saw from the pipeline context."""
+
+    name = "TestCaptureStage"
+    _requires: ClassVar[dict[str, type]] = {"operation_ids": set, "revision_id": uuid.UUID}
+
+    captured: ClassVar[dict[str, object]] = {}
+
+    async def _run(self, ctx: PipelineContext) -> None:
+        type(self).captured = {
+            "operation_ids": ctx.require("operation_ids", set),
+            "revision_id": ctx.require("revision_id", uuid.UUID),
+            "config": ctx.config,
+        }
+
+
+class _FailingStage(BasePipelineStage):
+    name = "TestFailingStage"
+
+    async def _run(self, ctx: PipelineContext) -> None:
+        msg = "extension stage exploded"
+        raise RuntimeError(msg)
+
+
+async def test_registered_stage_runs_inside_ingest(
+    ingest_context: Context,
+    registry_db: DatabaseSession,
+    clean_registry: None,
+    _isolated_stage_registry: None,
+) -> None:
+    """A registered extension stage runs last, sees the built-ins' context
+    products, and receives the loaded AppConfig for self-gating."""
+    _CaptureStage.captured = {}
+    register_pipeline_stage(PipelineStageSpec(name="test.capture", factory=_CaptureStage))
+
+    result = await Ingestor(ingest_context).ingest(_build_spec(), created_by="usr_test")
+
+    assert _CaptureStage.captured, "registered stage never ran"
+    assert _CaptureStage.captured["revision_id"] == result.revision_id
+    assert len(_CaptureStage.captured["operation_ids"]) == result.operation_count  # type: ignore[arg-type]
+    assert _CaptureStage.captured["config"] is ingest_context.config
+
+
+async def test_failing_registered_stage_rolls_back_ingest(
+    ingest_context: Context,
+    registry_db: DatabaseSession,
+    clean_registry: None,
+    _isolated_stage_registry: None,
+) -> None:
+    """A failing extension stage surfaces as IngestPipelineError and rolls back
+    everything the built-in stages persisted — exactly like a built-in failure."""
+    register_pipeline_stage(PipelineStageSpec(name="test.failing", factory=_FailingStage))
+
+    with pytest.raises(IngestPipelineError, match="extension stage exploded"):
+        await Ingestor(ingest_context).ingest(_build_spec(), created_by="usr_test")
+
+    async with registry_db.session() as session:
+        apis = (await session.execute(select(Api))).unique().scalars().all()
+        assert apis == [], "failed extension stage must roll back the whole ingest"

--- a/tests/unit/registry/ingest/test_stage_registry.py
+++ b/tests/unit/registry/ingest/test_stage_registry.py
@@ -1,0 +1,119 @@
+"""Tests for the ingest pipeline stage-registration seam (register_pipeline_stage)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from jentic_one.registry.ingest.models import ApiIdentifier, IngestSpecification, SpecType
+from jentic_one.registry.ingest.pipeline.ctx import PipelineContext
+from jentic_one.registry.ingest.pipeline.pipeline import PipelineFactory
+from jentic_one.registry.ingest.pipeline.stage_registry import (
+    _REGISTERED_STAGES,
+    PipelineStageSpec,
+    register_pipeline_stage,
+    registered_pipeline_stages,
+)
+from jentic_one.registry.ingest.stages.base import BasePipelineStage
+from jentic_one.registry.ingest.stages.search_text import BuildSearchTextForOperationsStage
+
+
+class _ExtensionStage(BasePipelineStage):
+    name = "ExtensionStage"
+
+    async def _run(self, ctx: PipelineContext) -> None:  # pragma: no cover - never run
+        pass
+
+
+class _OtherExtensionStage(BasePipelineStage):
+    name = "OtherExtensionStage"
+
+    async def _run(self, ctx: PipelineContext) -> None:  # pragma: no cover - never run
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry() -> Iterator[None]:
+    """Snapshot/restore the process-global registry around every test."""
+    before = dict(_REGISTERED_STAGES)
+    _REGISTERED_STAGES.clear()
+    try:
+        yield
+    finally:
+        _REGISTERED_STAGES.clear()
+        _REGISTERED_STAGES.update(before)
+
+
+def _openapi_spec() -> IngestSpecification:
+    return IngestSpecification(
+        spec_type=SpecType.OPENAPI,
+        api_identifier=ApiIdentifier(vendor="acme", name="pets", version="1.0.0"),
+        content={"openapi": "3.1.0"},
+    )
+
+
+def test_registered_stage_appends_after_builtins_and_search_text() -> None:
+    register_pipeline_stage(PipelineStageSpec(name="ext", factory=_ExtensionStage))
+
+    pipeline = PipelineFactory.from_specification(_openapi_spec(), include_search_text=True)
+
+    assert isinstance(pipeline.stages[-1], _ExtensionStage)
+    assert isinstance(pipeline.stages[-2], BuildSearchTextForOperationsStage)
+
+
+def test_registration_order_is_execution_order() -> None:
+    register_pipeline_stage(PipelineStageSpec(name="first", factory=_ExtensionStage))
+    register_pipeline_stage(PipelineStageSpec(name="second", factory=_OtherExtensionStage))
+
+    pipeline = PipelineFactory.from_specification(_openapi_spec())
+
+    assert isinstance(pipeline.stages[-2], _ExtensionStage)
+    assert isinstance(pipeline.stages[-1], _OtherExtensionStage)
+
+
+def test_duplicate_name_is_rejected() -> None:
+    register_pipeline_stage(PipelineStageSpec(name="ext", factory=_ExtensionStage))
+    with pytest.raises(ValueError, match="already registered"):
+        register_pipeline_stage(PipelineStageSpec(name="ext", factory=_OtherExtensionStage))
+
+
+def test_spec_type_filter_excludes_non_matching() -> None:
+    # No other SpecType exists yet, so prove the filter via an empty set (matches
+    # nothing) against the None default (matches everything).
+    register_pipeline_stage(
+        PipelineStageSpec(name="never", factory=_ExtensionStage, spec_types=frozenset())
+    )
+    register_pipeline_stage(PipelineStageSpec(name="always", factory=_OtherExtensionStage))
+
+    stages = registered_pipeline_stages(SpecType.OPENAPI)
+
+    assert [type(s) for s in stages] == [_OtherExtensionStage]
+
+
+def test_fresh_instance_per_pipeline_build() -> None:
+    register_pipeline_stage(PipelineStageSpec(name="ext", factory=_ExtensionStage))
+
+    first = PipelineFactory.from_specification(_openapi_spec()).stages[-1]
+    second = PipelineFactory.from_specification(_openapi_spec()).stages[-1]
+
+    assert first is not second
+
+
+def test_unregistered_pipeline_shape_is_unchanged() -> None:
+    with_search = PipelineFactory.from_specification(_openapi_spec(), include_search_text=True)
+    without = PipelineFactory.from_specification(_openapi_spec())
+
+    assert isinstance(with_search.stages[-1], BuildSearchTextForOperationsStage)
+    assert len(with_search.stages) == len(without.stages) + 1
+
+
+def test_pipeline_context_carries_optional_config() -> None:
+    sentinel = object()
+    ctx = PipelineContext(
+        session=None, specification=_openapi_spec(), created_by="usr_test", config=sentinel
+    )
+    assert ctx.config is sentinel
+
+    default = PipelineContext(session=None, specification=_openapi_spec(), created_by="usr_test")
+    assert default.config is None

--- a/tests/unit/registry/ingest/test_stage_registry.py
+++ b/tests/unit/registry/ingest/test_stage_registry.py
@@ -13,6 +13,7 @@ from jentic_one.registry.ingest.pipeline.stage_registry import (
     _REGISTERED_STAGES,
     PipelineStageSpec,
     register_pipeline_stage,
+    registered_pipeline_stage_specs,
     registered_pipeline_stages,
 )
 from jentic_one.registry.ingest.stages.base import BasePipelineStage
@@ -72,23 +73,41 @@ def test_registration_order_is_execution_order() -> None:
     assert isinstance(pipeline.stages[-1], _OtherExtensionStage)
 
 
-def test_duplicate_name_is_rejected() -> None:
+def test_identical_reregistration_is_idempotent() -> None:
+    spec = PipelineStageSpec(name="ext", factory=_ExtensionStage)
+    register_pipeline_stage(spec)
+    # Same frozen spec again (double import) — no-op, not an error.
+    register_pipeline_stage(PipelineStageSpec(name="ext", factory=_ExtensionStage))
+
+    assert registered_pipeline_stage_specs() == (spec,)
+
+
+def test_conflicting_name_is_rejected() -> None:
     register_pipeline_stage(PipelineStageSpec(name="ext", factory=_ExtensionStage))
     with pytest.raises(ValueError, match="already registered"):
         register_pipeline_stage(PipelineStageSpec(name="ext", factory=_OtherExtensionStage))
 
 
-def test_spec_type_filter_excludes_non_matching() -> None:
-    # No other SpecType exists yet, so prove the filter via an empty set (matches
-    # nothing) against the None default (matches everything).
+def test_empty_spec_types_filter_is_rejected() -> None:
+    with pytest.raises(ValueError, match="empty spec_types"):
+        register_pipeline_stage(
+            PipelineStageSpec(name="never", factory=_ExtensionStage, spec_types=frozenset())
+        )
+
+
+def test_spec_type_filter_and_none_default() -> None:
+    # Only one SpecType exists today, so prove the filter's two live branches:
+    # an explicit matching set and the None default (matches everything).
     register_pipeline_stage(
-        PipelineStageSpec(name="never", factory=_ExtensionStage, spec_types=frozenset())
+        PipelineStageSpec(
+            name="openapi_only", factory=_ExtensionStage, spec_types=frozenset({SpecType.OPENAPI})
+        )
     )
     register_pipeline_stage(PipelineStageSpec(name="always", factory=_OtherExtensionStage))
 
     stages = registered_pipeline_stages(SpecType.OPENAPI)
 
-    assert [type(s) for s in stages] == [_OtherExtensionStage]
+    assert [type(s) for s in stages] == [_ExtensionStage, _OtherExtensionStage]
 
 
 def test_fresh_instance_per_pipeline_build() -> None:
@@ -100,18 +119,36 @@ def test_fresh_instance_per_pipeline_build() -> None:
     assert first is not second
 
 
+def test_registered_specs_snapshot_is_a_copy() -> None:
+    spec = PipelineStageSpec(name="ext", factory=_ExtensionStage)
+    register_pipeline_stage(spec)
+
+    snapshot = registered_pipeline_stage_specs()
+
+    assert snapshot == (spec,)
+    assert isinstance(snapshot, tuple)  # immutable view, not the live registry
+
+
 def test_unregistered_pipeline_shape_is_unchanged() -> None:
+    # Full stage-type sequence, not just length: with nothing registered the
+    # factory output is identical to the hardcoded built-in pipeline.
     with_search = PipelineFactory.from_specification(_openapi_spec(), include_search_text=True)
     without = PipelineFactory.from_specification(_openapi_spec())
 
-    assert isinstance(with_search.stages[-1], BuildSearchTextForOperationsStage)
-    assert len(with_search.stages) == len(without.stages) + 1
+    with_search_types = [type(s) for s in with_search.stages]
+    without_types = [type(s) for s in without.stages]
+
+    assert with_search_types == [*without_types, BuildSearchTextForOperationsStage]
+    assert registered_pipeline_stage_specs() == ()
 
 
 def test_pipeline_context_carries_optional_config() -> None:
     sentinel = object()
     ctx = PipelineContext(
-        session=None, specification=_openapi_spec(), created_by="usr_test", config=sentinel
+        session=None,
+        specification=_openapi_spec(),
+        created_by="usr_test",
+        config=sentinel,  # type: ignore[arg-type]
     )
     assert ctx.config is sentinel
 


### PR DESCRIPTION
## Summary

Adds the one extension point overlays could not reach: the ingest pipeline. `PipelineFactory.from_specification` built a hardcoded stage list, so an overlay ingest stage (the concrete driver is embed-at-import for enterprise semantic search, jentic-one-enterprise#2) had nothing to attach to — every other seam (`register_strategy`, `register_config`, `register_target`, `register_telemetry_event`, `AppContainer`) already existed.

- **`register_pipeline_stage(PipelineStageSpec)`** (`registry/ingest/pipeline/stage_registry.py`) — mirrors the established seam grammar: process-global registry populated at import time, idempotent for an identical re-registration and loud (`ValueError`) on a conflicting name — the exact `register_config` / `register_telemetry_event` posture. Zero-arg factories return a fresh stage per pipeline build (the `register_strategy` posture); optional spec-type filter (empty filters rejected — they could only mean "never runs"). Public introspection via `registered_pipeline_stage_specs()`, mirroring `registered_config_models()`.
- **Contract:** registered stages always run **after every built-in stage** (including the search-text stage), in registration order. They see the built-ins' full context bag (`operation_ids`, `revision_id`, …) and share the ingest transaction — a failing extension stage rolls back the whole ingest, exactly like a built-in one. Proven by integration tests running a real `Ingestor`, not just asserted in prose.
- **Feature gating stays with the stage:** `PipelineContext` now optionally carries the loaded `AppConfig` (typed `AppConfig | None` via a `TYPE_CHECKING` import; the ingestor passes `ctx.config`), so an extension stage reads its own registered section via `ctx.config.extension("<name>")` and no-ops when disabled. The registry itself is config-blind, keeping registration a pure import-time side effect. Built-in stages keep taking explicit flags (`include_search_text`) — the comment in `ctx.py` pins that boundary.
- Seam re-exported from `jentic_one.registry.ingest` and `...ingest.pipeline`. Docs: `extending-jentic-one.md` gains the seam-table row (plus the previously missing `register_strategy` row) and a worked `EmbedOperationsStage` example.

No behavior change when nothing is registered: the factory output's full stage-type sequence is unchanged (pinned by test).

Reviewed by an architecture / code-quality / cold-eyes / bugbot board; all should-fixes addressed in the second commit. Follow-up filed for the pre-existing `register_strategy` silent-shadowing outlier.

## Test plan

- [x] `tests/unit/registry/ingest/test_stage_registry.py`: appends after built-ins/search-text, registration order = execution order, idempotent identical re-registration, conflicting-name rejection, empty-filter rejection, spec-type filtering, fresh-instance-per-build, snapshot accessor, full-sequence shape-unchanged, `PipelineContext.config` default/carry
- [x] `tests/integration/registry/ingest/test_ingestor_openapi.py`: a registered stage runs through the real `Ingestor` (sees `operation_ids`/`revision_id`, receives the loaded `AppConfig`); a failing registered stage raises `IngestPipelineError` and rolls back the whole ingest
- [x] Full unit + arch tiers: 2565 passed (coverage 78%)
- [x] Ingest+search unit tiers with the enterprise overlay loaded (`-p jentic_one_enterprise.pytest_plugin`): passed