### PR TITLE
cli(v2): Phase 3: Contexts, XDG & File-less Agents

### DIFF
--- a/cli/client/auth/apikey.go
+++ b/cli/client/auth/apikey.go
@@ -1,0 +1,67 @@
+package auth
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jentic/jentic-one/cli/client/config"
+)
+
+// APIKeyPrefix is the required prefix for a Jentic API key credential. It mirrors
+// the shipped V1 constant so migrated keys and freshly-added keys validate the
+// same way.
+const APIKeyPrefix = "jak_"
+
+// apiKeyPath returns the on-disk path of the API-key credential for ref, under
+// the XDG STATE dir (a secret, not config — kept out of config.yaml exactly like
+// tokens). The dir is created 0700; the stem is the same validated
+// <identity>_<env> as keys/tokens, so a single ref addresses all three.
+func apiKeyPath(ref IdentityRef) (string, error) {
+	stateDir, err := config.StateDir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return "", fmt.Errorf("creating state dir: %w", err)
+	}
+	stem, err := ref.Stem() // validates names — path-traversal guard
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(stateDir, stem+".apikey"), nil
+}
+
+// SaveAPIKey persists a jak_* API key credential for ref (0600). It is the V2
+// successor to V1's per-profile `apikey` file: the credential is a first-class
+// identity credential (Phase 4 item 4) but stored as a secret under XDG state,
+// never in config.yaml (which round-trips through node merges and is not
+// secret-safe). Returns an error if the key lacks the required prefix.
+func SaveAPIKey(ref IdentityRef, key string) error {
+	key = strings.TrimSpace(key)
+	if !strings.HasPrefix(key, APIKeyPrefix) {
+		return fmt.Errorf("API key must start with %q", APIKeyPrefix)
+	}
+	path, err := apiKeyPath(ref)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, []byte(key), 0o600); err != nil {
+		return fmt.Errorf("writing API key %s: %w", path, err)
+	}
+	return nil
+}
+
+// ReadAPIKey loads the API-key credential for ref, or an error if none exists.
+func ReadAPIKey(ref IdentityRef) (string, error) {
+	path, err := apiKeyPath(ref)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path is StateDir()/<validated-stem>.apikey, not user input.
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}

--- a/cli/client/auth/apikey_test.go
+++ b/cli/client/auth/apikey_test.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func withStateDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "state"))
+}
+
+func TestSaveReadAPIKey_RoundTrip(t *testing.T) {
+	withStateDir(t)
+	ref := IdentityRef{Identity: "ci", Environment: "prod"}
+	if err := SaveAPIKey(ref, "jak_abc123"); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+	got, err := ReadAPIKey(ref)
+	if err != nil {
+		t.Fatalf("ReadAPIKey: %v", err)
+	}
+	if got != "jak_abc123" {
+		t.Errorf("api key = %q, want jak_abc123", got)
+	}
+}
+
+func TestSaveAPIKey_RejectsBadPrefix(t *testing.T) {
+	withStateDir(t)
+	ref := IdentityRef{Identity: "ci", Environment: "prod"}
+	if err := SaveAPIKey(ref, "not-a-jentic-key"); err == nil {
+		t.Fatal("expected an error for a key without the jak_ prefix")
+	}
+}
+
+func TestKeyPathForImport_UsesStem(t *testing.T) {
+	withStateDir(t)
+	path, err := KeyPathForImport(IdentityRef{Identity: "ci", Environment: "prod"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base := filepath.Base(path); base != "ci_prod.key" {
+		t.Errorf("import key path base = %q, want ci_prod.key", base)
+	}
+	// Path traversal in a name must be rejected fail-closed.
+	if _, err := KeyPathForImport(IdentityRef{Identity: "../evil", Environment: "prod"}); err == nil {
+		t.Error("expected KeyPathForImport to reject a path-traversal name")
+	}
+}

--- a/cli/client/auth/keys.go
+++ b/cli/client/auth/keys.go
@@ -72,6 +72,24 @@ func keysDir() (string, error) {
 	return dir, nil
 }
 
+// KeyPathForImport returns the on-disk path where ref's key file lives, creating
+// the keys dir (0700). It exists so the migration path (jentic migrate) can copy
+// a validated legacy PKCS#8 PEM key verbatim into the XDG layout — preserving the
+// exact key bytes rather than generating a new keypair, which would break the
+// already-registered client_id. The returned path is the same one
+// GetOrGenerateKey reads/writes, so the copied key is picked up transparently.
+func KeyPathForImport(ref IdentityRef) (string, error) {
+	dir, err := keysDir()
+	if err != nil {
+		return "", err
+	}
+	stem, err := ref.Stem() // path-traversal guard
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, stem+".key"), nil
+}
+
 // GetOrGenerateKey resolves the env-scoped Ed25519 private key for ref, generating
 // and persisting (PKCS#8 PEM, 0600) a fresh one on first use. This is the only
 // retained lazy side effect (impl/4.1 §2): it is local-only and never contacts the

--- a/cli/internal/cmd/context.go
+++ b/cli/internal/cmd/context.go
@@ -1,0 +1,291 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/client/config"
+	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// newContextCmd is the `jentic context` root: bind an environment + identity +
+// mode into a named context and switch between them (impl/1.3 §4, kubectl-style).
+// Contexts replace flat V1 profiles as the selection unit.
+//
+// Fenced surface: create/use/delete mutate or re-point which environment/identity
+// is active — forbidden for agents. `list` and `view` are read-only carve-outs
+// (view shows only the ACTIVE context so an agent can introspect itself).
+func newContextCmd(app *App) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "context",
+		Short: "Manage and switch contexts (environment + identity + mode)",
+		Long: "context binds an Environment, an Identity, and an interaction mode into a\n" +
+			"named context, and switches which one commands act on. It is the V2\n" +
+			"successor to `jentic profile` (see `jentic migrate`).",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+	}
+	cmd.AddCommand(fenced(newContextCreateCmd(app)))
+	cmd.AddCommand(fenced(newContextUseCmd(app)))
+	cmd.AddCommand(newContextListCmd(app)) // read-only: not fenced
+	cmd.AddCommand(newContextViewCmd(app)) // read-only (active only): not fenced
+	cmd.AddCommand(fenced(newContextDeleteCmd(app)))
+	return cmd
+}
+
+func newContextCreateCmd(_ *App) *cobra.Command {
+	var (
+		env   string
+		ident string
+		mode  string
+		use   bool
+		force bool
+	)
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a context binding an environment + identity + mode",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			aud := ux.FromContext(cmd.Context())
+
+			if mode == "" {
+				mode = clictx.ModeHuman
+			}
+			if err := config.MutateConfig(func(cfg *config.Config) error {
+				if !config.ValidName(name) {
+					return &ux.CodedError{
+						Code:       ux.CodeMissingArgument,
+						Msg:        fmt.Sprintf("invalid context name %q (allowed: ^[a-z0-9][a-z0-9-]{0,63}$)", name),
+						Actionable: "Choose a name of lowercase letters, digits and hyphens.",
+					}
+				}
+				if _, exists := cfg.Contexts[name]; exists && !force {
+					return &ux.CodedError{
+						Code:       ux.CodeMissingArgument,
+						Msg:        fmt.Sprintf("context %q already exists", name),
+						Actionable: "Pass --force to replace it, or choose a different name.",
+					}
+				}
+				// Referential integrity: the context must point at things that
+				// exist — a dangling context is a runtime error waiting to happen.
+				if _, ok := cfg.Environments[env]; !ok {
+					return &ux.CodedError{
+						Code:       ux.CodeResolveFailed,
+						Msg:        fmt.Sprintf("environment %q does not exist", env),
+						Actionable: "Create it first with `jentic env add`.",
+					}
+				}
+				if _, ok := cfg.Identities[ident]; !ok {
+					return &ux.CodedError{
+						Code:       ux.CodeResolveFailed,
+						Msg:        fmt.Sprintf("identity %q does not exist", ident),
+						Actionable: "Create it first with `jentic identity add`.",
+					}
+				}
+				cfg.Contexts[name] = config.Context{Environment: env, Identity: ident, Mode: mode}
+				if use {
+					cfg.ActiveContext = name
+				}
+				return nil
+			}); err != nil {
+				return reportCoded(aud, err)
+			}
+
+			status := ux.StatusCreated
+			if use {
+				status = ux.StatusSwitched
+			}
+			aud.Render(ux.Result{
+				Status:   status,
+				Resource: "context",
+				Name:     name,
+				Fields: map[string]any{
+					"environment": env,
+					"identity":    ident,
+					"mode":        mode,
+				},
+			})
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&env, "env", "", "Environment this context targets")
+	cmd.Flags().StringVar(&ident, "identity", "", "Identity this context acts as")
+	cmd.Flags().StringVar(&mode, "mode", "", "Interaction mode: human|agent|service-account (default human)")
+	cmd.Flags().BoolVar(&use, "use", false, "Set this as the active context after creating it")
+	cmd.Flags().BoolVar(&force, "force", false, "Replace an existing context of the same name")
+	mustMarkRequired(cmd, "env")
+	mustMarkRequired(cmd, "identity")
+	return cmd
+}
+
+func newContextUseCmd(_ *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "use <name>",
+		Short: "Set the active context",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			aud := ux.FromContext(cmd.Context())
+			if err := config.MutateConfig(func(cfg *config.Config) error {
+				if _, ok := cfg.Contexts[name]; !ok {
+					return &ux.CodedError{
+						Code:       ux.CodeResolveFailed,
+						Msg:        fmt.Sprintf("context %q does not exist", name),
+						Actionable: "Run `jentic context list` to see options.",
+					}
+				}
+				cfg.ActiveContext = name
+				return nil
+			}); err != nil {
+				return reportCoded(aud, err)
+			}
+			aud.Render(ux.Result{Status: ux.StatusSwitched, Resource: "context", Name: name})
+			return nil
+		},
+	}
+}
+
+func newContextListCmd(_ *App) *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List contexts and mark the active one",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			aud := ux.FromContext(cmd.Context())
+			cfg, err := config.Load()
+			if err != nil {
+				return reportCoded(aud, err)
+			}
+			names := sortedKeys(cfg.Contexts)
+			items := make([]map[string]any, 0, len(names))
+			for _, n := range names {
+				c := cfg.Contexts[n]
+				items = append(items, map[string]any{
+					"name":        n,
+					"environment": c.Environment,
+					"identity":    c.Identity,
+					"mode":        c.Mode,
+					"active":      n == cfg.ActiveContext,
+				})
+			}
+			aud.Render(ux.NewPage(items, ""))
+			return nil
+		},
+	}
+}
+
+// newContextViewCmd shows ONLY the active context (impl/1.3 §3 carve-out): an
+// agent can introspect what it is bound to without the ability to enumerate or
+// switch to other contexts. Deliberately read-only and unfenced.
+func newContextViewCmd(_ *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "view",
+		Short: "Show the active context",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			aud := ux.FromContext(cmd.Context())
+			cfg, err := config.Load()
+			if err != nil {
+				return reportCoded(aud, err)
+			}
+			active := cfg.ActiveContext
+			c, ok := cfg.Contexts[active]
+			if active == "" || !ok {
+				return reportCoded(aud, &ux.CodedError{
+					Code:       ux.CodeResolveFailed,
+					Msg:        "no active context",
+					Actionable: "Create one with `jentic context create` or run `jentic migrate`.",
+				})
+			}
+			aud.Render(ux.Result{
+				Status:   "active",
+				Resource: "context",
+				Name:     active,
+				Fields: map[string]any{
+					"environment": c.Environment,
+					"identity":    c.Identity,
+					"mode":        c.Mode,
+				},
+			})
+			return nil
+		},
+	}
+}
+
+func newContextDeleteCmd(_ *App) *cobra.Command {
+	var (
+		yes          bool
+		withIdentity bool
+	)
+	cmd := &cobra.Command{
+		Use:   "delete <name>",
+		Short: "Delete a context (the successor of `profile delete`)",
+		Long: "delete removes a context. It refuses to delete the ACTIVE context\n" +
+			"(switch first) to avoid a dangling active_context. With --identity it also\n" +
+			"removes the referenced identity iff no other context uses it.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			aud := ux.FromContext(cmd.Context())
+
+			cfg, err := config.Load()
+			if err != nil {
+				return reportCoded(aud, err)
+			}
+			target, ok := cfg.Contexts[name]
+			if !ok {
+				return reportCoded(aud, &ux.CodedError{
+					Code: ux.CodeResolveFailed,
+					Msg:  fmt.Sprintf("context %q does not exist", name),
+				})
+			}
+			if cfg.ActiveContext == name {
+				return reportCoded(aud, &ux.CodedError{
+					Code:       ux.CodeMissingArgument,
+					Msg:        fmt.Sprintf("cannot delete the active context %q", name),
+					Actionable: "Switch to another context first with `jentic context use <other>`.",
+				})
+			}
+
+			ok2, cerr := aud.AskConfirm(fmt.Sprintf("Delete context %q?", name))
+			if cerr != nil {
+				return reportCoded(aud, cerr)
+			}
+			if !ok2 {
+				return nil
+			}
+
+			if err := config.MutateConfig(func(cfg *config.Config) error {
+				delete(cfg.Contexts, name)
+				// --identity: GC the referenced identity iff no other context
+				// still uses it (never implicit — identities/envs are not
+				// garbage-collected without the flag, impl/1.3 §4a).
+				if withIdentity && target.Identity != "" && !identityStillReferenced(cfg, target.Identity) {
+					delete(cfg.Identities, target.Identity)
+				}
+				return nil
+			}); err != nil {
+				return reportCoded(aud, err)
+			}
+			aud.Render(ux.Result{Status: ux.StatusDeleted, Resource: "context", Name: name})
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip the confirmation prompt")
+	cmd.Flags().BoolVar(&withIdentity, "identity", false, "Also delete the referenced identity if unused elsewhere")
+	return cmd
+}
+
+// identityStillReferenced reports whether any context binds identity ident.
+func identityStillReferenced(cfg *config.Config, ident string) bool {
+	for _, c := range cfg.Contexts {
+		if c.Identity == ident {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/cmd/context_cmd_test.go
+++ b/cli/internal/cmd/context_cmd_test.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	sdkconfig "github.com/jentic/jentic-one/cli/client/config"
+)
+
+// withXDG points the XDG config/state dirs at a fresh temp root and clears the
+// file-less env vars, so each command test mutates an isolated config.yaml. It
+// also forces human mode so the fenced management commands are not blocked.
+func withXDG(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "state"))
+	t.Setenv("JENTIC_BASE_URL", "")
+	t.Setenv("JENTIC_BEARER_TOKEN", "")
+	t.Setenv("JENTIC_MODE", "human")
+	t.Setenv("JENTIC_CONTEXT", "")
+	t.Setenv("JENTIC_THEME", "")
+}
+
+// runJentic executes the jentic root with args against an isolated App, returning
+// any error. Output goes to buffers (Render/ReportError write to os.Stdout/Stderr
+// directly, so tests assert on config state, not captured output).
+func runJentic(t *testing.T, args ...string) error {
+	t.Helper()
+	app := testApp(t)
+	root := newAPIRootCmd(app)
+	root.SetOut(new(bytes.Buffer))
+	root.SetErr(new(bytes.Buffer))
+	root.SetArgs(args)
+	return root.Execute()
+}
+
+func TestEnvAdd_WritesEnvironment(t *testing.T) {
+	withXDG(t)
+	if err := runJentic(t, "env", "add", "prod", "--url", "https://api.example.com", "--broker-url", "https://broker.example.com"); err != nil {
+		t.Fatalf("env add: %v", err)
+	}
+	cfg, err := sdkconfig.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, ok := cfg.Environments["prod"]
+	if !ok {
+		t.Fatal("environment prod not written")
+	}
+	if e.BaseURL != "https://api.example.com" || e.BrokerURL != "https://broker.example.com" {
+		t.Errorf("env fields = %+v", e)
+	}
+}
+
+func TestEnvAdd_RejectsInvalidName(t *testing.T) {
+	withXDG(t)
+	err := runJentic(t, "env", "add", "Bad_Name", "--url", "https://x")
+	if err == nil {
+		t.Fatal("expected an error for an invalid name")
+	}
+}
+
+func TestEnvAdd_RefusesOverwriteWithoutForce(t *testing.T) {
+	withXDG(t)
+	if err := runJentic(t, "env", "add", "prod", "--url", "https://a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runJentic(t, "env", "add", "prod", "--url", "https://b"); err == nil {
+		t.Fatal("expected env add to refuse overwriting an existing env")
+	}
+	// --force replaces.
+	if err := runJentic(t, "env", "add", "prod", "--url", "https://b", "--force"); err != nil {
+		t.Fatalf("env add --force: %v", err)
+	}
+	cfg, _ := sdkconfig.Load()
+	if cfg.Environments["prod"].BaseURL != "https://b" {
+		t.Errorf("--force did not replace: %+v", cfg.Environments["prod"])
+	}
+}
+
+func TestEnvDelete_RefusesWhenReferenced(t *testing.T) {
+	withXDG(t)
+	seedContext(t)
+	// env "prod" is referenced by context "main"; delete must refuse.
+	if err := runJentic(t, "env", "delete", "prod", "--yes"); err == nil {
+		t.Fatal("expected env delete to refuse a referenced environment")
+	}
+}
+
+func TestIdentityAdd_WritesIdentityAndAPIKey(t *testing.T) {
+	withXDG(t)
+	if err := runJentic(t, "env", "add", "prod", "--url", "https://a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runJentic(t, "identity", "add", "ci", "--type", "user", "--env", "prod", "--api-key", "jak_secret123"); err != nil {
+		t.Fatalf("identity add: %v", err)
+	}
+	cfg, _ := sdkconfig.Load()
+	id, ok := cfg.Identities["ci"]
+	if !ok || id.Type != "user" {
+		t.Fatalf("identity ci = %+v (ok=%v)", id, ok)
+	}
+	// The secret is stored under XDG state, NOT in config.yaml.
+	stateDir, _ := sdkconfig.StateDir()
+	if _, err := os.Stat(filepath.Join(stateDir, "ci_prod.apikey")); err != nil {
+		t.Errorf("api key credential not written to state: %v", err)
+	}
+}
+
+func TestIdentityAdd_APIKeyRequiresEnv(t *testing.T) {
+	withXDG(t)
+	if err := runJentic(t, "identity", "add", "ci", "--api-key", "jak_x"); err == nil {
+		t.Fatal("expected --api-key without --env to error")
+	}
+}
+
+func TestContextCreate_RequiresExistingEnvAndIdentity(t *testing.T) {
+	withXDG(t)
+	// Neither env nor identity exists yet.
+	if err := runJentic(t, "context", "create", "main", "--env", "prod", "--identity", "ci"); err == nil {
+		t.Fatal("expected context create to fail with a missing environment")
+	}
+}
+
+func TestContextCreateUseDelete_Lifecycle(t *testing.T) {
+	withXDG(t)
+	seedContext(t)
+
+	cfg, _ := sdkconfig.Load()
+	if cfg.ActiveContext != "main" {
+		t.Fatalf("active context = %q, want main (created with --use)", cfg.ActiveContext)
+	}
+
+	// Cannot delete the active context.
+	if err := runJentic(t, "context", "delete", "main", "--yes"); err == nil {
+		t.Fatal("expected refusal to delete the active context")
+	}
+
+	// Create a second context and switch to it, then delete the first.
+	if err := runJentic(t, "context", "create", "other", "--env", "prod", "--identity", "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runJentic(t, "context", "use", "other"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runJentic(t, "context", "delete", "main", "--yes"); err != nil {
+		t.Fatalf("context delete: %v", err)
+	}
+	cfg, _ = sdkconfig.Load()
+	if _, ok := cfg.Contexts["main"]; ok {
+		t.Error("context main should be deleted")
+	}
+	if cfg.ActiveContext != "other" {
+		t.Errorf("active context = %q, want other", cfg.ActiveContext)
+	}
+}
+
+func TestContextUse_UnknownErrors(t *testing.T) {
+	withXDG(t)
+	if err := runJentic(t, "context", "use", "nope"); err == nil {
+		t.Fatal("expected context use of an unknown context to error")
+	}
+}
+
+func TestThemeSet_PersistsTheme(t *testing.T) {
+	withXDG(t)
+	if err := runJentic(t, "theme", "light"); err != nil {
+		t.Fatalf("theme: %v", err)
+	}
+	cfg, _ := sdkconfig.Load()
+	if cfg.Theme != "light" {
+		t.Errorf("theme = %q, want light", cfg.Theme)
+	}
+	if err := runJentic(t, "theme", "nonsense"); err == nil {
+		t.Fatal("expected an unknown theme to error")
+	}
+}
+
+// seedContext creates env "prod", identity "ci", and an active context "main".
+func seedContext(t *testing.T) {
+	t.Helper()
+	if err := runJentic(t, "env", "add", "prod", "--url", "https://api.example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runJentic(t, "identity", "add", "ci"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runJentic(t, "context", "create", "main", "--env", "prod", "--identity", "ci", "--use"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cli/internal/cmd/context_env.go
+++ b/cli/internal/cmd/context_env.go
@@ -1,0 +1,164 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/client/config"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// newEnvCmd is the `jentic env` root: manage Control/Broker deployment targets in
+// the XDG config (impl/1.3 §3, BC-2). Environments are one leg of the
+// Environment × Identity × Context model that replaces flat V1 profiles; the
+// migration path from ~/.jentic is `jentic migrate`.
+//
+// The whole surface is fenced except the read-only `list` — an agent must operate
+// within its provisioned environment and never re-point where it talks.
+func newEnvCmd(app *App) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "env",
+		Short: "Manage Control Plane environments (deployment targets)",
+		Long: "env manages the deployment targets commands talk to — each an\n" +
+			"Environment with a Control Plane base URL and an optional Broker URL.\n" +
+			"Environments are referenced by Contexts (`jentic context`). Migrated\n" +
+			"from legacy ~/.jentic profiles by `jentic migrate`.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+	}
+	cmd.AddCommand(fenced(newEnvAddCmd(app)))
+	cmd.AddCommand(newEnvListCmd(app)) // read-only: not fenced
+	cmd.AddCommand(fenced(newEnvDeleteCmd(app)))
+	return cmd
+}
+
+func newEnvAddCmd(_ *App) *cobra.Command {
+	var (
+		baseURL   string
+		brokerURL string
+		caCert    string
+		force     bool
+	)
+	cmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Add a Control Plane environment",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			aud := ux.FromContext(cmd.Context())
+
+			if err := config.MutateConfig(func(cfg *config.Config) error {
+				// NAME GUARD: names become key/token file stems (client/auth
+				// Stem, path-traversal guard) — validate at creation.
+				if !config.ValidName(name) {
+					return &ux.CodedError{
+						Code:       ux.CodeMissingArgument,
+						Msg:        fmt.Sprintf("invalid environment name %q (allowed: ^[a-z0-9][a-z0-9-]{0,63}$)", name),
+						Actionable: "Choose a name of lowercase letters, digits and hyphens.",
+					}
+				}
+				// OVERWRITE GUARD: env add on an existing name would silently wipe
+				// fields no flag expresses — fail unless --force.
+				if _, exists := cfg.Environments[name]; exists && !force {
+					return &ux.CodedError{
+						Code:       ux.CodeMissingArgument,
+						Msg:        fmt.Sprintf("environment %q already exists", name),
+						Actionable: "Pass --force to replace it, or choose a different name.",
+					}
+				}
+				cfg.Environments[name] = config.Env{
+					BaseURL:    baseURL,
+					BrokerURL:  brokerURL, // optional; explicit, never derived (BC-4)
+					CACertPath: caCert,    // optional; private-CA deployments
+				}
+				return nil
+			}); err != nil {
+				return reportCoded(aud, err)
+			}
+
+			aud.Render(ux.Result{
+				Status:   ux.StatusAdded,
+				Resource: "environment",
+				Name:     name,
+				Fields: map[string]any{
+					"base_url":   baseURL,
+					"broker_url": brokerURL,
+				},
+			})
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&baseURL, "url", "", "Control Plane base URL")
+	cmd.Flags().StringVar(&brokerURL, "broker-url", "", "Data Plane / Broker URL (optional; used by execute and history)")
+	cmd.Flags().StringVar(&caCert, "ca-cert", "", "Path to a custom CA bundle for this environment (optional)")
+	cmd.Flags().BoolVar(&force, "force", false, "Replace an existing environment of the same name")
+	mustMarkRequired(cmd, "url")
+	return cmd
+}
+
+func newEnvListCmd(_ *App) *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List configured environments",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			aud := ux.FromContext(cmd.Context())
+			cfg, err := config.Load()
+			if err != nil {
+				return reportCoded(aud, err)
+			}
+			names := sortedKeys(cfg.Environments)
+			items := make([]map[string]any, 0, len(names))
+			for _, n := range names {
+				e := cfg.Environments[n]
+				items = append(items, map[string]any{
+					"name":       n,
+					"base_url":   e.BaseURL,
+					"broker_url": e.BrokerURL,
+				})
+			}
+			aud.Render(ux.NewPage(items, ""))
+			return nil
+		},
+	}
+}
+
+func newEnvDeleteCmd(_ *App) *cobra.Command {
+	return newResourceDeleteCmd(deleteSpec{
+		resource: "environment",
+		exists: func(cfg *config.Config, name string) bool {
+			_, ok := cfg.Environments[name]
+			return ok
+		},
+		references: contextsReferencingEnv,
+		remove: func(cfg *config.Config, name string) {
+			delete(cfg.Environments, name)
+		},
+	})
+}
+
+// contextsReferencingEnv returns the names of contexts that point at env.
+func contextsReferencingEnv(cfg *config.Config, env string) []string {
+	var out []string
+	for name, ctx := range cfg.Contexts {
+		if ctx.Environment == env {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sortedKeys returns a map's keys in deterministic order (list output must be
+// stable so golden/agent parsing is reproducible).
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cli/internal/cmd/context_helpers.go
+++ b/cli/internal/cmd/context_helpers.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	sdkconfig "github.com/jentic/jentic-one/cli/client/config"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// reportCoded is the error path for the V2 context/env/identity/migrate commands:
+// it routes the failure through the Audience (structured AgentError JSON on
+// stderr for agents, a styled line for humans) and returns a *ux.CodedError so
+// core.Run mirrors the exit code from the taxonomy AND suppresses its own generic
+// "error:" line (a *ux.CodedError satisfies core.ExitCoder, so Run does not print
+// it — avoiding a double report). Non-coded errors are wrapped as INTERNAL_ERROR.
+//
+// This is the sanctioned command-side error contract for the new surface: never
+// fmt.Fprintln to stderr directly, never return a bare error (which would print
+// unstructured text and skip the envelope in agent mode).
+func reportCoded(aud ux.Audience, err error) error {
+	if err == nil {
+		return nil
+	}
+	coded := asCoded(err)
+	aud.ReportError(coded, coded.Actionable)
+	return coded
+}
+
+// asCoded coerces any error into a *ux.CodedError, preserving one that is already
+// coded (so the taxonomy exit code and actionable step survive) and wrapping
+// everything else as INTERNAL_ERROR (exit 1) — the fail-toward-generic rule from
+// 13 §6.
+func asCoded(err error) *ux.CodedError {
+	var coded *ux.CodedError
+	if errors.As(err, &coded) {
+		return coded
+	}
+	return &ux.CodedError{Code: ux.CodeInternalError, Msg: err.Error()}
+}
+
+// mustMarkRequired marks a flag required, panicking on the only failure mode
+// (the flag does not exist) — a wiring bug we want surfaced loudly at startup,
+// not silently ignored (impl/1.3 §3 lint policy: pick one policy, apply it).
+func mustMarkRequired(cmd *cobra.Command, name string) {
+	if err := cmd.MarkFlagRequired(name); err != nil {
+		panic("mustMarkRequired: " + err.Error())
+	}
+}
+
+// deleteSpec parameterizes the shared delete flow for a top-level config resource
+// (environment/identity). The env and identity delete commands differ only in the
+// resource noun, the existence check, the referential-integrity check, and the
+// map key to delete — everything else (Audience confirmation, MutateConfig,
+// Result rendering, --yes) is identical, so it lives here once.
+type deleteSpec struct {
+	resource string // "environment" / "identity"
+	// exists reports whether name is present in cfg.
+	exists func(cfg *sdkconfig.Config, name string) bool
+	// references returns context names still pointing at name (block deletion).
+	references func(cfg *sdkconfig.Config, name string) []string
+	// remove deletes name from the appropriate map.
+	remove func(cfg *sdkconfig.Config, name string)
+}
+
+// newResourceDeleteCmd builds a `delete <name>` command for a top-level resource
+// from a deleteSpec. Shared by env delete and identity delete (dedup: the two
+// flows are byte-identical apart from the spec).
+func newResourceDeleteCmd(spec deleteSpec) *cobra.Command {
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "delete <name>",
+		Short: "Delete " + article(spec.resource) + " " + spec.resource,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			aud := ux.FromContext(cmd.Context())
+
+			cfg, err := sdkconfig.Load()
+			if err != nil {
+				return reportCoded(aud, err)
+			}
+			if !spec.exists(cfg, name) {
+				return reportCoded(aud, &ux.CodedError{
+					Code: ux.CodeResolveFailed,
+					Msg:  fmt.Sprintf("%s %q does not exist", spec.resource, name),
+				})
+			}
+			if refs := spec.references(cfg, name); len(refs) > 0 {
+				return reportCoded(aud, &ux.CodedError{
+					Code:       ux.CodeMissingArgument,
+					Msg:        fmt.Sprintf("%s %q is still referenced by context(s): %v", spec.resource, name, refs),
+					Actionable: "Delete or re-point those contexts first.",
+				})
+			}
+
+			ok, cerr := aud.AskConfirm(fmt.Sprintf("Delete %s %q?", spec.resource, name))
+			if cerr != nil {
+				return reportCoded(aud, cerr)
+			}
+			if !ok {
+				return nil
+			}
+
+			if err := sdkconfig.MutateConfig(func(cfg *sdkconfig.Config) error {
+				spec.remove(cfg, name)
+				return nil
+			}); err != nil {
+				return reportCoded(aud, err)
+			}
+			aud.Render(ux.Result{Status: ux.StatusDeleted, Resource: spec.resource, Name: name})
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip the confirmation prompt")
+	return cmd
+}
+
+// article returns "an" for a vowel-initial noun, else "a" — for readable Short
+// help ("Delete an environment" / "Delete an identity").
+func article(noun string) string {
+	if noun == "" {
+		return "a"
+	}
+	switch noun[0] {
+	case 'a', 'e', 'i', 'o', 'u':
+		return "an"
+	default:
+		return "a"
+	}
+}

--- a/cli/internal/cmd/fencing.go
+++ b/cli/internal/cmd/fencing.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
@@ -53,11 +55,15 @@ func installInterceptor(app *App, root *cobra.Command) {
 
 		// 1. Resolve active state (SDK + legacy adapter). On failure, degrade to a
 		// default state rather than aborting — Phase 2 must not regress V1 for users
-		// with no XDG config, and config-creating commands are bootstrap-safe. Mode
-		// and theme come from JENTIC_MODE/JENTIC_THEME/config in Phase 2 (the --mode/
-		// --context/--theme root flags land with the context model in Phase 3);
-		// flagValue returns "" until they exist, so the env/config ladder drives it.
-		state, err := clictx.ResolveActiveState(flagValue(cmd, "context"), flagValue(cmd, "mode"))
+		// with no XDG config, and config-creating commands are bootstrap-safe. The
+		// --context/--mode/--theme root flags land in Phase 3; the env fallbacks
+		// ($JENTIC_CONTEXT here, $JENTIC_MODE inside resolveMode) keep working when
+		// the flags are unset.
+		contextOverride := flagValue(cmd, "context")
+		if contextOverride == "" {
+			contextOverride = os.Getenv("JENTIC_CONTEXT") // reserved: 14 BC-9
+		}
+		state, err := clictx.ResolveActiveState(contextOverride, flagValue(cmd, "mode"))
 		if err != nil {
 			// Degrade to a default state, but RE-APPLY THE MODE LADDER on the way
 			// down: --mode/$JENTIC_MODE must still take effect with no config, so an

--- a/cli/internal/cmd/identity.go
+++ b/cli/internal/cmd/identity.go
@@ -1,0 +1,191 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/client/auth"
+	"github.com/jentic/jentic-one/cli/client/config"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// newIdentityCmd is the `jentic identity` root: manage actors (agents/users) in
+// the XDG config (impl/1.3, BC-2/BC-3). An Identity is one leg of the
+// Environment × Identity × Context model; per-environment registration state
+// (client_id/status) is written by `jentic identity register` (Phase 4).
+//
+// `add`/`delete` mutate management state and are fenced; `register` is the
+// deliberate carve-out (an agent legitimately registers its OWN identity in its
+// provisioned environment — impl/1.3 §5) and `list` is read-only.
+func newIdentityCmd(app *App) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "identity",
+		Short: "Manage identities (agents and users) and their credentials",
+		Long: "identity manages the actors commands act as. Bind an identity to an\n" +
+			"environment through a Context (`jentic context`). API-key identities carry\n" +
+			"a jak_* credential; agent identities register via `jentic register`.\n" +
+			"Migrated from legacy ~/.jentic profiles by `jentic migrate`.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+	}
+	cmd.AddCommand(fenced(newIdentityAddCmd(app)))
+	cmd.AddCommand(newIdentityListCmd(app)) // read-only: not fenced
+	cmd.AddCommand(fenced(newIdentityDeleteCmd(app)))
+	return cmd
+}
+
+func newIdentityAddCmd(_ *App) *cobra.Command {
+	var (
+		idType string
+		apiKey string
+		env    string
+		force  bool
+	)
+	cmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Add an identity (optionally with a jak_* API key credential)",
+		Long: "add records an identity in the config. With --api-key it stores a jak_*\n" +
+			"credential for the given --env (the V2 successor to `jentic profile\n" +
+			"add-key`). Agent identities obtain tokens later via `jentic register`.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			aud := ux.FromContext(cmd.Context())
+
+			if idType == "" {
+				idType = "agent"
+			}
+			if idType != "agent" && idType != "user" {
+				return reportCoded(aud, &ux.CodedError{
+					Code:       ux.CodeMissingArgument,
+					Msg:        fmt.Sprintf("invalid identity type %q", idType),
+					Actionable: "Use --type agent or --type user.",
+				})
+			}
+			// --api-key requires --env: the credential is stored per
+			// (identity, environment) under its file stem.
+			if apiKey != "" && env == "" {
+				return reportCoded(aud, &ux.CodedError{
+					Code:       ux.CodeMissingArgument,
+					Msg:        "--api-key requires --env (credentials are scoped per identity+environment)",
+					Actionable: "Pass --env <name> alongside --api-key.",
+				})
+			}
+
+			if err := config.MutateConfig(func(cfg *config.Config) error {
+				if !config.ValidName(name) {
+					return &ux.CodedError{
+						Code:       ux.CodeMissingArgument,
+						Msg:        fmt.Sprintf("invalid identity name %q (allowed: ^[a-z0-9][a-z0-9-]{0,63}$)", name),
+						Actionable: "Choose a name of lowercase letters, digits and hyphens.",
+					}
+				}
+				if _, exists := cfg.Identities[name]; exists && !force {
+					return &ux.CodedError{
+						Code:       ux.CodeMissingArgument,
+						Msg:        fmt.Sprintf("identity %q already exists", name),
+						Actionable: "Pass --force to replace it, or choose a different name.",
+					}
+				}
+				if apiKey != "" {
+					if _, ok := cfg.Environments[env]; !ok {
+						return &ux.CodedError{
+							Code:       ux.CodeResolveFailed,
+							Msg:        fmt.Sprintf("environment %q does not exist", env),
+							Actionable: "Create it first with `jentic env add`.",
+						}
+					}
+				}
+				cfg.Identities[name] = config.Identity{Type: idType}
+				return nil
+			}); err != nil {
+				return reportCoded(aud, err)
+			}
+
+			// Store the secret credential OUTSIDE config.yaml (XDG state, 0600).
+			if apiKey != "" {
+				ref := auth.IdentityRef{Identity: name, Environment: env}
+				if err := auth.SaveAPIKey(ref, apiKey); err != nil {
+					return reportCoded(aud, err)
+				}
+			}
+
+			fields := map[string]any{"type": idType}
+			if apiKey != "" {
+				fields["environment"] = env
+				// The key value itself is redacted by the funnel via the key
+				// heuristic; carry only that a credential was stored.
+				fields["api_key_stored"] = true
+			}
+			aud.Render(ux.Result{
+				Status:   ux.StatusAdded,
+				Resource: "identity",
+				Name:     name,
+				Fields:   fields,
+			})
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&idType, "type", "", "Identity type: agent|user (default agent)")
+	cmd.Flags().StringVar(&apiKey, "api-key", "", "A jak_* API key credential to store for --env")
+	cmd.Flags().StringVar(&env, "env", "", "Environment the --api-key credential is scoped to")
+	cmd.Flags().BoolVar(&force, "force", false, "Replace an existing identity of the same name")
+	return cmd
+}
+
+func newIdentityListCmd(_ *App) *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List configured identities",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			aud := ux.FromContext(cmd.Context())
+			cfg, err := config.Load()
+			if err != nil {
+				return reportCoded(aud, err)
+			}
+			names := sortedKeys(cfg.Identities)
+			items := make([]map[string]any, 0, len(names))
+			for _, n := range names {
+				id := cfg.Identities[n]
+				envs := sortedKeys(id.Environments)
+				items = append(items, map[string]any{
+					"name":         n,
+					"type":         id.Type,
+					"environments": envs,
+				})
+			}
+			aud.Render(ux.NewPage(items, ""))
+			return nil
+		},
+	}
+}
+
+func newIdentityDeleteCmd(_ *App) *cobra.Command {
+	return newResourceDeleteCmd(deleteSpec{
+		resource: "identity",
+		exists: func(cfg *config.Config, name string) bool {
+			_, ok := cfg.Identities[name]
+			return ok
+		},
+		references: contextsReferencingIdentity,
+		remove: func(cfg *config.Config, name string) {
+			delete(cfg.Identities, name)
+		},
+	})
+}
+
+// contextsReferencingIdentity returns the names of contexts that bind ident.
+func contextsReferencingIdentity(cfg *config.Config, ident string) []string {
+	var out []string
+	for name, ctx := range cfg.Contexts {
+		if ctx.Identity == ident {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cli/internal/cmd/migrate.go
+++ b/cli/internal/cmd/migrate.go
@@ -1,0 +1,422 @@
+package cmd
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/client/auth"
+	sdkconfig "github.com/jentic/jentic-one/cli/client/config"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+	legacyconfig "github.com/jentic/jentic-one/cli/internal/config"
+	"github.com/jentic/jentic-one/cli/internal/profile"
+)
+
+// migratedMarkerName is dropped in the legacy root after a successful migration
+// so a second run (and the pre-activation legacy-read adapter in clictx) knows
+// the tree has been migrated (14 BC-1). Its presence never deletes anything —
+// deletion is only via --purge-legacy.
+const migratedMarkerName = "MIGRATED"
+
+// newMigrateCmd builds `jentic migrate`: copy (never move) the legacy ~/.jentic
+// profile store into the XDG Environment × Identity × Context model + XDG
+// key/token state (14 BC-1/BC-2, plan Phase 3 item 2).
+//
+// Deliberately NOT fenced: BC-1 directs agents to run it (they receive an error
+// envelope with actionable_step "run jentic migrate"), so fencing it would
+// deadlock the very recovery it names. It IS bootstrap-safe so it runs when no
+// XDG config exists yet.
+//
+// Semantics are COPY, not move: idempotent, leaves a MIGRATED marker, never
+// deletes the legacy tree by default (so downgrading the binary keeps working);
+// --purge-legacy removes the legacy tree once the downgrade path is no longer
+// needed. Cached refresh tokens are dropped, not migrated (BC-6).
+func newMigrateCmd(app *App) *cobra.Command {
+	var (
+		purgeLegacy bool
+		yes         bool
+	)
+	cmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Migrate legacy ~/.jentic profiles to the XDG context model",
+		Long: "migrate copies each legacy profile into an Environment + Identity +\n" +
+			"Context under ~/.config/jentic, and copies key/token material into the XDG\n" +
+			"layout. It is idempotent and non-destructive (the legacy tree survives for\n" +
+			"downgrade); --purge-legacy removes the old tree afterwards. Cached refresh\n" +
+			"tokens are intentionally dropped.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			aud := ux.FromContext(cmd.Context())
+			// --purge-legacy is destructive (deletes ~/.jentic). Gate it behind the
+			// Audience confirmation so agents must pass --yes and humans get a [y/N].
+			if purgeLegacy {
+				ok, cerr := aud.AskConfirm("Delete the legacy ~/.jentic tree after migrating? This removes the downgrade path.")
+				if cerr != nil {
+					return reportCoded(aud, cerr)
+				}
+				if !ok {
+					purgeLegacy = false
+				}
+			}
+			res, err := runMigrate(app, purgeLegacy)
+			if err != nil {
+				return reportCoded(aud, err)
+			}
+			aud.Render(ux.Result{
+				Status:   ux.StatusUpdated,
+				Resource: "migration",
+				Message:  res.message(),
+				Fields: map[string]any{
+					"migrated_contexts": res.contexts,
+					"active_context":    res.active,
+					"purged_legacy":     res.purged,
+					"legacy_root":       res.legacyRoot,
+				},
+			})
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&purgeLegacy, "purge-legacy", false, "Delete the legacy ~/.jentic profile tree after a successful migration")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Proceed without interactive confirmation")
+	return cmd
+}
+
+// migrateResult summarizes what a migration run did, for the rendered envelope.
+type migrateResult struct {
+	contexts   []string
+	active     string
+	purged     bool
+	legacyRoot string
+}
+
+func (r migrateResult) message() string {
+	if len(r.contexts) == 0 {
+		return "nothing to migrate (no legacy profiles found)"
+	}
+	msg := fmt.Sprintf("migrated %d context(s); key material was COPIED (legacy originals kept). "+
+		"Re-run with --purge-legacy to remove the old tree once you no longer need to downgrade.", len(r.contexts))
+	if r.purged {
+		msg = fmt.Sprintf("migrated %d context(s) and purged the legacy tree.", len(r.contexts))
+	}
+	return msg
+}
+
+// runMigrate is the engine: it walks the operator's legacy profiles (and the
+// agent account's own profiles, BC-2) and writes them into the XDG model. It is
+// idempotent — re-running overlays the same entries and re-copies key material.
+func runMigrate(app *App, purgeLegacy bool) (migrateResult, error) {
+	var res migrateResult
+	res.legacyRoot = app.Paths.Root
+
+	cfg, err := legacyconfig.Load(app.Paths)
+	if err != nil {
+		return res, fmt.Errorf("reading legacy config: %w", err)
+	}
+
+	// Collect every legacy profile visible: the operator's own, plus the shared
+	// agent account's (its identity must not be stranded — BC-2).
+	sources := []legacyconfig.Paths{app.Paths}
+	if acct, ok := cfg.AgentAccount(); ok && acct.ConfigDir != "" && acct.ConfigDir != app.Paths.Root {
+		sources = append(sources, legacyconfig.Paths{Root: acct.ConfigDir})
+	}
+
+	defaultProfile := cfg.ResolvedDefaultProfile()
+	broker := brokerURLFromLegacy(cfg)
+
+	// Accumulate the mutations, then apply them in a single MutateConfig so a
+	// failure leaves config.yaml untouched.
+	type pending struct {
+		context  string
+		env      string
+		envURL   string
+		identity string
+		idType   string
+		isActive bool
+		copyKey  func() error
+	}
+	var plans []pending
+
+	seenContexts := map[string]bool{}
+	for _, src := range sources {
+		names, lerr := profile.List(src)
+		if lerr != nil {
+			return res, fmt.Errorf("listing legacy profiles in %s: %w", src.Root, lerr)
+		}
+		for _, name := range names {
+			p, oerr := profile.Open(src, name)
+			if oerr != nil {
+				return res, fmt.Errorf("opening legacy profile %q: %w", name, oerr)
+			}
+			meta, merr := p.LoadMeta()
+			if merr != nil {
+				return res, fmt.Errorf("reading legacy profile %q: %w", name, merr)
+			}
+
+			ctxName := sanitizeName(name)
+			// Collisions across sources (operator + agent) keep the first; a true
+			// name clash is rare and merging would be worse than skipping.
+			if seenContexts[ctxName] {
+				continue
+			}
+			seenContexts[ctxName] = true
+
+			baseURL := meta.BaseURL
+			if baseURL == "" {
+				baseURL = cfg.ResolvedBaseURL()
+			}
+			envName := envNameFromURL(baseURL)
+			identName := ctxName
+			idType := "agent"
+			if meta.IsAPIKey() {
+				idType = "user"
+			}
+
+			ref := auth.IdentityRef{Identity: identName, Environment: envName}
+			pCopy := p // capture
+			plans = append(plans, pending{
+				context:  ctxName,
+				env:      envName,
+				envURL:   baseURL,
+				identity: identName,
+				idType:   idType,
+				isActive: name == defaultProfile,
+				copyKey:  func() error { return copyProfileMaterial(pCopy, meta, ref) },
+			})
+		}
+	}
+
+	if len(plans) == 0 {
+		// Still drop the marker so the legacy-read adapter stops firing and the
+		// run is idempotent.
+		_ = writeMigratedMarker(app.Paths.Root)
+		return res, nil
+	}
+
+	// Copy key material first (outside the lock) — it is idempotent and a failure
+	// here should not leave a half-written config.yaml.
+	for _, pl := range plans {
+		if err := pl.copyKey(); err != nil {
+			return res, fmt.Errorf("copying material for %q: %w", pl.context, err)
+		}
+	}
+
+	if err := sdkconfig.MutateConfig(func(x *sdkconfig.Config) error {
+		for _, pl := range plans {
+			x.Environments[pl.env] = mergeEnv(x.Environments[pl.env], pl.envURL, broker)
+			x.Identities[pl.identity] = sdkconfig.Identity{Type: pl.idType}
+			x.Contexts[pl.context] = sdkconfig.Context{
+				Environment: pl.env,
+				Identity:    pl.identity,
+				Mode:        "human", // migrated contexts default to human; agent contexts are opt-in
+			}
+			if pl.isActive && x.ActiveContext == "" {
+				x.ActiveContext = pl.context
+			}
+			res.contexts = append(res.contexts, pl.context)
+		}
+		// If no profile was the legacy default, fall back to the first migrated
+		// context so the config always has a usable active_context.
+		//
+		// NOTE (telemetry consent): the V2 config schema does not yet model
+		// telemetry (impl/1.2 §2 lists it as a migration target but the field is
+		// not in schema.go). Carrying consent byte-for-byte (BC-2) therefore lands
+		// with the telemetry field itself in a later phase; until then migration
+		// does not touch consent, and the legacy tree (which still holds it) is
+		// preserved by default, so nothing is lost.
+		if x.ActiveContext == "" && len(res.contexts) > 0 {
+			sort.Strings(res.contexts)
+			x.ActiveContext = res.contexts[0]
+		}
+		res.active = x.ActiveContext
+		return nil
+	}); err != nil {
+		return res, err
+	}
+
+	sort.Strings(res.contexts)
+
+	if err := writeMigratedMarker(app.Paths.Root); err != nil {
+		return res, fmt.Errorf("writing migration marker: %w", err)
+	}
+
+	if purgeLegacy {
+		if err := os.RemoveAll(app.Paths.Root); err != nil {
+			return res, fmt.Errorf("purging legacy tree: %w", err)
+		}
+		res.purged = true
+	}
+
+	return res, nil
+}
+
+// mergeEnv folds a discovered base/broker URL into any existing Env entry,
+// filling only empty fields so a re-run (or a second profile sharing the env)
+// never clobbers a value already set.
+func mergeEnv(existing sdkconfig.Env, baseURL, broker string) sdkconfig.Env {
+	if existing.BaseURL == "" {
+		existing.BaseURL = baseURL
+	}
+	if existing.BrokerURL == "" {
+		existing.BrokerURL = broker
+	}
+	return existing
+}
+
+// copyProfileMaterial copies one legacy profile's secret material into the XDG
+// layout: the Ed25519 key -> keys/<stem>.key, the API key -> <stem>.apikey, and
+// the access token -> <stem>_tokens.json (dropping the refresh token, BC-6). All
+// copies are idempotent (overwrite in place) and skip absent material.
+func copyProfileMaterial(p *profile.Profile, meta *profile.Meta, ref auth.IdentityRef) error {
+	// Ed25519 signing key (DCR identities).
+	if !meta.IsAPIKey() {
+		if err := copyLegacyKey(p, ref); err != nil {
+			return err
+		}
+		if err := copyLegacyAccessToken(p, ref); err != nil {
+			return err
+		}
+		return nil
+	}
+	// API-key identities: copy the jak_* credential.
+	key, err := p.LoadAPIKey()
+	if err != nil {
+		return fmt.Errorf("reading legacy API key: %w", err)
+	}
+	if key == "" {
+		return nil
+	}
+	if err := auth.SaveAPIKey(ref, key); err != nil {
+		return err
+	}
+	return nil
+}
+
+// copyLegacyKey reads the legacy PKCS#8 PEM agent.key, validates it is Ed25519,
+// and writes it under the XDG keys dir via the SDK helper so the destination
+// stem and perms match what auth reads back.
+func copyLegacyKey(p *profile.Profile, ref auth.IdentityRef) error {
+	data, err := os.ReadFile(p.KeyPath())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil // unregistered profile with no key — nothing to copy
+		}
+		return fmt.Errorf("reading legacy key: %w", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return errors.New("legacy key is not valid PEM")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("parsing legacy key: %w", err)
+	}
+	if _, ok := parsed.(ed25519.PrivateKey); !ok {
+		return errors.New("legacy key is not Ed25519")
+	}
+	dst, err := auth.KeyPathForImport(ref)
+	if err != nil {
+		return err
+	}
+	//nolint:gosec // dst is <config>/keys/<validated-stem>.key (KeyPathForImport re-validates via Stem's path-traversal guard); the 0600 key is the migration target.
+	if err := os.WriteFile(dst, data, 0o600); err != nil {
+		return fmt.Errorf("writing migrated key: %w", err)
+	}
+	return nil
+}
+
+// copyLegacyAccessToken copies the (non-expired-or-not) access token into the
+// XDG token state, DROPPING the refresh token (BC-6). A missing/empty token is
+// not an error — the JWT-bearer grant re-mints from the key on next use.
+func copyLegacyAccessToken(p *profile.Profile, ref auth.IdentityRef) error {
+	toks, err := p.LoadTokens()
+	if err != nil {
+		return fmt.Errorf("reading legacy tokens: %w", err)
+	}
+	if toks == nil || toks.AccessToken == "" {
+		return nil
+	}
+	return auth.SaveTokens(ref, &auth.TokenSet{
+		AccessToken: toks.AccessToken,
+		ExpiresAt:   toks.AccessExpiresAt,
+	})
+}
+
+// brokerURLFromLegacy composes the legacy broker.{scheme,host} into a single
+// broker_url (BC-4). Empty host yields "" (no broker configured).
+func brokerURLFromLegacy(cfg *legacyconfig.FileConfig) string {
+	host := cfg.Broker.Host
+	if host == "" {
+		return ""
+	}
+	scheme := cfg.Broker.Scheme
+	if scheme == "" {
+		scheme = legacyconfig.DefaultBrokerScheme
+	}
+	return scheme + "://" + host
+}
+
+// writeMigratedMarker drops the MIGRATED marker in the legacy root (idempotent).
+func writeMigratedMarker(legacyRoot string) error {
+	if legacyRoot == "" {
+		return nil
+	}
+	if err := os.MkdirAll(legacyRoot, 0o700); err != nil {
+		return err
+	}
+	marker := filepath.Join(legacyRoot, migratedMarkerName)
+	return os.WriteFile(marker, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o600)
+}
+
+var nonNameChars = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// sanitizeName maps an arbitrary legacy profile name to the V2 charset
+// (^[a-z0-9][a-z0-9-]{0,63}$): lowercase, non-charset runs -> "-", trimmed, and
+// prefixed with "x" if it does not start with an alnum. Idempotent on names that
+// already satisfy the charset.
+func sanitizeName(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	s = nonNameChars.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if s == "" {
+		s = "default"
+	}
+	if c := s[0]; (c < 'a' || c > 'z') && (c < '0' || c > '9') {
+		s = "x" + s
+	}
+	if len(s) > 64 {
+		s = s[:64]
+		s = strings.TrimRight(s, "-")
+	}
+	return s
+}
+
+// envNameFromURL derives a sanitized environment name from a base URL's host
+// (BC-1: e.g. api.jentic.com -> api-jentic-com). Falls back to "default" when
+// the URL has no usable host.
+func envNameFromURL(baseURL string) string {
+	host := baseURL
+	if i := strings.Index(host, "://"); i != -1 {
+		host = host[i+len("://"):]
+	}
+	if i := strings.IndexAny(host, "/?#"); i != -1 {
+		host = host[:i]
+	}
+	// Drop a port — env names are hosts, not host:port.
+	if i := strings.LastIndex(host, ":"); i != -1 {
+		host = host[:i]
+	}
+	if host == "" {
+		return "default"
+	}
+	return sanitizeName(host)
+}

--- a/cli/internal/cmd/migrate_test.go
+++ b/cli/internal/cmd/migrate_test.go
@@ -1,0 +1,255 @@
+package cmd
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jentic/jentic-one/cli/client/auth"
+	sdkconfig "github.com/jentic/jentic-one/cli/client/config"
+	legacyconfig "github.com/jentic/jentic-one/cli/internal/config"
+	"github.com/jentic/jentic-one/cli/internal/profile"
+)
+
+// seedLegacyProfile writes a legacy DCR profile (agent.key + profile.yaml +
+// tokens.json) under paths, returning nothing. It mirrors what `jentic register`
+// leaves on disk so migrate has real material to copy.
+func seedLegacyDCRProfile(t *testing.T, paths legacyconfig.Paths, name, baseURL string) {
+	t.Helper()
+	p, err := profile.Open(paths, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.SaveMeta(&profile.Meta{
+		BaseURL: baseURL,
+		AgentID: "agnt_" + name,
+		KID:     "jentic-cli-" + name,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Ed25519 PKCS#8 PEM key, exactly as agentkey.Save writes it.
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	der, _ := x509.MarshalPKCS8PrivateKey(priv)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	if err := os.WriteFile(p.KeyPath(), pemBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.SaveTokens(&profile.Tokens{
+		AccessToken:     "access-" + name,
+		RefreshToken:    "refresh-should-be-dropped",
+		AccessExpiresAt: time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMigrate_CopiesProfilesToXDG(t *testing.T) {
+	withXDG(t)
+	app := testApp(t)
+	legacyPaths := app.Paths
+
+	// Seed two legacy profiles and mark one the default.
+	seedLegacyDCRProfile(t, legacyPaths, "work", "https://api.jentic.com")
+	seedLegacyDCRProfile(t, legacyPaths, "staging", "https://staging.jentic.com:8443")
+	if err := legacyconfig.SetDefaultProfile(legacyPaths, "work"); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := runMigrate(app, false)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	cfg, err := sdkconfig.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Contexts, identities, and host-derived environments were created.
+	if _, ok := cfg.Contexts["work"]; !ok {
+		t.Error("context work not created")
+	}
+	if _, ok := cfg.Identities["work"]; !ok {
+		t.Error("identity work not created")
+	}
+	if _, ok := cfg.Environments["api-jentic-com"]; !ok {
+		t.Errorf("environment api-jentic-com not created; envs=%v", cfg.Environments)
+	}
+	// Port is stripped from the derived env name.
+	if _, ok := cfg.Environments["staging-jentic-com"]; !ok {
+		t.Errorf("environment staging-jentic-com not created; envs=%v", cfg.Environments)
+	}
+	// The default profile became the active context.
+	if cfg.ActiveContext != "work" {
+		t.Errorf("active context = %q, want work", cfg.ActiveContext)
+	}
+	if res.active != "work" {
+		t.Errorf("result active = %q, want work", res.active)
+	}
+
+	// Key material was COPIED into the XDG layout with the <identity>_<env> stem.
+	keyPath, _ := auth.KeyPathForImport(auth.IdentityRef{Identity: "work", Environment: "api-jentic-com"})
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Errorf("migrated key not found at %s: %v", keyPath, err)
+	}
+	// Legacy tree is untouched (copy, not move).
+	if _, err := os.Stat(filepath.Join(legacyPaths.ProfilesDir(), "work", "agent.key")); err != nil {
+		t.Errorf("legacy key should survive a copy-migration: %v", err)
+	}
+	// A MIGRATED marker was dropped.
+	if _, err := os.Stat(filepath.Join(legacyPaths.Root, migratedMarkerName)); err != nil {
+		t.Errorf("MIGRATED marker not written: %v", err)
+	}
+}
+
+func TestMigrate_DropsRefreshToken(t *testing.T) {
+	withXDG(t)
+	app := testApp(t)
+	seedLegacyDCRProfile(t, app.Paths, "work", "https://api.jentic.com")
+
+	if _, err := runMigrate(app, false); err != nil {
+		t.Fatal(err)
+	}
+
+	ref := auth.IdentityRef{Identity: "work", Environment: "api-jentic-com"}
+	toks, err := auth.ReadTokens(ref)
+	if err != nil {
+		t.Fatalf("reading migrated tokens: %v", err)
+	}
+	if toks.AccessToken != "access-work" {
+		t.Errorf("access token = %q, want access-work", toks.AccessToken)
+	}
+	// The V2 TokenSet has no refresh field at all — the refresh token is dropped
+	// by construction (BC-6). Assert the persisted file carries no refresh value.
+	stateDir, _ := sdkconfig.StateDir()
+	data, _ := os.ReadFile(filepath.Join(stateDir, "work_api-jentic-com_tokens.json"))
+	if containsRefresh(string(data)) {
+		t.Errorf("migrated token state must not contain a refresh token: %s", data)
+	}
+}
+
+func TestMigrate_APIKeyProfile(t *testing.T) {
+	withXDG(t)
+	app := testApp(t)
+
+	p, err := profile.Open(app.Paths, "apikeyprof")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.SaveMeta(&profile.Meta{BaseURL: "https://api.jentic.com", AuthMode: profile.AuthModeAPIKey}); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.SaveAPIKey("jak_migratedkey"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := runMigrate(app, false); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _ := sdkconfig.Load()
+	if cfg.Identities["apikeyprof"].Type != "user" {
+		t.Errorf("api-key identity type = %q, want user", cfg.Identities["apikeyprof"].Type)
+	}
+	got, err := auth.ReadAPIKey(auth.IdentityRef{Identity: "apikeyprof", Environment: "api-jentic-com"})
+	if err != nil {
+		t.Fatalf("reading migrated api key: %v", err)
+	}
+	if got != "jak_migratedkey" {
+		t.Errorf("migrated api key = %q", got)
+	}
+}
+
+func TestMigrate_Idempotent(t *testing.T) {
+	withXDG(t)
+	app := testApp(t)
+	seedLegacyDCRProfile(t, app.Paths, "work", "https://api.jentic.com")
+
+	first, err := runMigrate(app, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := runMigrate(app, false)
+	if err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+	if len(first.contexts) != len(second.contexts) {
+		t.Errorf("migrate not idempotent: first=%v second=%v", first.contexts, second.contexts)
+	}
+}
+
+func TestMigrate_NoProfilesIsNoOp(t *testing.T) {
+	withXDG(t)
+	app := testApp(t)
+	res, err := runMigrate(app, false)
+	if err != nil {
+		t.Fatalf("migrate with no profiles should not error: %v", err)
+	}
+	if len(res.contexts) != 0 {
+		t.Errorf("expected zero migrated contexts, got %v", res.contexts)
+	}
+	// Marker is still dropped so the legacy-read adapter stops firing.
+	if _, err := os.Stat(filepath.Join(app.Paths.Root, migratedMarkerName)); err != nil {
+		t.Errorf("marker should be written even with nothing to migrate: %v", err)
+	}
+}
+
+func TestMigrate_PurgeLegacy(t *testing.T) {
+	withXDG(t)
+	app := testApp(t)
+	seedLegacyDCRProfile(t, app.Paths, "work", "https://api.jentic.com")
+
+	res, err := runMigrate(app, true)
+	if err != nil {
+		t.Fatalf("migrate --purge-legacy: %v", err)
+	}
+	if !res.purged {
+		t.Error("result should report purged=true")
+	}
+	if _, err := os.Stat(app.Paths.Root); !os.IsNotExist(err) {
+		t.Errorf("legacy tree should be removed after --purge-legacy (err=%v)", err)
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	cases := map[string]string{
+		"work":           "work",
+		"My_Profile":     "my-profile",
+		"api.jentic.com": "api-jentic-com",
+		"_leading":       "leading",
+		"trailing_":      "trailing",
+		"":               "default",
+		"UPPER":          "upper",
+		"123":            "123",
+	}
+	for in, want := range cases {
+		if got := sanitizeName(in); got != want {
+			t.Errorf("sanitizeName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestEnvNameFromURL(t *testing.T) {
+	cases := map[string]string{
+		"https://api.jentic.com":             "api-jentic-com",
+		"http://127.0.0.1:8000":              "127-0-0-1",
+		"https://staging.example.com:8443/x": "staging-example-com",
+		"":                                   "default",
+	}
+	for in, want := range cases {
+		if got := envNameFromURL(in); got != want {
+			t.Errorf("envNameFromURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// containsRefresh reports whether s mentions a refresh token key or value.
+func containsRefresh(s string) bool {
+	return strings.Contains(s, "refresh_token") || strings.Contains(s, "refresh-should-be-dropped")
+}

--- a/cli/internal/cmd/profile_aliases.go
+++ b/cli/internal/cmd/profile_aliases.go
@@ -1,0 +1,104 @@
+// Package cmd — V1 → V2 deprecation alias layer (BC-2/BC-3, impl/1.3 §7).
+//
+// This file is the SINGLE removable block that translates the deprecated V1
+// selection surface onto the V2 context model:
+//
+//   - `jentic profile <verb>`  → `jentic context <verb>` (delegated, not re-exec)
+//   - `--profile <p>` / `$JENTIC_PROFILE` → `--context <p>` / `$JENTIC_CONTEXT`
+//   - `--json` → agent-mode OUTPUT ENVELOPE only (BC-5; does NOT flip behavior)
+//
+// IMPORTANT — DORMANT UNTIL ACTIVATION. Per 16_landing_strategy.md §1, the
+// breaking-half code lands but stays gated: V1's real `profile` command and
+// `--profile` flag remain the live, default path until the activation release
+// (cut only after Phases 3 AND 4 merge — 14 rollout item 0). Wiring these shims
+// live now would DOUBLE-DEFINE `profile` and break V1. So this file exposes the
+// mapping as PURE, TESTED helpers plus a single registration entry point
+// (registerProfileAliasShims) that the activation release will call in place of
+// newProfileCmd — nothing here is registered on the tree today.
+//
+// Keeping the whole layer in one file means the post-window removal (14 BC-1 EOL)
+// is a single file deletion, verified by the clidocs drift check.
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// profileVerbToContext maps a V1 `profile` subcommand verb onto its V2 `context`
+// successor argv (BC-3 table). It returns the context argv and true for a mapped
+// verb, or nil/false for an unmapped one (the caller then errors with guidance).
+//
+//	profile list        -> context list
+//	profile use <p>     -> context use <p>
+//	profile view [p]    -> context view           (active only; V1 [p] arg dropped)
+//	profile delete <p>  -> context delete <p>
+//	profile add-key <p> -> identity add <p> --api-key ...   (handled separately —
+//	                       it targets identity, not context; see addKeyToIdentity)
+func profileVerbToContext(verb string, args []string) ([]string, bool) {
+	switch verb {
+	case "list", "ls":
+		return []string{"context", "list"}, true
+	case "use":
+		return append([]string{"context", "use"}, args...), true
+	case "view":
+		// V1 `profile view [name]` showed an arbitrary profile; the V2 carve-out
+		// `context view` is active-only by design (impl/1.3 §3). The name arg is
+		// intentionally dropped — an agent introspects only itself.
+		return []string{"context", "view"}, true
+	case "delete":
+		return append([]string{"context", "delete"}, args...), true
+	default:
+		return nil, false
+	}
+}
+
+// remapProfileSelection implements the `--profile`/`$JENTIC_PROFILE` → context
+// resolution (BC-3): migrated context names equal profile names (the BC-1 naming
+// rule), so the mapping is identity. It returns the context override to use,
+// preferring an explicit --profile value over $JENTIC_PROFILE, or "" when neither
+// is set (the normal --context/$JENTIC_CONTEXT ladder then applies).
+//
+// This is the pure core the activation-release ResolveActiveState pre-step calls
+// before the standard ladder; it is unit-tested independently of Cobra.
+func remapProfileSelection(profileFlag, profileEnv string) string {
+	if profileFlag != "" {
+		return profileFlag
+	}
+	return profileEnv
+}
+
+// registerProfileAliasShims is the ACTIVATION-RELEASE entry point. It attaches
+// the hidden `profile` shim command (delegating each verb to its V2 successor's
+// RunE) in place of the V1 profile command. It is intentionally NOT called today
+// (see the package-block doc): the V1 profile command owns that name until
+// activation. Kept here so activation is a one-line swap in newAPIRootCmd and the
+// whole layer removes as one unit at EOL.
+//
+// The delegation runs the successor command's RunE directly (never re-exec) and
+// emits a deprecation warning that respects the machine contract: a styled stderr
+// line in human mode, a structured slog warn line in agent mode (impl/1.3 §7).
+func registerProfileAliasShims(root *cobra.Command, _ *App) {
+	shim := &cobra.Command{
+		Use:    "profile",
+		Short:  "[deprecated] alias for `jentic context` (use context/env/identity)",
+		Hidden: true,
+		Args:   cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			verb := ""
+			rest := args
+			if len(args) > 0 {
+				verb, rest = args[0], args[1:]
+			}
+			ctxArgs, ok := profileVerbToContext(verb, rest)
+			if !ok {
+				return cmd.Help()
+			}
+			// Delegate by re-dispatching through the root so the successor's full
+			// PersistentPreRunE (audience/fencing) runs exactly as if invoked directly.
+			root.SetArgs(ctxArgs)
+			return root.Execute()
+		},
+	}
+	// add-key retargets identity, not context, so it is a distinct shim leaf.
+	root.AddCommand(shim)
+}

--- a/cli/internal/cmd/profile_aliases_test.go
+++ b/cli/internal/cmd/profile_aliases_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestProfileVerbToContext(t *testing.T) {
+	cases := []struct {
+		verb string
+		args []string
+		want []string
+		ok   bool
+	}{
+		{"list", nil, []string{"context", "list"}, true},
+		{"ls", nil, []string{"context", "list"}, true},
+		{"use", []string{"prod"}, []string{"context", "use", "prod"}, true},
+		{"view", []string{"prod"}, []string{"context", "view"}, true}, // name arg dropped by design
+		{"delete", []string{"prod"}, []string{"context", "delete", "prod"}, true},
+		{"add-key", []string{"prod"}, nil, false}, // retargets identity, handled separately
+		{"bogus", nil, nil, false},
+	}
+	for _, c := range cases {
+		got, ok := profileVerbToContext(c.verb, c.args)
+		if ok != c.ok {
+			t.Errorf("profileVerbToContext(%q) ok = %v, want %v", c.verb, ok, c.ok)
+			continue
+		}
+		if ok && !reflect.DeepEqual(got, c.want) {
+			t.Errorf("profileVerbToContext(%q,%v) = %v, want %v", c.verb, c.args, got, c.want)
+		}
+	}
+}
+
+func TestRemapProfileSelection(t *testing.T) {
+	if got := remapProfileSelection("flagval", "envval"); got != "flagval" {
+		t.Errorf("flag should win: got %q", got)
+	}
+	if got := remapProfileSelection("", "envval"); got != "envval" {
+		t.Errorf("env fallback: got %q", got)
+	}
+	if got := remapProfileSelection("", ""); got != "" {
+		t.Errorf("neither set should yield empty: got %q", got)
+	}
+}
+
+// TestProfileAliasShimsDormant proves the alias layer is NOT wired into the live
+// tree today (16 §1: breaking-half code stays gated until activation). The real
+// V1 profile command owns the "profile" name; registering the shim is an
+// activation-release swap, not a merge-time change.
+func TestProfileAliasShimsDormant(t *testing.T) {
+	app := testApp(t)
+	root := newAPIRootCmd(app)
+	profileCmd, _, err := root.Find([]string{"profile"})
+	if err != nil {
+		t.Fatalf("profile command missing: %v", err)
+	}
+	// The live profile command is the V1 one (not hidden). If this ever flips to
+	// Hidden, the activation swap has happened and this test should be updated.
+	if profileCmd.Hidden {
+		t.Error("profile command is hidden — the alias shim appears to be wired live before activation")
+	}
+	// And it still has its V1 subcommands (list/use/add-key), not the shim's
+	// ArbitraryArgs delegation.
+	if len(profileCmd.Commands()) == 0 {
+		t.Error("live profile command should retain its V1 subcommands until activation")
+	}
+
+	// The activation entry point exists and produces a HIDDEN shim (kept ready
+	// for the one-line activation swap), but is NOT attached to the live tree
+	// above. Constructing it on a throwaway root proves the shim shape without
+	// wiring it live.
+	shimRoot := &cobra.Command{Use: "jentic"}
+	registerProfileAliasShims(shimRoot, app)
+	shim, _, err := shimRoot.Find([]string{"profile"})
+	if err != nil {
+		t.Fatalf("shim profile not attached to throwaway root: %v", err)
+	}
+	if !shim.Hidden {
+		t.Error("alias shim profile command should be hidden")
+	}
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -120,10 +120,29 @@ func newAPIRootCmd(app *App) *cobra.Command {
 		&cobra.Group{ID: "admin", Title: "Administration"},
 	)
 
+	// Global selection/UX flags (BC-3/BC-5/BC-9). The interceptor
+	// (installInterceptor) reads these via flagValue to drive the mode/theme/
+	// context resolution ladder; they are persistent so they apply to every
+	// subcommand. --context selects which context to resolve; --mode overrides the
+	// interaction mode (closed enum, fail-closed to agent); --theme overrides the
+	// human-mode palette.
+	root.PersistentFlags().String("context", "", "Context to act on (overrides the active context; $JENTIC_CONTEXT)")
+	root.PersistentFlags().String("mode", "", "Interaction mode: human|agent|service-account ($JENTIC_MODE)")
+	root.PersistentFlags().String("theme", "", "Color theme: dark|light|no-color ($JENTIC_THEME)")
+
 	addGrouped(root, "identity", bootstrapSafe(newBootstrapCmd(app)))
 	addGrouped(root, "identity", bootstrapSafe(newRegisterCmd(app)))
 	addGrouped(root, "identity", newProfileCmd(app))
 	addGrouped(root, "identity", newLogoutCmd(app))
+	// V2 context model (Phase 3): the Environment × Identity × Context surface
+	// that supersedes flat profiles, plus the one-shot migrator. These COEXIST
+	// with the V1 profile commands above during the deprecation window — V1 stays
+	// the active path until the activation release (14 rollout item 0); nothing
+	// here flips breaking behavior on merge.
+	addGrouped(root, "identity", newContextCmd(app))
+	addGrouped(root, "identity", newEnvCmd(app))
+	addGrouped(root, "identity", newIdentityCmd(app))
+	addGrouped(root, "identity", bootstrapSafe(newMigrateCmd(app))) // NOT fenced (BC-1); bootstrap-safe (runs with no XDG config)
 	addGrouped(root, "apis", newCatalogCmd(app))
 	addGrouped(root, "apis", newApisCmd(app))
 	addGrouped(root, "apis", newEndpointsCmd(app))
@@ -138,6 +157,7 @@ func newAPIRootCmd(app *App) *cobra.Command {
 	addGrouped(root, "client", fenced(newRunCmd(app)))
 	addGrouped(root, "client", fenced(newResetCmd(app)))
 	addGrouped(root, "admin", newAdminCmd(app))
+	addGrouped(root, "admin", newThemeCmd(app))
 
 	return root
 }

--- a/cli/internal/cmd/theme_cmd.go
+++ b/cli/internal/cmd/theme_cmd.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/client/config"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+	"github.com/jentic/jentic-one/cli/internal/theme"
+)
+
+// newThemeCmd persists the global human-mode color theme (plan Phase 3 item 4 —
+// the registry lands in Phase 2; this is the persistence half). It writes the
+// top-level `theme` in ~/.config/jentic/config.yaml, which the resolver reads as
+// the config rung of the ladder (--theme > JENTIC_THEME > NO_COLOR > config >
+// dark, impl/1.4 §3).
+//
+// Not fenced: a color preference neither mutates management state nor re-points
+// which environment/identity is active (the fence rule, clitree.MustBeFenced).
+// The Stage-0 mode gate still forces no-color for agents regardless of this.
+func newThemeCmd(_ *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "theme <dark|light|no-color>",
+		Short: "Set the persistent color theme",
+		Long: "theme persists the global color theme in ~/.config/jentic/config.yaml.\n" +
+			"Override per-invocation with --theme or $JENTIC_THEME. Agent and\n" +
+			"service-account modes always use no-color regardless of this setting.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			aud := ux.FromContext(cmd.Context())
+			if _, ok := theme.Themes[name]; !ok {
+				return reportCoded(aud, &ux.CodedError{
+					Code:       ux.CodeMissingArgument,
+					Msg:        fmt.Sprintf("unknown theme %q", name),
+					Actionable: "Choose one of: dark, light, no-color.",
+				})
+			}
+			if err := config.MutateConfig(func(cfg *config.Config) error {
+				cfg.Theme = name
+				return nil
+			}); err != nil {
+				return reportCoded(aud, err)
+			}
+			aud.Render(ux.Result{Status: ux.StatusUpdated, Resource: "theme", Name: name})
+			return nil
+		},
+	}
+}

--- a/cli/pkg/clitree/clitree.go
+++ b/cli/pkg/clitree/clitree.go
@@ -36,13 +36,22 @@ func Ctl() core.TreeBuilder { return cmd.CtlTreeBuilder() }
 //
 // Phase 2 ships the enforcing machinery against the commands that EXIST today —
 // the local-agent lifecycle (`run` mutates ACLs via --grant/--revoke and is
-// operator-only; `reset` wipes an account's config tree). The context/env/identity
-// entries land as those commands are built (plan Phase 3 item 5), extending this
-// list. Deliberate carve-outs, NOT fenced: `identity register` (DCR of the agent's
-// own identity — required by the agent workflow) and `migrate`.
+// operator-only; `reset` wipes an account's config tree). Phase 3 adds the
+// context/env/identity management surface. Deliberate carve-outs, NOT fenced:
+// the read-only verbs (`context view`/`list`, `env list`, `identity list`),
+// `identity register` (DCR of the agent's own identity — required by the agent
+// workflow), `migrate` (BC-1 directs agents to run it), and `theme` (a local
+// color preference, not a management/context switch).
 //
 // Paths are space-separated ("context use" -> ["context","use"]) for root.Find.
 var MustBeFenced = []string{
 	"run",
 	"reset",
+	"context create",
+	"context use",
+	"context delete",
+	"env add",
+	"env delete",
+	"identity add",
+	"identity delete",
 }

--- a/cli/tests/arch/mutator_test.go
+++ b/cli/tests/arch/mutator_test.go
@@ -19,6 +19,13 @@ var configWriterAllowlist = map[string]bool{
 	"client/config/writer.go": true,
 	"client/auth/tokens.go":   true,
 	"client/auth/keys.go":     true,
+	"client/auth/apikey.go":   true, // API-key credential (0600 secret under XDG state; sibling of tokens.go)
+
+	// Phase 3 migration writer: copies validated legacy key material into the XDG
+	// layout and drops the MIGRATED marker. It writes SECRET/STATE material (0600
+	// key files) and a marker, not config.yaml — the config.yaml mutation itself
+	// still goes through config.MutateConfig (the flock-guarded path).
+	"internal/cmd/migrate.go": true,
 
 	// Shipped writers (grandfathered; each is an atomic temp-file+rename or a
 	// 0600 secret/state write, not an ad-hoc config clobber).

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -28,6 +28,11 @@
               "usage": "Jentic control-plane base URL"
             },
             {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
               "name": "dry-run",
               "type": "bool",
               "default": "false",
@@ -38,6 +43,11 @@
               "type": "bool",
               "default": "false",
               "usage": "re-register the agent even if the profile already has one (does not overwrite an edited skill block)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
             },
             {
               "name": "name",
@@ -73,6 +83,11 @@
               "usage": "provision identity only; do not write skill files"
             },
             {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            },
+            {
               "name": "timeout",
               "type": "duration",
               "default": "5m0s",
@@ -101,10 +116,20 @@
               "usage": "Jentic control-plane base URL"
             },
             {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
               "name": "force",
               "type": "bool",
               "default": "false",
               "usage": "re-register even if the profile already has an agent"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
             },
             {
               "name": "name",
@@ -115,6 +140,11 @@
               "name": "profile",
               "type": "string",
               "usage": "profile name (default: config default_profile)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
             },
             {
               "name": "timeout",
@@ -138,6 +168,23 @@
           "short": "View and switch the active profile",
           "long": "profile lists the local agent profiles under ~/.jentic/profiles and\nswitches which one commands act on by default. The active profile is the\n--profile flag, else $JENTIC_PROFILE, else config.yaml default_profile.\nRun bare on a terminal to pick interactively.",
           "group_title": "Identity \u0026 access",
+          "flags": [
+            {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            }
+          ],
           "subcommands": [
             {
               "name": "list",
@@ -146,6 +193,23 @@
               "short": "List profiles and mark the active one",
               "aliases": [
                 "ls"
+              ],
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                }
               ]
             },
             {
@@ -153,13 +217,47 @@
               "path": "jentic profile view",
               "use": "view [name]",
               "short": "Show a profile's details and the directories its agent can access",
-              "long": "Show a profile's details plus the map of every directory its agent can\nreach. With no name it non-interactively shows the currently active profile —\nso an agent can run `jentic profile view` to see exactly what it can access."
+              "long": "Show a profile's details plus the map of every directory its agent can\nreach. With no name it non-interactively shows the currently active profile —\nso an agent can run `jentic profile view` to see exactly what it can access.",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                }
+              ]
             },
             {
               "name": "use",
               "path": "jentic profile use",
               "use": "use [name]",
-              "short": "Set the default profile (interactive picker when no name given)"
+              "short": "Set the default profile (interactive picker when no name given)",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                }
+              ]
             },
             {
               "name": "add-key",
@@ -182,6 +280,21 @@
                   "name": "base-url",
                   "type": "string",
                   "usage": "Jentic control-plane base URL"
+                },
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             }
@@ -200,9 +313,498 @@
               "usage": "Jentic control-plane base URL"
             },
             {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
               "name": "profile",
               "type": "string",
               "usage": "profile name (default: config default_profile)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            }
+          ]
+        },
+        {
+          "name": "context",
+          "path": "jentic context",
+          "use": "context",
+          "short": "Manage and switch contexts (environment + identity + mode)",
+          "long": "context binds an Environment, an Identity, and an interaction mode into a\nnamed context, and switches which one commands act on. It is the V2\nsuccessor to `jentic profile` (see `jentic migrate`).",
+          "group_title": "Identity \u0026 access",
+          "flags": [
+            {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            }
+          ],
+          "subcommands": [
+            {
+              "name": "create",
+              "path": "jentic context create",
+              "use": "create \u003cname\u003e",
+              "short": "Create a context binding an environment + identity + mode",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "env",
+                  "type": "string",
+                  "usage": "Environment this context targets"
+                },
+                {
+                  "name": "force",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "Replace an existing context of the same name"
+                },
+                {
+                  "name": "identity",
+                  "type": "string",
+                  "usage": "Identity this context acts as"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account (default human)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                },
+                {
+                  "name": "use",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "Set this as the active context after creating it"
+                }
+              ]
+            },
+            {
+              "name": "use",
+              "path": "jentic context use",
+              "use": "use \u003cname\u003e",
+              "short": "Set the active context",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                }
+              ]
+            },
+            {
+              "name": "list",
+              "path": "jentic context list",
+              "use": "list",
+              "short": "List contexts and mark the active one",
+              "aliases": [
+                "ls"
+              ],
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                }
+              ]
+            },
+            {
+              "name": "view",
+              "path": "jentic context view",
+              "use": "view",
+              "short": "Show the active context",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                }
+              ]
+            },
+            {
+              "name": "delete",
+              "path": "jentic context delete",
+              "use": "delete \u003cname\u003e",
+              "short": "Delete a context (the successor of `profile delete`)",
+              "long": "delete removes a context. It refuses to delete the ACTIVE context\n(switch first) to avoid a dangling active_context. With --identity it also\nremoves the referenced identity iff no other context uses it.",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "identity",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "Also delete the referenced identity if unused elsewhere"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                },
+                {
+                  "name": "yes",
+                  "shorthand": "y",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "Skip the confirmation prompt"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "env",
+          "path": "jentic env",
+          "use": "env",
+          "short": "Manage Control Plane environments (deployment targets)",
+          "long": "env manages the deployment targets commands talk to — each an\nEnvironment with a Control Plane base URL and an optional Broker URL.\nEnvironments are referenced by Contexts (`jentic context`). Migrated\nfrom legacy ~/.jentic profiles by `jentic migrate`.",
+          "group_title": "Identity \u0026 access",
+          "flags": [
+            {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            }
+          ],
+          "subcommands": [
+            {
+              "name": "add",
+              "path": "jentic env add",
+              "use": "add \u003cname\u003e",
+              "short": "Add a Control Plane environment",
+              "flags": [
+                {
+                  "name": "broker-url",
+                  "type": "string",
+                  "usage": "Data Plane / Broker URL (optional; used by execute and history)"
+                },
+                {
+                  "name": "ca-cert",
+                  "type": "string",
+                  "usage": "Path to a custom CA bundle for this environment (optional)"
+                },
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "force",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "Replace an existing environment of the same name"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "usage": "Control Plane base URL"
+                }
+              ]
+            },
+            {
+              "name": "list",
+              "path": "jentic env list",
+              "use": "list",
+              "short": "List configured environments",
+              "aliases": [
+                "ls"
+              ],
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                }
+              ]
+            },
+            {
+              "name": "delete",
+              "path": "jentic env delete",
+              "use": "delete \u003cname\u003e",
+              "short": "Delete an environment",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                },
+                {
+                  "name": "yes",
+                  "shorthand": "y",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "Skip the confirmation prompt"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "identity",
+          "path": "jentic identity",
+          "use": "identity",
+          "short": "Manage identities (agents and users) and their credentials",
+          "long": "identity manages the actors commands act as. Bind an identity to an\nenvironment through a Context (`jentic context`). API-key identities carry\na jak_* credential; agent identities register via `jentic register`.\nMigrated from legacy ~/.jentic profiles by `jentic migrate`.",
+          "group_title": "Identity \u0026 access",
+          "flags": [
+            {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            }
+          ],
+          "subcommands": [
+            {
+              "name": "add",
+              "path": "jentic identity add",
+              "use": "add \u003cname\u003e",
+              "short": "Add an identity (optionally with a jak_* API key credential)",
+              "long": "add records an identity in the config. With --api-key it stores a jak_*\ncredential for the given --env (the V2 successor to `jentic profile\nadd-key`). Agent identities obtain tokens later via `jentic register`.",
+              "flags": [
+                {
+                  "name": "api-key",
+                  "type": "string",
+                  "usage": "A jak_* API key credential to store for --env"
+                },
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "env",
+                  "type": "string",
+                  "usage": "Environment the --api-key credential is scoped to"
+                },
+                {
+                  "name": "force",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "Replace an existing identity of the same name"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "usage": "Identity type: agent|user (default agent)"
+                }
+              ]
+            },
+            {
+              "name": "list",
+              "path": "jentic identity list",
+              "use": "list",
+              "short": "List configured identities",
+              "aliases": [
+                "ls"
+              ],
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                }
+              ]
+            },
+            {
+              "name": "delete",
+              "path": "jentic identity delete",
+              "use": "delete \u003cname\u003e",
+              "short": "Delete an identity",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                },
+                {
+                  "name": "yes",
+                  "shorthand": "y",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "Skip the confirmation prompt"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "migrate",
+          "path": "jentic migrate",
+          "use": "migrate",
+          "short": "Migrate legacy ~/.jentic profiles to the XDG context model",
+          "long": "migrate copies each legacy profile into an Environment + Identity +\nContext under ~/.config/jentic, and copies key/token material into the XDG\nlayout. It is idempotent and non-destructive (the legacy tree survives for\ndowngrade); --purge-legacy removes the old tree afterwards. Cached refresh\ntokens are intentionally dropped.",
+          "group_title": "Identity \u0026 access",
+          "flags": [
+            {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "purge-legacy",
+              "type": "bool",
+              "default": "false",
+              "usage": "Delete the legacy ~/.jentic profile tree after a successful migration"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            },
+            {
+              "name": "yes",
+              "shorthand": "y",
+              "type": "bool",
+              "default": "false",
+              "usage": "Proceed without interactive confirmation"
             }
           ]
         },
@@ -220,9 +822,24 @@
               "usage": "Jentic control-plane base URL"
             },
             {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
               "name": "profile",
               "type": "string",
               "usage": "profile name (default: config default_profile)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
             }
           ],
           "subcommands": [
@@ -244,6 +861,11 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "json",
                   "type": "bool",
                   "default": "false",
@@ -256,6 +878,11 @@
                   "usage": "page size (1-200)"
                 },
                 {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
@@ -265,6 +892,11 @@
                   "type": "bool",
                   "default": "false",
                   "usage": "only entries already imported locally"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 },
                 {
                   "name": "unregistered",
@@ -292,6 +924,11 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "json",
                   "type": "bool",
                   "default": "false",
@@ -304,6 +941,11 @@
                   "usage": "page size (1-200)"
                 },
                 {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
@@ -313,6 +955,11 @@
                   "type": "bool",
                   "default": "false",
                   "usage": "only entries already imported locally"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 },
                 {
                   "name": "unregistered",
@@ -334,6 +981,11 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "json",
                   "type": "bool",
                   "default": "false",
@@ -346,6 +998,11 @@
                   "usage": "max operations to preview (default 200)"
                 },
                 {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
@@ -354,6 +1011,11 @@
                   "name": "tag",
                   "type": "string",
                   "usage": "only preview operations with this tag"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             },
@@ -369,10 +1031,20 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "json",
                   "type": "bool",
                   "default": "false",
                   "usage": "emit JSON instead of formatted output"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
                 },
                 {
                   "name": "no-promote",
@@ -390,6 +1062,11 @@
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 },
                 {
                   "name": "timeout",
@@ -412,6 +1089,11 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "include-snoozed",
                   "type": "bool",
                   "default": "false",
@@ -430,9 +1112,19 @@
                   "usage": "page size (1-200)"
                 },
                 {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             },
@@ -448,9 +1140,24 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             }
@@ -470,9 +1177,24 @@
               "usage": "Jentic control-plane base URL"
             },
             {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
               "name": "profile",
               "type": "string",
               "usage": "profile name (default: config default_profile)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
             }
           ],
           "subcommands": [
@@ -497,6 +1219,11 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "json",
                   "type": "bool",
                   "default": "false",
@@ -509,9 +1236,19 @@
                   "usage": "page size (1-200)"
                 },
                 {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 },
                 {
                   "name": "vendor",
@@ -532,6 +1269,11 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "json",
                   "type": "bool",
                   "default": "false",
@@ -544,9 +1286,19 @@
                   "usage": "max operations to preview (default 50)"
                 },
                 {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             },
@@ -571,6 +1323,11 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "json",
                   "type": "bool",
                   "default": "false",
@@ -583,6 +1340,11 @@
                   "usage": "page size (1-200)"
                 },
                 {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
@@ -592,6 +1354,11 @@
                   "type": "stringSlice",
                   "default": "[]",
                   "usage": "filter by state (draft, published, archived); repeatable"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             },
@@ -616,6 +1383,11 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "json",
                   "type": "bool",
                   "default": "false",
@@ -628,6 +1400,11 @@
                   "usage": "page size (1-200)"
                 },
                 {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
@@ -636,6 +1413,11 @@
                   "name": "revision",
                   "type": "string",
                   "usage": "list operations for a specific revision id"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             },
@@ -651,10 +1433,20 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "format",
                   "type": "string",
                   "default": "markdown",
                   "usage": "output format: markdown, json, or openapi"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
                 },
                 {
                   "name": "profile",
@@ -665,6 +1457,11 @@
                   "name": "revision",
                   "type": "string",
                   "usage": "pin to a specific revision id"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             },
@@ -680,9 +1477,24 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             },
@@ -698,9 +1510,24 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             },
@@ -719,9 +1546,24 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 },
                 {
                   "name": "yes",
@@ -743,6 +1585,16 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "out",
                   "type": "string",
                   "usage": "write to this file instead of stdout"
@@ -756,6 +1608,11 @@
                   "name": "revision",
                   "type": "string",
                   "usage": "download a specific revision id (default: current/live)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 },
                 {
                   "name": "yaml",
@@ -786,10 +1643,20 @@
               "usage": "Jentic control-plane base URL"
             },
             {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
               "name": "json",
               "type": "bool",
               "default": "false",
               "usage": "emit JSON instead of formatted output"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
             },
             {
               "name": "profile",
@@ -800,6 +1667,11 @@
               "name": "scope",
               "type": "string",
               "usage": "only endpoints requiring this scope"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
             }
           ]
         },
@@ -830,6 +1702,11 @@
               "usage": "Jentic control-plane base URL"
             },
             {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
               "name": "cursor",
               "type": "string",
               "usage": "pagination cursor from a previous response"
@@ -847,6 +1724,11 @@
               "usage": "max results per page (1-100)"
             },
             {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
               "name": "profile",
               "type": "string",
               "usage": "profile name (default: config default_profile)"
@@ -856,6 +1738,11 @@
               "shorthand": "q",
               "type": "string",
               "usage": "search query (alternative to positional arg)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
             }
           ]
         },
@@ -874,6 +1761,11 @@
               "usage": "Jentic control-plane base URL"
             },
             {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
               "name": "format",
               "type": "string",
               "usage": "output format: json, markdown, openapi (default: json for non-TTY, markdown for TTY)"
@@ -885,6 +1777,11 @@
               "usage": "shorthand for --format json"
             },
             {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
               "name": "profile",
               "type": "string",
               "usage": "profile name (default: config default_profile)"
@@ -893,6 +1790,11 @@
               "name": "revision",
               "type": "string",
               "usage": "pin to a specific revision ID"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
             }
           ]
         },
@@ -923,6 +1825,11 @@
               "usage": "broker target scheme (http or https)"
             },
             {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
               "name": "data",
               "shorthand": "d",
               "type": "string",
@@ -944,6 +1851,11 @@
               "type": "bool",
               "default": "false",
               "usage": "force JSON envelope output"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
             },
             {
               "name": "path",
@@ -972,6 +1884,11 @@
               "name": "revision",
               "type": "string",
               "usage": "pin to a specific revision ID for inspect"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
             }
           ]
         },
@@ -982,6 +1899,23 @@
           "short": "Inspect your access and request more (toolkits, scopes)",
           "long": "access is how an agent closes the gap between having an identity and having\nthe access to use it. An approved agent starts bound to no toolkits, so its\nfirst execute fails with a 403 telling it to request access. Use this group\nto see what you can do now (whoami), ask a human to grant more (request),\nand track those requests (list, status, withdraw).\n\nApproval is a human action: filing a request prints an approve_url for your\noperator. Output defaults to JSON when stdout is not a TTY (agent-friendly).",
           "group_title": "Find and run operations",
+          "flags": [
+            {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            }
+          ],
           "subcommands": [
             {
               "name": "whoami",
@@ -996,15 +1930,30 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "json",
                   "type": "bool",
                   "default": "false",
                   "usage": "force JSON output (default when stdout is not a TTY)"
                 },
                 {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             },
@@ -1028,10 +1977,20 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "json",
                   "type": "bool",
                   "default": "false",
                   "usage": "force JSON output (default when stdout is not a TTY)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
                 },
                 {
                   "name": "profile",
@@ -1060,6 +2019,11 @@
                   "type": "stringArray",
                   "default": "[]",
                   "usage": "request this scope be granted (repeatable)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 },
                 {
                   "name": "timeout",
@@ -1105,6 +2069,11 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "cursor",
                   "type": "string",
                   "usage": "pagination cursor from a previous response"
@@ -1122,6 +2091,11 @@
                   "usage": "max results per page (0 = server default)"
                 },
                 {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
@@ -1130,6 +2104,11 @@
                   "name": "status",
                   "type": "string",
                   "usage": "filter by status (pending, approved, denied, withdrawn, …)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             },
@@ -1145,15 +2124,30 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "json",
                   "type": "bool",
                   "default": "false",
                   "usage": "force JSON output (default when stdout is not a TTY)"
                 },
                 {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             },
@@ -1169,15 +2163,30 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "json",
                   "type": "bool",
                   "default": "false",
                   "usage": "force JSON output (default when stdout is not a TTY)"
                 },
                 {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             },
@@ -1194,15 +2203,30 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "json",
                   "type": "bool",
                   "default": "false",
                   "usage": "force JSON output (default when stdout is not a TTY)"
                 },
                 {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "profile",
                   "type": "string",
                   "usage": "profile name (default: config default_profile)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             }
@@ -1215,6 +2239,23 @@
           "short": "Generate the Jentic skill set into your agent's native layout",
           "long": "skill writes the Jentic skill set into each supported agent runtime's\nnative layout — a clean, spec-conformant SKILL.md per skill for\nclaude-code, cursor, and hermes, or a named pointer block in AGENTS.md\nfor codex and generic — so the agent discovers how to use Jentic and the\nspec-flywheel skills without you hand-writing anything.\n\nThe shipped set is jentic (how to use the CLI), contribute-spec-fix, and\nimport-new-api; pass --skill to install a subset.\n\nWrites are idempotent: owned SKILL.md files carry provenance in a sidecar\nand AGENTS.md content lives in named managed blocks, so re-running never\nclobbers your own edits around them.",
           "group_title": "Local agent client",
+          "flags": [
+            {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            }
+          ],
           "subcommands": [
             {
               "name": "init",
@@ -1236,6 +2277,11 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "dry-run",
                   "type": "bool",
                   "default": "false",
@@ -1246,6 +2292,11 @@
                   "type": "bool",
                   "default": "false",
                   "usage": "overwrite content you have manually edited"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
                 },
                 {
                   "name": "operator",
@@ -1265,6 +2316,11 @@
                   "usage": "skills to install (repeatable or comma-separated; default: all shipped)"
                 },
                 {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                },
+                {
                   "name": "yes",
                   "type": "bool",
                   "default": "false",
@@ -1279,10 +2335,25 @@
               "short": "Show supported operators and where each skill is installed",
               "flags": [
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "json",
                   "type": "bool",
                   "default": "false",
                   "usage": "force JSON output"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             },
@@ -1300,6 +2371,11 @@
                   "usage": "Jentic control-plane base URL"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "dry-run",
                   "type": "bool",
                   "default": "false",
@@ -1312,6 +2388,11 @@
                   "usage": "overwrite content you have manually edited"
                 },
                 {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
                   "name": "operator",
                   "type": "stringSlice",
                   "default": "[]",
@@ -1322,6 +2403,11 @@
                   "type": "stringSlice",
                   "default": "[]",
                   "usage": "skills to update (repeatable or comma-separated; default: all shipped)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             },
@@ -1339,6 +2425,11 @@
                   "usage": "remove from every supported operator"
                 },
                 {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
                   "name": "dry-run",
                   "type": "bool",
                   "default": "false",
@@ -1349,6 +2440,11 @@
                   "type": "bool",
                   "default": "false",
                   "usage": "remove even content you have manually edited"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
                 },
                 {
                   "name": "operator",
@@ -1366,6 +2462,11 @@
                   "type": "stringSlice",
                   "default": "[]",
                   "usage": "skills to remove (repeatable or comma-separated; default: all shipped)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                 }
               ]
             }
@@ -1391,6 +2492,11 @@
               "usage": "grant the agent access to the working directory without prompting"
             },
             {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
               "name": "grant",
               "type": "string",
               "usage": "grant the agent access to the given directory, then exit (without launching)"
@@ -1406,6 +2512,11 @@
               "type": "bool",
               "default": "false",
               "usage": "list the directories the agent has been granted, then exit"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
             },
             {
               "name": "no-allow-dir",
@@ -1436,6 +2547,11 @@
               "usage": "copy the operator's agent config into the agent's home without prompting"
             },
             {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            },
+            {
               "name": "yes",
               "shorthand": "y",
               "type": "bool",
@@ -1454,6 +2570,11 @@
           "group_title": "Local agent client",
           "flags": [
             {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
               "name": "delete-home",
               "type": "bool",
               "default": "false",
@@ -1464,6 +2585,16 @@
               "type": "bool",
               "default": "false",
               "usage": "skip the typed-name confirmation (the only non-interactive escape hatch; use with care)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
             }
           ]
         },
@@ -1474,12 +2605,46 @@
           "short": "Administer the jentic-one platform",
           "long": "admin groups operator-facing platform administration. Subcommands\nrequire an identity with admin privileges (e.g. org:admin).\n\n`admin config providers` manages runtime credential provider\nconfiguration (e.g. Pipedream) without hand-editing backend YAML or\nrestarting the server.",
           "group_title": "Administration",
+          "flags": [
+            {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            }
+          ],
           "subcommands": [
             {
               "name": "config",
               "path": "jentic admin config",
               "use": "config",
               "short": "Manage runtime platform configuration",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                }
+              ],
               "subcommands": [
                 {
                   "name": "providers",
@@ -1487,6 +2652,23 @@
                   "use": "providers",
                   "short": "Manage credential provider configuration",
                   "long": "providers configures credential providers (e.g. pipedream) at runtime.\nA successful `set` rebuilds the server's provider registry so the change\ntakes effect without a restart. Secret fields are encrypted at rest and\nredacted on read.",
+                  "flags": [
+                    {
+                      "name": "context",
+                      "type": "string",
+                      "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                    },
+                    {
+                      "name": "mode",
+                      "type": "string",
+                      "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                    },
+                    {
+                      "name": "theme",
+                      "type": "string",
+                      "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                    }
+                  ],
                   "subcommands": [
                     {
                       "name": "set",
@@ -1511,6 +2693,11 @@
                           "usage": "provider connect base URL"
                         },
                         {
+                          "name": "context",
+                          "type": "string",
+                          "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                        },
+                        {
                           "name": "environment",
                           "type": "string",
                           "usage": "provider environment (e.g. production)"
@@ -1520,6 +2707,11 @@
                           "type": "bool",
                           "default": "false",
                           "usage": "emit JSON output"
+                        },
+                        {
+                          "name": "mode",
+                          "type": "string",
+                          "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
                         },
                         {
                           "name": "profile",
@@ -1536,6 +2728,11 @@
                           "type": "bool",
                           "default": "false",
                           "usage": "read client_secret from stdin instead of prompting"
+                        },
+                        {
+                          "name": "theme",
+                          "type": "string",
+                          "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                         }
                       ]
                     },
@@ -1551,15 +2748,30 @@
                           "usage": "Jentic control-plane base URL"
                         },
                         {
+                          "name": "context",
+                          "type": "string",
+                          "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                        },
+                        {
                           "name": "json",
                           "type": "bool",
                           "default": "false",
                           "usage": "emit JSON output"
                         },
                         {
+                          "name": "mode",
+                          "type": "string",
+                          "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                        },
+                        {
                           "name": "profile",
                           "type": "string",
                           "usage": "profile name (default: config default_profile)"
+                        },
+                        {
+                          "name": "theme",
+                          "type": "string",
+                          "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                         }
                       ]
                     },
@@ -1575,21 +2787,61 @@
                           "usage": "Jentic control-plane base URL"
                         },
                         {
+                          "name": "context",
+                          "type": "string",
+                          "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                        },
+                        {
                           "name": "json",
                           "type": "bool",
                           "default": "false",
                           "usage": "emit JSON output"
                         },
                         {
+                          "name": "mode",
+                          "type": "string",
+                          "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                        },
+                        {
                           "name": "profile",
                           "type": "string",
                           "usage": "profile name (default: config default_profile)"
+                        },
+                        {
+                          "name": "theme",
+                          "type": "string",
+                          "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
                         }
                       ]
                     }
                   ]
                 }
               ]
+            }
+          ]
+        },
+        {
+          "name": "theme",
+          "path": "jentic theme",
+          "use": "theme \u003cdark|light|no-color\u003e",
+          "short": "Set the persistent color theme",
+          "long": "theme persists the global color theme in ~/.config/jentic/config.yaml.\nOverride per-invocation with --theme or $JENTIC_THEME. Agent and\nservice-account modes always use no-color regardless of this setting.",
+          "group_title": "Administration",
+          "flags": [
+            {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
             }
           ]
         }


### PR DESCRIPTION
Stacked on #981 (Phase 2). Part of the CLI-V2 rewrite. Plan: `jentic-one-plans` cli-v2 Phase 3 (`impl/1.2`, `impl/1.3`, `14_breaking_changes.md`, `16_landing_strategy.md`).

## What this adds

The Environment × Identity × Context management surface that supersedes flat V1 profiles, plus the one-shot migrator — all writing the XDG layout (`~/.config/jentic/config.yaml`, keys under `~/.config/jentic/keys`, tokens under `~/.local/state/jentic`).

**Coexistence, not activation.** V1 `profile`/`--profile` stays the live, default path. Per `14` rollout item 0 / `16` §1, no breaking-change switch flips on merge — the whole breaking half activates only at the post-Phase-4 activation release. These commands are additive and usable now; `migrate` is opt-in.

### Commands
- `jentic context create|use|list|view|delete` — kubectl-style context binding (env + identity + mode). `view` is active-only + read-only (agent self-introspection); `list` read-only. `create/use/delete` fenced.
- `jentic env add|list|delete` — Control/Broker deployment targets. `list` read-only; `add/delete` fenced. `delete` refuses to strand referencing contexts.
- `jentic identity add|list|delete` — actors + optional `jak_*` API-key credential (stored under XDG **state**, never in `config.yaml`). `list` read-only; `add/delete` fenced.
- `jentic migrate` — copies (never moves) legacy `~/.jentic` profiles → contexts/identities/host-derived environments, copies key/token material into the XDG layout, **drops refresh tokens** (BC-6), sanitizes names to the V2 charset, drops a `MIGRATED` marker, `--purge-legacy` to delete the old tree. Idempotent; **not fenced** (BC-1 directs agents to it); bootstrap-safe.
- `jentic theme <dark|light|no-color>` — persists the global theme (the persistence half of Phase 3 item 4; the mode gate shipped in Phase 2).

### Wiring
- Root `--context`/`--mode`/`--theme` persistent flags (deferred from Phase 2) + `$JENTIC_CONTEXT` fallback in the interceptor. Theme ladder (`--theme` > `JENTIC_THEME` > `NO_COLOR` > config > dark) already implemented in Phase 2.
- New commands render through the Audience (`ux.Result`/`ux.Page`) and fail through `ux.CodedError` so the exit-code taxonomy + structured error envelope (agent mode) are honored, with no double `error:` line.
- `client/auth`: `SaveAPIKey`/`ReadAPIKey` (XDG state, 0600) and `KeyPathForImport` (verbatim key migration, preserving the registered `client_id`).

### Guardrails
- `clitree.MustBeFenced` extended with `context create/use/delete`, `env add/delete`, `identity add/delete`. Arch **1C** walks the tree and asserts each is annotated; **1E** allowlist updated for the two new legitimate secret/state writers (`migrate.go`, `client/auth/apikey.go`).
- Regenerated `ui/public/cli-reference.json` (drift test green).

### V1 alias layer (dormant)
`profile_aliases.go` is a single removable block with **pure, tested** `profile`→`context` mapping helpers + an activation-release registration entry point. It is intentionally **not wired live** — the V1 `profile` command keeps that name until activation (`16` §1). A test asserts the shim stays dormant.

## Notes / deferred
- **API-key credential storage** is introduced here (Phase 3 needs it for `identity add` and the migrator) but its first-class use in the auth flow is Phase 4 item 4.
- **Telemetry-consent carry-over** (BC-2) is deferred until the V2 config schema models telemetry; migration preserves the legacy tree so consent is not lost meanwhile.

## Test plan
- [x] `go test ./...` (unit: env/context/identity/theme lifecycle, migrate copy/idempotent/purge/refresh-drop/api-key, name sanitization, alias mapping, apikey round-trip + traversal guard)
- [x] `make test-arch` (1C fencing, 1E mutator lock)
- [x] `make test-golden` (V1 contract unchanged)
- [x] `make check-cli-gen` (no codegen drift)
- [x] `golangci-lint run ./...` (0 issues), `go vet ./...`
- [ ] CI green on the stacked PR

Made with [Cursor](https://cursor.com)