### PR TITLE
fix(ingest): keep bare YAML dates as strings so specs stay JSON-serializable

### DIFF
--- a/src/jentic_one/registry/ingest/fetch.py
+++ b/src/jentic_one/registry/ingest/fetch.py
@@ -77,27 +77,39 @@ IngestSource = Annotated[UrlSource | InlineSource, Field(discriminator="type")]
 
 
 class _JsonSafeLoader(yaml.SafeLoader):
-    """SafeLoader that keeps bare date/timestamp scalars as literal strings.
+    """SafeLoader whose output contains only JSON-serializable values.
 
     Real-world YAML specs are full of unquoted ISO dates (``version: 2022-01-16``,
-    changelog entries, example values). The stock ``SafeLoader`` resolves those to
-    ``datetime.date``/``datetime.datetime``, which every downstream ``json.dumps``
-    / JSONB column write then rejects (issue #979). A spec document must stay
-    JSON-serializable, so construct the ``!!timestamp`` tag as the scalar's
-    verbatim text — lossless, and identical to what the same spec yields when
-    served as JSON.
+    changelog entries, example values). The stock ``SafeLoader`` resolves those
+    to ``datetime.date``/``datetime.datetime``, which the ingest pipeline's later
+    JSON serialization (JSONB spec storage, operation extraction) rejects —
+    dead-lettering the import (issue #979). Spec documents must stay
+    JSON-serializable (the contract stated on ``IngestSpecification.content``),
+    so the two tags that produce non-JSON scalars — ``!!timestamp`` and
+    ``!!binary`` — construct the scalar's verbatim text (lossless, and identical
+    to what the same spec yields when served as JSON), and ``!!set`` constructs
+    a list of its keys. The remaining exotic tags (``!!omap``/``!!pairs``) yield
+    lists of tuples, which JSON-serialize as arrays already.
     """
 
 
-def _construct_timestamp_as_str(loader: _JsonSafeLoader, node: yaml.ScalarNode) -> str:
-    return str(loader.construct_scalar(node))
+def _construct_scalar_as_str(loader: _JsonSafeLoader, node: yaml.ScalarNode) -> str:
+    return loader.construct_scalar(node)
 
 
-_JsonSafeLoader.add_constructor("tag:yaml.org,2002:timestamp", _construct_timestamp_as_str)
+def _construct_set_as_list(loader: _JsonSafeLoader, node: yaml.MappingNode) -> list[Any]:
+    return list(loader.construct_mapping(node))
+
+
+# !!timestamp is the only tag here with an implicit resolver (bare scalars);
+# !!binary and !!set require an explicit tag but dead-letter identically.
+_JsonSafeLoader.add_constructor("tag:yaml.org,2002:timestamp", _construct_scalar_as_str)
+_JsonSafeLoader.add_constructor("tag:yaml.org,2002:binary", _construct_scalar_as_str)
+_JsonSafeLoader.add_constructor("tag:yaml.org,2002:set", _construct_set_as_list)
 
 
 def _load_yaml(raw: str) -> Any:
-    """``yaml.safe_load`` with date scalars kept as strings (see _JsonSafeLoader).
+    """``yaml.safe_load`` constrained to JSON-serializable output (see _JsonSafeLoader).
 
     The loader is a ``SafeLoader`` subclass, so this is exactly as safe as
     ``yaml.safe_load`` — hence the B506 suppression.
@@ -106,7 +118,12 @@ def _load_yaml(raw: str) -> Any:
 
 
 def parse_spec_content(raw: str, *, filename: str | None = None) -> dict[str, Any]:
-    """Parse raw spec content as JSON or YAML, returning a dict."""
+    """Parse raw spec content as JSON or YAML, returning a dict.
+
+    This is the single boundary where raw spec text becomes a document, and it
+    guarantees the result is JSON-serializable regardless of source format —
+    downstream stages (JSONB writes, ``json.dumps``) rely on that invariant.
+    """
     if not raw or not raw.strip():
         raise IngestStageError("spec content is empty")
 

--- a/src/jentic_one/registry/ingest/fetch.py
+++ b/src/jentic_one/registry/ingest/fetch.py
@@ -76,6 +76,35 @@ class UrlSource(BaseModel):
 IngestSource = Annotated[UrlSource | InlineSource, Field(discriminator="type")]
 
 
+class _JsonSafeLoader(yaml.SafeLoader):
+    """SafeLoader that keeps bare date/timestamp scalars as literal strings.
+
+    Real-world YAML specs are full of unquoted ISO dates (``version: 2022-01-16``,
+    changelog entries, example values). The stock ``SafeLoader`` resolves those to
+    ``datetime.date``/``datetime.datetime``, which every downstream ``json.dumps``
+    / JSONB column write then rejects (issue #979). A spec document must stay
+    JSON-serializable, so construct the ``!!timestamp`` tag as the scalar's
+    verbatim text — lossless, and identical to what the same spec yields when
+    served as JSON.
+    """
+
+
+def _construct_timestamp_as_str(loader: _JsonSafeLoader, node: yaml.ScalarNode) -> str:
+    return str(loader.construct_scalar(node))
+
+
+_JsonSafeLoader.add_constructor("tag:yaml.org,2002:timestamp", _construct_timestamp_as_str)
+
+
+def _load_yaml(raw: str) -> Any:
+    """``yaml.safe_load`` with date scalars kept as strings (see _JsonSafeLoader).
+
+    The loader is a ``SafeLoader`` subclass, so this is exactly as safe as
+    ``yaml.safe_load`` — hence the B506 suppression.
+    """
+    return yaml.load(raw, Loader=_JsonSafeLoader)  # nosec B506
+
+
 def parse_spec_content(raw: str, *, filename: str | None = None) -> dict[str, Any]:
     """Parse raw spec content as JSON or YAML, returning a dict."""
     if not raw or not raw.strip():
@@ -95,12 +124,12 @@ def parse_spec_content(raw: str, *, filename: str | None = None) -> dict[str, An
             parsed = json.loads(raw)
         except (json.JSONDecodeError, ValueError):
             try:
-                parsed = yaml.safe_load(raw)
+                parsed = _load_yaml(raw)
             except yaml.YAMLError as exc:
                 raise IngestStageError("failed to parse spec content as JSON or YAML") from exc
     else:
         try:
-            parsed = yaml.safe_load(raw)
+            parsed = _load_yaml(raw)
         except yaml.YAMLError:
             try:
                 parsed = json.loads(raw)

--- a/src/jentic_one/registry/ingest/models.py
+++ b/src/jentic_one/registry/ingest/models.py
@@ -37,6 +37,10 @@ class IngestSpecification(BaseModel):
     api_identifier: ApiIdentifier
     sha: str | None = None
     metadata: dict[str, Any] | None = None
+    #: The parsed spec document. Guaranteed JSON-serializable regardless of the
+    #: source format — the YAML parse boundary (``parse_spec_content``) keeps
+    #: date/binary scalars as strings (issue #979). Stage authors may
+    #: ``json.dumps`` this or write it to a JSONB column without an encoder.
     content: dict[str, Any] | None = None
     source_id: str | None = None
     source_type: ApiRevisionSourceType | None = None

--- a/tests/unit/registry/ingest/test_fetch_inline.py
+++ b/tests/unit/registry/ingest/test_fetch_inline.py
@@ -1,6 +1,7 @@
 """Tests for inline spec loading via load_specification."""
 
 import hashlib
+import json
 from typing import Any
 
 import pytest
@@ -23,6 +24,20 @@ info:
   title: Pet Store
   version: "1.0.0"
   x-vendor: acme
+"""
+
+# Real-world specs are full of unquoted ISO date scalars (issue #979): stock
+# yaml.safe_load turns these into datetime.date/datetime.datetime, which the
+# ingest pipeline's JSON serialization then rejects.
+_SPEC_YAML_BARE_DATES = """\
+openapi: "3.1.0"
+info:
+  title: Dated API
+  version: 2022-01-16
+  x-vendor: acme
+  x-released: 2015-02-22
+  x-audited: 2001-12-14t21:59:43.10-05:00
+paths: {}
 """
 
 
@@ -51,6 +66,27 @@ async def test_inline_yaml_produces_valid_specification() -> None:
     assert result.api_identifier.version == "1.0.0"
     assert result.sha == hashlib.sha256(_SPEC_YAML.encode()).hexdigest()
     assert result.source_type == "inline"
+
+
+@pytest.mark.asyncio
+async def test_yaml_bare_date_scalars_stay_json_serializable_strings() -> None:
+    """Bare YAML dates must parse as their literal strings, not datetime objects.
+
+    Regression for #979: yaml.safe_load resolves unquoted ISO dates to
+    datetime.date/datetime, which every downstream json.dumps / JSONB write
+    then rejects — dead-lettering the whole import.
+    """
+    result = await load_specification(_make_inline(_SPEC_YAML_BARE_DATES, filename="spec.yaml"))
+
+    assert result.content is not None
+    info = result.content["info"]
+    # Verbatim scalar text — not date/datetime, and not a reformatted ISO string.
+    assert info["version"] == "2022-01-16"
+    assert info["x-released"] == "2015-02-22"
+    assert info["x-audited"] == "2001-12-14t21:59:43.10-05:00"
+    json.dumps(result.content)  # the property the pipeline actually needs
+    # The date-typed version also drives API identity; it must slug cleanly.
+    assert result.api_identifier.version == "2022-01-16"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/registry/ingest/test_fetch_inline.py
+++ b/tests/unit/registry/ingest/test_fetch_inline.py
@@ -28,7 +28,8 @@ info:
 
 # Real-world specs are full of unquoted ISO date scalars (issue #979): stock
 # yaml.safe_load turns these into datetime.date/datetime.datetime, which the
-# ingest pipeline's JSON serialization then rejects.
+# ingest pipeline's later JSON serialization (spec storage, operation
+# extraction) rejects.
 _SPEC_YAML_BARE_DATES = """\
 openapi: "3.1.0"
 info:
@@ -37,6 +38,22 @@ info:
   x-vendor: acme
   x-released: 2015-02-22
   x-audited: 2001-12-14t21:59:43.10-05:00
+  x-legacy: 2001-12-14 21:59:43.10 -5
+paths: {}
+"""
+
+# Explicitly tagged !!binary (bytes) and !!set (set) are the other SafeLoader
+# outputs that json.dumps rejects — same dead-letter failure mode as #979.
+_SPEC_YAML_EXOTIC_TAGS = """\
+openapi: "3.1.0"
+info:
+  title: Exotic API
+  version: "1.0.0"
+  x-vendor: acme
+  x-blob: !!binary aGVsbG8=
+  x-flags: !!set
+    alpha:
+    beta:
 paths: {}
 """
 
@@ -72,9 +89,8 @@ async def test_inline_yaml_produces_valid_specification() -> None:
 async def test_yaml_bare_date_scalars_stay_json_serializable_strings() -> None:
     """Bare YAML dates must parse as their literal strings, not datetime objects.
 
-    Regression for #979: yaml.safe_load resolves unquoted ISO dates to
-    datetime.date/datetime, which every downstream json.dumps / JSONB write
-    then rejects — dead-lettering the whole import.
+    Regression for #979 — see the _SPEC_YAML_BARE_DATES comment for the failure
+    mode this pins.
     """
     result = await load_specification(_make_inline(_SPEC_YAML_BARE_DATES, filename="spec.yaml"))
 
@@ -84,9 +100,24 @@ async def test_yaml_bare_date_scalars_stay_json_serializable_strings() -> None:
     assert info["version"] == "2022-01-16"
     assert info["x-released"] == "2015-02-22"
     assert info["x-audited"] == "2001-12-14t21:59:43.10-05:00"
+    # YAML 1.1 canonical space-separated form with a bare-digit offset: the
+    # case where a reformat-based fix (isoformat) would diverge from source.
+    assert info["x-legacy"] == "2001-12-14 21:59:43.10 -5"
     json.dumps(result.content)  # the property the pipeline actually needs
     # The date-typed version also drives API identity; it must slug cleanly.
     assert result.api_identifier.version == "2022-01-16"
+
+
+@pytest.mark.asyncio
+async def test_yaml_binary_and_set_tags_stay_json_serializable() -> None:
+    """Explicit !!binary/!!set tags must not smuggle bytes/set past the parser."""
+    result = await load_specification(_make_inline(_SPEC_YAML_EXOTIC_TAGS, filename="spec.yaml"))
+
+    assert result.content is not None
+    info = result.content["info"]
+    assert info["x-blob"] == "aGVsbG8="  # verbatim base64 text, not bytes
+    assert info["x-flags"] == ["alpha", "beta"]  # key list, not a set
+    json.dumps(result.content)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #979 — importing real-world **YAML** specs with unquoted date scalars (`version: 2022-01-16`, changelog fields, example values) dead-lettered the whole job with `Object of type datetime is not JSON serializable` in `StoreSpecFileStage` / `ExtractOperationsStage`. Root cause: `yaml.safe_load` resolves bare ISO dates to `datetime.date`/`datetime.datetime`, and the pipeline's later JSON serialization (JSONB spec storage, operation extraction) has no encoder for those types.

## Changes

- `parse_spec_content` now parses YAML through `_JsonSafeLoader`, a `SafeLoader` subclass whose output contains only JSON-serializable values: `!!timestamp` and `!!binary` construct the scalar's **verbatim text** (lossless — no reformatting, `2022-01-16` stays exactly `2022-01-16` — and identical to what the same spec yields when served as JSON), `!!set` constructs a list of its keys. `parse_spec_content` is the single YAML-parse boundary for specs, so every downstream consumer is covered at one choke point.
- The JSON-serializable contract is stated where stage authors will see it: on `IngestSpecification.content` and in `parse_spec_content`'s docstring.
- The loader remains a `SafeLoader` subclass — no change to the safe-load security posture (bandit B506 suppressed with justification; CI bandit passes clean). The constructor registration is copy-on-write per subclass, so global `yaml.safe_load` behavior (e.g. app config loading) is untouched — verified in-process.
- Regression tests: bare date, `t`-separated datetime with offset, the YAML 1.1 space-separated form with bare-digit offset (the case a reformat-based fix would corrupt), a date-typed `info.version` through identity resolution, and explicit `!!binary`/`!!set` tags.

Reviewed by a five-lens board (correctness, code quality, architecture, security, Bugbot); all findings addressed in-branch. The one adjacent case left out (`.nan`/`.inf` float scalars, a pre-existing failure class not introduced here) is tracked in a follow-up issue.

## Test plan

- [x] Unit regression tests for bare-date/binary/set scalars at the parse boundary (fail on main)
- [x] Empirical repro/fix check against the issue's real-world spec (`api.apis.guru/v2/openapi.yaml`: fails on main, round-trips on this branch)
- [x] `pytest tests/unit tests/arch` (2711 passed), ruff, strict mypy, CI bandit invocation