### PR TITLE
cli(v2): Phase 2: The UX Strategy & Machine Contract

### DIFF
--- a/cli/internal/cli/clictx/clictx.go
+++ b/cli/internal/cli/clictx/clictx.go
@@ -64,16 +64,21 @@ func ResolveActiveState(contextOverride, modeOverride string) (*ActiveState, err
 
 	return &ActiveState{
 		ResolvedState: rs,
-		Mode:          resolveMode(modeOverride, rs.PersistedMode),
+		Mode:          ResolveMode(modeOverride, rs.PersistedMode),
 		ThemeName:     rs.PersistedTheme,
 	}, nil
 }
 
-// resolveMode implements the mode ladder (impl/1.2 §resolveMode, impl/3.2 §2):
+// ResolveMode implements the mode ladder (impl/1.2 §resolveMode, impl/3.2 §2):
 // --mode > $JENTIC_MODE > persisted-context-mode > human. There is deliberately
 // NO TTY rung — mode is an explicit choice, and an unknown value is validated
 // (fail-closed to agent) at UX construction in the root interceptor, not here.
-func resolveMode(flagOverride, persisted string) string {
+//
+// Exported so the root interceptor can re-apply the same ladder on its
+// state-resolution FALLBACK path: when there is no config at all, mode must still
+// honor --mode/$JENTIC_MODE. Fencing is a safety control — it must never silently
+// degrade to unfenced human just because config resolution failed.
+func ResolveMode(flagOverride, persisted string) string {
 	if flagOverride != "" {
 		return flagOverride
 	}

--- a/cli/internal/cli/clictx/clictx.go
+++ b/cli/internal/cli/clictx/clictx.go
@@ -1,0 +1,129 @@
+// Package clictx is the CLI-only leaf that bridges the UX-free SDK config
+// (client/config) to the Cobra command layer. It exists as its own package to
+// break an import cycle: the root interceptor (impl/3.2) and the client helpers
+// (impl/4.2) both need the resolved ActiveState, but neither may live in client/
+// (SDK-clean) nor pull in the whole command tree.
+//
+// Responsibilities that live strictly HERE, never in client/ (impl/3.2 "adapter
+// boundary"):
+//  1. Mode/Theme interpretation — the SDK carries only raw PersistedMode/Theme
+//     strings; ResolveActiveState applies flag overrides + the precedence ladder.
+//  2. The pre-activation legacy-read adapter — until `jentic migrate` reaches
+//     end-of-life, a user with no XDG config still resolves state from the legacy
+//     ~/.jentic profile store, so wrapping commands in the Audience is a no-op for
+//     existing users (plan Phase 2 item 1, 16 §5, 14 BC-1).
+//  3. State injection into the Cobra context (WithActiveState/FromContext).
+package clictx
+
+import (
+	"context"
+	"os"
+
+	sdkconfig "github.com/jentic/jentic-one/cli/client/config"
+	legacyconfig "github.com/jentic/jentic-one/cli/internal/config"
+)
+
+// Canonical mode strings (14 BC-9; mirrored in client/config Context.Mode docs).
+const (
+	ModeHuman          = "human"
+	ModeAgent          = "agent"
+	ModeServiceAccount = "service-account"
+)
+
+// ActiveState is the CLI's resolved view of the world: the SDK's UX-free
+// ResolvedState plus the CLI-only Mode/ThemeName the SDK deliberately leaves
+// uninterpreted. It embeds *ResolvedState so command code reads BaseURL/identity
+// through the same value.
+type ActiveState struct {
+	*sdkconfig.ResolvedState
+
+	// Mode is the resolved canonical mode ("human"/"agent"/"service-account").
+	Mode string
+	// ThemeName is the resolved config theme name fed to theme.ResolveTheme (the
+	// --theme/JENTIC_THEME overrides are applied by the theme resolver, not here).
+	ThemeName string
+}
+
+// ResolveActiveState loads state and layers the CLI mode/theme interpretation on
+// top. contextOverride is --context (may be ""); modeOverride is --mode (may be "").
+//
+// Resolution order:
+//  1. client/config.LoadState (env-var file-less path, else XDG config.yaml).
+//  2. On "no XDG config" ONLY, fall back to the legacy ~/.jentic adapter so
+//     unmigrated users keep working. Any other LoadState error propagates.
+//  3. Apply the mode ladder: --mode > $JENTIC_MODE > persisted > human.
+func ResolveActiveState(contextOverride, modeOverride string) (*ActiveState, error) {
+	rs, err := sdkconfig.LoadState(contextOverride)
+	if err != nil {
+		legacy, ok := loadLegacyState()
+		if !ok {
+			return nil, err // no XDG config AND no legacy config: surface the original error
+		}
+		rs = legacy
+	}
+
+	return &ActiveState{
+		ResolvedState: rs,
+		Mode:          resolveMode(modeOverride, rs.PersistedMode),
+		ThemeName:     rs.PersistedTheme,
+	}, nil
+}
+
+// resolveMode implements the mode ladder (impl/1.2 §resolveMode, impl/3.2 §2):
+// --mode > $JENTIC_MODE > persisted-context-mode > human. There is deliberately
+// NO TTY rung — mode is an explicit choice, and an unknown value is validated
+// (fail-closed to agent) at UX construction in the root interceptor, not here.
+func resolveMode(flagOverride, persisted string) string {
+	if flagOverride != "" {
+		return flagOverride
+	}
+	if env := os.Getenv("JENTIC_MODE"); env != "" { // reserved: 14 BC-9
+		return env
+	}
+	if persisted != "" {
+		return persisted
+	}
+	return ModeHuman
+}
+
+// loadLegacyState reads the legacy ~/.jentic profile store and maps it onto the
+// SDK ResolvedState shape (read-only; the adapter never writes the legacy tree).
+// Returns ok=false when no legacy config file exists, so the caller can surface
+// the original "no configuration" error rather than a silent empty state.
+//
+// The legacy store has no mode/theme concept, so those are left empty — the mode
+// ladder resolves them to human/default, which is exactly V1's behavior. This is
+// the pre-activation compatibility shim; it retires with `jentic migrate`'s
+// end-of-life (14 BC-1).
+func loadLegacyState() (*sdkconfig.ResolvedState, bool) {
+	paths, err := legacyconfig.NewPaths()
+	if err != nil {
+		return nil, false
+	}
+	fc, err := legacyconfig.Load(paths)
+	if err != nil || fc == nil || !fc.Loaded {
+		return nil, false
+	}
+	return &sdkconfig.ResolvedState{
+		IdentityName:    fc.ResolvedDefaultProfile(),
+		EnvironmentName: "legacy",
+		BaseURL:         fc.ResolvedBaseURL(),
+		// PersistedMode/PersistedTheme intentionally empty -> human/default.
+	}, true
+}
+
+type contextKey string
+
+const activeStateKey contextKey = "jentic_active_state"
+
+// WithActiveState stores the resolved state in the Cobra context.
+func WithActiveState(ctx context.Context, s *ActiveState) context.Context {
+	return context.WithValue(ctx, activeStateKey, s)
+}
+
+// FromContext retrieves the ActiveState, or nil if the root interceptor did not
+// run (callers that need it should treat nil as a wiring error).
+func FromContext(ctx context.Context) *ActiveState {
+	s, _ := ctx.Value(activeStateKey).(*ActiveState)
+	return s
+}

--- a/cli/internal/cli/clictx/clictx_test.go
+++ b/cli/internal/cli/clictx/clictx_test.go
@@ -1,0 +1,121 @@
+package clictx
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveMode_Ladder(t *testing.T) {
+	t.Setenv("JENTIC_MODE", "")
+	os.Unsetenv("JENTIC_MODE")
+
+	if got := resolveMode("agent", "human"); got != "agent" {
+		t.Errorf("--mode override lost: %q", got)
+	}
+
+	t.Setenv("JENTIC_MODE", "service-account")
+	if got := resolveMode("", "human"); got != "service-account" {
+		t.Errorf("JENTIC_MODE not honored: %q", got)
+	}
+
+	t.Setenv("JENTIC_MODE", "")
+	os.Unsetenv("JENTIC_MODE")
+	if got := resolveMode("", "agent"); got != "agent" {
+		t.Errorf("persisted mode not honored: %q", got)
+	}
+	if got := resolveMode("", ""); got != ModeHuman {
+		t.Errorf("default should be human, got %q", got)
+	}
+}
+
+func TestResolveActiveState_FileLess(t *testing.T) {
+	// The SDK file-less path (JENTIC_BASE_URL + JENTIC_BEARER_TOKEN) resolves to
+	// agent mode with an injected token, bypassing disk entirely.
+	t.Setenv("JENTIC_BASE_URL", "https://example.test")
+	t.Setenv("JENTIC_BEARER_TOKEN", "tok-123")
+	t.Setenv("JENTIC_MODE", "")
+	os.Unsetenv("JENTIC_MODE")
+
+	st, err := ResolveActiveState("", "")
+	if err != nil {
+		t.Fatalf("file-less resolve failed: %v", err)
+	}
+	if st.Mode != ModeAgent {
+		t.Errorf("file-less mode = %q, want agent", st.Mode)
+	}
+	if st.BaseURL != "https://example.test" || st.InjectedBearerToken != "tok-123" {
+		t.Errorf("file-less state not mapped: %+v", st.ResolvedState)
+	}
+}
+
+func TestResolveActiveState_LegacyFallback(t *testing.T) {
+	// No XDG config, but a legacy ~/.jentic/config.yaml exists: the adapter must
+	// resolve state (V1 keeps working) rather than erroring.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Isolate the XDG path so LoadState finds nothing there.
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-empty"))
+	t.Setenv("JENTIC_HOME", "")
+	os.Unsetenv("JENTIC_HOME")
+	// Ensure file-less env is off.
+	t.Setenv("JENTIC_BASE_URL", "")
+	os.Unsetenv("JENTIC_BASE_URL")
+	t.Setenv("JENTIC_BEARER_TOKEN", "")
+	os.Unsetenv("JENTIC_BEARER_TOKEN")
+	t.Setenv("JENTIC_MODE", "")
+	os.Unsetenv("JENTIC_MODE")
+
+	// Write a minimal legacy config at ~/.jentic/config.yaml.
+	legacyDir := filepath.Join(home, ".jentic")
+	if err := os.MkdirAll(legacyDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	legacy := "base_url: https://legacy.test\ndefault_profile: oldprofile\n"
+	if err := os.WriteFile(filepath.Join(legacyDir, "config.yaml"), []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := ResolveActiveState("", "")
+	if err != nil {
+		t.Fatalf("legacy fallback should resolve, got error: %v", err)
+	}
+	if st.BaseURL != "https://legacy.test" {
+		t.Errorf("legacy base URL not mapped: %q", st.BaseURL)
+	}
+	if st.IdentityName != "oldprofile" {
+		t.Errorf("legacy profile not mapped to identity: %q", st.IdentityName)
+	}
+	// Legacy store has no mode -> defaults to human.
+	if st.Mode != ModeHuman {
+		t.Errorf("legacy mode should default to human, got %q", st.Mode)
+	}
+}
+
+func TestResolveActiveState_NoConfigErrors(t *testing.T) {
+	// No XDG config AND no legacy config: surface the original error.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-empty"))
+	t.Setenv("JENTIC_HOME", "")
+	os.Unsetenv("JENTIC_HOME")
+	t.Setenv("JENTIC_BASE_URL", "")
+	os.Unsetenv("JENTIC_BASE_URL")
+	t.Setenv("JENTIC_BEARER_TOKEN", "")
+	os.Unsetenv("JENTIC_BEARER_TOKEN")
+
+	if _, err := ResolveActiveState("", ""); err == nil {
+		t.Error("expected an error when neither XDG nor legacy config exists")
+	}
+}
+
+func TestActiveStateContextRoundTrip(t *testing.T) {
+	st := &ActiveState{Mode: ModeAgent, ThemeName: "no-color"}
+	ctx := WithActiveState(t.Context(), st)
+	if got := FromContext(ctx); got == nil || got.Mode != ModeAgent {
+		t.Errorf("ActiveState did not round-trip: %+v", got)
+	}
+	if FromContext(t.Context()) != nil {
+		t.Error("missing ActiveState should return nil")
+	}
+}

--- a/cli/internal/cli/clictx/clictx_test.go
+++ b/cli/internal/cli/clictx/clictx_test.go
@@ -10,21 +10,21 @@ func TestResolveMode_Ladder(t *testing.T) {
 	t.Setenv("JENTIC_MODE", "")
 	os.Unsetenv("JENTIC_MODE")
 
-	if got := resolveMode("agent", "human"); got != "agent" {
+	if got := ResolveMode("agent", "human"); got != "agent" {
 		t.Errorf("--mode override lost: %q", got)
 	}
 
 	t.Setenv("JENTIC_MODE", "service-account")
-	if got := resolveMode("", "human"); got != "service-account" {
+	if got := ResolveMode("", "human"); got != "service-account" {
 		t.Errorf("JENTIC_MODE not honored: %q", got)
 	}
 
 	t.Setenv("JENTIC_MODE", "")
 	os.Unsetenv("JENTIC_MODE")
-	if got := resolveMode("", "agent"); got != "agent" {
+	if got := ResolveMode("", "agent"); got != "agent" {
 		t.Errorf("persisted mode not honored: %q", got)
 	}
-	if got := resolveMode("", ""); got != ModeHuman {
+	if got := ResolveMode("", ""); got != ModeHuman {
 		t.Errorf("default should be human, got %q", got)
 	}
 }

--- a/cli/internal/cli/ux/agent.go
+++ b/cli/internal/cli/ux/agent.go
@@ -1,0 +1,89 @@
+package ux
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/jentic/jentic-one/cli/internal/theme"
+)
+
+// AgentUX is the ruthlessly strict machine mode shared by `agent` and
+// `service-account` (impl/3.1 §0): never prompts, no color, one JSON document per
+// Render on stdout, structured error envelope on stderr.
+type AgentUX struct {
+	theme theme.Palette
+	// assumeYes mirrors the global --yes. AgentUX cannot prompt, so this is the ONLY
+	// way AskConfirm returns true for an agent (the root hook wires it in).
+	assumeYes bool
+}
+
+// NewAgentUX builds the agent audience. The palette is always no-color.
+func NewAgentUX(assumeYes bool) *AgentUX {
+	return &AgentUX{theme: theme.Themes["no-color"], assumeYes: assumeYes}
+}
+
+// Ask cannot prompt an agent; it returns a MISSING_ARGUMENT CodedError.
+func (a *AgentUX) Ask(_ /*question*/, flagName string, _ bool) (string, error) {
+	// Agents cannot be prompted. Fail immediately with a typed error so ReportError
+	// emits the machine contract's error_code (13 §3a).
+	return "", &CodedError{
+		Code:       CodeMissingArgument,
+		Msg:        fmt.Sprintf("the required flag '--%s' was not provided", flagName),
+		Actionable: fmt.Sprintf("Re-run the command with --%s <value>", flagName),
+	}
+}
+
+// AskConfirm returns true only if the global --yes pre-authorized; otherwise it
+// returns an INTERACTIVE_CONFIRM_BLOCKED CodedError.
+func (a *AgentUX) AskConfirm(_ string) (bool, error) {
+	// The global --yes is the explicit, auditable authorization; without it, reject
+	// with guidance rather than blocking.
+	if a.assumeYes {
+		return true, nil
+	}
+	return false, &CodedError{
+		Code:       CodeConfirmBlocked,
+		Msg:        "command requires confirmation",
+		Actionable: "Re-run with the '--yes' flag to explicitly authorize this action",
+	}
+}
+
+// Render writes one compact, redacted JSON document to stdout.
+func (a *AgentUX) Render(data any) {
+	// One compact JSON document per call (one object, or one array for collections),
+	// newline-terminated. NOT NDJSON: each Render produces exactly one top-level
+	// value — what oapi response structs unmarshal to.
+	fmt.Fprintln(os.Stdout, string(safeMarshal(data)))
+}
+
+// ReportError writes the redacted structured error envelope to stderr.
+func (a *AgentUX) ReportError(err error, step string) {
+	// JSON so the agent can parse it. safeMarshal routes the error string through the
+	// byte-level redaction backstop (M6): agents capture 2>&1, so an error echoing a
+	// backend body is scrubbed like any payload.
+	ae := AgentError{
+		SchemaVersion: currentSchemaVersion,
+		ErrorCode:     CodeInternalError, // fallback; unknown/internal => "stop and report"
+		Error:         err.Error(),
+		Actionable:    step,
+	}
+	var coded *CodedError
+	if errors.As(err, &coded) {
+		ae.ErrorCode = coded.Code
+		ae.Details = coded.Details
+		if ae.Actionable == "" {
+			ae.Actionable = coded.Actionable
+		}
+	}
+	fmt.Fprintln(os.Stderr, string(safeMarshal(ae)))
+}
+
+// Theme returns the agent (always no-color) palette.
+func (a *AgentUX) Theme() Palette { return a.theme }
+
+// IsFenced reports that agents are locked out of admin commands.
+func (a *AgentUX) IsFenced() bool { return true }
+
+// ForcesNoColor reports that agent output must never carry ANSI (protects LLM parsers).
+func (a *AgentUX) ForcesNoColor() bool { return true }

--- a/cli/internal/cli/ux/audience.go
+++ b/cli/internal/cli/ux/audience.go
@@ -1,0 +1,57 @@
+package ux
+
+import (
+	"os"
+
+	"github.com/charmbracelet/x/term"
+)
+
+// Audience is the sole gatekeeper between a command's business logic and the
+// caller's terminal. Commands must NEVER call fmt.Println / huh directly — they go
+// through an Audience so the CLI shape-shifts by mode (impl/3.1 §1).
+type Audience interface {
+	// Ask prompts for missing information. Humans get a TUI prompt; agents get a
+	// typed CodedError explaining the missing flag (no interactive fallback).
+	Ask(question, flagName string, required bool) (string, error)
+
+	// AskConfirm prompts for a destructive action. Humans get [y/N]; agents
+	// auto-reject unless the global --yes was passed.
+	AskConfirm(warning string) (bool, error)
+
+	// Render writes a success payload to stdout. Intentionally VOID: the only
+	// realistic failure is a marshal error on an exotic value (channel/func) — a
+	// programmer bug — which marshalRedacted turns into a guaranteed-encodable error
+	// envelope, so stdout always carries exactly one valid JSON document. Callers
+	// treat Render as a terminal "this succeeded".
+	Render(data any)
+
+	// ReportError writes a failure to stderr (never stdout — stdout is reserved for
+	// Render). Humans get a red line; agents get the structured error envelope. Both
+	// pass the byte-level redaction backstop (review M6).
+	ReportError(err error, actionableNextStep string)
+
+	// Theme returns the active palette.
+	Theme() Palette
+
+	// IsFenced reports whether this mode is forbidden from state-mutating admin
+	// commands (the root interceptor enforces it — impl/3.2 §2).
+	IsFenced() bool
+
+	// ForcesNoColor reports whether ANSI must be suppressed regardless of theme, to
+	// protect downstream machine parsers.
+	ForcesNoColor() bool
+}
+
+// promptable reports whether the current session may open an interactive prompt.
+// A TTY is necessary but NOT sufficient (jentic-one#841): TERM=dumb makes huh
+// switch to an accessible input loop that ignores context cancellation, so Ctrl-C
+// is swallowed on pty harnesses (emacs shell, expect, agent sandboxes). The rule
+// is TTY AND TERM != "dumb" (mode is checked by the caller — only HumanUX prompts).
+// A non-promptable human session behaves like agent Ask: fail with the missing-flag
+// instruction instead of hanging on a prompt.
+func promptable() bool {
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	return term.IsTerminal(os.Stdin.Fd())
+}

--- a/cli/internal/cli/ux/audience_test.go
+++ b/cli/internal/cli/ux/audience_test.go
@@ -1,0 +1,131 @@
+package ux
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestExitCodeFor(t *testing.T) {
+	cases := map[string]int{
+		CodeMissingArgument:   ExitError,
+		CodeFenced:            ExitError,
+		CodeBrokerDenied:      ExitDenied,
+		CodeResolveFailed:     ExitDenied,
+		CodeTimeoutPending:    ExitTimeoutPending,
+		CodePartialApproval:   ExitPartial,
+		CodePendingApproval:   ExitError, // exit 3 only via TIMEOUT_PENDING, a distinct code
+		"UNKNOWN_FUTURE_CODE": ExitError, // unknown => generic failure bucket
+		"":                    ExitError,
+	}
+	for code, want := range cases {
+		if got := exitCodeFor(code); got != want {
+			t.Errorf("exitCodeFor(%q) = %d, want %d", code, got, want)
+		}
+	}
+}
+
+func TestCodedError_SatisfiesExitCoder(t *testing.T) {
+	// CodedError.ExitCode() must map through the contract table.
+	var err error = &CodedError{Code: CodeBrokerDenied, Msg: "denied"}
+	type exitCoder interface{ ExitCode() int }
+	ec, ok := err.(exitCoder)
+	if !ok {
+		t.Fatal("CodedError does not satisfy the ExitCoder shape")
+	}
+	if ec.ExitCode() != ExitDenied {
+		t.Errorf("BROKER_DENIED exit = %d, want %d", ec.ExitCode(), ExitDenied)
+	}
+}
+
+func TestAgentUX_Ask_FailsWithMissingArgument(t *testing.T) {
+	a := NewAgentUX(false)
+	_, err := a.Ask("name?", "name", true)
+	var coded *CodedError
+	if !errors.As(err, &coded) || coded.Code != CodeMissingArgument {
+		t.Fatalf("Ask err = %v, want MISSING_ARGUMENT CodedError", err)
+	}
+}
+
+func TestAgentUX_AskConfirm(t *testing.T) {
+	// Without --yes: rejected with a coded error.
+	deny := NewAgentUX(false)
+	ok, err := deny.AskConfirm("delete everything?")
+	if ok {
+		t.Error("agent AskConfirm returned true without --yes")
+	}
+	var coded *CodedError
+	if !errors.As(err, &coded) || coded.Code != CodeConfirmBlocked {
+		t.Errorf("err = %v, want INTERACTIVE_CONFIRM_BLOCKED", err)
+	}
+	// With --yes: proceeds.
+	yes := NewAgentUX(true)
+	if ok, err := yes.AskConfirm("go?"); !ok || err != nil {
+		t.Errorf("agent --yes AskConfirm = (%v,%v), want (true,nil)", ok, err)
+	}
+}
+
+func TestAgentUX_ModeFlags(t *testing.T) {
+	a := NewAgentUX(false)
+	if !a.IsFenced() {
+		t.Error("AgentUX must be fenced")
+	}
+	if !a.ForcesNoColor() {
+		t.Error("AgentUX must force no-color")
+	}
+}
+
+// TestAgentError_EnvelopeShape verifies ReportError's envelope carries the coded
+// error's code, actionable step, and details, redacted. We can't easily capture
+// os.Stderr here without plumbing, so exercise the envelope construction directly
+// via safeMarshal on the same shape ReportError builds.
+func TestAgentError_EnvelopeShape(t *testing.T) {
+	coded := &CodedError{
+		Code:       CodeBrokerDenied,
+		Msg:        "broker denied: missing scope",
+		Actionable: "jentic access request --scope write:issues",
+		Details:    map[string]any{"http_status": 403, "api_key": "leaked-secret"},
+	}
+	ae := AgentError{
+		SchemaVersion: currentSchemaVersion,
+		ErrorCode:     coded.Code,
+		Error:         coded.Msg,
+		Actionable:    coded.Actionable,
+		Details:       coded.Details,
+	}
+	out := safeMarshal(ae)
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("envelope not valid JSON: %v", err)
+	}
+	if got["error_code"] != CodeBrokerDenied {
+		t.Errorf("error_code = %v", got["error_code"])
+	}
+	if got["schema_version"] != "1" {
+		t.Errorf("schema_version = %v", got["schema_version"])
+	}
+	// Details.api_key must be redacted even inside the error envelope.
+	details, _ := got["details"].(map[string]any)
+	if details["api_key"] != "[REDACTED]" {
+		t.Errorf("sensitive detail not redacted: %v", details["api_key"])
+	}
+}
+
+func TestHumanUX_ModeFlags(t *testing.T) {
+	h := NewHumanUX(Palette{}, false)
+	if h.IsFenced() {
+		t.Error("HumanUX must not be fenced")
+	}
+	if h.ForcesNoColor() {
+		t.Error("HumanUX must not force no-color")
+	}
+}
+
+func TestFromContext_FallsBackToAgent(t *testing.T) {
+	// No audience in context => strict agent fallback (never a human prompt).
+	aud := FromContext(context.Background())
+	if !aud.IsFenced() {
+		t.Error("missing-audience fallback should be fenced agent mode")
+	}
+}

--- a/cli/internal/cli/ux/context.go
+++ b/cli/internal/cli/ux/context.go
@@ -1,0 +1,30 @@
+package ux
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+type contextKey string
+
+const audienceKey contextKey = "jentic_audience"
+
+// WithAudience stores the resolved Audience in the context for downstream commands.
+func WithAudience(ctx context.Context, aud Audience) context.Context {
+	return context.WithValue(ctx, audienceKey, aud)
+}
+
+// FromContext retrieves the Audience. If none is present it FAILS CLOSED to strict
+// agent mode (never a human prompt): reaching this branch means the root
+// PersistentPreRunE didn't run — a wiring bug. Silently dropping a human into
+// no-prompt agent mode is confusing to debug, so warn loudly on stderr (never
+// stdout — that must stay machine-parseable).
+func FromContext(ctx context.Context) Audience {
+	aud, ok := ctx.Value(audienceKey).(Audience)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "warning: no Audience in context; falling back to strict agent mode (root PersistentPreRunE may not have run)")
+		return NewAgentUX(false) // never auto-confirm destructive actions in the fallback
+	}
+	return aud
+}

--- a/cli/internal/cli/ux/contract.go
+++ b/cli/internal/cli/ux/contract.go
@@ -1,0 +1,62 @@
+package ux
+
+// This file is the Go encoding of the machine contract (13_agent_machine_contract
+// §3a/§4): the closed error_code enum and the exit-code taxonomy. It is the single
+// source of truth for the code->exit mapping that CodedError.ExitCode() uses, so
+// the emitted error_code and the process exit code can never drift apart.
+
+// Exit-code taxonomy (13 §4). core.Run maps any ExitCoder to these; nothing calls
+// os.Exit directly (arch rule).
+const (
+	ExitOK             = 0 // success (for execute: broker returned an upstream response, even a 4xx/5xx)
+	ExitError          = 1 // generic/local failure: transport, missing arg, fencing, CLI bug
+	ExitDenied         = 2 // Jentic said no: broker policy denial or resolve failure — change the ask, don't retry
+	ExitTimeoutPending = 3 // --wait expired while still pending: retry later is meaningful
+	ExitPartial        = 4 // partial approval of a composite request: inspect per-item status
+)
+
+// error_code enum (13 §3a). Closed set: agents treat an unknown code as
+// INTERNAL_ERROR-like ("stop and report"). New codes are additive; add them here
+// AND to errorCodeExit.
+const (
+	CodeMissingArgument    = "MISSING_ARGUMENT"
+	CodeConfirmBlocked     = "INTERACTIVE_CONFIRM_BLOCKED"
+	CodeFenced             = "FENCED_COMMAND"
+	CodeNotAuthenticated   = "NOT_AUTHENTICATED"
+	CodePendingApproval    = "PENDING_APPROVAL"
+	CodeResolveFailed      = "RESOLVE_FAILED"
+	CodeBrokerDenied       = "BROKER_DENIED"
+	CodeTimeoutPending     = "TIMEOUT_PENDING"
+	CodePartialApproval    = "PARTIAL_APPROVAL"
+	CodeConfinementMissing = "CONFINEMENT_UNAVAILABLE"
+	CodeTransportError     = "TRANSPORT_ERROR"
+	CodeInternalError      = "INTERNAL_ERROR"
+)
+
+// errorCodeExit maps each closed error_code to its exit code (13 §3a "Typical
+// exit" column). PENDING_APPROVAL is exit 1 here — the exit-3 variant is only for
+// the --wait timeout, which surfaces as TIMEOUT_PENDING, a distinct code.
+var errorCodeExit = map[string]int{
+	CodeMissingArgument:    ExitError,
+	CodeConfirmBlocked:     ExitError,
+	CodeFenced:             ExitError,
+	CodeNotAuthenticated:   ExitError,
+	CodePendingApproval:    ExitError,
+	CodeResolveFailed:      ExitDenied,
+	CodeBrokerDenied:       ExitDenied,
+	CodeTimeoutPending:     ExitTimeoutPending,
+	CodePartialApproval:    ExitPartial,
+	CodeConfinementMissing: ExitError,
+	CodeTransportError:     ExitError,
+	CodeInternalError:      ExitError,
+}
+
+// exitCodeFor returns the exit code for a closed error_code. An unknown/empty code
+// maps to ExitError (1) — fail toward the generic-failure bucket, matching the
+// "treat unknown as INTERNAL_ERROR" agent rule (13 §6).
+func exitCodeFor(code string) int {
+	if c, ok := errorCodeExit[code]; ok {
+		return c
+	}
+	return ExitError
+}

--- a/cli/internal/cli/ux/envelope.go
+++ b/cli/internal/cli/ux/envelope.go
@@ -1,0 +1,96 @@
+package ux
+
+import "github.com/jentic/jentic-one/cli/internal/theme"
+
+// Palette aliases the global theme palette so command code depends only on ux.
+type Palette = theme.Palette
+
+// Result is the canonical success payload for state-mutating commands (context
+// use, env add, identity add, credential create, identity register, ...). It
+// replaces ad-hoc map[string]string literals: those had no compile-time safety
+// and drifted on key names and status verbs. Sensitive fields MUST use
+// `redact:"true"` so layer 1 scrubs them — never put a raw secret in Fields.
+type Result struct {
+	// SchemaVersion pins the envelope shape for agents (13 §2/§6). Call sites may
+	// leave it empty; marshalRedacted stamps the current version at render time.
+	SchemaVersion string `json:"schema_version"`
+	// Status is the outcome verb (StatusCreated, StatusSwitched, ...).
+	Status string `json:"status"`
+	// Resource is the kind of thing acted on ("environment", "context", "identity").
+	Resource string `json:"resource,omitempty"`
+	// Name is the human/identifier name of the affected resource, when it has one.
+	Name string `json:"name,omitempty"`
+	// ID is the server- or client-assigned identifier, when one was produced.
+	ID string `json:"id,omitempty"`
+	// Message is optional human-oriented context (e.g. "awaiting operator approval").
+	Message string `json:"message,omitempty"`
+	// Fields is the escape hatch for genuinely command-specific data. Prefer a
+	// first-class field above; use this only when nothing else fits.
+	Fields map[string]any `json:"fields,omitempty"`
+}
+
+// Status verbs — the closed set of outcomes a Result may report. Named constants
+// (not literals per call site) prevent the "added"/"created"/"switched" drift the
+// map[string]string approach allowed. Mirrors 13 §2.
+const (
+	StatusCreated    = "created"
+	StatusAdded      = "added"
+	StatusUpdated    = "updated"
+	StatusSwitched   = "switched"
+	StatusDeleted    = "deleted"
+	StatusRegistered = "registered"
+	StatusPending    = "pending"
+)
+
+// Page is the pagination envelope for list commands (13 §2, impl/3.3). It carries
+// the underlying items plus the opaque cursor for the next page. Cursor form only
+// — Jentic list APIs are cursor-paginated (data + has_more + next_cursor); there
+// is no page-number UX.
+type Page struct {
+	SchemaVersion string `json:"schema_version"`
+	Items         any    `json:"items"`
+	// NextToken is the opaque cursor for the next page; empty on the last page.
+	NextToken string `json:"next_token,omitempty"`
+}
+
+// HasNext reports whether another page is available.
+func (p Page) HasNext() bool { return p.NextToken != "" }
+
+// NextHint is the human-mode footer telling the user how to fetch the next page.
+// Cursor APIs use `--cursor <token>` (never `--page N`), so the hint is explicit
+// about the token to pass.
+func (p Page) NextHint() string {
+	if !p.HasNext() {
+		return ""
+	}
+	return "More results available. Re-run with --cursor " + p.NextToken
+}
+
+// CodedError is the typed error every fenced/validation/denial path returns so the
+// error envelope can carry a closed-enum error_code. The enum values and their
+// exit codes are owned by 13 §3a — do not invent codes here; add them to
+// errorCodeExit in contract.go.
+type CodedError struct {
+	Code       string         // e.g. "MISSING_ARGUMENT", "BROKER_DENIED"
+	Msg        string         // human/LLM-readable prose (redacted on output)
+	Actionable string         // machine-runnable recovery step, when one exists
+	Details    map[string]any // e.g. {"agent_directive": ..., "http_status": 403}
+}
+
+func (e *CodedError) Error() string { return e.Msg }
+
+// ExitCode makes every CodedError satisfy pkg/core's ExitCoder mechanically, so
+// core.Run maps the closed enum to the exit taxonomy (13 §4) with no per-command
+// wiring. Without it, a forgotten wrapper would exit 1 even for BROKER_DENIED
+// (exit 2) or TIMEOUT_PENDING (exit 3). The code->exit table lives in contract.go.
+func (e *CodedError) ExitCode() int { return exitCodeFor(e.Code) }
+
+// AgentError is the stderr error envelope — the Go shape of the contract in 13 §3.
+// That document is canonical; this struct mirrors it.
+type AgentError struct {
+	SchemaVersion string         `json:"schema_version"`
+	ErrorCode     string         `json:"error_code"`
+	Error         string         `json:"error"`
+	Actionable    string         `json:"actionable_step,omitempty"`
+	Details       map[string]any `json:"details,omitempty"`
+}

--- a/cli/internal/cli/ux/envelope.go
+++ b/cli/internal/cli/ux/envelope.go
@@ -56,6 +56,16 @@ type Page struct {
 // HasNext reports whether another page is available.
 func (p Page) HasNext() bool { return p.NextToken != "" }
 
+// NewPage builds a Page envelope from a typed item slice and the opaque
+// next-page cursor (empty on the last page). It is the bridge from the SDK's
+// client/paginate walk helper (whose Page[T].Next is the cursor) to the machine
+// contract's rendered envelope: a command walks pages with paginate.All/ForEach,
+// then hands the collected items here for Render. Kept generic so callers pass
+// their concrete []T without an interface conversion at the call site.
+func NewPage[T any](items []T, nextToken string) Page {
+	return Page{Items: items, NextToken: nextToken}
+}
+
 // NextHint is the human-mode footer telling the user how to fetch the next page.
 // Cursor APIs use `--cursor <token>` (never `--page N`), so the hint is explicit
 // about the token to pass.

--- a/cli/internal/cli/ux/envelope_test.go
+++ b/cli/internal/cli/ux/envelope_test.go
@@ -1,0 +1,60 @@
+package ux
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNewPage_AndHints(t *testing.T) {
+	last := NewPage([]string{"a", "b"}, "")
+	if last.HasNext() {
+		t.Error("empty NextToken should mean no next page")
+	}
+	if last.NextHint() != "" {
+		t.Errorf("last page should have no hint, got %q", last.NextHint())
+	}
+
+	more := NewPage([]int{1, 2, 3}, "cursor-xyz")
+	if !more.HasNext() {
+		t.Error("non-empty NextToken should mean HasNext")
+	}
+	if !strings.Contains(more.NextHint(), "--cursor cursor-xyz") {
+		t.Errorf("hint should name the cursor flag+token, got %q", more.NextHint())
+	}
+}
+
+func TestPage_RendersAsAgentEnvelope(t *testing.T) {
+	// AgentUX.Render on a Page must emit the {schema_version, items, next_token}
+	// envelope. We assert the marshaled shape (Render writes to os.Stdout).
+	p := NewPage([]map[string]any{{"id": "1"}}, "next-1")
+	out := safeMarshal(p)
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("page envelope not valid JSON: %v", err)
+	}
+	if got["schema_version"] != "1" {
+		t.Errorf("schema_version = %v", got["schema_version"])
+	}
+	if got["next_token"] != "next-1" {
+		t.Errorf("next_token = %v", got["next_token"])
+	}
+	if _, ok := got["items"]; !ok {
+		t.Error("items key missing from page envelope")
+	}
+}
+
+func TestResult_StatusVerbsAreClosed(t *testing.T) {
+	// The status constants are the closed vocabulary (13 §2); guard the values so a
+	// rename is a visible break.
+	want := map[string]string{
+		StatusCreated: "created", StatusAdded: "added", StatusUpdated: "updated",
+		StatusSwitched: "switched", StatusDeleted: "deleted",
+		StatusRegistered: "registered", StatusPending: "pending",
+	}
+	for got, exp := range want {
+		if got != exp {
+			t.Errorf("status verb drift: %q != %q", got, exp)
+		}
+	}
+}

--- a/cli/internal/cli/ux/human.go
+++ b/cli/internal/cli/ux/human.go
@@ -1,0 +1,138 @@
+package ux
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/jentic/jentic-one/cli/internal/theme"
+)
+
+// HumanUX is the interactive mode: huh prompts, themed accents, indented JSON /
+// formatted lines on stdout, a red error line on stderr.
+type HumanUX struct {
+	theme     theme.Palette
+	assumeYes bool // --yes: skip the [y/N] prompt and proceed
+}
+
+// NewHumanUX builds the human audience with the resolved palette and the global
+// --yes setting.
+func NewHumanUX(t Palette, assumeYes bool) *HumanUX {
+	return &HumanUX{theme: t, assumeYes: assumeYes}
+}
+
+// Ask prompts the human for a value, or fails with a missing-flag CodedError when
+// the session is not promptable.
+func (h *HumanUX) Ask(question, flagName string, required bool) (string, error) {
+	// A TTY is necessary but not sufficient (jentic-one#841): a non-promptable human
+	// session (piped, TERM=dumb) must NOT open a form that can hang uncancellably.
+	// Behave like agent Ask instead — fail with the missing-flag instruction.
+	if !promptable() {
+		return "", &CodedError{
+			Code:       CodeMissingArgument,
+			Msg:        fmt.Sprintf("the required flag '--%s' was not provided", flagName),
+			Actionable: fmt.Sprintf("Re-run the command with --%s <value>", flagName),
+		}
+	}
+
+	var response string
+	err := huh.NewInput().
+		Title(question).
+		Description("Equivalent to passing --" + flagName).
+		Value(&response).
+		Run()
+	if err != nil {
+		return "", err
+	}
+	if required && response == "" {
+		return "", errors.New("this field is required")
+	}
+	return response, nil
+}
+
+// AskConfirm asks the human for [y/N] confirmation (auto-yes when --yes was set).
+func (h *HumanUX) AskConfirm(warning string) (bool, error) {
+	// --yes pre-authorizes: skip the prompt entirely.
+	if h.assumeYes {
+		return true, nil
+	}
+	// Non-promptable human session: reject with guidance instead of hanging.
+	if !promptable() {
+		return false, &CodedError{
+			Code:       CodeConfirmBlocked,
+			Msg:        "command requires confirmation but the session is not interactive",
+			Actionable: "Re-run with the '--yes' flag to authorize this action",
+		}
+	}
+	var confirm bool
+	err := huh.NewConfirm().Title(warning).Value(&confirm).Run()
+	return confirm, err
+}
+
+// Render writes data to stdout: Page footers, Result status lines, or indented JSON.
+func (h *HumanUX) Render(data any) {
+	// Paginated results arrive wrapped in a Page: render the items, then a navigation
+	// footer. Non-paginated data falls through to the type switch below.
+	if page, ok := data.(Page); ok {
+		fmt.Fprintln(os.Stdout, string(safeMarshalIndent(page.Items)))
+		if page.HasNext() {
+			hint := lipgloss.NewStyle().Foreground(h.theme.Muted)
+			fmt.Fprintln(os.Stdout, hint.Render("\n"+page.NextHint()))
+		}
+		return
+	}
+
+	// State-changing commands hand us a Result: render one styled status line
+	// ("✓ environment 'local' added") rather than a raw JSON dump.
+	if res, ok := data.(Result); ok {
+		fmt.Fprintln(os.Stdout, h.renderResultLine(res))
+		return
+	}
+
+	// Everything else: pretty-printed JSON (data uses the default terminal color;
+	// theme colors are for UI accents, not raw data).
+	fmt.Fprintln(os.Stdout, string(safeMarshalIndent(data)))
+}
+
+// renderResultLine composes the one-line human confirmation for a Result.
+func (h *HumanUX) renderResultLine(res Result) string {
+	ok := lipgloss.NewStyle().Foreground(h.theme.Success).Bold(true)
+	subject := res.Resource
+	if res.Name != "" {
+		subject = fmt.Sprintf("%s '%s'", res.Resource, res.Name)
+	}
+	line := ok.Render("✓") + " "
+	if subject != "" {
+		line += fmt.Sprintf("%s %s.", subject, res.Status)
+	} else {
+		line += res.Status
+	}
+	if res.Message != "" {
+		line += " " + res.Message
+	}
+	return line
+}
+
+// ReportError writes a redacted, styled error line (and optional next step) to stderr.
+func (h *HumanUX) ReportError(err error, step string) {
+	// Errors MUST go to stderr: stdout is reserved for Render payloads (a single
+	// stray byte corrupts a downstream parser). Redact the error path too (M6):
+	// error strings routinely echo backend bodies and callers capture 2>&1.
+	msg := redactString(err.Error())
+	style := lipgloss.NewStyle().Foreground(h.theme.Error).Bold(true)
+	fmt.Fprintf(os.Stderr, "%s\n", style.Render("✖ Error: "+msg))
+	if step != "" {
+		fmt.Fprintf(os.Stderr, "  Next Step: %s\n", step)
+	}
+}
+
+// Theme returns the resolved human palette.
+func (h *HumanUX) Theme() Palette { return h.theme }
+
+// IsFenced reports that humans may run admin commands.
+func (h *HumanUX) IsFenced() bool { return false }
+
+// ForcesNoColor reports that human mode respects theme/color preferences.
+func (h *HumanUX) ForcesNoColor() bool { return false }

--- a/cli/internal/cli/ux/human.go
+++ b/cli/internal/cli/ux/human.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/jentic/jentic-one/cli/internal/install"
 	"github.com/jentic/jentic-one/cli/internal/theme"
 )
 
@@ -38,11 +39,15 @@ func (h *HumanUX) Ask(question, flagName string, required bool) (string, error) 
 	}
 
 	var response string
-	err := huh.NewInput().
-		Title(question).
-		Description("Equivalent to passing --" + flagName).
-		Value(&response).
-		Run()
+	// Route through install.Input so the prompt inherits the shared brand theme and
+	// the TERM=dumb-safe keymap/quit handling (the form-guard test enforces this;
+	// it's also the jentic-one#841 fix promptable() guards against).
+	err := install.NewForm(huh.NewGroup(
+		install.Input().
+			Title(question).
+			Description("Equivalent to passing --" + flagName).
+			Value(&response),
+	)).Run()
 	if err != nil {
 		return "", err
 	}
@@ -67,7 +72,9 @@ func (h *HumanUX) AskConfirm(warning string) (bool, error) {
 		}
 	}
 	var confirm bool
-	err := huh.NewConfirm().Title(warning).Value(&confirm).Run()
+	// install.RunConfirm applies the shared theme + quit keymap and the fixed
+	// confirm handling (no swallowed first-Enter).
+	err := install.RunConfirm(huh.NewConfirm().Title(warning).Value(&confirm))
 	return confirm, err
 }
 

--- a/cli/internal/cli/ux/redact.go
+++ b/cli/internal/cli/ux/redact.go
@@ -1,0 +1,384 @@
+// Package ux is the CLI's audience-aware I/O layer (impl/3.1, impl/3.2). Commands
+// never call fmt.Println / huh directly — they go through an Audience, so the CLI
+// shape-shifts by mode (human vs agent/service-account) and every output byte,
+// on BOTH stdout and stderr, passes the fail-closed redaction funnel in this file.
+package ux
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// --- Layer 1 support: generated SensitiveFields tables -----------------------
+
+// sensitiveFieldsByType maps a generated struct's type NAME (e.g.
+// "CredentialResponse") to the json names of its `x-sensitive` properties
+// (impl/2.1 §4b). oapi-codegen emits no custom struct tags, so redactTagged can't
+// see a `redact:"true"` on generated types; instead it consults this table by
+// type name. The composition layer registers the real per-plane tables via
+// RegisterSensitiveFields so ux stays decoupled from client/generated (and unit-
+// testable). Guarded by a mutex only for registration-at-init safety.
+var (
+	sensitiveFieldsMu   sync.RWMutex
+	sensitiveFieldsType = map[string]map[string]bool{}
+)
+
+// RegisterSensitiveFields merges a plane's generated SensitiveFields table
+// (type name -> []json field names) into the redaction registry. Idempotent and
+// additive; call once per plane at startup.
+func RegisterSensitiveFields(table map[string][]string) {
+	sensitiveFieldsMu.Lock()
+	defer sensitiveFieldsMu.Unlock()
+	for typeName, fields := range table {
+		set := sensitiveFieldsType[typeName]
+		if set == nil {
+			set = make(map[string]bool, len(fields))
+			sensitiveFieldsType[typeName] = set
+		}
+		for _, f := range fields {
+			set[f] = true
+		}
+	}
+}
+
+func sensitiveFieldsFor(typeName string) map[string]bool {
+	sensitiveFieldsMu.RLock()
+	defer sensitiveFieldsMu.RUnlock()
+	return sensitiveFieldsType[typeName]
+}
+
+// --- Layer 2 support: key heuristics -----------------------------------------
+
+// sensitiveKeyExact: keys that ARE a secret name (exact, case-insensitive after
+// camelToSnake). Includes the bare spellings of the suffix rules below, because a
+// bare name never matches its own "_"-prefixed suffix ("api_key" doesn't end in
+// "_api_key"). The impl/0.0 §2 redaction unit tests assert these.
+var sensitiveKeyExact = map[string]bool{
+	"authorization": true,
+	"x-api-key":     true,
+	"jwt":           true,
+	"assertion":     true,
+	"cookie":        true,
+	"set-cookie":    true,
+	"password":      true,
+	"passwd":        true,
+	"secret":        true,
+	"token":         true,
+	"api_key":       true,
+	"apikey":        true,
+	"private_key":   true,
+	"privatekey":    true,
+	"signing_key":   true,
+	"signingkey":    true,
+	"credential":    true,
+	"credentials":   true,
+}
+
+// sensitiveKeySuffixes: redact only when the (snake-cased) key ENDS with one of
+// these. Suffix (not substring) matching is what excludes the false positives
+// (next_token, token_count, public_key, key_id, secret_name, password_policy).
+var sensitiveKeySuffixes = []string{
+	"_token",
+	"_secret",
+	"_password",
+	"_passwd",
+	"_api_key",
+	"_apikey",
+	"_private_key",
+	"_privatekey",
+	"_signing_key",
+	"_credential",
+	"_credentials",
+}
+
+// sensitiveKeyAllowlist: keys that LOOK sensitive by the suffix/exact rules but are
+// known-safe and MUST NOT be redacted, because redacting them corrupts output
+// agents depend on. `next_token` is a pagination cursor (ends in `_token`);
+// `has_api_key`/`has_credentials` are booleans reporting presence, not the secret
+// itself. These win over the exact/suffix matches below (impl/3.1 §1 names them as
+// the false positives the scoped design must protect; mirrored in the arch sweep
+// allowlist, tests/arch/spec_test.go).
+var sensitiveKeyAllowlist = map[string]bool{
+	"next_token":      true,
+	"has_api_key":     true,
+	"has_credentials": true,
+	"has_credential":  true,
+}
+
+// isSensitiveKey reports whether a (case-insensitive) key should be redacted. The
+// key is normalized camelCase -> snake_case first so apiKey/clientSecret match the
+// same rules as api_key/client_secret (many JS backends emit camelCase).
+func isSensitiveKey(key string) bool {
+	k := camelToSnake(key)
+	if sensitiveKeyAllowlist[k] {
+		return false // known-safe: beats the exact/suffix rules below
+	}
+	if sensitiveKeyExact[k] {
+		return true
+	}
+	for _, suf := range sensitiveKeySuffixes {
+		if strings.HasSuffix(k, suf) {
+			return true
+		}
+	}
+	return false
+}
+
+// camelToSnake lowercases a key, inserting `_` at word boundaries. ACRONYM-AWARE:
+// a run of capitals is one word, so "APIKey" -> "api_key" and "HTTPSProxy" ->
+// "https_proxy" (a naive per-capital split gives "a_p_i_key", which matches
+// nothing and lets the key escape). Existing separators pass through.
+func camelToSnake(key string) string {
+	rs := []rune(key)
+	var b strings.Builder
+	for i, r := range rs {
+		if r >= 'A' && r <= 'Z' {
+			prevLower := i > 0 && (rs[i-1] >= 'a' && rs[i-1] <= 'z' || rs[i-1] >= '0' && rs[i-1] <= '9')
+			nextLower := i+1 < len(rs) && rs[i+1] >= 'a' && rs[i+1] <= 'z'
+			prevUpper := i > 0 && rs[i-1] >= 'A' && rs[i-1] <= 'Z'
+			if prevLower || (prevUpper && nextLower) {
+				b.WriteByte('_')
+			}
+			r += 'a' - 'A'
+		}
+		b.WriteRune(r)
+	}
+	return strings.ReplaceAll(b.String(), "__", "_")
+}
+
+// redactValue returns a REDACTED DEEP COPY of an already-unmarshaled generic value
+// (map/slice/scalar). It never mutates the input (a command may reuse the struct
+// after Render). A depth cap guards adversarially deep/cyclic payloads: beyond
+// maxRedactDepth the subtree is replaced wholesale — fail CLOSED.
+const maxRedactDepth = 64
+
+func redactValue(v any) any { return redactValueDepth(v, 0) }
+
+func redactValueDepth(v any, depth int) any {
+	if depth > maxRedactDepth {
+		return "[REDACTED: too deep]"
+	}
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			if isSensitiveKey(k) {
+				out[k] = "[REDACTED]"
+			} else {
+				out[k] = redactValueDepth(val, depth+1)
+			}
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, val := range t {
+			out[i] = redactValueDepth(val, depth+1)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// Precompiled byte-backstop patterns (compiled once at init, not per call).
+var (
+	// reKV matches any JSON "key": "value" pair; the ReplaceAllFunc below re-checks
+	// the captured key through isSensitiveKey so the byte pass and the structured
+	// pass share ONE definition of sensitive (incl. the allowlist — otherwise the
+	// byte pass would clobber a legitimate next_token the structured pass preserved).
+	reKV     = regexp.MustCompile(`(?i)"([a-z0-9_\-]+)"(\s*:\s*)"[^"]*"`)
+	reBearer = regexp.MustCompile(`(?i)(bearer\s+)[a-zA-Z0-9_\-\.=]+`)
+	rePEM    = regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
+)
+
+// redactSensitive is the NARROW byte-level backstop applied after marshaling (and
+// directly to error strings on the stderr path). It catches secrets embedded in
+// free-form strings (log lines, error bodies) that carried no sensitive key.
+//
+// We INTENTIONALLY omit a generic "three base64url segments" JWT matcher: it
+// false-positives on dotted version strings and file paths, silently corrupting
+// valid output. Keyed JWTs are handled by the structured pass; a bare JWT in a log
+// line is rare enough to accept the residual risk over mangling every dotted token.
+func redactSensitive(data []byte) []byte {
+	out := reKV.ReplaceAllFunc(data, func(m []byte) []byte {
+		sub := reKV.FindSubmatch(m)
+		if sub == nil || !isSensitiveKey(string(sub[1])) {
+			return m // not a sensitive key (honors the allowlist): leave untouched
+		}
+		return []byte(`"` + string(sub[1]) + `"` + string(sub[2]) + `"[REDACTED]"`)
+	})
+	out = reBearer.ReplaceAll(out, []byte(`${1}[REDACTED]`))
+	out = rePEM.ReplaceAll(out, []byte(`[REDACTED PRIVATE KEY]`))
+	return out
+}
+
+// redactString is the stderr convenience wrapper (error messages / slog lines):
+// the byte backstop over a string. Used by every ReportError path (review M6).
+func redactString(s string) string { return string(redactSensitive([]byte(s))) }
+
+// safeMarshal / safeMarshalIndent are the single funnel every Render path uses.
+// They redact by struct tag (typed reflection), by field name (key heuristics),
+// AND by pattern (byte backstop). safeMarshal emits compact JSON (agent output);
+// safeMarshalIndent emits 2-space-indented JSON (human output). The indentation is
+// fixed by design (no caller needs another width) so it is not a parameter.
+func safeMarshal(data any) []byte       { return marshalRedacted(data, false) }
+func safeMarshalIndent(data any) []byte { return marshalRedacted(data, true) }
+
+// currentSchemaVersion pins the machine-contract envelope shape (13 §2/§6).
+const currentSchemaVersion = "1"
+
+func marshalRedacted(data any, indent bool) []byte {
+	// Envelope defaulting: Result/Page carry schema_version (13 §2/§6). Call sites
+	// may leave it empty; stamp the current version so emitted JSON always has it.
+	switch v := data.(type) {
+	case Result:
+		if v.SchemaVersion == "" {
+			v.SchemaVersion = currentSchemaVersion
+		}
+		data = v
+	case Page:
+		if v.SchemaVersion == "" {
+			v.SchemaVersion = currentSchemaVersion
+		}
+		data = v
+	}
+
+	// THREE-LAYER FAIL-CLOSED REDACTION (order matters):
+	//  1 TYPED (exact): walk the typed value; redact `redact:"true"` fields and
+	//    generated fields listed in SensitiveFields. MUST run before any json
+	//    round-trip because marshaling to interface{} discards struct tags.
+	//  2 KEY heuristics: redactValue redacts untagged sensitive map keys.
+	//  3 BYTE backstop: redactSensitive scrubs secrets in free-form strings.
+	generic := redactTagged(reflect.ValueOf(data))
+	generic = redactValue(generic)
+
+	var out []byte
+	var err error
+	if indent {
+		out, err = json.MarshalIndent(generic, "", "  ")
+	} else {
+		out, err = json.Marshal(generic)
+	}
+	if err != nil {
+		// FAIL-SAFE (Audience.Render contract): unencodable payload (channel/func) is
+		// a programmer bug. Never emit an empty/half-written document — fall back to a
+		// guaranteed-encodable envelope of string fields only (no redaction round-trip
+		// needed; its contents are static).
+		out, _ = json.Marshal(renderFailure{Error: "render_failed", Detail: err.Error()})
+	}
+	return redactSensitive(out)
+}
+
+// renderFailure is the fixed shape emitted when a payload cannot be marshaled. It
+// contains only string fields so it can itself never fail to encode.
+type renderFailure struct {
+	Error  string `json:"error"`
+	Detail string `json:"detail"`
+}
+
+// redactTagged walks a TYPED reflect.Value and returns a generic (map/slice/scalar)
+// copy in which every struct field tagged `redact:"true"` — or, for generated
+// structs, every field whose json name is in that type's SensitiveFields entry —
+// is replaced with "[REDACTED]". It is the typed equivalent of json.Marshal
+// (honors `json` tags, omitempty, `-`) but can SEE the redact tag / consult the
+// table because it runs before the value is flattened to interface{}.
+func redactTagged(v reflect.Value) any {
+	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.Struct:
+		// time.Time (and any json.Marshaler) must go to the encoder verbatim, not be
+		// walked field-by-field, or we corrupt its encoding.
+		if v.Type() == timeType || implementsJSONMarshaler(v) {
+			return v.Interface()
+		}
+		out := make(map[string]any)
+		t := v.Type()
+		tableFields := sensitiveFieldsFor(t.Name()) // generated SensitiveFields, if any
+		for i := range t.NumField() {
+			f := t.Field(i)
+			if f.PkgPath != "" { // unexported: json ignores it, so do we
+				continue
+			}
+			name, omitempty, skip := jsonFieldName(f)
+			if skip {
+				continue
+			}
+			fv := v.Field(i)
+			if omitempty && fv.IsZero() {
+				continue
+			}
+			if f.Tag.Get("redact") == "true" || (tableFields != nil && tableFields[name]) {
+				out[name] = "[REDACTED]"
+				continue
+			}
+			out[name] = redactTagged(fv)
+		}
+		return out
+	case reflect.Map:
+		if v.IsNil() {
+			return nil
+		}
+		out := make(map[string]any, v.Len())
+		for _, key := range v.MapKeys() {
+			out[fmt.Sprintf("%v", key.Interface())] = redactTagged(v.MapIndex(key))
+		}
+		return out
+	case reflect.Slice, reflect.Array:
+		if v.Kind() == reflect.Slice && v.IsNil() {
+			return nil
+		}
+		out := make([]any, v.Len())
+		for i := range v.Len() {
+			out[i] = redactTagged(v.Index(i))
+		}
+		return out
+	default:
+		if !v.IsValid() {
+			return nil
+		}
+		return v.Interface()
+	}
+}
+
+var (
+	timeType          = reflect.TypeOf(time.Time{})
+	jsonMarshalerType = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+)
+
+func implementsJSONMarshaler(v reflect.Value) bool {
+	t := v.Type()
+	return t.Implements(jsonMarshalerType) ||
+		(v.CanAddr() && reflect.PointerTo(t).Implements(jsonMarshalerType))
+}
+
+// jsonFieldName resolves a struct field's effective JSON key, mirroring
+// encoding/json: `json:"-"` skips; `json:"name,omitempty"` renames + flags
+// omitempty; an empty/absent tag falls back to the Go field name.
+func jsonFieldName(f reflect.StructField) (name string, omitempty, skip bool) {
+	tag := f.Tag.Get("json")
+	if tag == "-" {
+		return "", false, true
+	}
+	parts := strings.Split(tag, ",")
+	name = parts[0]
+	if name == "" {
+		name = f.Name
+	}
+	for _, opt := range parts[1:] {
+		if opt == "omitempty" {
+			omitempty = true
+		}
+	}
+	return name, omitempty, false
+}

--- a/cli/internal/cli/ux/redact_test.go
+++ b/cli/internal/cli/ux/redact_test.go
@@ -1,0 +1,169 @@
+package ux
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCamelToSnake(t *testing.T) {
+	cases := map[string]string{
+		"apiKey":        "api_key",
+		"APIKey":        "api_key",
+		"HTTPSProxy":    "https_proxy",
+		"clientSecret":  "client_secret",
+		"refreshToken":  "refresh_token",
+		"already_snake": "already_snake",
+		"PublicKey":     "public_key",
+	}
+	for in, want := range cases {
+		if got := camelToSnake(in); got != want {
+			t.Errorf("camelToSnake(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIsSensitiveKey(t *testing.T) {
+	sensitive := []string{
+		"authorization", "password", "secret", "token", "api_key", "apiKey",
+		"private_key", "client_secret", "access_token", "refresh_token",
+		"webhook_secret", "db_password", "clientSecret", "credentials",
+	}
+	notSensitive := []string{
+		"next_token", "token_count", "public_key", "key_id", "secret_name",
+		"password_policy", "name", "id", "url", "count", "has_api_key",
+	}
+	for _, k := range sensitive {
+		if !isSensitiveKey(k) {
+			t.Errorf("isSensitiveKey(%q) = false, want true", k)
+		}
+	}
+	for _, k := range notSensitive {
+		if isSensitiveKey(k) {
+			t.Errorf("isSensitiveKey(%q) = true, want false (false-positive)", k)
+		}
+	}
+}
+
+// Layer 1 — typed redact tag.
+type taggedSecret struct {
+	Name     string `json:"name"`
+	APIKey   string `json:"api_key" redact:"true"`
+	Password string `json:"password"` // caught by key heuristic (layer 2 on generic), too
+}
+
+func TestSafeMarshal_TypedTagRedaction(t *testing.T) {
+	out := safeMarshal(taggedSecret{Name: "svc", APIKey: "sk-live-xyz", Password: "hunter2"})
+	s := string(out)
+	if strings.Contains(s, "sk-live-xyz") {
+		t.Errorf("redact:\"true\" field leaked: %s", s)
+	}
+	if strings.Contains(s, "hunter2") {
+		t.Errorf("password value leaked: %s", s)
+	}
+	if !strings.Contains(s, `"name":"svc"`) {
+		t.Errorf("non-sensitive field was dropped/mangled: %s", s)
+	}
+}
+
+// Layer 1 via generated SensitiveFields registry (no struct tag).
+type genLike struct {
+	Token string `json:"token_value"`
+	Name  string `json:"name"`
+}
+
+func TestSafeMarshal_RegisteredSensitiveFields(t *testing.T) {
+	RegisterSensitiveFields(map[string][]string{"genLike": {"token_value"}})
+	out := string(safeMarshal(genLike{Token: "supersecret", Name: "ok"}))
+	if strings.Contains(out, "supersecret") {
+		t.Errorf("registered sensitive field leaked: %s", out)
+	}
+	if !strings.Contains(out, `"name":"ok"`) {
+		t.Errorf("non-sensitive field dropped: %s", out)
+	}
+}
+
+// Layer 2 — key heuristic on generic maps.
+func TestSafeMarshal_KeyHeuristic(t *testing.T) {
+	data := map[string]any{
+		"access_token": "at-123",
+		"public_key":   "pub-ok",
+		"nested": map[string]any{
+			"client_secret": "cs-456",
+			"next_token":    "cursor-ok",
+		},
+	}
+	out := string(safeMarshal(data))
+	if strings.Contains(out, "at-123") || strings.Contains(out, "cs-456") {
+		t.Errorf("sensitive map keys leaked: %s", out)
+	}
+	if !strings.Contains(out, "pub-ok") || !strings.Contains(out, "cursor-ok") {
+		t.Errorf("false-positive: legitimate keys were redacted: %s", out)
+	}
+}
+
+// Layer 3 — byte backstop for secrets in free-form strings.
+func TestRedactSensitive_ByteBackstop(t *testing.T) {
+	in := []byte(`{"log":"Authorization: Bearer abc.def.ghi failed"}`)
+	out := string(redactSensitive(in))
+	if strings.Contains(out, "abc.def.ghi") {
+		t.Errorf("bearer token in free-form string leaked: %s", out)
+	}
+
+	pem := []byte("prefix -----BEGIN PRIVATE KEY-----\nMIIBVg==\n-----END PRIVATE KEY----- suffix")
+	if strings.Contains(string(redactSensitive(pem)), "MIIBVg==") {
+		t.Errorf("PEM private key leaked")
+	}
+}
+
+func TestRedactValue_DoesNotMutateInput(t *testing.T) {
+	in := map[string]any{"api_key": "secret", "name": "keep"}
+	_ = safeMarshal(in)
+	if in["api_key"] != "secret" {
+		t.Errorf("redaction mutated caller's data: %v", in)
+	}
+}
+
+func TestRedactValue_DepthCap(t *testing.T) {
+	// Build a map nested deeper than maxRedactDepth.
+	var node any = "leaf"
+	for range maxRedactDepth + 5 {
+		node = map[string]any{"child": node}
+	}
+	out := string(safeMarshal(node))
+	if !strings.Contains(out, "too deep") {
+		t.Errorf("depth cap not applied: %s", out[:min(200, len(out))])
+	}
+}
+
+func TestSafeMarshal_FailSafeOnUnencodable(t *testing.T) {
+	// A channel cannot be JSON-encoded; the funnel must emit the render_failed
+	// envelope, never an empty/half document.
+	out := string(safeMarshal(map[string]any{"bad": make(chan int)}))
+	if !strings.Contains(out, "render_failed") {
+		t.Errorf("expected render_failed fallback, got: %s", out)
+	}
+	// It must be valid JSON.
+	if !json.Valid([]byte(out)) {
+		t.Errorf("fail-safe output is not valid JSON: %s", out)
+	}
+}
+
+func TestMarshalRedacted_StampsSchemaVersion(t *testing.T) {
+	out := string(safeMarshal(Result{Status: StatusCreated, Resource: "environment", Name: "local"}))
+	if !strings.Contains(out, `"schema_version":"1"`) {
+		t.Errorf("Result schema_version not stamped: %s", out)
+	}
+	pout := string(safeMarshal(Page{Items: []int{1, 2}, NextToken: "c1"}))
+	if !strings.Contains(pout, `"schema_version":"1"`) {
+		t.Errorf("Page schema_version not stamped: %s", pout)
+	}
+}
+
+func TestSafeMarshalIndent_IsIndented(t *testing.T) {
+	out := safeMarshalIndent(map[string]any{"a": 1})
+	if !bytes.Contains(out, []byte("\n")) {
+		t.Errorf("indent output not multi-line: %s", out)
+	}
+}

--- a/cli/internal/cmd/fencing.go
+++ b/cli/internal/cmd/fencing.go
@@ -59,7 +59,15 @@ func installInterceptor(app *App, root *cobra.Command) {
 		// flagValue returns "" until they exist, so the env/config ladder drives it.
 		state, err := clictx.ResolveActiveState(flagValue(cmd, "context"), flagValue(cmd, "mode"))
 		if err != nil {
-			state = &clictx.ActiveState{Mode: clictx.ModeHuman, ThemeName: "no-color"}
+			// Degrade to a default state, but RE-APPLY THE MODE LADDER on the way
+			// down: --mode/$JENTIC_MODE must still take effect with no config, so an
+			// agent on an un-provisioned machine is still fenced. Hardcoding human
+			// here would silently disable fencing (fail-OPEN) — the opposite of what
+			// a safety guard must do. Theme degrades to no-color regardless.
+			state = &clictx.ActiveState{
+				Mode:      clictx.ResolveMode(flagValue(cmd, "mode"), ""),
+				ThemeName: "no-color",
+			}
 		}
 
 		// 2. Resolve theme. STAGE 0 — mode gate: agent/service-account force

--- a/cli/internal/cmd/fencing.go
+++ b/cli/internal/cmd/fencing.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+	"github.com/jentic/jentic-one/cli/internal/theme"
+)
+
+// fenced marks a command as host-mutating management surface that must NOT run in
+// agent/service-account mode (impl/3.2 §2a). The root interceptor reads this
+// annotation off the RESOLVED leaf command and blocks the command with a
+// FENCED_COMMAND error when the audience IsFenced(). A command that forgets this
+// annotation is silently NOT fenced — the arch guard Test1C asserts the canonical
+// set (clitree.MustBeFenced) is annotated so a new admin command can't slip through.
+func fenced(cmd *cobra.Command) *cobra.Command {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations["fenced"] = "true"
+	return cmd
+}
+
+// bootstrapSafe marks a command that must run even when no configuration exists
+// yet (the config-creating commands and the always-available help/version). For
+// these, a state-resolution failure in the interceptor degrades to a default
+// human/no-color state instead of aborting — otherwise the command that creates
+// the config could never run (impl/3.2 §2 bootstrap exemption).
+func bootstrapSafe(cmd *cobra.Command) *cobra.Command {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations["bootstrap-safe"] = "true"
+	return cmd
+}
+
+// installInterceptor wires the audience-aware root PersistentPreRunE (impl/3.2 §2)
+// onto a root command: resolve state -> resolve theme (Stage-0 mode gate) ->
+// construct the Audience -> ENFORCE FENCING -> inject Audience + ActiveState into
+// the context. It preserves the existing banner/nudge side effects.
+//
+// SCOPE (Phase 2): this enforces fencing and makes the Audience/ActiveState
+// available in the context; the shipped commands still render through the legacy
+// output path (the strangler-fig cutover to aud.Render is Phase 3). Resolution
+// failures are non-fatal for everything except an explicit fenced-in-agent-mode
+// block, so V1 behavior is preserved on un-migrated machines.
+func installInterceptor(app *App, root *cobra.Command) {
+	root.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		// Preserve the shipped banner + update nudge (previously PersistentPreRun).
+		app.banner(cmd)
+		app.maybeNudgeUpdate(cmd)
+
+		// 1. Resolve active state (SDK + legacy adapter). On failure, degrade to a
+		// default state rather than aborting — Phase 2 must not regress V1 for users
+		// with no XDG config, and config-creating commands are bootstrap-safe. Mode
+		// and theme come from JENTIC_MODE/JENTIC_THEME/config in Phase 2 (the --mode/
+		// --context/--theme root flags land with the context model in Phase 3);
+		// flagValue returns "" until they exist, so the env/config ladder drives it.
+		state, err := clictx.ResolveActiveState(flagValue(cmd, "context"), flagValue(cmd, "mode"))
+		if err != nil {
+			state = &clictx.ActiveState{Mode: clictx.ModeHuman, ThemeName: "no-color"}
+		}
+
+		// 2. Resolve theme. STAGE 0 — mode gate: agent/service-account force
+		// no-color, beating --theme/JENTIC_THEME/NO_COLOR/config so machine output is
+		// never corrupted by ANSI. Human falls through to the normal ladder.
+		var palette ux.Palette
+		if state.Mode == clictx.ModeAgent || state.Mode == clictx.ModeServiceAccount {
+			palette = theme.Themes["no-color"]
+		} else {
+			palette = theme.ResolveTheme(flagValue(cmd, "theme"), state.ThemeName)
+		}
+
+		// 3. Construct the Audience. FAIL CLOSED on an unknown mode (typo'd
+		// JENTIC_MODE / stale config): the most restrictive AgentUX, never the
+		// unfenced HumanUX — otherwise JENTIC_MODE=agnet would bypass fencing.
+		assumeYes := boolFlag(cmd, "yes")
+		var audience ux.Audience
+		switch state.Mode {
+		case clictx.ModeHuman:
+			audience = ux.NewHumanUX(palette, assumeYes)
+		case clictx.ModeAgent, clictx.ModeServiceAccount:
+			audience = ux.NewAgentUX(assumeYes)
+		default:
+			audience = ux.NewAgentUX(assumeYes)
+		}
+
+		// 4. FENCING (guardrail; the enforced boundary is server-side scope + OS
+		// isolation). Block a fenced management command in a fenced mode.
+		if audience.IsFenced() && cmd.Annotations["fenced"] == "true" {
+			ferr := &ux.CodedError{
+				Code: ux.CodeFenced,
+				Msg:  "management commands are disabled in agent mode",
+			}
+			audience.ReportError(ferr, "Agents must operate within their provisioned environment. Do not attempt to switch contexts.")
+			return ferr
+		}
+
+		// 5. Inject Audience + ActiveState (and mirror the palette for theme.FromContext).
+		ctx := ux.WithAudience(cmd.Context(), audience)
+		ctx = clictx.WithActiveState(ctx, state)
+		ctx = theme.WithContext(ctx, palette)
+		cmd.SetContext(ctx)
+		return nil
+	}
+}
+
+// flagValue returns the string value of a persistent flag if present and set,
+// else "". Safe to call for flags a given root may not define.
+func flagValue(cmd *cobra.Command, name string) string {
+	if f := cmd.Flags().Lookup(name); f != nil {
+		return f.Value.String()
+	}
+	return ""
+}
+
+// boolFlag returns the bool value of a flag if present, else false.
+func boolFlag(cmd *cobra.Command, name string) bool {
+	if f := cmd.Flags().Lookup(name); f != nil {
+		if b, err := cmd.Flags().GetBool(name); err == nil {
+			return b
+		}
+	}
+	return false
+}

--- a/cli/internal/cmd/fencing_test.go
+++ b/cli/internal/cmd/fencing_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// TestFencing_BlocksFencedCommandInAgentMode proves the interceptor wiring
+// end-to-end (impl/3.2 §2a): with JENTIC_MODE=agent, a fenced command (reset) is
+// blocked with a FENCED_COMMAND CodedError before its RunE ever executes. This is
+// the behavioral complement to the arch guard Test1C (which only checks the
+// annotation is present).
+func TestFencing_BlocksFencedCommandInAgentMode(t *testing.T) {
+	t.Setenv("JENTIC_MODE", "agent")
+
+	app := testApp(t)
+	root := newAPIRootCmd(app)
+	root.SetOut(new(bytes.Buffer))
+	root.SetErr(new(bytes.Buffer))
+	// No --help: help short-circuits before PersistentPreRunE, so we exercise the
+	// real interceptor path. The fence returns before reset's RunE does any work.
+	root.SetArgs([]string{"reset", "some-profile"})
+
+	err := root.Execute()
+	var coded *ux.CodedError
+	if !errors.As(err, &coded) {
+		t.Fatalf("expected a FENCED_COMMAND CodedError, got %v", err)
+	}
+	if coded.Code != ux.CodeFenced {
+		t.Errorf("error code = %q, want %q", coded.Code, ux.CodeFenced)
+	}
+	if coded.ExitCode() != ux.ExitError {
+		t.Errorf("fenced exit code = %d, want %d", coded.ExitCode(), ux.ExitError)
+	}
+}
+
+// TestFencing_AllowsFencedCommandInHumanMode confirms the fence does NOT block a
+// human: the same command in human mode is not short-circuited by the interceptor
+// (it proceeds to its own logic — here --help exits cleanly).
+func TestFencing_AllowsFencedCommandInHumanMode(t *testing.T) {
+	t.Setenv("JENTIC_MODE", "human")
+
+	app := testApp(t)
+	root := newAPIRootCmd(app)
+	root.SetOut(new(bytes.Buffer))
+	root.SetErr(new(bytes.Buffer))
+	root.SetArgs([]string{"reset", "--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("human mode should not be fenced, got %v", err)
+	}
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -30,14 +30,12 @@ func newBaseRoot(app *App, binary string) *cobra.Command {
 		Version:       version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		// Print the jentic wordmark before every command (TTY only; see banner),
-		// then nudge if a newer release is available (stderr, throttled; see
-		// maybeNudgeUpdate).
-		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-			app.banner(cmd)
-			app.maybeNudgeUpdate(cmd)
-		},
 	}
+
+	// Audience-aware interceptor (impl/3.2 §2): resolves mode/theme, constructs the
+	// Audience, enforces fencing, and injects both into the context. It also carries
+	// the shipped banner + update-nudge side effects (previously PersistentPreRun).
+	installInterceptor(app, root)
 
 	root.SetHelpFunc(app.helpFunc)
 	root.SetVersionTemplate(
@@ -47,6 +45,11 @@ func newBaseRoot(app *App, binary string) *cobra.Command {
 	// Preserve the AddCommand order below in help output (cobra sorts
 	// alphabetically by default) so the list follows the onboarding flow.
 	cobra.EnableCommandSorting = false
+
+	// Parent PersistentPreRunE hooks (audience injection, fencing) must run even
+	// when a subcommand defines its own hook; without this Cobra runs only the
+	// nearest one and silently disables fencing for that subtree (impl/3.2 §2).
+	cobra.EnableTraverseRunHooks = true
 
 	return root
 }
@@ -117,8 +120,8 @@ func newAPIRootCmd(app *App) *cobra.Command {
 		&cobra.Group{ID: "admin", Title: "Administration"},
 	)
 
-	addGrouped(root, "identity", newBootstrapCmd(app))
-	addGrouped(root, "identity", newRegisterCmd(app))
+	addGrouped(root, "identity", bootstrapSafe(newBootstrapCmd(app)))
+	addGrouped(root, "identity", bootstrapSafe(newRegisterCmd(app)))
 	addGrouped(root, "identity", newProfileCmd(app))
 	addGrouped(root, "identity", newLogoutCmd(app))
 	addGrouped(root, "apis", newCatalogCmd(app))
@@ -132,8 +135,8 @@ func newAPIRootCmd(app *App) *cobra.Command {
 	// (generate its skills, launch it under isolation, tear its account down),
 	// distinct from the catalog find/run operations above.
 	addGrouped(root, "client", newSkillCmd(app))
-	addGrouped(root, "client", newRunCmd(app))
-	addGrouped(root, "client", newResetCmd(app))
+	addGrouped(root, "client", fenced(newRunCmd(app)))
+	addGrouped(root, "client", fenced(newResetCmd(app)))
 	addGrouped(root, "admin", newAdminCmd(app))
 
 	return root

--- a/cli/internal/theme/palette.go
+++ b/cli/internal/theme/palette.go
@@ -1,0 +1,22 @@
+package theme
+
+import "github.com/charmbracelet/lipgloss"
+
+// Palette is the semantic colour set the Audience layer (impl/3.1) styles UI
+// accents from. It is deliberately SEPARATE from the brand palette/styles in
+// theme.go: those are fixed company-brand tokens for the banner and installer
+// wizard, whereas a Palette is mode/preference-resolved at runtime (dark, light,
+// or no-color) and threads through HumanUX.
+//
+// Fields are lipgloss.TerminalColor (the interface), NOT the concrete
+// lipgloss.Color: the no-color palette assigns lipgloss.NoColor{} — a different
+// concrete type — which does not fit a lipgloss.Color-typed field. TerminalColor
+// is the interface both satisfy and what every lipgloss Style setter accepts.
+type Palette struct {
+	Primary   lipgloss.TerminalColor
+	Secondary lipgloss.TerminalColor
+	Error     lipgloss.TerminalColor
+	Success   lipgloss.TerminalColor
+	Warning   lipgloss.TerminalColor
+	Muted     lipgloss.TerminalColor
+}

--- a/cli/internal/theme/registry.go
+++ b/cli/internal/theme/registry.go
@@ -1,0 +1,38 @@
+package theme
+
+import "github.com/charmbracelet/lipgloss"
+
+// Themes is the registry of built-in palettes, keyed by the names persisted in
+// config (Context/Config theme) and accepted by --theme / JENTIC_THEME. The three
+// keys are the closed set (14 BC-9): "dark", "light", "no-color". ResolveTheme
+// falls back to "dark" for any unknown name.
+//
+// The "dark"/"light" accents intentionally reuse the brand tokens (theme.go) so
+// the runtime UI matches the banner; "no-color" zeroes every slot with
+// lipgloss.NoColor{} so machine consumers never see an ANSI escape.
+var Themes = map[string]Palette{
+	"dark": {
+		Primary:   Brand,  // teal
+		Secondary: Blue,   // #68BAEC
+		Error:     Red,    // #DB3B0F
+		Success:   Green,  // mint
+		Warning:   Orange, // #FDBD79
+		Muted:     Muted,  // grey-teal
+	},
+	"light": {
+		Primary:   lipgloss.Color("#4B0082"), // dark indigo
+		Secondary: lipgloss.Color("#008B8B"), // dark cyan
+		Error:     lipgloss.Color("#B22222"), // firebrick
+		Success:   lipgloss.Color("#228B22"), // forest green
+		Warning:   lipgloss.Color("#B8860B"), // dark goldenrod
+		Muted:     lipgloss.Color("#A9A9A9"), // dark grey
+	},
+	"no-color": {
+		Primary:   lipgloss.NoColor{},
+		Secondary: lipgloss.NoColor{},
+		Error:     lipgloss.NoColor{},
+		Success:   lipgloss.NoColor{},
+		Warning:   lipgloss.NoColor{},
+		Muted:     lipgloss.NoColor{},
+	},
+}

--- a/cli/internal/theme/resolve.go
+++ b/cli/internal/theme/resolve.go
@@ -1,0 +1,59 @@
+package theme
+
+import (
+	"context"
+	"os"
+)
+
+// ResolveTheme applies the HUMAN-mode precedence ladder and returns the resolved
+// Palette. The Stage-0 Mode gate (agent/service-account -> no-color) is applied by
+// the root interceptor (impl/3.2 §2) BEFORE this function and overrides everything
+// here; this function only owns the human-mode ladder (impl/1.4 §3):
+//
+//	--theme  >  JENTIC_THEME  >  NO_COLOR  >  config theme  >  dark
+//
+// flagOverride is the --theme value (may be ""); configTheme is
+// ActiveState.ThemeName (the persisted config `theme`).
+func ResolveTheme(flagOverride, configTheme string) Palette {
+	// NO_COLOR wins over JENTIC_THEME/config but NOT over an explicit --theme, per
+	// the no-color.org convention: its mere presence (even empty) disables colour.
+	if _, noColor := os.LookupEnv("NO_COLOR"); noColor && flagOverride == "" {
+		return Themes["no-color"]
+	}
+	name := firstNonEmpty(flagOverride, os.Getenv("JENTIC_THEME"), configTheme, "dark")
+	if p, ok := Themes[name]; ok {
+		return p
+	}
+	return Themes["dark"] // unknown name falls back rather than erroring
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// WithContext / FromContext carry the resolved Palette through a command context.
+// This is the CONVENIENCE accessor for low-level UI helpers that hold a
+// context.Context but not the Audience; the Audience (aud.Theme()) is the primary
+// runtime source (impl/1.4 §3, impl/3.2). The root hook keeps both in sync.
+type ctxKey string
+
+const paletteKey ctxKey = "jentic_palette"
+
+// WithContext stores the resolved Palette in the context for UI helpers that hold
+// a context.Context but not the Audience.
+func WithContext(ctx context.Context, p Palette) context.Context {
+	return context.WithValue(ctx, paletteKey, p)
+}
+
+// FromContext returns the Palette carried in ctx, or the dark default if absent.
+func FromContext(ctx context.Context) Palette {
+	if p, ok := ctx.Value(paletteKey).(Palette); ok {
+		return p
+	}
+	return Themes["dark"]
+}

--- a/cli/internal/theme/resolve_test.go
+++ b/cli/internal/theme/resolve_test.go
@@ -1,0 +1,97 @@
+package theme
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestThemesRegistryClosedSet(t *testing.T) {
+	for _, name := range []string{"dark", "light", "no-color"} {
+		if _, ok := Themes[name]; !ok {
+			t.Errorf("Themes missing %q", name)
+		}
+	}
+	// no-color must zero every slot with NoColor{} so no ANSI escapes leak.
+	nc := Themes["no-color"]
+	for label, c := range map[string]lipgloss.TerminalColor{
+		"Primary": nc.Primary, "Secondary": nc.Secondary, "Error": nc.Error,
+		"Success": nc.Success, "Warning": nc.Warning, "Muted": nc.Muted,
+	} {
+		if _, ok := c.(lipgloss.NoColor); !ok {
+			t.Errorf("no-color.%s = %T, want lipgloss.NoColor", label, c)
+		}
+	}
+}
+
+func TestResolveTheme_Ladder(t *testing.T) {
+	// Ensure NO_COLOR is absent (present-but-empty still counts as present).
+	t.Setenv("NO_COLOR", "")
+	os.Unsetenv("NO_COLOR")
+	t.Setenv("JENTIC_THEME", "")
+
+	t.Run("flag override wins", func(t *testing.T) {
+		got := ResolveTheme("light", "dark")
+		if got.Primary != Themes["light"].Primary {
+			t.Error("--theme light did not win")
+		}
+	})
+
+	t.Run("JENTIC_THEME beats config", func(t *testing.T) {
+		t.Setenv("JENTIC_THEME", "light")
+		got := ResolveTheme("", "dark")
+		if got.Primary != Themes["light"].Primary {
+			t.Error("JENTIC_THEME=light did not beat config dark")
+		}
+	})
+
+	t.Run("config theme used when no flag/env", func(t *testing.T) {
+		t.Setenv("JENTIC_THEME", "")
+		got := ResolveTheme("", "light")
+		if got.Primary != Themes["light"].Primary {
+			t.Error("config theme light not used")
+		}
+	})
+
+	t.Run("default dark", func(t *testing.T) {
+		t.Setenv("JENTIC_THEME", "")
+		got := ResolveTheme("", "")
+		if got.Primary != Themes["dark"].Primary {
+			t.Error("expected dark fallback")
+		}
+	})
+
+	t.Run("unknown name falls back to dark", func(t *testing.T) {
+		got := ResolveTheme("chartreuse", "")
+		if got.Primary != Themes["dark"].Primary {
+			t.Error("unknown theme did not fall back to dark")
+		}
+	})
+}
+
+func TestResolveTheme_NoColorEnv(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	t.Setenv("JENTIC_THEME", "dark")
+
+	// NO_COLOR present + no explicit --theme => no-color, beating JENTIC_THEME/config.
+	if _, ok := ResolveTheme("", "dark").Primary.(lipgloss.NoColor); !ok {
+		t.Error("NO_COLOR should force no-color when no --theme is given")
+	}
+	// But an explicit --theme overrides NO_COLOR (per no-color.org: user asked).
+	if _, ok := ResolveTheme("light", "dark").Primary.(lipgloss.NoColor); ok {
+		t.Error("explicit --theme light should override NO_COLOR")
+	}
+}
+
+func TestPaletteContextRoundTrip(t *testing.T) {
+	ctx := WithContext(context.Background(), Themes["light"])
+	if FromContext(ctx).Primary != Themes["light"].Primary {
+		t.Error("palette did not round-trip through context")
+	}
+	// Missing palette falls back to dark.
+	if FromContext(context.Background()).Primary != Themes["dark"].Primary {
+		t.Error("empty context should return dark default")
+	}
+}

--- a/cli/pkg/clitree/clitree.go
+++ b/cli/pkg/clitree/clitree.go
@@ -25,3 +25,24 @@ func API() core.TreeBuilder { return cmd.APITreeBuilder() }
 // Ctl returns the built-in `jenticctl` (installer / lifecycle) command-tree
 // builder.
 func Ctl() core.TreeBuilder { return cmd.CtlTreeBuilder() }
+
+// MustBeFenced is THE canonical fence set: the command paths that MUST carry the
+// `fenced` annotation so an autonomous agent cannot run them (impl/3.2 §2a). Every
+// other doc (plan Phase 3 item 5, 07 §2, impl/1.3 §3, rules/01 §4, rules/03 §4)
+// defers to this list; if a doc and this list disagree, this list wins. The rule:
+// a command is fenced iff it (a) mutates host-level management state (contexts,
+// environments, identities, local-agent lifecycle), or (b) reveals/switches to
+// contexts other than the active one.
+//
+// Phase 2 ships the enforcing machinery against the commands that EXIST today —
+// the local-agent lifecycle (`run` mutates ACLs via --grant/--revoke and is
+// operator-only; `reset` wipes an account's config tree). The context/env/identity
+// entries land as those commands are built (plan Phase 3 item 5), extending this
+// list. Deliberate carve-outs, NOT fenced: `identity register` (DCR of the agent's
+// own identity — required by the agent workflow) and `migrate`.
+//
+// Paths are space-separated ("context use" -> ["context","use"]) for root.Find.
+var MustBeFenced = []string{
+	"run",
+	"reset",
+}

--- a/cli/tests/arch/fencing_test.go
+++ b/cli/tests/arch/fencing_test.go
@@ -1,46 +1,55 @@
 package arch
 
 import (
-	"go/types"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/pkg/clitree"
+	"github.com/jentic/jentic-one/cli/pkg/core"
 )
 
-// Test1C_SecurityFencing is the guardrail that every host-mutating command
-// carries the `fenced` annotation (impl/0.0 §1C, canonical set in impl/3.2 §2a),
-// so an autonomous agent cannot hijack the operator's contexts, identities, or
-// local-agent lifecycle.
+// Test1C_SecurityFencing is the guardrail that every command in the canonical
+// fence set (clitree.MustBeFenced, impl/3.2 §2a) carries the `fenced` annotation,
+// so an autonomous agent cannot hijack the operator's local-agent lifecycle,
+// contexts, or identities. It also asserts cobra.EnableTraverseRunHooks is set,
+// because without it a subcommand's own PersistentPreRunE would silently disable
+// the fencing hook for its whole subtree.
 //
-// Activation is keyed on the fencing machinery itself, not on a package's mere
-// existence: pkg/clitree already ships today as the command-tree composition
-// layer, but the `fenced` annotation, the canonical mustBeFenced set, and the
-// enforcing PersistentPreRunE all arrive in Phase 2. We detect that machinery by
-// the presence of an exported clitree.MustBeFenced symbol. Until it exists there
-// is nothing to assert; once it exists this test MUST be upgraded (and fails
-// loudly if it wasn't) to walk the constructed tree and assert:
-//
-//	root := clitree.API()(&core.AppContainer{})
-//	– every path in clitree.MustBeFenced has Annotations["fenced"]=="true"
-//	– every other mutating command is in the documented exemption set
-//	  (migrate, identity register — impl/3.2 §2a)
-//	– cobra.EnableTraverseRunHooks == true (else a child PersistentPreRunE
-//	  silently disables the fence for its subtree)
+// This test was DORMANT until the fencing machinery (clitree.MustBeFenced) shipped
+// in Phase 2; it now walks the constructed command tree and asserts the contract.
+// As Phase 3 adds context/env/identity commands, they extend clitree.MustBeFenced
+// and this test covers them automatically.
 func Test1C_SecurityFencing(t *testing.T) {
-	pkgs := loadCLI(t)
+	if len(clitree.MustBeFenced) == 0 {
+		t.Fatal("clitree.MustBeFenced is empty; the canonical fence set must list every host-mutating command")
+	}
 
-	var clitreePkg *types.Package
-	for _, p := range pkgs {
-		if rel(p.PkgPath) == "pkg/clitree" && p.Types != nil {
-			clitreePkg = p.Types
+	// Build the real jentic tree the same way the binary does.
+	root := clitree.API()(&core.AppContainer{})
+
+	for _, path := range clitree.MustBeFenced {
+		fields := strings.Fields(path) // "context use" -> ["context","use"]
+		cmd, _, err := root.Find(fields)
+		if err != nil {
+			t.Errorf("fenced command %q not found in the jentic tree: %v", path, err)
+			continue
+		}
+		// root.Find returns the nearest match; confirm we resolved the exact leaf,
+		// not a parent (e.g. a typo'd path that resolves to root).
+		if cmd.Name() != fields[len(fields)-1] {
+			t.Errorf("fenced path %q resolved to %q, not the intended leaf", path, cmd.CommandPath())
+			continue
+		}
+		if cmd.Annotations["fenced"] != "true" {
+			t.Errorf("command %q is NOT fenced; agent mode could run it. Wrap its constructor in fenced(...)", path)
 		}
 	}
-	if clitreePkg == nil {
-		t.Skip("dormant: pkg/clitree not loaded")
-	}
-	if clitreePkg.Scope().Lookup("MustBeFenced") == nil {
-		t.Skip("dormant: fencing machinery (clitree.MustBeFenced, Phase 2) not present — the `fenced` annotation and its PersistentPreRunE do not exist to assert against")
-	}
 
-	// The machinery exists; this stub must have been replaced with the real
-	// tree-walk assertion described in the doc comment.
-	t.Fatal("clitree.MustBeFenced exists but Test1C_SecurityFencing was not upgraded to assert the fenced contract against the constructed command tree — see the doc comment (impl/0.0 §1C, impl/3.2 §2a)")
+	// The fencing hook lives on the parent root; a child PersistentPreRunE would
+	// bypass it unless traversal is enabled (impl/3.2 §2 "COBRA HAZARD").
+	if !cobra.EnableTraverseRunHooks {
+		t.Error("cobra.EnableTraverseRunHooks is false; a subcommand's own PersistentPreRunE would silently disable fencing for its subtree")
+	}
 }


### PR DESCRIPTION
## What this is

**Phase 2** of the CLI V2 landing plan (`themes/cli-v2/plan.md`), stacked on
[#980](https://github.com/jentic/jentic-one/pull/980) (Phase 1). It builds the
audience-aware I/O layer and the agent machine contract, and turns on command
fencing. Everything here is **net-new foundation**: the shipped commands still
render through the legacy output path — the per-command strangler-fig cutover to
`aud.Render` is Phase 3. V1 behavior is unchanged (golden tests green).

## Plan items delivered

- **Item 1 — `Audience` interface** (`internal/cli/ux`): `Ask`/`AskConfirm`/
  `Render`/`ReportError`/`Theme`/`IsFenced`/`ForcesNoColor` with `HumanUX`
  (interactive, themed) and `AgentUX` (never prompts, no-color, JSON). Includes the
  **minimal theme registry** (`internal/theme`: `Palette`, `Themes{dark,light,no-color}`,
  `ResolveTheme` ladder) added alongside the existing brand palette, and the
  **pre-activation legacy-read adapter** in `clictx` so wrapping commands in the
  Audience is a no-op for un-migrated users.
- **Item 2 — machine contract** (`ux/contract.go`, `ux/envelope.go`): `Result`/
  `Page`/`AgentError` envelopes with `schema_version` stamping, the closed
  `error_code` enum, the exit-code taxonomy (0/1/2/3/4), and `CodedError.ExitCode()`
  so `core.Run` maps codes to exits with no per-command wiring.
- **Item 3 — fail-closed redaction** (`ux/redact.go`): three layers — typed
  `redact:"true"` + generated `SensitiveFields` registry, scoped key heuristics
  (acronym-aware `camelToSnake`, exact+suffix with a false-positive allowlist for
  `next_token`/`has_api_key`/…), and a byte backstop — applied on **both** stdout
  (`safeMarshal`) and stderr (`redactString`). `render_failed` fail-safe guarantees
  stdout always carries one valid JSON document.
- **Item 4 — command fencing** (`internal/cmd/fencing.go`, `pkg/clitree`): the
  `fenced()` annotation + root `PersistentPreRunE` interceptor that resolves mode/
  theme, constructs the Audience, and **blocks fenced management commands in agent
  mode** with a `FENCED_COMMAND` envelope. `cobra.EnableTraverseRunHooks = true`
  (the impl/3.2 §2 hazard fix). Exported `clitree.MustBeFenced` (run, reset today).
- **Item 5 — pagination UX**: `ux.NewPage` bridges `client/paginate`'s typed walk
  result into the `{schema_version, items, next_token}` envelope (cursor form only).

## Notable decisions

- **Byte-backstop shares the key definition.** Instead of impl/3.1's fixed suffix
  regex, the byte pass re-checks each JSON key through `isSensitiveKey`, so the
  structured and byte passes can never disagree (both preserve `next_token`).
- **HumanUX prompts route through `install.NewForm`/`Input`/`RunConfirm`** — the
  shared, `TERM=dumb`-safe constructors (jentic-one#841), enforced by the existing
  form-guard test — rather than raw `huh`.
- **No `--mode`/`--theme`/`--context` root flags yet.** Mode/theme resolve from
  `JENTIC_MODE`/`JENTIC_THEME`/`NO_COLOR`/config in Phase 2; the flags land with the
  context model in Phase 3, so there's no `cli-reference.json` drift.
- **Arch guard 1C is now live** (was dormant): it walks `clitree.API()` and asserts
  every `MustBeFenced` path is annotated + `EnableTraverseRunHooks` is set. It grows
  automatically as Phase 3 extends the fence set.

## Verification

- Full CLI module: `go build`, `go vet`, `golangci-lint` (0 issues), `go test` all green.
- Arch guards 1A/1B/1C(new)/1E/1F/1H pass; 1G still correctly dormant (waits for
  Phase 3's `internal/cli/api`). V1 golden contract unchanged.
- New unit tests cover all three redaction layers + false-positive protection +
  depth cap + non-mutation + fail-safe, the exit-code table, agent/human behavior,
  the theme ladder, the pagination bridge, the mode ladder, and the legacy adapter.

## Test plan

- [ ] CI green on the stack.
- [ ] Sanity: `JENTIC_MODE=agent jentic reset x` emits the `FENCED_COMMAND` JSON
      envelope on stderr and exits non-zero; human mode is unaffected.

Made with [Cursor](https://cursor.com)