### PR TITLE
fix(cli): distinguish "docker not installed" from a stopped daemon

### DIFF
--- a/cli/internal/cmd/doctor.go
+++ b/cli/internal/cmd/doctor.go
@@ -218,8 +218,15 @@ func (d *doctor) checkDeploy(section string) {
 		// and the sibling `control`/`compose ps` checks also warn on a
 		// not-running dependency — a down daemon shouldn't flip the exit code.
 		if detail, healthy := doctorDockerProbe(d.ctx); !healthy {
-			d.add(section, "docker daemon", statusWarn, detail,
-				install.DockerDaemonRecoveryHint()+", then `jenticctl start`")
+			// A missing binary points at install docs; a present-but-down
+			// daemon points at starting it (#954).
+			hint := install.DockerDaemonRecoveryHint() + ", then `jenticctl start`"
+			name := "docker daemon"
+			if install.DockerNotInstalled(detail) {
+				hint = install.DockerNotInstalledHint()
+				name = "docker"
+			}
+			d.add(section, name, statusWarn, detail, hint)
 			return
 		}
 		out, err := install.ComposePs(composePath)

--- a/cli/internal/cmd/doctor_test.go
+++ b/cli/internal/cmd/doctor_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/jentic/jentic-one/cli/internal/config"
+	"github.com/jentic/jentic-one/cli/internal/install"
 )
 
 // offlineOpts points the server probe at a closed port so doctor never depends
@@ -156,6 +157,45 @@ func TestDoctorReportsDockerDaemonDown(t *testing.T) {
 		if d.checks[i].name == "deploy" {
 			t.Errorf("deploy check should return early on a down daemon, not record a `deploy` row: %+v", d.checks[i])
 		}
+	}
+}
+
+// When the `docker` binary is missing (not merely a stopped daemon), doctor's
+// deploy check reports it under a `docker` row pointing at install docs rather
+// than the "start your Docker daemon" hint (#954).
+func TestDoctorReportsDockerNotInstalled(t *testing.T) {
+	orig := doctorDockerProbe
+	t.Cleanup(func() { doctorDockerProbe = orig })
+	// Mirror what the real probe returns when the binary is absent.
+	notInstalled := install.DockerNotInstalledDetail()
+	doctorDockerProbe = func(context.Context) (string, bool) { return notInstalled, false }
+
+	app := testApp(t)
+	if err := os.WriteFile(app.Paths.ComposePath(), []byte("services: {}\n"), 0o600); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+
+	d := &doctor{app: app, ctx: context.Background()}
+	d.checkDeploy("Server")
+
+	var row *check
+	for i := range d.checks {
+		if d.checks[i].name == "docker" {
+			row = &d.checks[i]
+			break
+		}
+	}
+	if row == nil {
+		t.Fatalf("deploy check did not record a `docker` row for a missing binary: %+v", d.checks)
+	}
+	if row.status != statusWarn {
+		t.Errorf("missing docker should be statusWarn (CI-safe), got %v", row.status)
+	}
+	if !strings.Contains(row.hint, "get-docker") {
+		t.Errorf("missing-docker hint should point at install docs, got %q", row.hint)
+	}
+	if strings.Contains(row.hint, "start your Docker daemon") {
+		t.Errorf("missing-docker hint should not tell the user to start a daemon: %q", row.hint)
 	}
 }
 

--- a/cli/internal/install/preflight.go
+++ b/cli/internal/install/preflight.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -197,6 +198,16 @@ func dockerInfoOnce(ctx context.Context, timeout time.Duration) (string, bool) {
 	if ctx.Err() == context.DeadlineExceeded {
 		return "the Docker daemon did not respond in time (is it starting up or wedged?)", false
 	}
+	// A missing `docker` binary is a different problem from a stopped daemon:
+	// exec can't find the executable at all (empty output), so the generic
+	// "daemon not reachable" reason would misdiagnose it. Flag it distinctly so
+	// callers can point at the install docs instead of the "start Docker" hint
+	// (#954). This only bites a user who uninstalled Docker after installing —
+	// the runtime guards sit behind a compose-file check — but it should still
+	// read correctly.
+	if errors.Is(err, exec.ErrNotFound) {
+		return dockerNotInstalledDetail, false
+	}
 	if err != nil {
 		return firstLine(string(out)), false
 	}
@@ -238,6 +249,24 @@ const dockerDaemonRecoveryHint = "start your Docker daemon " +
 	"(Docker Desktop users: open it, or run `docker desktop start` on 4.37+; " +
 	"Linux: `sudo systemctl start docker`; Colima: `colima start`)"
 
+// dockerNotInstalledDetail is the reason the probe reports when the `docker`
+// binary itself is not on PATH (exec.ErrNotFound), as opposed to a present
+// binary whose daemon is down. Kept as a package constant so callers can tell
+// the two apart and swap the recovery guidance (#954).
+const dockerNotInstalledDetail = "the docker command was not found on PATH"
+
+// dockerNotInstalledHint is the "how to fix a missing Docker" guidance — it
+// points at installation rather than starting a daemon, since there is nothing
+// to start. Paired with dockerNotInstalledDetail.
+const dockerNotInstalledHint = "install Docker (https://docs.docker.com/get-docker/)"
+
+// dockerNotInstalled reports whether a probe detail means the binary is absent
+// (vs. a present-but-unresponsive daemon), so callers render the install hint
+// instead of the start-the-daemon hint.
+func dockerNotInstalled(detail string) bool {
+	return detail == dockerNotInstalledDetail
+}
+
 // DaemonError builds an actionable error for a present-but-unresponsive Docker
 // daemon, so the install fails fast here instead of crashing mid-build.
 func DaemonError(check CheckResult) error {
@@ -274,6 +303,11 @@ func RequireDockerDaemon(ctx context.Context, command string) error {
 	if healthy {
 		return nil
 	}
+	// A missing binary needs install guidance, not "start the daemon".
+	if dockerNotInstalled(detail) {
+		return fmt.Errorf("docker is required but not installed: %s — %s, "+
+			"then re-run `%s`", detail, dockerNotInstalledHint, command)
+	}
 	if detail == "" {
 		detail = daemonUnreachableFallback
 	}
@@ -285,6 +319,23 @@ func RequireDockerDaemon(ctx context.Context, command string) error {
 // daemon" guidance so callers outside this package (e.g. the doctor deploy
 // check) render the exact same advice as the fail-fast errors.
 func DockerDaemonRecoveryHint() string { return dockerDaemonRecoveryHint }
+
+// DockerNotInstalled reports whether a probe detail (from
+// DockerDaemonResponsiveQuick) means the `docker` binary is absent rather than
+// its daemon being down, so callers can pick DockerNotInstalledHint over
+// DockerDaemonRecoveryHint (#954).
+func DockerNotInstalled(detail string) bool { return dockerNotInstalled(detail) }
+
+// DockerNotInstalledHint returns the "install Docker" guidance for the
+// binary-absent case, mirroring DockerDaemonRecoveryHint for the daemon-down
+// case.
+func DockerNotInstalledHint() string { return dockerNotInstalledHint }
+
+// DockerNotInstalledDetail returns the exact probe reason emitted when the
+// `docker` binary is absent — the string DockerNotInstalled recognizes. Exposed
+// so callers/tests can reason about the binary-absent case without duplicating
+// the literal.
+func DockerNotInstalledDetail() string { return dockerNotInstalledDetail }
 
 // DockerDaemonResponsiveQuick is a single-round-trip daemon probe for callers
 // that must stay fast and non-blocking — `doctor` is read-only and should not

--- a/cli/internal/install/preflight_test.go
+++ b/cli/internal/install/preflight_test.go
@@ -144,6 +144,12 @@ func TestRequireDockerDaemon(t *testing.T) {
 			command: "jenticctl stop",
 			want:    []string{"not reachable", "jenticctl stop"},
 		},
+		{
+			name:    "missing binary points at install docs, not the daemon-start hint",
+			probe:   func(context.Context) (string, bool) { return dockerNotInstalledDetail, false },
+			command: "jenticctl start",
+			want:    []string{"not installed", "was not found on PATH", "get-docker", "jenticctl start"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dockerDaemonProbe = tc.probe
@@ -158,6 +164,13 @@ func TestRequireDockerDaemon(t *testing.T) {
 				}
 			}
 		})
+	}
+
+	// The not-installed message must NOT tell the user to start a daemon —
+	// there's nothing to start.
+	dockerDaemonProbe = func(context.Context) (string, bool) { return dockerNotInstalledDetail, false }
+	if msg := RequireDockerDaemon(context.Background(), "jenticctl start").Error(); strings.Contains(msg, "start your Docker daemon") {
+		t.Errorf("not-installed error should not use the daemon-start hint: %q", msg)
 	}
 }
 
@@ -236,5 +249,25 @@ func TestDefaultDockerDaemonProbeCancelable(t *testing.T) {
 	}
 	if detail == "" {
 		t.Error("canceled probe should return a non-empty reason")
+	}
+}
+
+// TestProbeDistinguishesMissingBinary is the #954 guarantee: when the `docker`
+// binary is absent from PATH the probe reports a distinct "not installed"
+// reason (so callers can point at install docs) rather than the generic
+// daemon-down reason. Point PATH at an empty dir so the real exec can't find
+// docker regardless of the host.
+func TestProbeDistinguishesMissingBinary(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	detail, healthy := dockerInfoOnce(context.Background(), 2*time.Second)
+	if healthy {
+		t.Fatal("no docker binary on PATH should not report healthy")
+	}
+	if detail != dockerNotInstalledDetail {
+		t.Errorf("missing binary detail = %q, want %q", detail, dockerNotInstalledDetail)
+	}
+	if !dockerNotInstalled(detail) {
+		t.Errorf("dockerNotInstalled did not recognize its own detail: %q", detail)
 	}
 }


### PR DESCRIPTION
## What & why

Follow-up to #942 (flagged SHOULD-FIX by the Go-correctness review, deferred because it touches the shared probe).

The daemon probe (`dockerInfoOnce` in `cli/internal/install/preflight.go`) runs `docker info …`. When the `docker` **binary is absent from PATH**, `exec` returns `exec.ErrNotFound` with empty output, so `firstLine("")` fell through to the generic *"the Docker daemon is not reachable"* reason and the *"start your Docker daemon"* recovery hint. That's misleading: the daemon isn't down — Docker isn't installed at all, so there's nothing to start.

## What changed

- **`internal/install/preflight.go`**
  - `dockerInfoOnce` now checks `errors.Is(err, exec.ErrNotFound)` and returns a distinct reason: `"the docker command was not found on PATH"`.
  - New `dockerNotInstalledHint` (`install Docker (https://docs.docker.com/get-docker/)`) and a `dockerNotInstalled(detail)` predicate.
  - `RequireDockerDaemon` branches on it: a missing binary yields *"docker is required but not installed … install Docker …"* instead of the daemon-start error.
  - Exported `DockerNotInstalled(detail)`, `DockerNotInstalledHint()`, `DockerNotInstalledDetail()` so out-of-package callers (doctor) render the right guidance.
- **`internal/cmd/doctor.go`** — the deploy check reports a `docker` row pointing at install docs when the binary is missing, vs. the existing `docker daemon` row + start-the-daemon hint when it's merely down.

## Behaviour

| Situation | Before | After |
| --- | --- | --- |
| Daemon down | "start your Docker daemon …" | unchanged |
| **Binary missing** | "daemon not reachable / start your Docker daemon" (wrong) | "docker not installed → install Docker (get-docker docs)" |

Low impact in practice — the runtime guards sit behind a `proc.FileExists(composePath)` check, so this only bites someone who uninstalled Docker after installing — but the message now reads correctly.

## Tests

- `TestProbeDistinguishesMissingBinary`: with an empty PATH the real probe returns the not-installed reason (not the daemon-down one).
- `TestRequireDockerDaemon`: new table case asserts the missing-binary error points at install docs and does **not** use the daemon-start hint.
- `TestDoctorReportsDockerNotInstalled`: doctor records a `docker` warn row with the install hint.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test -race ./internal/install/... ./internal/cmd/...` (green; only pre-existing sandbox-only failures, which pass outside the sandbox)

Closes #954

Made with [Cursor](https://cursor.com)