### PR TITLE
fix(skills): sync #911 reuse guidance into the jentic skill source

### DIFF
--- a/skills/jentic/SKILL.md
+++ b/skills/jentic/SKILL.md
@@ -147,7 +147,10 @@ jentic access request --provision stripe.com/api \
     describes the whole path (create toolkit, provision + bind a credential with
     your proposed rules, bind you), which a human fulfils and approves in the
     dashboard. The directive's `suggested_command` already points at `--provision`
-    in this case.
+    in this case. The plan does **not** force a new toolkit: during fulfilment
+    the operator can add the credential to a toolkit they already have (the
+    wizard offers both) — worth relaying when your operator mentions an
+    existing toolkit they want to extend.
   - `toolkit_serves_api: true` — a toolkit already serves this API and you just
     aren't bound to it; the directive suggests `jentic access request --toolkit
     <vendor/name> --wait`. File that and wait for approval.
@@ -457,7 +460,8 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
     bare `--toolkit` bind would be **denied** ("No toolkit serves API …"); the
     directive suggests `--provision` instead — file that plan (propose `--auth`
     and `--rules-json` from the spec, pass `--reason`) and your operator fulfils
-    it in the dashboard.
+    it in the dashboard, into a new toolkit **or one they already have** — an
+    existing toolkit never has to be recreated.
   - **424 `credential_not_provisioned`** → the directive gives a
     `provisioning_url` for your operator to connect an account (an access
     request won't help).


### PR DESCRIPTION
## What

The release CI on `main` is failing in **Unit tests → architecture tests** (`tests/arch/test_skill_drift.py`): the two generated `jentic.md` skill mirrors have drifted from the single source of truth.

```
skills_sync: out of date: cli/internal/skillgen/content/jentic.md (run `make skills`)
skills_sync: out of date: src/jentic_one/shared/web/content/jentic.md (run `make skills`)
2 failed, 139 passed ... test-arch Error 1
```

## Why (root cause)

- #966 (`feat(skills): distribute a served skill set to agents`) introduced the single source of truth at `skills/jentic/SKILL.md` + the `make skills` generator + the drift guard.
- #911 (`surface existing-toolkit reuse on the provision path`) was branched **before** #966 and, following the then-current model, edited the **generated mirrors** (`cli/internal/skillgen/content/jentic.md` and `src/jentic_one/shared/web/content/jentic.md`) directly with its reuse/recovery guidance.
- #911 merged **after** #966, so its two additions landed in the mirrors but never in the new source. The mirrors ended up *ahead* of `skills/jentic/SKILL.md` → drift → arch test fails on `main`.

## Fix

Port #911's two reuse blurbs into the **source** `skills/jentic/SKILL.md` and regenerate with `make skills`. This **preserves #911's intent** (agents keep the "you can reuse an existing toolkit" guidance) rather than reverting it. The regenerated mirrors come out **byte-identical to their current committed content**, so this PR touches only the source file — the mirrors are a net-zero regeneration.

## Verification

- `make skills` → mirrors unchanged (net-zero); only `skills/jentic/SKILL.md` differs.
- `tests/arch/test_skill_drift.py` → 7 passed.
- Full `tests/arch` suite → 273 passed.
- `GOWORK=off go build ./internal/skillgen/...` → clean (embed still compiles).

Made with [Cursor](https://cursor.com)