### PR TITLE
docs(.github): align the PR template with the shared description convention

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,44 @@
 <!--
 Thanks for contributing to Jentic One!
 Keep PRs focused and reviewable. Do not include secrets or credentials.
+Match the depth to the change: a typo fix needs one Summary sentence;
+a structural change needs every section (and ideally a diagram).
 -->
 
 ## Summary
 
-<!-- What does this change and why? -->
+<!-- 1-3 sentences: the problem and why this change is the fix. Written for
+     a reader who has NOT seen the diff — lead with the impact, not the
+     mechanics. -->
+
+## Changes
+
+<!-- One bullet per meaningful change, most important first. Name the surface
+     (`control`, `ui`, `cli`, `deploy`, …). Say what is deliberately OUT of
+     scope. For topology/flow changes, a ```mermaid``` block renders here. -->
+
+-
+
+## Risk & rollback
+
+<!-- Required when the change warrants it: breaking changes, migrations,
+     auth/credential/permission surface, new config/env vars — each on its
+     own line. How to revert. If genuinely low-risk: "Low risk: <reason>". -->
+
+## Test plan
+
+<!-- How this was verified: commands run (`make check`, e2e), or manual steps
+     a reviewer can reproduce. UI changes: screenshot or short recording.
+     If no automated tests: "No automated tests; manual verification: …" -->
+
+## Review guide
+
+<!-- Optional, for larger PRs: where to start reading, in what order, what to
+     scrutinize. Delete if not needed. -->
 
 ## Related issue
 
 <!-- e.g. Closes #123 -->
-
-## Changes
-
--
-
-## Testing
-
-<!-- How did you verify this? `make check` output, new/updated tests, manual steps. -->
 
 ## Checklist
 


### PR DESCRIPTION
## Summary

The repo's PR template predates the structured PR-description convention (jentic/jentic-one-rules#19), so authors and agents starting from the template produced differently-shaped bodies than the convention asks for. This aligns the public template with the shared skeleton.

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md`: sections now Summary / Changes / Risk & rollback / Test plan / Review guide / Related issue / Checklist, each with inline guidance comments
- adds the depth-scaling note (typo fix = one sentence; structural change = all sections + diagram) and a mermaid hint for topology changes
- out of scope: the convention text itself (lives in the private rules repo); the checklist and DCO requirements are unchanged

## Risk & rollback

Low risk: template-only change, no code or CI impact; revert the squash commit to roll back.

## Test plan

- No automated tests; manual verification: markdown renders correctly in preview, all original checklist items preserved

Made with [Cursor](https://cursor.com)