### PR TITLE
fix(ingest): keep non-finite YAML floats as strings so specs stay JSON-serializable

### DIFF
--- a/src/jentic_one/registry/ingest/fetch.py
+++ b/src/jentic_one/registry/ingest/fetch.py
@@ -131,6 +131,17 @@ def _load_yaml(raw: str) -> Any:
     return yaml.load(raw, Loader=_JsonSafeLoader)  # nosec B506
 
 
+def _load_json(raw: str) -> Any:
+    """``json.loads`` with non-finite float tokens kept as their literal text.
+
+    Python's ``json.loads`` accepts the non-standard ``NaN``/``Infinity``/
+    ``-Infinity`` tokens by default and produces non-finite floats — the same
+    JSONB-rejected values the YAML loader guards against (issue #984). Keep
+    the token text verbatim, mirroring ``_JsonSafeLoader``.
+    """
+    return json.loads(raw, parse_constant=str)
+
+
 def parse_spec_content(raw: str, *, filename: str | None = None) -> dict[str, Any]:
     """Parse raw spec content as JSON or YAML, returning a dict.
 
@@ -152,7 +163,7 @@ def parse_spec_content(raw: str, *, filename: str | None = None) -> dict[str, An
     parsed: Any = None
     if json_first:
         try:
-            parsed = json.loads(raw)
+            parsed = _load_json(raw)
         except (json.JSONDecodeError, ValueError):
             try:
                 parsed = _load_yaml(raw)
@@ -163,7 +174,7 @@ def parse_spec_content(raw: str, *, filename: str | None = None) -> dict[str, An
             parsed = _load_yaml(raw)
         except yaml.YAMLError:
             try:
-                parsed = json.loads(raw)
+                parsed = _load_json(raw)
             except (json.JSONDecodeError, ValueError) as exc:
                 raise IngestStageError("failed to parse spec content as JSON or YAML") from exc
 

--- a/src/jentic_one/registry/ingest/fetch.py
+++ b/src/jentic_one/registry/ingest/fetch.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import math
 from typing import Annotated, Any, Literal
 from urllib.parse import urljoin, urlparse
 
@@ -88,8 +89,12 @@ class _JsonSafeLoader(yaml.SafeLoader):
     so the two tags that produce non-JSON scalars — ``!!timestamp`` and
     ``!!binary`` — construct the scalar's verbatim text (lossless, and identical
     to what the same spec yields when served as JSON), and ``!!set`` constructs
-    a list of its keys. The remaining exotic tags (``!!omap``/``!!pairs``) yield
-    lists of tuples, which JSON-serialize as arrays already.
+    a list of its keys. Non-finite ``!!float`` scalars (``.nan``/``.inf``) also
+    fall back to verbatim text (issue #984): ``json.dumps`` emits them as the
+    non-standard ``NaN``/``Infinity`` tokens, which JSON parsers and Postgres
+    JSONB reject — while finite floats keep parsing as numbers. The remaining
+    exotic tags (``!!omap``/``!!pairs``) yield lists of tuples, which
+    JSON-serialize as arrays already.
     """
 
 
@@ -101,11 +106,20 @@ def _construct_set_as_list(loader: _JsonSafeLoader, node: yaml.MappingNode) -> l
     return list(loader.construct_mapping(node))
 
 
-# !!timestamp is the only tag here with an implicit resolver (bare scalars);
-# !!binary and !!set require an explicit tag but dead-letter identically.
+def _construct_json_safe_float(loader: _JsonSafeLoader, node: yaml.ScalarNode) -> float | str:
+    value = yaml.SafeLoader.construct_yaml_float(loader, node)
+    if math.isfinite(value):
+        return value
+    return loader.construct_scalar(node)
+
+
+# !!timestamp and !!float are the tags here with implicit resolvers (bare
+# scalars); !!binary and !!set require an explicit tag but dead-letter
+# identically.
 _JsonSafeLoader.add_constructor("tag:yaml.org,2002:timestamp", _construct_scalar_as_str)
 _JsonSafeLoader.add_constructor("tag:yaml.org,2002:binary", _construct_scalar_as_str)
 _JsonSafeLoader.add_constructor("tag:yaml.org,2002:set", _construct_set_as_list)
+_JsonSafeLoader.add_constructor("tag:yaml.org,2002:float", _construct_json_safe_float)
 
 
 def _load_yaml(raw: str) -> Any:

--- a/src/jentic_one/registry/ingest/models.py
+++ b/src/jentic_one/registry/ingest/models.py
@@ -39,8 +39,9 @@ class IngestSpecification(BaseModel):
     metadata: dict[str, Any] | None = None
     #: The parsed spec document. Guaranteed JSON-serializable regardless of the
     #: source format — the YAML parse boundary (``parse_spec_content``) keeps
-    #: date/binary scalars as strings (issue #979). Stage authors may
-    #: ``json.dumps`` this or write it to a JSONB column without an encoder.
+    #: date/binary scalars and non-finite floats as strings (issues #979, #984).
+    #: Stage authors may ``json.dumps`` this or write it to a JSONB column
+    #: without an encoder.
     content: dict[str, Any] | None = None
     source_id: str | None = None
     source_type: ApiRevisionSourceType | None = None

--- a/tests/unit/registry/ingest/test_fetch_inline.py
+++ b/tests/unit/registry/ingest/test_fetch_inline.py
@@ -57,6 +57,24 @@ info:
 paths: {}
 """
 
+# Non-finite float scalars (issue #984): json.dumps emits float('nan')/
+# float('inf') as the non-standard NaN/Infinity tokens (it does not raise),
+# which JSON parsers and Postgres JSONB reject — dead-lettering the import at
+# the JSONB write. Finite floats must keep parsing as numbers.
+_SPEC_YAML_NONFINITE_FLOATS = """\
+openapi: "3.1.0"
+info:
+  title: Floaty API
+  version: "1.0.0"
+  x-vendor: acme
+  x-nan: .nan
+  x-inf: .inf
+  x-neg-inf: -.INF
+  x-finite: 1.5
+  x-exponent: 2.5e+3
+paths: {}
+"""
+
 
 @pytest.mark.asyncio
 async def test_inline_json_produces_valid_specification() -> None:
@@ -118,6 +136,32 @@ async def test_yaml_binary_and_set_tags_stay_json_serializable() -> None:
     assert info["x-blob"] == "aGVsbG8="  # verbatim base64 text, not bytes
     assert info["x-flags"] == ["alpha", "beta"]  # key list, not a set
     json.dumps(result.content)
+
+
+@pytest.mark.asyncio
+async def test_yaml_nonfinite_floats_stay_json_serializable_strings() -> None:
+    """Non-finite float scalars parse as verbatim strings; finite floats as numbers.
+
+    Regression for #984 — see the _SPEC_YAML_NONFINITE_FLOATS comment for the
+    failure mode this pins.
+    """
+    result = await load_specification(
+        _make_inline(_SPEC_YAML_NONFINITE_FLOATS, filename="spec.yaml")
+    )
+
+    assert result.content is not None
+    info = result.content["info"]
+    # Verbatim scalar text — case preserved, no normalization to "Infinity".
+    assert info["x-nan"] == ".nan"
+    assert info["x-inf"] == ".inf"
+    assert info["x-neg-inf"] == "-.INF"
+    # Finite floats are untouched — still numbers, not strings. (The exponent
+    # form needs the sign — PyYAML's YAML 1.1 resolver treats signless "2.5e3"
+    # as a plain string, with or without this fix.)
+    assert info["x-finite"] == 1.5
+    assert info["x-exponent"] == 2500.0
+    # Strict-JSON serializable: allow_nan=False raises if a non-finite leaked.
+    json.dumps(result.content, allow_nan=False)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/registry/ingest/test_fetch_inline.py
+++ b/tests/unit/registry/ingest/test_fetch_inline.py
@@ -165,6 +165,29 @@ async def test_yaml_nonfinite_floats_stay_json_serializable_strings() -> None:
 
 
 @pytest.mark.asyncio
+async def test_json_nonfinite_tokens_stay_json_serializable_strings() -> None:
+    """The JSON path has the same gap: json.loads accepts NaN/Infinity tokens.
+
+    Python's json.loads is laxer than RFC 8259 and produces non-finite floats
+    for them by default — same dead-letter failure as the YAML case (#984).
+    """
+    spec = (
+        '{"openapi":"3.1.0","info":{"title":"Floaty JSON","version":"1.0.0",'
+        '"x-vendor":"acme","x-nan":NaN,"x-inf":Infinity,"x-neg-inf":-Infinity,'
+        '"x-finite":1.5},"paths":{}}'
+    )
+    result = await load_specification(_make_inline(spec, filename="spec.json"))
+
+    assert result.content is not None
+    info = result.content["info"]
+    assert info["x-nan"] == "NaN"
+    assert info["x-inf"] == "Infinity"
+    assert info["x-neg-inf"] == "-Infinity"
+    assert info["x-finite"] == 1.5
+    json.dumps(result.content, allow_nan=False)
+
+
+@pytest.mark.asyncio
 async def test_catalog_api_id_carried_verbatim() -> None:
     """The catalog slug survives loading untouched (#910) — unlike the same
     value passed as api_name, which identity resolution slugifies. The


### PR DESCRIPTION
## Summary

Fixes #984 — the follow-up the #983 review board filed. YAML `.nan`/`.inf`/`-.inf` scalars parse to `float('nan')`/`float('inf')`; `json.dumps` emits those as the non-standard `NaN`/`Infinity` tokens (it does not raise by default), which JSON parsers and Postgres JSONB reject — dead-lettering the import at the JSONB write, the same failure mode #979 had for dates. (On SQLite embedded mode such specs previously *did* persist — and then produced RFC-invalid JSON in API responses; this fix improves that case too.)

## Changes

- `_JsonSafeLoader` gains a `!!float` constructor that delegates to the stock `SafeLoader` float construction and falls back to the scalar's **verbatim text** only when the result is non-finite (`math.isfinite`). Finite floats — including YAML 1.1 sexagesimals and underscore forms — keep parsing as numbers, unchanged. Overflowing literals (which stock PyYAML silently turns into `inf`) now stay verbatim text as a bonus.
- The **JSON path** had the same gap (Bugbot): Python's `json.loads` accepts `NaN`/`Infinity`/`-Infinity` tokens by default. Both `json.loads` call sites now go through `_load_json`, which keeps those tokens as their literal text via `parse_constant=str`.
- Contract comments updated (`IngestSpecification.content`, loader docstring) to cover #984.
- Regression tests for both paths: YAML (`.nan`, `.inf`, `-.INF` case-preserved verbatim; finite floats stay numeric) and JSON (`NaN`/`Infinity`/`-Infinity` tokens → strings), each asserting `json.dumps(..., allow_nan=False)` — the strict-JSON property JSONB actually needs.

Review: correctness reviewer approved (verified the full YAML 1.1 float matrix empirically — underscores/sexagesimals never hit the verbatim fallback); Bugbot's JSON-path finding fixed in-branch. The pre-existing `!!float <garbage>` raw-ValueError escape (present on main, not widened here) is tracked in a follow-up issue.

## Test plan

- [x] Unit regression tests for both parse paths (fail on main)
- [x] `pytest tests/unit tests/arch` (2713 passed), ruff, strict mypy, CI bandit invocation