### PR TITLE
fix(ingest): wrap constructor escapes so malformed tagged scalars fail cleanly

### DIFF
--- a/src/jentic_one/registry/ingest/fetch.py
+++ b/src/jentic_one/registry/ingest/fetch.py
@@ -127,8 +127,22 @@ def _load_yaml(raw: str) -> Any:
 
     The loader is a ``SafeLoader`` subclass, so this is exactly as safe as
     ``yaml.safe_load`` — hence the B506 suppression.
+
+    PyYAML's stock scalar constructors leak raw builtin exceptions on
+    malformed explicitly-tagged scalars instead of raising ``YAMLError``
+    (issue #988): ``!!float abc`` -> ``ValueError``, ``!!int ''`` ->
+    ``IndexError``, ``!!bool abc`` -> ``KeyError`` — and the escape set is
+    PyYAML-version-dependent. Normalize every constructor escape to
+    ``yaml.YAMLError`` so ``parse_spec_content``'s handlers wrap it into a
+    clean ``IngestStageError`` instead of dead-lettering with an internal
+    traceback.
     """
-    return yaml.load(raw, Loader=_JsonSafeLoader)  # nosec B506
+    try:
+        return yaml.load(raw, Loader=_JsonSafeLoader)  # nosec B506
+    except yaml.YAMLError:
+        raise
+    except Exception as exc:
+        raise yaml.YAMLError(f"invalid tagged scalar: {exc}") from exc
 
 
 def _load_json(raw: str) -> Any:

--- a/src/jentic_one/registry/ingest/fetch.py
+++ b/src/jentic_one/registry/ingest/fetch.py
@@ -142,7 +142,7 @@ def _load_yaml(raw: str) -> Any:
     except yaml.YAMLError:
         raise
     except Exception as exc:
-        raise yaml.YAMLError(f"invalid tagged scalar: {exc}") from exc
+        raise yaml.YAMLError(f"YAML document construction failed: {exc}") from exc
 
 
 def _load_json(raw: str) -> Any:
@@ -152,8 +152,18 @@ def _load_json(raw: str) -> Any:
     ``-Infinity`` tokens by default and produces non-finite floats — the same
     JSONB-rejected values the YAML loader guards against (issue #984). Keep
     the token text verbatim, mirroring ``_JsonSafeLoader``.
+
+    Escapes that aren't ``ValueError`` (e.g. ``RecursionError`` on a deeply
+    nested document) are normalized to it, symmetric with ``_load_yaml``, so
+    both ``parse_spec_content`` call sites produce a clean parse error
+    (``json.JSONDecodeError`` is a ``ValueError`` subclass).
     """
-    return json.loads(raw, parse_constant=str)
+    try:
+        return json.loads(raw, parse_constant=str)
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError(f"JSON document construction failed: {exc}") from exc
 
 
 def parse_spec_content(raw: str, *, filename: str | None = None) -> dict[str, Any]:

--- a/tests/unit/registry/ingest/test_fetch_inline.py
+++ b/tests/unit/registry/ingest/test_fetch_inline.py
@@ -211,6 +211,29 @@ async def test_invalid_content_raises_ingest_stage_error() -> None:
         await load_specification(_make_inline("<<<not valid>>>"))
 
 
+@pytest.mark.parametrize(
+    "scalar",
+    [
+        "!!float abc",  # ValueError from float()
+        "!!float ''",  # IndexError from value[0]
+        "!!int abc",  # ValueError from int()
+        "!!bool abc",  # KeyError from the bool lookup table
+    ],
+)
+@pytest.mark.asyncio
+async def test_malformed_tagged_scalars_raise_ingest_stage_error(scalar: str) -> None:
+    """Malformed explicitly-tagged scalars must fail as a clean parse error.
+
+    Regression for #988: PyYAML's stock constructors leak raw builtin
+    exceptions (ValueError/IndexError/KeyError) for these instead of a
+    YAMLError, which used to dead-letter the import with an internal
+    traceback rather than an operator-facing message.
+    """
+    spec = f'openapi: "3.1.0"\ninfo:\n  title: Bad API\n  version: "1.0.0"\n  x-bad: {scalar}\n'
+    with pytest.raises(IngestStageError, match="failed to parse"):
+        await load_specification(_make_inline(spec, filename="spec.yaml"))
+
+
 @pytest.mark.asyncio
 async def test_unparseable_content_raises_ingest_stage_error() -> None:
     with pytest.raises(IngestStageError, match="failed to parse"):

--- a/tests/unit/registry/ingest/test_fetch_inline.py
+++ b/tests/unit/registry/ingest/test_fetch_inline.py
@@ -234,6 +234,23 @@ async def test_malformed_tagged_scalars_raise_ingest_stage_error(scalar: str) ->
         await load_specification(_make_inline(spec, filename="spec.yaml"))
 
 
+@pytest.mark.parametrize(
+    # Deep nesting exhausts the recursion limit inside both parsers —
+    # RecursionError is neither a YAMLError nor a ValueError, so without the
+    # _load_yaml/_load_json normalization it leaked raw through both parse
+    # orders (found by the #989 review).
+    "content, filename",
+    [
+        ('{"a":' * 10_000 + "1" + "}" * 10_000, "spec.json"),  # JSON-first order
+        ("[" * 10_000, "spec.yaml"),  # YAML-first order
+    ],
+)
+@pytest.mark.asyncio
+async def test_deeply_nested_content_raises_ingest_stage_error(content: str, filename: str) -> None:
+    with pytest.raises(IngestStageError, match="failed to parse"):
+        await load_specification(_make_inline(content, filename=filename))
+
+
 @pytest.mark.asyncio
 async def test_unparseable_content_raises_ingest_stage_error() -> None:
     with pytest.raises(IngestStageError, match="failed to parse"):


### PR DESCRIPTION
## Summary

Fixes #988 — the pre-existing escape the #987 correctness review surfaced. A YAML spec with a malformed explicitly-tagged scalar (`x: !!float abc`) dead-lettered the import with a raw internal traceback (`builtins.ValueError: could not convert string to float`) instead of the clean operator-facing `IngestStageError` every other parse failure gets.

## Changes

- Investigation showed the escape set is wider than the issue documented and PyYAML-version-dependent: `!!float abc` → `ValueError`, `!!float ''`/`!!int ''` → `IndexError`, `!!bool abc` → `KeyError`. So rather than enumerating builtin exceptions at the call sites, `_load_yaml` now normalizes **any** non-`YAMLError` constructor escape to `yaml.YAMLError` — `parse_spec_content`'s existing handlers then wrap it into `IngestStageError` (and the YAML→JSON fallback semantics are preserved unchanged: only error *types* change, never success/failure of valid documents).
- The review found the JSON path had the same class of leak: `json.loads` raises `RecursionError` on deeply nested documents, which is neither a `JSONDecodeError` nor a `ValueError` — it escaped raw through **both** parse orders. `_load_json` now normalizes non-`ValueError` escapes symmetrically.
- Parametrized regression tests: the four discovered tagged-scalar escapes, plus deep-nesting documents through both parse orders.

Review: correctness reviewer approved (verified all four tests fail on main with the exact raw exceptions, `KeyboardInterrupt`/`SystemExit` pass through untouched, and full chained tracebacks are preserved in dead-letter logs); the reviewer's one should-fix (the JSON-path `RecursionError` leak) and wording nit are fixed in-branch. Bugbot found no bugs.

## Test plan

- [x] Parametrized unit tests for `!!float abc`, `!!float ''`, `!!int abc`, `!!bool abc` (all fail on main with raw builtin exceptions)
- [x] Deep-nesting regression tests for both parse orders (fail on main with raw RecursionError)
- [x] `pytest tests/unit tests/arch` (2719 passed), ruff, strict mypy, CI bandit invocation