### PR TITLE
fix(cli): let Ctrl-C cancel the Docker-daemon probe's cold-start wait

### DIFF
--- a/cli/internal/cmd/docker_guard.go
+++ b/cli/internal/cmd/docker_guard.go
@@ -16,8 +16,9 @@ import (
 //
 // It can block up to ~30s while the underlying probe waits out a cold-starting
 // daemon, so callers must announce the check first (via announceDaemonCheck)
-// or the command looks like it hung. Tests that swap this global must not run
-// with t.Parallel().
+// or the command looks like it hung. The ctx (the command's context) lets an
+// operator cancel that wait with Ctrl-C (#953). Tests that swap this global
+// must not run with t.Parallel().
 var requireDockerDaemon = install.RequireDockerDaemon
 
 // composeUp / composeDown / composeDownVolumes are package-level seams over the

--- a/cli/internal/cmd/doctor.go
+++ b/cli/internal/cmd/doctor.go
@@ -203,9 +203,9 @@ func (d *doctor) checkServer() {
 // (empty when healthy) and whether the daemon answered. It is a fast,
 // single-round-trip probe (distinct from install's ~30s polling probe): doctor
 // is read-only and must not block for the full cold-start window when the daemon
-// is simply down.
-var doctorDockerProbe = func() (string, bool) {
-	return install.DockerDaemonResponsiveQuick(2 * time.Second)
+// is simply down. The ctx lets doctor's overall run be canceled (Ctrl-C).
+var doctorDockerProbe = func(ctx context.Context) (string, bool) {
+	return install.DockerDaemonResponsiveQuick(ctx, 2*time.Second)
 }
 
 func (d *doctor) checkDeploy(section string) {
@@ -217,7 +217,7 @@ func (d *doctor) checkDeploy(section string) {
 		// is documented as safe to wire into CI ("warnings keep a zero exit"),
 		// and the sibling `control`/`compose ps` checks also warn on a
 		// not-running dependency — a down daemon shouldn't flip the exit code.
-		if detail, healthy := doctorDockerProbe(); !healthy {
+		if detail, healthy := doctorDockerProbe(d.ctx); !healthy {
 			d.add(section, "docker daemon", statusWarn, detail,
 				install.DockerDaemonRecoveryHint()+", then `jenticctl start`")
 			return

--- a/cli/internal/cmd/doctor_test.go
+++ b/cli/internal/cmd/doctor_test.go
@@ -120,14 +120,14 @@ func TestDotFor(t *testing.T) {
 func TestDoctorReportsDockerDaemonDown(t *testing.T) {
 	orig := doctorDockerProbe
 	t.Cleanup(func() { doctorDockerProbe = orig })
-	doctorDockerProbe = func() (string, bool) { return "Cannot connect to the Docker daemon", false }
+	doctorDockerProbe = func(context.Context) (string, bool) { return "Cannot connect to the Docker daemon", false }
 
 	app := testApp(t)
 	if err := os.WriteFile(app.Paths.ComposePath(), []byte("services: {}\n"), 0o600); err != nil {
 		t.Fatalf("write compose: %v", err)
 	}
 
-	d := &doctor{app: app}
+	d := &doctor{app: app, ctx: context.Background()}
 	d.checkDeploy("Server")
 
 	var daemon *check

--- a/cli/internal/cmd/install.go
+++ b/cli/internal/cmd/install.go
@@ -166,7 +166,7 @@ func (a *App) runInstall(cmd *cobra.Command, opts *installOptions) error {
 	// venv (from the local checkout if we're inside the repo, otherwise clone
 	// from GitHub first) and apply migrations.
 	if local {
-		if err := installLocal(a, draft, out); err != nil {
+		if err := installLocal(cmd.Context(), a, draft, out); err != nil {
 			banner.Stop()
 			return err
 		}
@@ -184,7 +184,7 @@ func (a *App) runInstall(cmd *cobra.Command, opts *installOptions) error {
 	// installDocker records the true outcome on draft.AppStarted (a failed
 	// `compose up` is non-fatal and leaves it false).
 	if docker {
-		if err := a.installDocker(draft, out, logsDir, opts.noStart); err != nil {
+		if err := a.installDocker(cmd.Context(), draft, out, logsDir, opts.noStart); err != nil {
 			banner.Stop()
 			return err
 		}
@@ -346,8 +346,8 @@ func (a *App) writeCLIConfig(draft *install.Draft) {
 // the combined app image (from the local checkout or a fresh clone), write the
 // generated docker-compose stack, apply migrations in a one-shot container, and
 // optionally bring the stack up. Mirrors installLocal for the Docker path.
-func (a *App) installDocker(draft *install.Draft, configPath, logsDir string, noStart bool) error {
-	results := install.Preflight(draft)
+func (a *App) installDocker(ctx context.Context, draft *install.Draft, configPath, logsDir string, noStart bool) error {
+	results := install.Preflight(ctx, draft)
 	fmt.Fprintln(a.Out)
 	fmt.Fprint(a.Out, install.RenderPreflight(results))
 	if missing := install.Missing(results); len(missing) > 0 {
@@ -435,7 +435,7 @@ func (a *App) startAppBackground(draft *install.Draft, configPath, logsDir strin
 	fmt.Fprintln(a.Out, theme.Successf("  Broker started (pid %d, port %s)", brokerPID, draft.BrokerPort))
 }
 
-func installLocal(a *App, draft *install.Draft, configPath string) error {
+func installLocal(ctx context.Context, a *App, draft *install.Draft, configPath string) error {
 	venvDir := a.Paths.VenvPath()
 	srcDir := a.Paths.SrcPath()
 
@@ -444,7 +444,7 @@ func installLocal(a *App, draft *install.Draft, configPath string) error {
 	install.EnsureUv(a.Out)
 
 	// Preflight: confirm required tools are available before doing any work.
-	results := install.Preflight(draft)
+	results := install.Preflight(ctx, draft)
 	fmt.Fprintln(a.Out)
 	fmt.Fprint(a.Out, install.RenderPreflight(results))
 	if missing := install.Missing(results); len(missing) > 0 {

--- a/cli/internal/cmd/reset-password.go
+++ b/cli/internal/cmd/reset-password.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -31,8 +32,8 @@ func newResetPasswordCmd(app *App) *cobra.Command {
 			"reset. It also clears any login lockout. Drives the app's reset path against\n" +
 			"the running stack (Docker compose) or the local install (venv).",
 		Args: cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return app.resetPasswordE(opts)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return app.resetPasswordE(cmd.Context(), opts)
 		},
 	}
 	cmd.Flags().StringVar(&opts.config, "config", "",
@@ -44,7 +45,7 @@ func newResetPasswordCmd(app *App) *cobra.Command {
 	return cmd
 }
 
-func (a *App) resetPasswordE(opts *resetPasswordOptions) error {
+func (a *App) resetPasswordE(ctx context.Context, opts *resetPasswordOptions) error {
 	// A generated compose file marks a Docker install: the reset runs in a
 	// one-shot app container. Probe the daemon up front — before prompting for
 	// credentials — so a user on a stopped daemon isn't asked to type an email
@@ -54,7 +55,7 @@ func (a *App) resetPasswordE(opts *resetPasswordOptions) error {
 	dockerInstall := proc.FileExists(composePath)
 	if dockerInstall {
 		announceDaemonCheck(a.Out)
-		if err := requireDockerDaemon("jenticctl reset-password"); err != nil {
+		if err := requireDockerDaemon(ctx, "jenticctl reset-password"); err != nil {
 			return err
 		}
 	}

--- a/cli/internal/cmd/reset-password_test.go
+++ b/cli/internal/cmd/reset-password_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"strings"
@@ -30,7 +31,7 @@ func TestResetPasswordNonInteractiveValidation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			app := testApp(t)
-			err := app.resetPasswordE(tc.opts)
+			err := app.resetPasswordE(context.Background(), tc.opts)
 			if err == nil {
 				t.Fatalf("expected validation error, got nil")
 			}
@@ -46,7 +47,7 @@ func TestResetPasswordNonInteractiveValidation(t *testing.T) {
 // passed validation and the command tried to act.
 func TestResetPasswordRequiresInstall(t *testing.T) {
 	app := testApp(t)
-	err := app.resetPasswordE(&resetPasswordOptions{
+	err := app.resetPasswordE(context.Background(), &resetPasswordOptions{
 		yes:      true,
 		email:    "user@example.com",
 		password: "a-strong-password",
@@ -69,7 +70,7 @@ func TestResetPasswordDockerFailsFastWhenDaemonDown(t *testing.T) {
 	}
 	sentinel := stubDaemonDown(t)
 
-	err := app.resetPasswordE(&resetPasswordOptions{
+	err := app.resetPasswordE(context.Background(), &resetPasswordOptions{
 		yes:      true,
 		email:    "user@example.com",
 		password: "a-strong-password",

--- a/cli/internal/cmd/setup.go
+++ b/cli/internal/cmd/setup.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -33,8 +34,8 @@ func newSetupCmd(app *App) *cobra.Command {
 			"further users from the admin UI. Run `jenticctl install` first if you have\n" +
 			"not set up locally yet.",
 		Args: cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return app.setupE(opts)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return app.setupE(cmd.Context(), opts)
 		},
 	}
 	cmd.Flags().StringVar(&opts.config, "config", "",
@@ -46,7 +47,7 @@ func newSetupCmd(app *App) *cobra.Command {
 	return cmd
 }
 
-func (a *App) setupE(opts *setupOptions) error {
+func (a *App) setupE(ctx context.Context, opts *setupOptions) error {
 	// A generated compose file marks a Docker install: the admin is created in a
 	// one-shot app container. Probe the daemon up front — before prompting for
 	// credentials — so a user on a stopped daemon isn't asked to type an email
@@ -56,7 +57,7 @@ func (a *App) setupE(opts *setupOptions) error {
 	dockerInstall := proc.FileExists(composePath)
 	if dockerInstall {
 		announceDaemonCheck(a.Out)
-		if err := requireDockerDaemon("jenticctl setup"); err != nil {
+		if err := requireDockerDaemon(ctx, "jenticctl setup"); err != nil {
 			return err
 		}
 	}

--- a/cli/internal/cmd/setup_test.go
+++ b/cli/internal/cmd/setup_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"strings"
@@ -30,7 +31,7 @@ func TestSetupNonInteractiveValidation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			app := testApp(t)
-			err := app.setupE(tc.opts)
+			err := app.setupE(context.Background(), tc.opts)
 			if err == nil {
 				t.Fatalf("expected validation error, got nil")
 			}
@@ -46,7 +47,7 @@ func TestSetupNonInteractiveValidation(t *testing.T) {
 // passed validation and the command tried to act.
 func TestSetupRequiresInstall(t *testing.T) {
 	app := testApp(t)
-	err := app.setupE(&setupOptions{
+	err := app.setupE(context.Background(), &setupOptions{
 		yes:      true,
 		email:    "admin@example.com",
 		password: "a-strong-password",
@@ -69,7 +70,7 @@ func TestSetupDockerFailsFastWhenDaemonDown(t *testing.T) {
 	}
 	sentinel := stubDaemonDown(t)
 
-	err := app.setupE(&setupOptions{
+	err := app.setupE(context.Background(), &setupOptions{
 		yes:      true,
 		email:    "admin@example.com",
 		password: "a-strong-password",

--- a/cli/internal/cmd/start.go
+++ b/cli/internal/cmd/start.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -26,8 +27,8 @@ func newStartCmd(app *App) *cobra.Command {
 			"It requires a completed `jenticctl install` (a generated config and a built\n" +
 			"venv); if either is missing it tells you to run `jenticctl install` first.",
 		Args: cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return app.startE(opts)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return app.startE(cmd.Context(), opts)
 		},
 	}
 	cmd.Flags().StringVar(&opts.config, "config", "",
@@ -35,12 +36,12 @@ func newStartCmd(app *App) *cobra.Command {
 	return cmd
 }
 
-func (a *App) startE(opts *startOptions) error {
+func (a *App) startE(ctx context.Context, opts *startOptions) error {
 	// A generated compose file marks a Docker install: drive the stack with
 	// docker compose instead of the local background process.
 	composePath := a.Paths.ComposePath()
 	if proc.FileExists(composePath) {
-		return a.startDocker(composePath)
+		return a.startDocker(ctx, composePath)
 	}
 
 	pidPath := a.Paths.AppPIDPath()
@@ -124,7 +125,7 @@ func brokerPortFromManifest(a *App) string {
 }
 
 // startDocker brings the generated docker-compose stack up in detached mode.
-func (a *App) startDocker(composePath string) error {
+func (a *App) startDocker(ctx context.Context, composePath string) error {
 	// The compose file proves a Docker install, but not that the daemon is up:
 	// with the daemon down (e.g. Docker Desktop closed after a reboot) `docker
 	// compose up` fails with a raw "Cannot connect to the Docker daemon" error.
@@ -133,7 +134,7 @@ func (a *App) startDocker(composePath string) error {
 	// (~30s), so announce it — otherwise the command looks hung. This must come
 	// before the schema check below, which also needs a live daemon.
 	announceDaemonCheck(a.Out)
-	if err := requireDockerDaemon("jenticctl start"); err != nil {
+	if err := requireDockerDaemon(ctx, "jenticctl start"); err != nil {
 		return err
 	}
 	if err := a.ensureDockerSchema(composePath); err != nil {

--- a/cli/internal/cmd/start_test.go
+++ b/cli/internal/cmd/start_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -17,7 +18,7 @@ func stubDaemonDown(t *testing.T) error {
 	orig := requireDockerDaemon
 	t.Cleanup(func() { requireDockerDaemon = orig })
 	sentinel := errors.New("docker daemon is not responding: start Docker Desktop")
-	requireDockerDaemon = func(string) error { return sentinel }
+	requireDockerDaemon = func(context.Context, string) error { return sentinel }
 	return sentinel
 }
 
@@ -27,7 +28,7 @@ func stubDaemonUp(t *testing.T) {
 	t.Helper()
 	orig := requireDockerDaemon
 	t.Cleanup(func() { requireDockerDaemon = orig })
-	requireDockerDaemon = func(string) error { return nil }
+	requireDockerDaemon = func(context.Context, string) error { return nil }
 }
 
 // A Docker install (compose file present) with a stopped daemon must fail fast
@@ -47,7 +48,7 @@ func TestStartDockerFailsFastWhenDaemonDown(t *testing.T) {
 		return nil
 	}
 
-	err := app.startE(&startOptions{})
+	err := app.startE(context.Background(), &startOptions{})
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("start should surface the daemon guard error, got %v", err)
 	}
@@ -76,7 +77,7 @@ func TestStartDockerProceedsWhenDaemonUp(t *testing.T) {
 		return nil
 	}
 
-	if err := app.startE(&startOptions{}); err != nil {
+	if err := app.startE(context.Background(), &startOptions{}); err != nil {
 		t.Fatalf("start with a healthy daemon should succeed, got %v", err)
 	}
 	if upCalls != 1 {

--- a/cli/internal/cmd/stop.go
+++ b/cli/internal/cmd/stop.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -33,8 +34,8 @@ func newStopCmd(app *App) *cobra.Command {
 			"(SQLite data or the managed Postgres data dir). Use it to recover from an\n" +
 			"incompatible Postgres image upgrade. This destroys the database.",
 		Args: cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return app.stopE(opts)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return app.stopE(cmd.Context(), opts)
 		},
 	}
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", 10*time.Second,
@@ -46,12 +47,12 @@ func newStopCmd(app *App) *cobra.Command {
 	return cmd
 }
 
-func (a *App) stopE(opts *stopOptions) error {
+func (a *App) stopE(ctx context.Context, opts *stopOptions) error {
 	// A generated compose file marks a Docker install: tear the stack down with
 	// docker compose instead of signalling a local process.
 	composePath := a.Paths.ComposePath()
 	if proc.FileExists(composePath) {
-		return a.stopDocker(opts, composePath)
+		return a.stopDocker(ctx, opts, composePath)
 	}
 
 	if opts.volumes {
@@ -114,14 +115,14 @@ func (a *App) stopProcess(pidPath, label string, timeout time.Duration) error {
 // stopDocker tears down the Docker stack. With --volumes it also removes the
 // stack's data volumes (`down -v`), which destroys the database; it confirms
 // first unless --yes is set.
-func (a *App) stopDocker(opts *stopOptions, composePath string) error {
+func (a *App) stopDocker(ctx context.Context, opts *stopOptions, composePath string) error {
 	// `docker compose down` needs a live daemon; with the daemon down it fails
 	// with a raw transport error. Probe first (before the destructive --volumes
 	// confirmation prompt) so a stopped daemon yields actionable recovery
 	// guidance instead (#783). The probe can wait out a cold-starting daemon
 	// (~30s), so announce it — otherwise the command looks hung.
 	announceDaemonCheck(a.Out)
-	if err := requireDockerDaemon("jenticctl stop"); err != nil {
+	if err := requireDockerDaemon(ctx, "jenticctl stop"); err != nil {
 		return err
 	}
 	if !opts.volumes {

--- a/cli/internal/cmd/stop_test.go
+++ b/cli/internal/cmd/stop_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -23,7 +24,7 @@ func TestStopDockerFailsFastWhenDaemonDown(t *testing.T) {
 		return nil
 	}
 
-	err := app.stopE(&stopOptions{})
+	err := app.stopE(context.Background(), &stopOptions{})
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("stop should surface the daemon guard error, got %v", err)
 	}
@@ -48,7 +49,7 @@ func TestStopDockerVolumesFailsFastBeforeConfirm(t *testing.T) {
 		return nil
 	}
 
-	err := app.stopE(&stopOptions{volumes: true})
+	err := app.stopE(context.Background(), &stopOptions{volumes: true})
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("stop --volumes should surface the daemon guard error before confirming, got %v", err)
 	}

--- a/cli/internal/cmd/update.go
+++ b/cli/internal/cmd/update.go
@@ -182,7 +182,7 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 	daemonChecked := false
 	if doCLI && doStack && manifest.Mode == config.ModeDocker && proc.FileExists(a.Paths.ComposePath()) {
 		announceDaemonCheck(a.Out)
-		if err := requireDockerDaemon("jenticctl update"); err != nil {
+		if err := requireDockerDaemon(ctx, "jenticctl update"); err != nil {
 			return err
 		}
 		daemonChecked = true
@@ -198,7 +198,7 @@ func (a *App) updateE(ctx context.Context, opts *updateOptions) error {
 		}
 	}
 	if doStack {
-		if err := a.updateStack(manifest.Mode, ref, pinned, daemonChecked); err != nil {
+		if err := a.updateStack(ctx, manifest.Mode, ref, pinned, daemonChecked); err != nil {
 			return err
 		}
 		// Only now is the stack genuinely at `ref`. Recording it earlier (or
@@ -427,20 +427,20 @@ func binaryVersion(path string) (string, error) {
 // the stack is built from — the same one the CLI half targets, so the two halves
 // stay in lockstep. daemonChecked is true when updateE already probed the Docker
 // daemon up front (combined run), so the docker path skips a redundant probe.
-func (a *App) updateStack(mode, ref string, pinned, daemonChecked bool) error {
+func (a *App) updateStack(ctx context.Context, mode, ref string, pinned, daemonChecked bool) error {
 	fmt.Fprintln(a.Out)
 	fmt.Fprintln(a.Out, theme.Warn.Render("Stack update runs forward-only migrations — back up your data first"))
 	fmt.Fprintln(a.Out, theme.Dim.Render("  SQLite: copy ~/.jentic/data/*.db · Postgres: pg_dump your database"))
 
 	if mode == config.ModeDocker {
-		return a.updateStackDocker(ref, pinned, daemonChecked)
+		return a.updateStackDocker(ctx, ref, pinned, daemonChecked)
 	}
-	return a.updateStackLocal(ref, pinned)
+	return a.updateStackLocal(ctx, ref, pinned)
 }
 
 // updateStackLocal pulls the source, reinstalls into the existing venv, applies
 // migrations, and restarts the app if it was running.
-func (a *App) updateStackLocal(ref string, pinned bool) error {
+func (a *App) updateStackLocal(ctx context.Context, ref string, pinned bool) error {
 	configPath := a.Paths.InstallConfigPath()
 	if !proc.FileExists(configPath) {
 		return fmt.Errorf("not configured: %s not found — run `jenticctl install` first", configPath)
@@ -460,7 +460,7 @@ func (a *App) updateStackLocal(ref string, pinned bool) error {
 		return fmt.Errorf("migrations failed: %w", err)
 	}
 
-	a.restartLocalIfRunning()
+	a.restartLocalIfRunning(ctx)
 	fmt.Fprintln(a.Out, theme.Successf("Stack updated (local)."))
 	return nil
 }
@@ -470,7 +470,7 @@ func (a *App) updateStackLocal(ref string, pinned bool) error {
 // is true when updateE already probed the daemon up front (combined run), so we
 // skip a redundant second probe/announce; a standalone/stack-only call passes
 // false and probes here.
-func (a *App) updateStackDocker(ref string, pinned, daemonChecked bool) error {
+func (a *App) updateStackDocker(ctx context.Context, ref string, pinned, daemonChecked bool) error {
 	composePath := a.Paths.ComposePath()
 	if !proc.FileExists(composePath) {
 		return fmt.Errorf("no compose stack at %s — run `jenticctl install` first", composePath)
@@ -482,7 +482,7 @@ func (a *App) updateStackDocker(ref string, pinned, daemonChecked bool) error {
 	// for a cold-starting daemon, so announce it first (see start.go/stop.go).
 	if !daemonChecked {
 		announceDaemonCheck(a.Out)
-		if err := requireDockerDaemon("jenticctl update"); err != nil {
+		if err := requireDockerDaemon(ctx, "jenticctl update"); err != nil {
 			return err
 		}
 	}
@@ -512,7 +512,7 @@ func (a *App) updateStackDocker(ref string, pinned, daemonChecked bool) error {
 
 // restartLocalIfRunning bounces the background app so the rebuilt code takes
 // effect, but only when it was already running; otherwise it leaves it stopped.
-func (a *App) restartLocalIfRunning() {
+func (a *App) restartLocalIfRunning(ctx context.Context) {
 	_, running, _ := proc.LivePID(a.Paths.AppPIDPath())
 	if !running {
 		fmt.Fprintln(a.Out, theme.Dim.Render("  app not running — start it with `jenticctl start`"))
@@ -520,8 +520,8 @@ func (a *App) restartLocalIfRunning() {
 	}
 	fmt.Fprintln(a.Out)
 	fmt.Fprintln(a.Out, theme.Infof("Restarting app ..."))
-	_ = a.stopE(&stopOptions{timeout: 10 * time.Second})
-	_ = a.startE(&startOptions{})
+	_ = a.stopE(ctx, &stopOptions{timeout: 10 * time.Second})
+	_ = a.startE(ctx, &startOptions{})
 }
 
 func confirmApply(doCLI, doStack, brewCLI bool, repo, ref string) (bool, error) {

--- a/cli/internal/cmd/update_test.go
+++ b/cli/internal/cmd/update_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -177,7 +178,7 @@ func TestUpdateStackDockerFailsFastWhenDaemonDown(t *testing.T) {
 		return nil
 	}
 
-	err := app.updateStackDocker("", false, false)
+	err := app.updateStackDocker(context.Background(), "", false, false)
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("update should surface the daemon guard error, got %v", err)
 	}

--- a/cli/internal/install/preflight.go
+++ b/cli/internal/install/preflight.go
@@ -67,8 +67,9 @@ func requirementsFor(d *Draft) []Requirement {
 	return reqs
 }
 
-// Preflight probes every Requirement for the chosen path.
-func Preflight(d *Draft) []CheckResult {
+// Preflight probes every Requirement for the chosen path. ctx bounds the Docker
+// daemon probe so a cold-start wait can be canceled (Ctrl-C).
+func Preflight(ctx context.Context, d *Draft) []CheckResult {
 	reqs := requirementsFor(d)
 	results := make([]CheckResult, 0, len(reqs))
 	for _, req := range reqs {
@@ -83,7 +84,7 @@ func Preflight(d *Draft) []CheckResult {
 			// so we can fail fast with an actionable "start Docker" message.
 			if req.Name == "docker" {
 				res.DaemonChecked = true
-				if detail, ok := dockerDaemonHealth(); ok {
+				if detail, ok := dockerDaemonHealth(ctx); ok {
 					res.Healthy = true
 				} else {
 					res.DaemonDetail = detail
@@ -125,12 +126,14 @@ func toolVersion(name string) string {
 
 // dockerDaemonProbe is the seam the daemon-health check runs through so tests
 // can simulate a stopped/unhealthy daemon without a real Docker. It returns a
-// short reason (empty when healthy) and whether the daemon answered.
+// short reason (empty when healthy) and whether the daemon answered. The ctx
+// lets callers cancel the (up to ~30s) cold-start wait — e.g. an operator who
+// hits Ctrl-C once they realize the daemon is down (#953).
 var dockerDaemonProbe = defaultDockerDaemonProbe
 
 // dockerDaemonHealth reports whether the Docker daemon is up and responsive.
-func dockerDaemonHealth() (detail string, healthy bool) {
-	return dockerDaemonProbe()
+func dockerDaemonHealth(ctx context.Context) (detail string, healthy bool) {
+	return dockerDaemonProbe(ctx)
 }
 
 // daemonProbeBackoff is the pause between daemon probe attempts. Kept named so
@@ -150,22 +153,27 @@ const daemonUnreachableFallback = "the Docker daemon is not reachable"
 // halfway through (#653). A cold Docker Desktop can take 15–40s to answer after
 // launch, so we poll a few times before declaring it down rather than failing
 // on a single short timeout and sending the operator down a false "wedged" path.
-func defaultDockerDaemonProbe() (string, bool) {
+func defaultDockerDaemonProbe(ctx context.Context) (string, bool) {
 	// Up to ~30s total (4 attempts × 6s timeout + 3 × 2s backoff): a snappy
 	// daemon answers on the first try in well under a second; a cold-starting
 	// one usually comes up within this window. Matches the "~30s" the callers
-	// advertise before probing.
+	// advertise before probing. A canceled ctx (Ctrl-C) short-circuits the wait.
 	const attempts = 4
 	const perAttempt = 6 * time.Second
 	var lastDetail string
 	for i := range attempts {
-		detail, ok := dockerInfoOnce(perAttempt)
+		detail, ok := dockerInfoOnce(ctx, perAttempt)
 		if ok {
 			return "", true
 		}
 		lastDetail = detail
 		if i < attempts-1 {
-			time.Sleep(daemonProbeBackoff)
+			// Cancelable backoff: return promptly if the caller gave up.
+			select {
+			case <-ctx.Done():
+				return "the Docker daemon check was canceled", false
+			case <-time.After(daemonProbeBackoff):
+			}
 		}
 	}
 	if lastDetail == "" {
@@ -174,13 +182,18 @@ func defaultDockerDaemonProbe() (string, bool) {
 	return lastDetail, false
 }
 
-// dockerInfoOnce runs a single `docker info` round-trip with the given timeout.
-func dockerInfoOnce(timeout time.Duration) (string, bool) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+// dockerInfoOnce runs a single `docker info` round-trip, bounded by the smaller
+// of the given timeout and the caller's ctx.
+func dockerInfoOnce(ctx context.Context, timeout time.Duration) (string, bool) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	// `--format {{.ServerVersion}}` forces a round-trip to the daemon and keeps
 	// the output to one line we can show; a stopped daemon errors here.
 	out, err := exec.CommandContext(ctx, "docker", "info", "--format", "{{.ServerVersion}}").CombinedOutput()
+	// A caller cancellation reads as a canceled context, not a dead daemon.
+	if ctx.Err() == context.Canceled {
+		return "the Docker daemon check was canceled", false
+	}
 	if ctx.Err() == context.DeadlineExceeded {
 		return "the Docker daemon did not respond in time (is it starting up or wedged?)", false
 	}
@@ -254,9 +267,10 @@ func DaemonError(check CheckResult) error {
 // The probe (dockerDaemonHealth) polls for up to ~30s to tolerate a
 // cold-starting daemon, so callers should announce the check before invoking
 // this — otherwise the command appears to hang. See the callers in
-// internal/cmd/start.go and stop.go.
-func RequireDockerDaemon(command string) error {
-	detail, healthy := dockerDaemonHealth()
+// internal/cmd/start.go and stop.go. The ctx (the command's context) lets an
+// operator cancel that wait with Ctrl-C (#953).
+func RequireDockerDaemon(ctx context.Context, command string) error {
+	detail, healthy := dockerDaemonHealth(ctx)
 	if healthy {
 		return nil
 	}
@@ -276,10 +290,10 @@ func DockerDaemonRecoveryHint() string { return dockerDaemonRecoveryHint }
 // that must stay fast and non-blocking — `doctor` is read-only and should not
 // hang for the full cold-start polling window when the daemon is simply down.
 // Unlike RequireDockerDaemon it does not tolerate a cold-starting Docker
-// Desktop; it answers within `timeout`. It returns a short human reason (empty
-// when healthy) and whether the daemon answered.
-func DockerDaemonResponsiveQuick(timeout time.Duration) (detail string, healthy bool) {
-	return dockerInfoOnce(timeout)
+// Desktop; it answers within `timeout` (or when ctx is canceled). It returns a
+// short human reason (empty when healthy) and whether the daemon answered.
+func DockerDaemonResponsiveQuick(ctx context.Context, timeout time.Duration) (detail string, healthy bool) {
+	return dockerInfoOnce(ctx, timeout)
 }
 
 // RenderPreflight returns a styled checklist of the probe results.

--- a/cli/internal/install/preflight_test.go
+++ b/cli/internal/install/preflight_test.go
@@ -1,9 +1,11 @@
 package install
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestMissing(t *testing.T) {
@@ -39,7 +41,7 @@ func TestPreflightProbesRequirements(t *testing.T) {
 	// requirement; the probe should return one result per requirement.
 	d := NewDraft()
 	d.RuntimePath = RuntimeDocker
-	results := Preflight(d)
+	results := Preflight(context.Background(), d)
 	if len(results) == 0 {
 		t.Fatal("expected at least one preflight result")
 	}
@@ -114,20 +116,20 @@ func TestRequireDockerDaemon(t *testing.T) {
 	t.Cleanup(func() { dockerDaemonProbe = orig })
 
 	// Healthy daemon → no error, so `start`/`stop` proceed.
-	dockerDaemonProbe = func() (string, bool) { return "", true }
-	if err := RequireDockerDaemon("jenticctl start"); err != nil {
+	dockerDaemonProbe = func(context.Context) (string, bool) { return "", true }
+	if err := RequireDockerDaemon(context.Background(), "jenticctl start"); err != nil {
 		t.Errorf("healthy daemon should not error, got %v", err)
 	}
 
 	for _, tc := range []struct {
 		name    string
-		probe   func() (string, bool)
+		probe   func(context.Context) (string, bool)
 		command string
 		want    []string
 	}{
 		{
 			name:    "down with detail names the caller and stays runtime-agnostic",
-			probe:   func() (string, bool) { return "Cannot connect to the Docker daemon", false },
+			probe:   func(context.Context) (string, bool) { return "Cannot connect to the Docker daemon", false },
 			command: "jenticctl start",
 			// Leads with the generic instruction, then Docker Desktop / Linux /
 			// Colima specifics, and names the command the operator ran.
@@ -138,14 +140,14 @@ func TestRequireDockerDaemon(t *testing.T) {
 		},
 		{
 			name:    "down with empty detail falls back to a usable reason",
-			probe:   func() (string, bool) { return "", false },
+			probe:   func(context.Context) (string, bool) { return "", false },
 			command: "jenticctl stop",
 			want:    []string{"not reachable", "jenticctl stop"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dockerDaemonProbe = tc.probe
-			err := RequireDockerDaemon(tc.command)
+			err := RequireDockerDaemon(context.Background(), tc.command)
 			if err == nil {
 				t.Fatal("stopped daemon should return an error")
 			}
@@ -173,11 +175,11 @@ func TestPreflightDaemonProbeSeam(t *testing.T) {
 
 	orig := dockerDaemonProbe
 	t.Cleanup(func() { dockerDaemonProbe = orig })
-	dockerDaemonProbe = func() (string, bool) { return "daemon stopped", false }
+	dockerDaemonProbe = func(context.Context) (string, bool) { return "daemon stopped", false }
 
 	d := NewDraft()
 	d.RuntimePath = RuntimeDocker
-	results := Preflight(d)
+	results := Preflight(context.Background(), d)
 
 	var sawDocker bool
 	for _, r := range results {
@@ -200,5 +202,39 @@ func TestPreflightDaemonProbeSeam(t *testing.T) {
 	}
 	if !sawDocker {
 		t.Fatal("expected a docker requirement in the docker-path preflight")
+	}
+}
+
+// TestDefaultDockerDaemonProbeCancelable is the core #953 guarantee: an operator
+// who hits Ctrl-C (a canceled context) doesn't have to sit through the full
+// ~30s cold-start polling window. With an already-canceled ctx the real probe
+// must give up promptly rather than sleeping out every attempt/backoff.
+func TestDefaultDockerDaemonProbeCancelable(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled before we even start probing
+
+	done := make(chan struct{})
+	var detail string
+	var healthy bool
+	start := time.Now()
+	go func() {
+		detail, healthy = defaultDockerDaemonProbe(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("canceled probe did not return promptly — it appears to be waiting out the full polling window")
+	}
+
+	if elapsed := time.Since(start); elapsed >= 15*time.Second {
+		t.Errorf("probe took %s; a canceled ctx should short-circuit the ~30s window", elapsed)
+	}
+	if healthy {
+		t.Error("canceled probe reported the daemon healthy")
+	}
+	if detail == "" {
+		t.Error("canceled probe should return a non-empty reason")
 	}
 }


### PR DESCRIPTION
## What & why

Follow-up to #942. The daemon guard polls `docker info` for up to ~30s so it can wait out a cold-starting Docker Desktop. Until now that wait was **uncancelable**: the inter-attempt backoff was a bare `time.Sleep`, and the probe ran on `context.Background()`. So if you realized the daemon was actually down (or you launched the wrong command), Ctrl-C did nothing until the whole window elapsed.

This threads the command's `context.Context` all the way through the probe so a cancel takes effect promptly.

## What changed

- **`internal/install/preflight.go`** — `Preflight`, `RequireDockerDaemon`, `DockerDaemonResponsiveQuick`, `dockerDaemonHealth`, `defaultDockerDaemonProbe`, `dockerInfoOnce` and the `dockerDaemonProbe` seam now take a `context.Context`. The backoff between attempts `select`s on `ctx.Done()`, and each `docker info` round trip is bound by the caller's ctx. A canceled ctx returns a distinct "the Docker daemon check was canceled" reason (not a false "daemon down").
- **`internal/cmd/*`** — the command context (`cmd.Context()`, which cobra already cancels on SIGINT/SIGTERM) is threaded through `startE`/`stopE`/`setupE`/`resetPasswordE`/`updateE` → `startDocker`/`stopDocker`/`updateStack(Docker|Local)` → `requireDockerDaemon`, plus the `install` path (`installDocker`/`installLocal` → `Preflight`) and the `doctor` deploy probe (which already carried `ctx` on the `doctor` struct).

## Behaviour

- Daemon up → unchanged (fast pass-through).
- Daemon cold-starting → unchanged (~30s poll), but **Ctrl-C now aborts it immediately**.
- Daemon down → unchanged actionable "start your Docker daemon …" message.

## Tests

- Added `TestDefaultDockerDaemonProbeCancelable`: an already-canceled ctx makes the real probe return well under the polling window instead of sleeping out every attempt.
- Updated the existing probe/guard stubs and E-func calls across `install` and `cmd` to the new context-taking signatures.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test -race ./internal/install/... ./internal/cmd/...` (green; the only failures are pre-existing sandbox-only `git init`/tempdir issues, which pass outside the sandbox)

Closes #953

Made with [Cursor](https://cursor.com)