### PR TITLE
feat(skills): add demo-flywheel presenter skill + verification harness

### DIFF
--- a/config/local-sqlite-demo.yaml
+++ b/config/local-sqlite-demo.yaml
@@ -1,0 +1,77 @@
+# Local SQLite config for the demo-flywheel skill / flywheel_verify.py.
+#
+# A full copy of config/local-sqlite.yaml PLUS the two settings Flow 3 needs so
+# the loopback fixture (scripts/flow3_upstream_fixture.py) is probeable:
+#   - catalog.update_check_interval_seconds: 1  (small POSITIVE value; 0 would
+#       DISABLE the sweep entirely — it's the kill switch, not "check always")
+#   - ingest.egress.allowed_private_subnets: [127.0.0.0/8]  (admit loopback past
+#       the SSRF guard so the 127.0.0.1:8099 fixture can be fetched)
+#
+# JENTIC_CONFIG_FILE is a full-replacement config, not an overlay, so this file
+# duplicates the base rather than editing it in place (keeps the committed
+# local-sqlite.yaml untouched).
+#
+# Usage: JENTIC_CONFIG_FILE=config/local-sqlite-demo.yaml make start-app
+
+databases:
+  registry:
+    backend: sqlite
+    path: .data/registry.db
+    schema_name: registry
+  control:
+    backend: sqlite
+    path: .data/control.db
+    schema_name: control
+  admin:
+    backend: sqlite
+    path: .data/admin.db
+    schema_name: admin
+
+runtime:
+  debug: true
+  log_level: DEBUG
+
+server:
+  host: 127.0.0.1
+  port: 8000
+  reload: true
+
+search:
+  enabled: true
+  search_enabled: true
+  search_mode: lexical
+
+# --- Flow-3 additions (absent from the base local-sqlite.yaml) --------------
+catalog:
+  # Point the catalog at the loopback fixture so `POST /catalog:refresh` loads
+  # `flow3-e2e.test` as an importable entry (the base config points at the real
+  # jentic-public-apis manifest). LOCAL-DEMO-ONLY.
+  manifest_url: "http://127.0.0.1:8099/apis.json"
+  # Small positive interval so back-to-back /catalog:refresh calls actually
+  # re-probe the fixture. 0 disables the sweep entirely, so do NOT use 0.
+  update_check_interval_seconds: 1
+
+ingest:
+  egress:
+    # Admit loopback so the SSRF guard lets the app fetch the fixture upstream
+    # at 127.0.0.1:8099. LOCAL-DEMO-ONLY — never widen egress like this in prod.
+    allowed_private_subnets:
+      - 127.0.0.0/8
+# ----------------------------------------------------------------------------
+
+credentials:
+  encryption:
+    active_id: v1
+    entries:
+      - id: v1
+        material: "Z9BctysLqeHhzbFLfSU4djsvAX7N5EVVos5G0QN7C5Q="  # pragma: allowlist secret
+  providers:
+    direct_oauth2:
+      kind: direct_oauth2
+      redirect_uri: "http://127.0.0.1:8000/credentials/oauth/callback"
+
+observability:
+  metrics:
+    exporter: none
+  tracing:
+    exporter: none

--- a/scripts/flywheel_verify.py
+++ b/scripts/flywheel_verify.py
@@ -1,0 +1,487 @@
+"""Self-verifying harness for the three spec-flywheel flows.
+
+A companion to `skills/demo-flywheel/SKILL.md`: the skill is the narrated,
+human-in-the-loop walkthrough an agent performs live; this script is the
+non-interactive proof that each flow's *real effects* landed on the local
+control plane. It asserts server state over HTTP and exits non-zero on any
+failure, so it doubles as a smoke test.
+
+Scope: control-plane surfaces only (matches `make start-app-sqlite`, which does
+NOT start the broker). It never touches GitHub — the genuine `gh` PR/issue steps
+are the human-gated part of the skill; here Flow 2 verifies only the *local*
+registry import effect. Every mutation uses a per-run suffix so re-runs stay
+fresh (no existence-gate / duplicate-version collisions).
+
+Flows (run in the skill's 2 -> 1 -> 3 narrative order):
+  2  import a brand-new API into the local registry (inline POST /apis -> job)
+  1  improve a catalogued API via an overlay: submit -> confirm (materialize)
+     -> served spec reflects the fix -> rollback reverts it
+  3  react to an upstream change: needs the flow3 fixture on :8099
+     (import -> bump -> catalog:refresh -> update_available flips -> re-import clears)
+
+Usage:
+  python scripts/flywheel_verify.py --flow all
+  python scripts/flywheel_verify.py --flow 1
+  BASE=http://127.0.0.1:8000 python scripts/flywheel_verify.py --flow 3 \
+      --fixture http://127.0.0.1:8099
+
+Requires the stack up (`make start-app-sqlite`). On a fresh DB the harness
+bootstraps the org-admin via POST /users:create-admin; on a re-run it logs in.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+from typing import Any
+
+import httpx
+
+BASE = os.environ.get("BASE", "http://127.0.0.1:8000")
+FIXTURE = os.environ.get("FLOW3_FIXTURE", "http://127.0.0.1:8099")
+
+# A stable admin identity so a re-run can log back in after the create-admin
+# endpoint self-closes (410). Password is deterministic for the demo box only.
+ADMIN_EMAIL = "flywheel-admin@demo.test"
+ADMIN_PW = "FlywheelDemo!234"
+
+client = httpx.Client(base_url=BASE, timeout=30.0)
+
+
+# --------------------------------------------------------------------------- #
+# PASS/FAIL harness (modeled on scripts/flywheel_manual.py)                    #
+# --------------------------------------------------------------------------- #
+_results: list[tuple[str, bool, str]] = []
+
+
+def check(label: str, got: object, expect: object) -> bool:
+    """Record a PASS/FAIL row; return whether it passed."""
+    ok = got == expect
+    _results.append((label, ok, f"got={got!r} want={expect!r}"))
+    print(f"  [{'PASS' if ok else 'FAIL'}] {label}: got={got!r} want={expect!r}")
+    return ok
+
+
+def note(msg: str) -> None:
+    print(f"  .. {msg}")
+
+
+def h(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+def rid() -> str:
+    """A short per-run id so every run picks fresh identifiers."""
+    return uuid.uuid4().hex[:8]
+
+
+# --------------------------------------------------------------------------- #
+# Auth                                                                         #
+# --------------------------------------------------------------------------- #
+def admin_token() -> str:
+    """Bootstrap (fresh DB) or log in (re-run) the org-admin, return its token.
+
+    POST /users:create-admin returns an already-org-admin LoginResponse with
+    must_change_password:false (no rotation). It self-closes (410) after the
+    first admin exists, so on a re-run we fall back to /auth/login.
+    """
+    r = client.post(
+        "/users:create-admin",
+        json={
+            "email": ADMIN_EMAIL,
+            "password": ADMIN_PW,
+            "first_name": "Fly",
+            "last_name": "Wheel",
+        },
+    )
+    if r.status_code == 410:
+        r = client.post("/auth/login", json={"email": ADMIN_EMAIL, "password": ADMIN_PW})
+    r.raise_for_status()
+    token: str = r.json()["access_token"]
+    return token
+
+
+# --------------------------------------------------------------------------- #
+# Shared helpers                                                               #
+# --------------------------------------------------------------------------- #
+def wait_for_job(token: str, job_id: str, *, timeout: float = 90.0) -> str:
+    """Poll GET /jobs/{id} until terminal; return the final status string."""
+    terminal_ok = {"succeeded", "completed", "done"}
+    terminal_bad = {"failed", "cancelled", "canceled", "error"}
+    deadline = time.time() + timeout
+    status = "unknown"
+    while time.time() < deadline:
+        r = client.get(f"/jobs/{job_id}", headers=h(token))
+        if r.status_code == 200:
+            status = str(r.json().get("status", "unknown")).lower()
+            if status in terminal_ok or status in terminal_bad:
+                return status
+        time.sleep(1.0)
+    return status
+
+
+def job_ok(status: str) -> bool:
+    return status in {"succeeded", "completed", "done"}
+
+
+def promote_draft(token: str, v: str, n: str, ver: str) -> str | None:
+    """Promote the API's draft revision to live so it has a current revision.
+
+    A fresh `POST /apis` import lands as a DRAFT; overlays (and the served spec)
+    need a current/live revision, so the demo promotes it — mirroring
+    `jentic apis promote` in the import-new-api skill. Returns the promoted
+    revision id, or None if no draft was found.
+    """
+    r = client.get(f"/apis/{v}/{n}/{ver}/revisions?state=draft", headers=h(token))
+    if r.status_code != 200:
+        return None
+    rows = r.json().get("data", [])
+    if not rows:
+        return None
+    revision_id = rows[0]["revision_id"]
+    p = client.post(
+        f"/apis/{v}/{n}/{ver}/revisions/{revision_id}:promote",
+        headers=h(token),
+        json={},
+    )
+    return revision_id if 200 <= p.status_code < 300 else None
+
+
+def _find_api(token: str, name_prefix: str) -> dict[str, Any] | None:
+    """Return the first GET /apis row whose api.name starts with name_prefix."""
+    r = client.get("/apis", headers=h(token))
+    rows = r.json().get("data", []) if r.status_code == 200 else []
+    return next(
+        (row for row in rows if (row.get("api") or {}).get("name", "").startswith(name_prefix)),
+        None,
+    )
+
+
+def _minimal_spec(title: str, server: str, op_id: str) -> dict[str, Any]:
+    """A tiny valid OpenAPI 3 spec with x-vendor so local ingest resolves vendor."""
+    vendor_domain = f"{title.lower().replace(' ', '-')}.demo.test"
+    return {
+        "openapi": "3.0.3",
+        "info": {
+            "title": title,
+            "version": "1.0.0",
+            "x-vendor": vendor_domain,
+            "x-jentic-source-url": f"https://{vendor_domain}/openapi.json",
+        },
+        "servers": [{"url": server}],
+        "paths": {
+            "/ping": {
+                "get": {
+                    "operationId": op_id,
+                    "summary": "Ping",
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Flow 2 — import a brand-new API into the local registry                      #
+# --------------------------------------------------------------------------- #
+def flow2(token: str, run_id: str) -> None:
+    print("\n== Flow 2: import a NEW API into the local registry ==")
+    title = f"Flywheel Demo {run_id}"
+    op_id = f"ping_{run_id}"
+    spec = _minimal_spec(title, "https://api.flywheel-demo.test", op_id)
+
+    r = client.post(
+        "/apis",
+        headers=h(token),
+        json={
+            "sources": [
+                {
+                    "type": "inline",
+                    "content": json.dumps(spec),
+                    "filename": "openapi.json",
+                }
+            ]
+        },
+    )
+    if not check("POST /apis accepted (202)", r.status_code, 202):
+        note(f"import not accepted: {r.status_code} {r.text[:200]}")
+        return
+    job_id = r.json()["job_id"]
+    note(f"import job {job_id}")
+    status = wait_for_job(token, job_id)
+    check("import job reached success", job_ok(status), True)
+
+    # Resolve the slugified identity from the listing (don't guess the slug).
+    match = _find_api(token, "flywheel-demo")
+    check("imported API is listable", match is not None, True)
+    if match is None:
+        return
+
+    # A fresh import is a draft — promote it so the API is live and executable.
+    api = match["api"]
+    promote_draft(token, api["vendor"], api["name"], api["version"])
+    refreshed = _find_api(token, "flywheel-demo")
+    check(
+        "imported API has a live revision",
+        (refreshed or {}).get("current_revision_id") is not None,
+        True,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Flow 1 — improve a catalogued API via an overlay (submit/confirm/rollback)   #
+# --------------------------------------------------------------------------- #
+def flow1(token: str, run_id: str) -> None:
+    print("\n== Flow 1: improve an API via an overlay (submit -> confirm -> rollback) ==")
+    # Seed a catalogued API to overlay: import a spec whose servers we will fix.
+    title = f"Overlay Subject {run_id}"
+    op_id = f"call_{run_id}"
+    bad_server = "https://us.overlay-subject.demo.test"
+    spec = _minimal_spec(title, bad_server, op_id)
+
+    r = client.post(
+        "/apis",
+        headers=h(token),
+        json={
+            "sources": [{"type": "inline", "content": json.dumps(spec), "filename": "openapi.json"}]
+        },
+    )
+    if r.status_code != 202:
+        check("seed import accepted (202)", r.status_code, 202)
+        note(f"cannot seed overlay subject: {r.text[:200]}")
+        return
+    if wait_for_job(token, r.json()["job_id"]) not in {"succeeded", "completed", "done"}:
+        check("seed import completed", False, True)
+        return
+
+    # Resolve the slugified registry identity of the API we just imported.
+    subject = _find_api(token, "overlay-subject")
+    if subject is None:
+        check("overlay subject present after import", False, True)
+        return
+    api = subject["api"]
+    v, n, ver = api["vendor"], api["name"], api["version"]
+    note(f"registry identity: {v}/{n}/{ver}")
+
+    # Promote the draft so the API has a current (live) revision — overlays and
+    # the served spec require one (else confirm 404s with no_current_revision).
+    promote_draft(token, v, n, ver)
+
+    # Submit an idempotent remove-then-set overlay that corrects the server URL.
+    good_server = "https://eu.overlay-subject.demo.test"
+    overlay_doc = {
+        "overlay": "1.0.0",
+        "info": {"title": f"Overlay for {title}", "version": "1.0.0"},
+        "actions": [
+            {"description": "Drop the wrong server.", "target": "$.servers", "remove": True},
+            {
+                "description": "Add the corrected server.",
+                "target": "$",
+                "update": {"servers": [{"url": good_server}]},
+            },
+        ],
+    }
+    r = client.post(
+        f"/apis/{v}/{n}/{ver}/overlays",
+        headers=h(token),
+        json={"document": overlay_doc, "contributed_by": "flywheel_verify"},
+    )
+    if not check("overlay submitted (201)", r.status_code, 201):
+        note(f"submit failed: {r.text[:200]}")
+        return
+    overlay_id = r.json()["id"]
+    check("submitted overlay is pending", r.json().get("status"), "pending")
+
+    # Confirm (materialize). Async: returns before the re-ingest completes, and
+    # the confirm response carries no job id — poll the overlay itself.
+    r = client.post(
+        f"/apis/{v}/{n}/{ver}/overlays/{overlay_id}:confirm",
+        headers=h(token),
+        json={},
+    )
+    if not check("confirm accepted (2xx)", 200 <= r.status_code < 300, True):
+        note(f"confirm failed: {r.status_code} {r.text[:200]}")
+        return
+
+    confirmed_rev = _poll_overlay_confirmed(token, v, n, ver, overlay_id)
+    check("overlay materialized (confirmed_revision_id set)", confirmed_rev is not None, True)
+
+    # The served spec must now reflect the fix.
+    served = client.get(f"/apis/{v}/{n}/{ver}/openapi", headers=h(token))
+    served_servers = served.json().get("servers", []) if served.status_code == 200 else []
+    check(
+        "served spec shows the fix",
+        any(good_server in s.get("url", "") for s in served_servers),
+        True,
+    )
+
+    # Roll back — restores the superseded revision; overlay becomes deprecated.
+    r = client.post(
+        f"/apis/{v}/{n}/{ver}/overlays/{overlay_id}:rollback",
+        headers=h(token),
+        json={},
+    )
+    check("rollback accepted (2xx)", 200 <= r.status_code < 300, True)
+    reverted = _poll_served_reverts(token, v, n, ver, good_server)
+    check("served spec reverted after rollback", reverted, True)
+    after = client.get(f"/apis/{v}/{n}/{ver}/overlays/{overlay_id}", headers=h(token))
+    check("overlay is deprecated after rollback", after.json().get("status"), "deprecated")
+
+
+def _poll_overlay_confirmed(
+    token: str, v: str, n: str, ver: str, overlay_id: str, *, timeout: float = 60.0
+) -> str | None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        r = client.get(f"/apis/{v}/{n}/{ver}/overlays/{overlay_id}", headers=h(token))
+        if r.status_code == 200:
+            crid = r.json().get("confirmed_revision_id")
+            if crid:
+                return str(crid)
+        time.sleep(1.0)
+    return None
+
+
+def _poll_served_reverts(
+    token: str, v: str, n: str, ver: str, gone_url: str, *, timeout: float = 60.0
+) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        served = client.get(f"/apis/{v}/{n}/{ver}/openapi", headers=h(token))
+        if served.status_code == 200:
+            servers = served.json().get("servers", [])
+            if not any(gone_url in s.get("url", "") for s in servers):
+                return True
+        time.sleep(1.0)
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Flow 3 — react to an upstream change (needs the flow3 fixture on :8099)      #
+# --------------------------------------------------------------------------- #
+def flow3(token: str, fixture_url: str) -> None:
+    print("\n== Flow 3: react to an upstream change (update-notify loop) ==")
+    fixture = httpx.Client(base_url=fixture_url, timeout=10.0)
+    try:
+        if fixture.get("/healthz").status_code != 200:
+            raise httpx.ConnectError("bad healthz")
+    except httpx.HTTPError:
+        _results.append(("Flow 3 fixture reachable on :8099", False, "SKIPPED"))
+        print(
+            f"  [SKIP] Flow 3: fixture upstream not reachable at {fixture_url} "
+            f"(start it: python scripts/flow3_upstream_fixture.py)"
+        )
+        return
+
+    catalog_api_id = "flow3-e2e.test"
+    import_path = f"/catalog/{catalog_api_id}:import"
+
+    # 1. Refresh loads the fixture manifest -> flow3-e2e.test becomes importable.
+    r = client.post("/catalog:refresh", headers=h(token))
+    check("catalog:refresh (load manifest) ok", 200 <= r.status_code < 300, True)
+
+    # 2. Import the catalog API (async).
+    r = client.post(import_path, headers=h(token), json={})
+    if not check("catalog import accepted (202)", r.status_code, 202):
+        note(f"import failed: {r.text[:200]}")
+        return
+    if wait_for_job(token, r.json()["job_id"]) not in {"succeeded", "completed", "done"}:
+        check("catalog import completed", False, True)
+        return
+
+    check("fresh import is not outdated", _fixture_update_available(token), False)
+
+    # 3. Simulate an upstream change (new bytes -> new digest).
+    check("fixture bump ok", 200 <= fixture.post("/control/bump").status_code < 300, True)
+
+    # 4. Trigger the sweep.
+    r = client.post("/catalog:refresh", headers=h(token))
+    check("catalog:refresh (sweep) ok", 200 <= r.status_code < 300, True)
+
+    # 5. The sweep must flag the API and emit an actionable event.
+    check("update_available flips true", _poll_update_available(token, True), True)
+    outdated = client.get("/catalog?outdated_only=true", headers=h(token))
+    check("catalog outdated_count >= 1", outdated.json().get("outdated_count", 0) >= 1, True)
+    check("actionable catalog.update_available event exists", _has_update_event(token), True)
+
+    # 6. Re-import adopts upstream: clears the flag.
+    r = client.post(import_path, headers=h(token), json={})
+    if wait_for_job(token, r.json()["job_id"]) not in {"succeeded", "completed", "done"}:
+        check("re-import completed", False, True)
+        return
+    check("update_available cleared after re-import", _poll_update_available(token, False), False)
+
+
+def _fixture_row(token: str) -> dict[str, Any]:
+    r = client.get("/apis", headers=h(token))
+    rows = r.json().get("data", []) if r.status_code == 200 else []
+    return next((row for row in rows if row.get("origin") == "catalog"), {})
+
+
+def _fixture_update_available(token: str) -> bool:
+    return bool(_fixture_row(token).get("update_available"))
+
+
+def _poll_update_available(token: str, want: bool, *, timeout: float = 30.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if _fixture_update_available(token) == want:
+            return want
+        time.sleep(1.0)
+    return _fixture_update_available(token)
+
+
+def _has_update_event(token: str) -> bool:
+    r = client.get(
+        "/events?event_type=catalog.update_available&requires_action=true",
+        headers=h(token),
+    )
+    if r.status_code != 200:
+        return False
+    return any(e.get("type") == "catalog.update_available" for e in r.json().get("data", []))
+
+
+# --------------------------------------------------------------------------- #
+# Entrypoint                                                                   #
+# --------------------------------------------------------------------------- #
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify the three spec-flywheel flows.")
+    parser.add_argument("--flow", choices=["1", "2", "3", "all"], default="all")
+    parser.add_argument("--fixture", default=FIXTURE, help="Flow-3 upstream base URL")
+    args = parser.parse_args()
+
+    print(f"== flywheel_verify against {BASE} (flow={args.flow}) ==")
+    try:
+        token = admin_token()
+    except httpx.HTTPError as exc:
+        print(f"FATAL: could not obtain admin token from {BASE}: {exc}")
+        print("Is the stack up? Try: make start-app-sqlite")
+        return 2
+
+    run_id = rid()
+    note(f"run id: {run_id}")
+
+    if args.flow in ("2", "all"):
+        flow2(token, run_id)
+    if args.flow in ("1", "all"):
+        flow1(token, run_id)
+    if args.flow in ("3", "all"):
+        flow3(token, args.fixture)
+
+    print("\n== summary ==")
+    failures = 0
+    for label, ok, detail in _results:
+        mark = "PASS" if ok else ("SKIP" if detail == "SKIPPED" else "FAIL")
+        if mark == "FAIL":
+            failures += 1
+        print(f"  {mark:4}  {label}")
+    print(f"\n{failures} failure(s), {len(_results)} check(s).")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/demo-flywheel/SKILL.md
+++ b/skills/demo-flywheel/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: demo-flywheel
+description: Guided, human-in-the-loop demo of the three spec-flywheel flows against a local Jentic stack — import a brand-new API, improve it with an OpenAPI Overlay, and react to an upstream change — pausing at each real-world gate (agent approval, overlay confirm, public GitHub actions, rollback) and finishing with a self-verifying harness that proves each flow's effects landed. Use when the user says "demo the flywheel", "walk me through the three flows", "show the import/overlay/update-notify loop", or is preparing a live presentation of the contribute-spec-fix / import-new-api story. This is a presenter tool, not an agent capability — it orchestrates the real skills; it does not replace them.
+metadata:
+  kind: freeform
+  argument-hint: "[flow: all|2|1|3]"
+---
+
+# Demo the spec-flywheel (import → improve → react), human-in-the-loop
+
+Run all three flywheel flows end-to-end against a **local** Jentic control plane
+as one coherent story about a single API's lifecycle:
+
+```
+   Flow 2            Flow 1                       Flow 3
+   import  ───►  improve via overlay  ───►  react to upstream + rollback
+   (new API)    (confirm makes it live)     (update-notify, then teardown)
+```
+
+You (the agent) **narrate and execute the real steps**, pausing for a human at
+every irreversible / public / privileged gate, then run
+`scripts/flywheel_verify.py` to prove each flow's effects actually landed.
+
+Target: `$ARGUMENTS` — which flow to run (`all` default, or `2` / `1` / `3`).
+
+This skill **orchestrates** the real skills — it points at
+[`import-new-api`](../import-new-api/SKILL.md) and
+[`contribute-spec-fix`](../contribute-spec-fix/SKILL.md) for the authoritative
+command sequences and reuses their exact steps. Read those two skills before
+presenting; this one adds the demo scaffolding (preflight, gates, ordering,
+teardown, verification) around them.
+
+## The demo at a glance
+
+```mermaid
+flowchart TD
+  subgraph setup [Setup]
+    S1["make start-app-sqlite with the demo config (:8000)"] --> S2["POST /users:create-admin → org-admin token"]
+    S2 --> S3["jentic bootstrap (GATE: human approves the agent)"]
+    S3 --> S4["RUN_ID = timestamp → fresh vendor / version / branch"]
+  end
+  setup --> F2
+  subgraph F2 [Flow 2 · import a NEW API]
+    B1["existence check (gh api) — fresh RUN_ID vendor"] --> B2["find an official spec (prefer Path 1)"]
+    B2 --> B3["local-first import: POST /apis {inline} → poll job → promote"]
+    B3 --> B4{"GATE: publish publicly?"}
+    B4 -->|"default: --no-github OR presenter fork"| B5["push spec; print / file the [AUTO] issue"]
+  end
+  F2 --> F1
+  subgraph F1 [Flow 1 · improve THAT API]
+    A1["write overlay {document:{actions}}"] --> A2["POST …/overlays (apis:write)"]
+    A2 --> A3{"GATE: confirm — rewrites the served spec"}
+    A3 -->|"org-admin token"| A4["POST …/overlays/{id}:confirm"]
+    A4 --> A5["poll GET …/overlays/{id} until confirmed_revision_id set"]
+    A5 --> A6["GET …/openapi shows the fix live"]
+    A6 --> A7{"GATE: open the human PR?"}
+    A7 -->|"--draft + [DEMO] label"| A8["gh pr create (fork by default)"]
+  end
+  F1 --> F3
+  subgraph F3 [Flow 3 · react + teardown]
+    C1["run flow3_upstream_fixture.py (:8099)"] --> C2["import the fixture API"]
+    C2 --> C3["POST /control/bump"] --> C4["POST /catalog:refresh (org:admin)"]
+    C4 --> C5["poll GET /apis + /catalog?outdated_only + /events"]
+    C5 --> C6{"GATE: rollback?"}
+    C6 -->|yes| C7["…:rollback + close demo PR/issue + delete branch"]
+  end
+  F3 --> V["python scripts/flywheel_verify.py --flow all → PASS/FAIL table"]
+```
+
+## Human-in-the-loop protocol (read before you start)
+
+Gate exactly **four** kinds of step — the irreversible, the public, and the
+privileged. **Auto-proceed** on everything local and reversible (writing an
+overlay, a local import, submitting a still-pending overlay, reading events).
+Before each gated step, emit this line verbatim and wait:
+
+> **PAUSE — needs human: `<what>` (`<why it matters>`). Proceed? (y/n)**
+
+The four gates:
+1. **Agent approval / access grant** — `jentic bootstrap` and any
+   `jentic access request` block on a human approver in the console.
+2. **Overlay `:confirm`** — materializes the overlay and **rewrites the served
+   spec**; needs the elevated `overlays:confirm` scope (org-admin token).
+3. **Any public `gh` action** — `gh pr create`, `gh issue create`, or a push to
+   a public repo. You are acting under the presenter's GitHub identity.
+4. **Rollback** — restores the superseded revision; the audience should see the
+   human decide to revert.
+
+## Preflight (do this before the audience arrives)
+
+A stalled demo is worse than no demo. Verify all of this first:
+
+- **Stack up with the demo config** (Flow 3 needs the loopback egress + short
+  probe interval, see below):
+  ```
+  JENTIC_CONFIG_FILE=config/local-sqlite-demo.yaml make start-app-sqlite
+  ```
+  Liveness: `curl -fsS http://127.0.0.1:8000/health` → `{"status":"ok",...}`.
+  Setup-readiness: `curl -fsS http://127.0.0.1:8000/admin/health` →
+  `setup_required` tells you whether the first admin still needs creating.
+- **Org-admin token** (covers `overlays:confirm` + `org:admin`, which agents
+  cannot self-grant). On a fresh DB:
+  ```
+  curl -fsS -X POST http://127.0.0.1:8000/users:create-admin \
+    -H 'Content-Type: application/json' \
+    -d '{"email":"flywheel-admin@demo.test","password":"FlywheelDemo!234","first_name":"Fly","last_name":"Wheel"}'
+  ```
+  Returns a `LoginResponse` with `access_token` (already org-admin,
+  `must_change_password:false` — no rotation). On a re-run this 410s; log in via
+  `POST /auth/login` with the same credentials instead. (This is exactly what
+  `scripts/flywheel_verify.py` does — you can reuse its token.)
+- **Agent token** for the CLI-driven steps: `jentic bootstrap` done (token at
+  `~/.jentic/profiles/<p>/tokens.json`, key `access_token`). This is **gate 1**.
+- **`gh auth status`** on the intended account/**fork** (see GitHub safety).
+- **Pre-warm the flaky bits** so they don't fail live: `npx --yes bump-cli --version`
+  (first run downloads over the network) and `spectral --version`.
+- **Pin the `jentic-public-apis` checkout path** for Flow 1 — don't rely on a
+  slow `find ~`. Know it in advance.
+- **Establish a `RUN_ID`** (e.g. `RUN_ID=$(date +%Y%m%d-%H%M%S)`) and thread it
+  into every vendor / version / branch / issue title so re-runs never collide
+  (the existence gate STOPs on a known vendor and the import workflow hard-fails
+  on a duplicate version).
+
+Print the plan — "I will create a public spec commit, a draft PR, and (in
+dry-run) show the issue body I would file" — **before** doing anything.
+
+## GitHub safety (this is the real blast radius)
+
+A real `[AUTO]` issue on `jentic/jentic-public-apis` triggers a live,
+LLM-backed import workflow that **spends the repo's Bedrock secret and
+auto-opens a PR to `main`** — it cannot be a draft. So, by default, **do not
+fire that issue at the public repo**. Choose one:
+
+- **`--no-github` dry-run (default):** run Flow 2 through publishing the spec to
+  the presenter's own repo, then **print the exact `[AUTO]` issue body you
+  would file** (with `import_oas_url:` + `vendor_name:`) instead of running
+  `gh issue create`. Narrate "…and this issue is what drives it into the
+  community catalog" without firing public CI.
+- **Presenter-owned fork:** target `gh issue create --repo <presenter>/jentic-public-apis`
+  (its own secret, its own `main`) so the run is genuinely end-to-end but
+  contained.
+
+For Flow 1's **human** PR (which you *can* make a draft):
+`gh pr create --draft`, title prefixed `[DEMO — do not merge]`, `--label demo`,
+on a `RUN_ID`-namespaced branch (`demo/<RUN_ID>-<vendor>`).
+
+## Flow 2 — import a brand-new API
+
+Follow [`import-new-api`](../import-new-api/SKILL.md) verbatim, with these demo
+adjustments:
+- Use a **fresh `RUN_ID` vendor** so Step 1's existence gate doesn't STOP.
+- Prefer **Path 1** (an official vendor spec) over LLM generation — a download
+  is fast and deterministic; generation is the flaky path.
+- Do the **local-first import** (`POST /apis` inline → poll `GET /jobs/{id}` →
+  `jentic apis promote`) so the API is immediately executable — this is the
+  visible payoff. (`apis:write` may need a one-time `jentic access request` —
+  that's **gate 1**.)
+- At the **publish gate (gate 3)**, default to `--no-github`/fork per above.
+
+**What you should now see:** the new API listable via `jentic search`/`GET /apis`,
+and (dry-run) the issue body printed, or (fork) a real issue + auto-PR on the fork.
+
+## Flow 1 — improve THAT API via an overlay
+
+Now the vendor **is** catalogued (Flow 2 imported it), so
+[`contribute-spec-fix`](../contribute-spec-fix/SKILL.md) is legitimately the
+right skill. Follow it verbatim, with these corrected mechanics baked in:
+
+- **Overlay submit body is `{"document": {"actions": [...]}}`** — only
+  `document.actions` is validated; do not wrap it in extra top-level keys
+  (the request model is `extra="forbid"`).
+- **Confirm is async and returns no job id.** After `…:confirm`, **poll
+  `GET …/overlays/{id}` until `confirmed_revision_id` is non-null** (equivalently
+  until `_links.rollback` appears) — do NOT try to poll `GET /jobs/{id}` (you
+  can't get the id from confirm). Then `GET …/openapi` shows the fix.
+- **Confirm is gate 2**; use the org-admin token from preflight.
+- Remember the **folder-path ≠ registry-identity** slug gotcha — resolve the
+  slugified `$V/$N/$VER` from `GET /apis` (match on `catalog_api_id`), don't
+  reuse the `jentic-public-apis` folder segments.
+- Opening the community PR is **gate 3**: `--draft`, `[DEMO — do not merge]`,
+  `--label demo`, on the `RUN_ID` branch.
+
+**What you should now see:** the served spec (`GET …/openapi`) reflects the fix,
+the overlay is `confirmed` with a `confirmed_revision_id`, and a draft PR URL.
+
+## Flow 3 — react to an upstream change, then roll back (teardown)
+
+You can't force the real upstream catalog to change on cue, so use the
+controllable fixture. This flow doubles as the demo's teardown.
+
+- Ensure the stack was started with `config/local-sqlite-demo.yaml` (it adds
+  `catalog.update_check_interval_seconds: 1` and
+  `ingest.egress.allowed_private_subnets: [127.0.0.0/8]` — both **absent** from
+  the base sqlite config; interval `1`, never `0`, because `0` disables the
+  sweep).
+- Start the fixture upstream:
+  ```
+  python scripts/flow3_upstream_fixture.py    # listens on 127.0.0.1:8099
+  ```
+- Drive the loop (this mirrors the real update-notify e2e):
+  ```
+  # 1. Refresh loads the fixture manifest → flow3-e2e.test becomes importable.
+  curl -fsS -X POST $BASE/catalog:refresh -H "Authorization: Bearer $ADMIN"
+  # 2. Import it (async 202 + job_id); poll GET /jobs/{id} to a terminal success.
+  curl -fsS -X POST $BASE/catalog/flow3-e2e.test:import -H "Authorization: Bearer $ADMIN" -d '{}'
+  # 3. Simulate an upstream change.
+  curl -fsS -X POST http://127.0.0.1:8099/control/bump
+  # 4. Trigger the sweep.
+  curl -fsS -X POST $BASE/catalog:refresh -H "Authorization: Bearer $ADMIN"
+  # 5. Observe the flags flip.
+  curl -fsS "$BASE/apis" -H "Authorization: Bearer $ADMIN"                          # update_available: true
+  curl -fsS "$BASE/catalog?outdated_only=true" -H "Authorization: Bearer $ADMIN"    # outdated_count: 1
+  curl -fsS "$BASE/events?event_type=catalog.update_available&requires_action=true" -H "Authorization: Bearer $ADMIN"
+  ```
+- **What you should now see:** `update_available` flips to `true`, one outdated
+  catalog row, and an actionable `catalog.update_available` event. A re-import
+  adopts upstream and clears it.
+
+### Teardown (mandatory — leave the box clean and re-runnable)
+
+This is **gate 4** (rollback), plus cleanup:
+- **Roll back** the Flow-1 overlay (`…/overlays/{id}:rollback` with the org-admin
+  token) so the served spec returns to baseline.
+- **Close** the demo PR and issue and **delete** the `demo/<RUN_ID>-…` branch
+  (and the fork's PR if you used the fork path).
+- Optionally `DELETE /apis/{v}/{n}/{ver}` to drop the locally-imported demo APIs
+  so the next run's Flow 2 is genuinely fresh.
+
+## Closing — prove it with the harness
+
+Run the self-verifying harness and report the PASS/FAIL table plus the (draft
+PR / dry-run issue) URLs:
+
+```
+python scripts/flywheel_verify.py --flow all
+```
+
+It bootstraps its own org-admin, exercises the local effects of each flow
+(import → listable; overlay submit → confirm → served-spec fix → rollback
+reverts; fixture bump → refresh → `update_available` flips → re-import clears),
+prints a compact table, and **exits non-zero on any failure** — so a green table
+is your proof the demo actually worked, not just that it ran. (Flow 3 self-skips
+if the fixture on `:8099` isn't up.)
+
+## Guardrails
+
+- **Never self-escalate privilege.** `overlays:confirm` / `org:admin` come from
+  the bootstrap org-admin token — treat acquiring it as a human/operator step.
+- **Never fire the real `[AUTO]` issue at `jentic/jentic-public-apis` in a
+  demo.** Default to `--no-github` or a presenter fork; it spends a real LLM
+  secret and opens a non-draftable PR to `main`.
+- **Always run teardown.** A demo that leaves a confirmed overlay, an open PR,
+  and an imported API can't be re-run cleanly.
+- **Fresh `RUN_ID` every run** — the existence gate and the import workflow both
+  hard-fail on repeats.
+- **This skill is not served.** It's a presenter tool under `skills/`, run on
+  demand (like `init-design`) — it is intentionally not in the agent-facing
+  served set and ships no embedded/HTTP mirror.


### PR DESCRIPTION
## Summary

Adds a **presenter tool** for demoing the three spec-flywheel flows end-to-end against a local stack, plus a self-verifying harness that proves each flow's real effects landed. It **orchestrates** the existing skills ([`import-new-api`](../blob/main/skills/import-new-api/SKILL.md), [`contribute-spec-fix`](../blob/main/skills/contribute-spec-fix/SKILL.md)) — it doesn't replace them.

Kept **un-served** (like `init-design`): it's a presenter tool, not an agent capability, so there's no `SERVED_SKILLS` entry, no `cli/`/`src/` mirrors, and no drift-test obligation (drift test stays green).

## The demo (one API's lifecycle, in 2 → 1 → 3 order)

```mermaid
flowchart LR
  F2["Flow 2\nimport a NEW API"] --> F1["Flow 1\nimprove it via an overlay\n(confirm makes it live)"] --> F3["Flow 3\nreact to an upstream change\n+ rollback (teardown)"]
```

Flow 1 needs an already-catalogued API, so running Flow 2 first (which creates one) makes the whole demo a single coherent subject: **import → improve → live → react/rollback**.

## What's here

- **`skills/demo-flywheel/SKILL.md`** — the narrated walkthrough with an explicit **4-gate** human-in-the-loop protocol (agent approval, overlay `:confirm`, any public `gh` action, rollback), auto-proceeding on everything local/reversible.
- **`scripts/flywheel_verify.py`** — an `httpx` PASS/FAIL harness (`--flow 2|1|3|all`). Bootstraps its own org-admin, promotes imported drafts, polls the overlay for `confirmed_revision_id`, and **exits non-zero on any failure** (so it doubles as a smoke test). Flow 3 self-skips if the fixture isn't up.
- **`config/local-sqlite-demo.yaml`** — a non-destructive full-copy config that adds only what Flow 3 needs: the fixture `manifest_url`, `update_check_interval_seconds: 1` (never `0`, which is the kill switch), and `127.0.0.0/8` egress so the loopback fixture is probeable.

## Safety / blast-radius

A real \`[AUTO]\` issue on \`jentic/jentic-public-apis\` triggers a live LLM-backed workflow that spends the repo's Bedrock secret and opens a **non-draftable** PR to \`main\`. So the demo defaults to a **\`--no-github\` dry-run or a presenter-owned fork**, makes the Flow-1 human PR a **draft** with a \`[DEMO — do not merge]\` title, uses a fresh \`RUN_ID\` per run (to dodge the existence-gate STOP and the duplicate-version hard-fail), and ends with a mandatory teardown (rollback + close/delete PR/issue/branch). The harness itself never touches GitHub.

## Test plan

Verified end-to-end against \`make start-app-sqlite\` (with the demo config) + the Flow-3 fixture:

- [x] \`python scripts/flywheel_verify.py --flow all\` → **21/21 PASS** (import + promote + listable/live; overlay submit → confirm → served-spec fix → rollback reverts → deprecated; fixture bump → refresh → \`update_available\` flips → re-import clears).
- [x] Flow-3 skip path exits 0 when the fixture is down.
- [x] \`ruff\` + \`ruff format\` + \`mypy\` clean on the harness.
- [x] \`tools/skills_sync.py --check\` and \`tests/arch/test_skill_drift.py\` green (un-served skill imposes no obligation).

> Reviewer note: please use **squash + merge**.

Made with [Cursor](https://cursor.com)