### PR TITLE
fix(install.sh): make the piped re-exec source URL overridable

### DIFF
--- a/tests/tools/install_test.sh
+++ b/tests/tools/install_test.sh
@@ -396,16 +396,18 @@ fi
 # the piped re-exec loops back to the origin that served the script instead of
 # hard-depending on raw.githubusercontent.com (jentic-one#962). Prove it with a
 # stubbed curl that records its argv and fails: the recorded URL must be the
-# override, and the error message must name it.
+# override, and the error message must name it. Each invocation clears the
+# JENTIC_* env that could leak in from a developer shell and skew the run.
 if [ -x /bin/sh ]; then
   bindir="$(mktemp -d "${TMPDIR:-/tmp}/jentic-test-bin.XXXXXX")"
   make_min_path "$bindir"
   curl_log="$(mktemp "${TMPDIR:-/tmp}/jentic-test-curl.XXXXXX")"
-  printf '#!/bin/sh\necho "$@" >> %s\nexit 22\n' "$curl_log" > "$bindir/curl"
+  printf '#!/bin/sh\nprintf '"'"'%%s\\n'"'"' "$*" >> "%s"\nexit 22\n' "$curl_log" > "$bindir/curl"
   chmod +x "$bindir/curl"
 
   set +e
-  out="$(PATH="$bindir" JENTIC_INSTALL_SOURCE_URL="https://jentic.example/install.sh" \
+  out="$(PATH="$bindir" JENTIC_INSTALL_SELF= JENTIC_INSTALL_REEXEC= JENTIC_REPO= JENTIC_REF= \
+    JENTIC_INSTALL_SOURCE_URL="https://jentic.example/install.sh" \
     GITHUB_TOKEN="secret-token" /bin/sh < "$INSTALL_SH" 2>&1)"
   set -e
   recorded="$(cat "$curl_log" 2>/dev/null || true)"
@@ -417,18 +419,66 @@ if [ -x /bin/sh ]; then
     "$recorded" "secret-token"
   assert_contains "re-exec override: failure message names the override URL" \
     "$out" "https://jentic.example/install.sh"
+  assert_not_contains "re-exec override: error message does not mention GitHub raw" \
+    "$out" "raw.githubusercontent.com"
 
   # Default (no override): the canonical raw URL is fetched, and the token IS
   # attached for GitHub (private-fork support unchanged).
   : > "$curl_log"
   set +e
-  out="$(PATH="$bindir" GITHUB_TOKEN="secret-token" /bin/sh < "$INSTALL_SH" 2>&1)"
+  out="$(PATH="$bindir" JENTIC_INSTALL_SELF= JENTIC_INSTALL_REEXEC= JENTIC_REPO= JENTIC_REF= \
+    GITHUB_TOKEN="secret-token" /bin/sh < "$INSTALL_SH" 2>&1)"
   set -e
   recorded="$(cat "$curl_log" 2>/dev/null || true)"
   assert_contains "re-exec default: canonical raw URL fetched" \
     "$recorded" "https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh"
   assert_contains "re-exec default: GITHUB_TOKEN attached for GitHub origin" \
     "$recorded" "secret-token"
+
+  # Empty override: ':-' falls back to the canonical URL (guards a future
+  # '${VAR-…}' typo that would silently fetch an empty URL).
+  : > "$curl_log"
+  set +e
+  out="$(PATH="$bindir" JENTIC_INSTALL_SELF= JENTIC_INSTALL_REEXEC= JENTIC_REPO= JENTIC_REF= \
+    JENTIC_INSTALL_SOURCE_URL="" /bin/sh < "$INSTALL_SH" 2>&1)"
+  set -e
+  assert_contains "re-exec empty override: falls back to canonical raw URL" \
+    "$(cat "$curl_log")" "https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh"
+
+  # Precedence: JENTIC_INSTALL_SELF wins over SOURCE_URL (no network fetch).
+  : > "$curl_log"
+  set +e
+  out="$(PATH="$bindir" JENTIC_INSTALL_REEXEC= JENTIC_REPO= JENTIC_REF= \
+    JENTIC_INSTALL_SELF="$INSTALL_SH" JENTIC_INSTALL_SOURCE_URL="https://jentic.example/install.sh" \
+    /bin/sh < "$INSTALL_SH" 2>&1)"
+  set -e
+  assert_eq "re-exec: SELF wins over SOURCE_URL (curl never called)" "" "$(cat "$curl_log")"
+  assert_contains "re-exec: SELF wins over SOURCE_URL (reaches prereq check)" \
+    "$out" "required command not found: git"
+
+  # Override on github.com itself: the token IS attached (private-fork proxy).
+  : > "$curl_log"
+  set +e
+  out="$(PATH="$bindir" JENTIC_INSTALL_SELF= JENTIC_INSTALL_REEXEC= JENTIC_REPO= JENTIC_REF= \
+    GITHUB_TOKEN="secret-token" \
+    JENTIC_INSTALL_SOURCE_URL="https://github.com/jentic/fork/raw/main/tools/install.sh" \
+    /bin/sh < "$INSTALL_SH" 2>&1)"
+  set -e
+  assert_contains "re-exec override on github.com: token IS attached" \
+    "$(cat "$curl_log")" "secret-token"
+
+  # Non-https override: refused fail-closed before any fetch (http:// would
+  # hand code execution to an on-path attacker; leading '-' would be parsed
+  # as a curl option).
+  : > "$curl_log"
+  set +e
+  out="$(PATH="$bindir" JENTIC_INSTALL_SELF= JENTIC_INSTALL_REEXEC= JENTIC_REPO= JENTIC_REF= \
+    JENTIC_INSTALL_SOURCE_URL="http://jentic.example/install.sh" \
+    /bin/sh < "$INSTALL_SH" 2>&1)"
+  set -e
+  assert_contains "re-exec non-https override: refused with a clear error" \
+    "$out" "must be an https:// URL"
+  assert_eq "re-exec non-https override: curl never called" "" "$(cat "$curl_log")"
 
   rm -rf "$bindir" "$curl_log"
 fi

--- a/tests/tools/install_test.sh
+++ b/tests/tools/install_test.sh
@@ -391,6 +391,48 @@ if [ -x /bin/sh ]; then
   assert_not_contains "piped re-exec without curl: no bash syntax error" "$out" "syntax error"
 fi
 
+# --- re-fetch source override: JENTIC_INSTALL_SOURCE_URL is honoured ---------
+# First-party install endpoints set (or serve-time-rewrite) this variable so
+# the piped re-exec loops back to the origin that served the script instead of
+# hard-depending on raw.githubusercontent.com (jentic-one#962). Prove it with a
+# stubbed curl that records its argv and fails: the recorded URL must be the
+# override, and the error message must name it.
+if [ -x /bin/sh ]; then
+  bindir="$(mktemp -d "${TMPDIR:-/tmp}/jentic-test-bin.XXXXXX")"
+  make_min_path "$bindir"
+  curl_log="$(mktemp "${TMPDIR:-/tmp}/jentic-test-curl.XXXXXX")"
+  printf '#!/bin/sh\necho "$@" >> %s\nexit 22\n' "$curl_log" > "$bindir/curl"
+  chmod +x "$bindir/curl"
+
+  set +e
+  out="$(PATH="$bindir" JENTIC_INSTALL_SOURCE_URL="https://jentic.example/install.sh" \
+    GITHUB_TOKEN="secret-token" /bin/sh < "$INSTALL_SH" 2>&1)"
+  set -e
+  recorded="$(cat "$curl_log" 2>/dev/null || true)"
+  assert_contains "re-exec override: stub curl fetched the override URL" \
+    "$recorded" "https://jentic.example/install.sh"
+  assert_not_contains "re-exec override: raw.githubusercontent.com not contacted" \
+    "$recorded" "raw.githubusercontent.com"
+  assert_not_contains "re-exec override: GITHUB_TOKEN not sent to non-GitHub origin" \
+    "$recorded" "secret-token"
+  assert_contains "re-exec override: failure message names the override URL" \
+    "$out" "https://jentic.example/install.sh"
+
+  # Default (no override): the canonical raw URL is fetched, and the token IS
+  # attached for GitHub (private-fork support unchanged).
+  : > "$curl_log"
+  set +e
+  out="$(PATH="$bindir" GITHUB_TOKEN="secret-token" /bin/sh < "$INSTALL_SH" 2>&1)"
+  set -e
+  recorded="$(cat "$curl_log" 2>/dev/null || true)"
+  assert_contains "re-exec default: canonical raw URL fetched" \
+    "$recorded" "https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh"
+  assert_contains "re-exec default: GITHUB_TOKEN attached for GitHub origin" \
+    "$recorded" "secret-token"
+
+  rm -rf "$bindir" "$curl_log"
+fi
+
 # ---------------------------------------------------------------------------
 if [ "$FAIL" -ne 0 ]; then
   printf '\nFAILED\n' >&2

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -26,13 +26,16 @@
 #   JENTIC_NO_INSTALL   set to 1 to stop after installing the binaries, skipping
 #                       the automatic hand-off into `jenticctl install`
 #   JENTIC_INSTALL_SOURCE_URL
-#                       URL the piped re-exec re-fetches this script from
-#                       (default: the canonical raw.githubusercontent.com URL
-#                       for JENTIC_REPO/JENTIC_REF). First-party install
-#                       endpoints that serve this script (e.g. a website proxy)
-#                       should set — or rewrite at serve time — this variable so
-#                       the re-exec loops back to the origin that served the
-#                       script instead of hard-depending on GitHub raw.
+#                       https:// URL the piped re-exec re-fetches this script
+#                       from (default: the canonical raw.githubusercontent.com
+#                       URL for JENTIC_REPO/JENTIC_REF; non-https values are
+#                       refused). First-party install endpoints that serve this
+#                       script (e.g. a website proxy) should set it — by
+#                       prepending an `export …` line or replacing the
+#                       assignment with a statically configured value; never
+#                       interpolate request-derived data — so the re-exec loops
+#                       back to the origin that served the script instead of
+#                       hard-depending on GitHub raw.
 #
 # This script is invoked via `curl ... | sh`, so it re-execs itself under a
 # full (non-POSIX) bash (below) to get predictable behavior across shells.
@@ -99,9 +102,26 @@ if _need_bash_reexec; then
       exit 1
     fi
     # JENTIC_INSTALL_SOURCE_URL: single greppable seam for the re-exec source.
-    # A first-party proxy can rewrite this line (or export the variable) so the
-    # executed bytes come from the same origin that served the script.
+    # First-party install endpoints should set this so the executed bytes come
+    # from the origin that served the script. Two safe ways, in order of
+    # preference: (1) prepend a whole generated `export JENTIC_INSTALL_SOURCE_URL=…`
+    # line to the served body, or (2) replace this exact assignment line with a
+    # STATICALLY CONFIGURED value. Never interpolate request-derived data
+    # (Host/X-Forwarded-* headers) into the served shell source — that is a
+    # shell-injection vector — and keep the value to https:// plus
+    # [A-Za-z0-9._/-] only.
     _reexec_url="${JENTIC_INSTALL_SOURCE_URL:-https://raw.githubusercontent.com/${_reexec_repo}/${_reexec_ref}/tools/install.sh}"
+    # Fail closed on anything but https: the default is https-by-construction,
+    # and a plaintext/exotic-scheme override would hand code execution to an
+    # on-path attacker (curl accepts http/ftp/file with -fsSL). This also
+    # rejects values starting with "-" that curl would parse as options.
+    case "$_reexec_url" in
+      https://*) ;;
+      *)
+        rm -f "$_reexec_tmp"
+        echo "error: JENTIC_INSTALL_SOURCE_URL must be an https:// URL" >&2
+        exit 1 ;;
+    esac
     # Only attach the GitHub token when fetching from GitHub itself — never
     # leak it to a third-party/first-party override origin.
     _reexec_auth=""

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -29,13 +29,15 @@
 #                       https:// URL the piped re-exec re-fetches this script
 #                       from (default: the canonical raw.githubusercontent.com
 #                       URL for JENTIC_REPO/JENTIC_REF; non-https values are
-#                       refused). First-party install endpoints that serve this
-#                       script (e.g. a website proxy) should set it — by
-#                       prepending an `export …` line or replacing the
-#                       assignment with a statically configured value; never
-#                       interpolate request-derived data — so the re-exec loops
-#                       back to the origin that served the script instead of
-#                       hard-depending on GitHub raw.
+#                       refused, and empty is treated as unset — a failed
+#                       template substitution falls back to GitHub rather than
+#                       fetching an empty URL). First-party install endpoints
+#                       that serve this script (e.g. a website proxy) should
+#                       set it — by prepending an `export …` line or replacing
+#                       the assignment with a statically configured value;
+#                       never interpolate request-derived data — so the
+#                       re-exec loops back to the origin that served the
+#                       script instead of hard-depending on GitHub raw.
 #
 # This script is invoked via `curl ... | sh`, so it re-execs itself under a
 # full (non-POSIX) bash (below) to get predictable behavior across shells.
@@ -130,7 +132,7 @@ if _need_bash_reexec; then
         https://raw.githubusercontent.com/*|https://github.com/*) _reexec_auth="Authorization: Bearer ${GITHUB_TOKEN}" ;;
       esac
     fi
-    if ! curl -fsSL ${_reexec_auth:+-H "$_reexec_auth"} "$_reexec_url" -o "$_reexec_tmp"; then
+    if ! curl -fsSL ${_reexec_auth:+-H "$_reexec_auth"} -o "$_reexec_tmp" -- "$_reexec_url"; then
       rm -f "$_reexec_tmp"
       echo "error: failed to fetch the installer from ${_reexec_url} to re-exec under bash" >&2
       echo "       (for a private fork set GITHUB_TOKEN, or run the script from a checkout)" >&2

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -25,6 +25,14 @@
 #   GITHUB_TOKEN        token for cloning a private fork  (default: unset/anonymous)
 #   JENTIC_NO_INSTALL   set to 1 to stop after installing the binaries, skipping
 #                       the automatic hand-off into `jenticctl install`
+#   JENTIC_INSTALL_SOURCE_URL
+#                       URL the piped re-exec re-fetches this script from
+#                       (default: the canonical raw.githubusercontent.com URL
+#                       for JENTIC_REPO/JENTIC_REF). First-party install
+#                       endpoints that serve this script (e.g. a website proxy)
+#                       should set — or rewrite at serve time — this variable so
+#                       the re-exec loops back to the origin that served the
+#                       script instead of hard-depending on GitHub raw.
 #
 # This script is invoked via `curl ... | sh`, so it re-execs itself under a
 # full (non-POSIX) bash (below) to get predictable behavior across shells.
@@ -70,6 +78,9 @@ if _need_bash_reexec; then
   # a full copy under bash and run that:
   #   * JENTIC_INSTALL_SELF=/path  -> use that local file (used by tests, and to
   #     re-run a local copy without a network round-trip);
+  #   * JENTIC_INSTALL_SOURCE_URL -> re-fetch from that URL (set by first-party
+  #     install endpoints so the re-exec loops back to the origin that served
+  #     the script — see the configuration comment above);
   #   * otherwise re-fetch tools/install.sh from the canonical raw URL for the
   #     configured repo/ref (the same source curl fetched it from), honouring
   #     GITHUB_TOKEN for private forks (mirrors `jenticctl update`).
@@ -87,11 +98,17 @@ if _need_bash_reexec; then
       echo "error: curl is required to bootstrap the installer under bash" >&2
       exit 1
     fi
-    _reexec_url="https://raw.githubusercontent.com/${_reexec_repo}/${_reexec_ref}/tools/install.sh"
+    # JENTIC_INSTALL_SOURCE_URL: single greppable seam for the re-exec source.
+    # A first-party proxy can rewrite this line (or export the variable) so the
+    # executed bytes come from the same origin that served the script.
+    _reexec_url="${JENTIC_INSTALL_SOURCE_URL:-https://raw.githubusercontent.com/${_reexec_repo}/${_reexec_ref}/tools/install.sh}"
+    # Only attach the GitHub token when fetching from GitHub itself — never
+    # leak it to a third-party/first-party override origin.
+    _reexec_auth=""
     if [ -n "${GITHUB_TOKEN:-}" ]; then
-      _reexec_auth="Authorization: Bearer ${GITHUB_TOKEN}"
-    else
-      _reexec_auth=""
+      case "$_reexec_url" in
+        https://raw.githubusercontent.com/*|https://github.com/*) _reexec_auth="Authorization: Bearer ${GITHUB_TOKEN}" ;;
+      esac
     fi
     if ! curl -fsSL ${_reexec_auth:+-H "$_reexec_auth"} "$_reexec_url" -o "$_reexec_tmp"; then
       rm -f "$_reexec_tmp"


### PR DESCRIPTION
## Summary

When invoked via the documented `curl … | sh`, the installer re-execs itself by re-fetching from a hardcoded `raw.githubusercontent.com` URL — so the executed bytes always come from GitHub raw regardless of which origin served the script. This defeats first-party install endpoints (jentic/jentic-website#366): they gain no outage resilience, and the served and executed bytes can diverge. This PR hoists the re-exec URL into a single env-overridable, greppable variable, `JENTIC_INSTALL_SOURCE_URL`, so a serving origin can loop the re-exec back to itself.

## Changes

- `tools/install.sh`: the piped re-exec fetch URL is now `${JENTIC_INSTALL_SOURCE_URL:-<canonical raw URL>}` — one clearly-marked line a first-party proxy can rewrite at serve time (or callers can export). Default behavior is byte-for-byte unchanged.
- `tools/install.sh`: `GITHUB_TOKEN` is now only attached when the re-exec fetch targets GitHub (`raw.githubusercontent.com`/`github.com`) — it is never leaked to an override origin. For the default URL the token behavior is unchanged (private forks keep working).
- `tests/tools/install_test.sh`: 6 new offline checks with a stubbed `curl` — override URL is fetched (and GitHub raw is not), the failure message names the override, the token is withheld from non-GitHub origins, and the default path still fetches the canonical URL with the token attached.
- Out of scope: `fetch_source()` still clones `github.com` to build, so full GitHub-outage resilience additionally needs prebuilt release artifacts — tracked in #974.

## Risk & rollback

- Low risk: no behavior change unless `JENTIC_INSTALL_SOURCE_URL` is explicitly set; the only default-path change is the token-scoping guard, which keeps sending the token to GitHub as before.
- New env var: `JENTIC_INSTALL_SOURCE_URL` (documented in the header comment).
- Revert the squash commit to roll back.

## Test plan

- `bash tests/tools/install_test.sh` — all 42 checks pass (36 pre-existing + 6 new).
- `shellcheck -S warning tools/install.sh` — clean.
- Manual e2e of the #962 repro (stubbed `curl` where GitHub is unreachable but the override origin serves the script): without the override the run dies at the re-exec fetch with the exact error quoted in the issue; with `JENTIC_INSTALL_SOURCE_URL=https://jentic.example/install.sh` the re-exec completes and the installer proceeds to the prereq check.

Closes #962

Made with [Cursor](https://cursor.com)

## Checklist

- [x] Commits follow Conventional Commits with a scope (sign-off to be carried by the squash commit)
- [x] `make check` equivalents pass in CI (lint & type-check, security scan, unit tests, installer script tests — all green)
- [x] Tests added/updated for the change (6 new offline checks in `tests/tools/install_test.sh`)
- [x] Docs updated where relevant (env var documented in the script header)
- [x] No secrets, credentials, or internal-only references included