### PR TITLE
cli(v2): Phase 4: Auth Hardening

### DIFF
--- a/cli/client/auth/middleware.go
+++ b/cli/client/auth/middleware.go
@@ -27,39 +27,76 @@ func (c Credentials) IdentityRef() IdentityRef {
 // the bearer token, fetching/refreshing it as needed.
 func RequestEditor(creds Credentials) func(ctx context.Context, req *http.Request) error {
 	return func(_ context.Context, req *http.Request) error {
-		// 0. TRANSPORT GUARD (ref F3). Before attaching ANY bearer — injected or
-		// minted — refuse a non-HTTPS, non-loopback target. req.URL is the actual
-		// outbound destination derived from a possibly attacker-influenced BaseURL;
-		// without this, a poisoned base URL turns the middleware into a
-		// token-exfiltration primitive. Same invariant tokenEndpoint enforces (F1).
-		if err := requireSecureHost(req.URL); err != nil {
-			return fmt.Errorf("refusing to attach credentials: %w", err)
-		}
+		return AttachAuth(creds, req)
+	}
+}
 
-		// 1. FILE-LESS OVERRIDE. If the orchestrator injected a token, use it.
-		if creds.InjectedBearerToken != "" {
-			req.Header.Set("Authorization", "Bearer "+creds.InjectedBearerToken)
-			return nil
-		}
+// AttachAuth stamps the appropriate Authorization header on req for creds. It is
+// the shared attach path used by both the request-editor middleware and the
+// response-side 401 retry (transport.go), so the two can never disagree on which
+// credential to present. Order: transport guard -> injected token -> API-key
+// credential -> disk token (exchanged if missing/expired).
+func AttachAuth(creds Credentials, req *http.Request) error {
+	// 0. TRANSPORT GUARD (ref F3). Before attaching ANY bearer — injected or
+	// minted — refuse a non-HTTPS, non-loopback target. req.URL is the actual
+	// outbound destination derived from a possibly attacker-influenced BaseURL;
+	// without this, a poisoned base URL turns the middleware into a
+	// token-exfiltration primitive. Same invariant tokenEndpoint enforces (F1).
+	if err := requireSecureHost(req.URL); err != nil {
+		return fmt.Errorf("refusing to attach credentials: %w", err)
+	}
 
-		// 2. DISK-BASED TOKEN STATE. Treat missing/corrupt/expired uniformly as
-		// "needs exchange"; we never dereference tokens unless it is non-nil and
-		// unexpired, so a nil TokenSet (returned on any ReadTokens failure) can
-		// never panic here.
-		tokens, err := ReadTokens(creds.IdentityRef())
-		needsExchange := err != nil || tokens == nil || time.Now().After(tokens.ExpiresAt)
-		if needsExchange {
-			newTokens, xerr := performOAuthExchange(creds)
-			if xerr != nil {
-				return fmt.Errorf("failed to authenticate: %w", xerr)
-			}
-			if serr := SaveTokens(creds.IdentityRef(), newTokens); serr != nil {
-				return serr
-			}
-			tokens = newTokens
-		}
-
-		req.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
+	// 1. FILE-LESS OVERRIDE. If the orchestrator injected a token, use it.
+	if creds.InjectedBearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+creds.InjectedBearerToken)
 		return nil
 	}
+
+	// 2. API-KEY CREDENTIAL (Phase 4 item 4). A jak_* agent API key is a
+	// first-class, long-lived credential that operators and CI use. Unlike the
+	// Ed25519/JWT-bearer flow it is NOT exchanged or minted — the backend
+	// dispatches on the key prefix, so the raw key IS the bearer value
+	// (parity with V1: internal/agentauth Session.ValidToken returns the stored
+	// key verbatim, sent by httpx as `Authorization: Bearer <key>`). Presence of
+	// the on-disk credential is the signal; we only treat a read error as
+	// "no API key, fall through to OAuth" — never as a hard failure, so an
+	// identity without a stored key still reaches the exchange path below.
+	if key, err := ReadAPIKey(creds.IdentityRef()); err == nil && key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+		return nil
+	}
+
+	// 3. DISK-BASED TOKEN STATE. Treat missing/corrupt/expired uniformly as
+	// "needs exchange"; we never dereference tokens unless it is non-nil and
+	// unexpired, so a nil TokenSet (returned on any ReadTokens failure) can
+	// never panic here.
+	tokens, err := ReadTokens(creds.IdentityRef())
+	needsExchange := err != nil || tokens == nil || time.Now().After(tokens.ExpiresAt)
+	if needsExchange {
+		newTokens, xerr := performOAuthExchange(creds)
+		if xerr != nil {
+			return fmt.Errorf("failed to authenticate: %w", xerr)
+		}
+		if serr := SaveTokens(creds.IdentityRef(), newTokens); serr != nil {
+			return serr
+		}
+		tokens = newTokens
+	}
+
+	req.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
+	return nil
+}
+
+// CanReExchange reports whether creds can mint a NEW token on a 401 (i.e. the
+// exchange-backed disk path). Injected tokens and API keys are fixed credentials:
+// a 401 on those is a hard denial, not something a re-exchange can fix, so the
+// transport must not loop on them.
+func CanReExchange(creds Credentials) bool {
+	if creds.InjectedBearerToken != "" {
+		return false
+	}
+	if key, err := ReadAPIKey(creds.IdentityRef()); err == nil && key != "" {
+		return false
+	}
+	return true
 }

--- a/cli/client/auth/register.go
+++ b/cli/client/auth/register.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// RegistrationResult is the RFC 7591 Dynamic Client Registration response.
+// registration_access_token is intentionally NOT retained: V2 re-derives all auth
+// from the environment-scoped key, so a stored management token would be dead
+// weight and a needless long-lived secret (same posture as the dropped refresh
+// token — see tokens.go §1).
+type RegistrationResult struct {
+	ClientID string `json:"client_id"`
+	Status   string `json:"status"`
+}
+
+// Register performs RFC 7591 Dynamic Client Registration against the control
+// plane's /register endpoint. It is a hand-rolled POST (not a generated client
+// call) because /register and /oauth/token are auth-server routes that are NOT
+// part of the documented control-plane OpenAPI surface — the shipped V1 CLI
+// (internal/authclient) speaks to them directly and this preserves that contract.
+//
+// SECURITY (ref F1): the base URL is attacker-influenceable, and registration
+// publishes the agent's PUBLIC key (not a secret) — but it still creates
+// server-side state and returns a client_id we will sign assertions as, so we
+// hold it to the same TLS/loopback invariant as tokenEndpoint. requireSecureHost
+// keeps the two call sites from drifting.
+func Register(baseURL, clientName string, jwks JWKS) (*RegistrationResult, error) {
+	u, err := url.Parse(strings.TrimRight(baseURL, "/"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL %q: %w", baseURL, err)
+	}
+	if err := requireSecureHost(u); err != nil {
+		return nil, err
+	}
+	u.Path += "/register"
+
+	// RFC 7591 field names: client_name + jwks. The shipped endpoint takes a JSON
+	// body (matching the token endpoint's deviation from RFC 6749 form-encoding).
+	reqBody, err := json.Marshal(map[string]any{
+		"client_name": clientName,
+		"jwks":        jwks,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encoding registration request: %w", err)
+	}
+
+	resp, err := httpClient.Post(u.String(), "application/json", bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("registration request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+		var problem struct {
+			Detail string `json:"detail"`
+			Title  string `json:"title"`
+		}
+		_ = json.Unmarshal(data, &problem)
+		detail := problem.Detail
+		if detail == "" {
+			detail = problem.Title
+		}
+		if detail != "" {
+			return nil, fmt.Errorf("registration failed (status %d): %s", resp.StatusCode, detail)
+		}
+		return nil, fmt.Errorf("registration failed (status %d)", resp.StatusCode)
+	}
+
+	var out RegistrationResult
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decoding registration response: %w", err)
+	}
+	return &out, nil
+}

--- a/cli/client/auth/register_test.go
+++ b/cli/client/auth/register_test.go
@@ -1,0 +1,186 @@
+package auth
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestAttachAuth_APIKeyTakesPrecedence proves the Phase 4 item-4 branch: when a
+// jak_* credential is stored for the ref, AttachAuth sends it verbatim as
+// `Authorization: Bearer jak_...` and does NOT reach the OAuth exchange path.
+func TestAttachAuth_APIKeyTakesPrecedence(t *testing.T) {
+	withConfigDir(t)
+	ref := IdentityRef{Identity: "ci", Environment: "prod"}
+	const key = "jak_secretkeyvalue"
+	if err := SaveAPIKey(ref, key); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+
+	creds := Credentials{
+		BaseURL:         "https://ctl.example",
+		IdentityName:    "ci",
+		EnvironmentName: "prod",
+	}
+	req, _ := http.NewRequest(http.MethodGet, "https://ctl.example/toolkits", nil)
+	if err := AttachAuth(creds, req); err != nil {
+		t.Fatalf("AttachAuth: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer "+key {
+		t.Errorf("Authorization = %q, want Bearer %s", got, key)
+	}
+}
+
+// TestAttachAuth_InjectedBeatsAPIKey: a file-less injected token wins over any
+// on-disk API key (the orchestrator's intent is explicit).
+func TestAttachAuth_InjectedBeatsAPIKey(t *testing.T) {
+	withConfigDir(t)
+	ref := IdentityRef{Identity: "ci", Environment: "prod"}
+	if err := SaveAPIKey(ref, "jak_ondiskkey"); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+	creds := Credentials{
+		BaseURL:             "https://ctl.example",
+		IdentityName:        "ci",
+		EnvironmentName:     "prod",
+		InjectedBearerToken: "at_injected",
+	}
+	req, _ := http.NewRequest(http.MethodGet, "https://ctl.example/toolkits", nil)
+	if err := AttachAuth(creds, req); err != nil {
+		t.Fatalf("AttachAuth: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer at_injected" {
+		t.Errorf("Authorization = %q, want Bearer at_injected", got)
+	}
+}
+
+// TestAttachAuth_TransportGuard: an insecure, non-loopback target is refused
+// before any credential is attached (F3).
+func TestAttachAuth_TransportGuard(t *testing.T) {
+	withConfigDir(t)
+	creds := Credentials{InjectedBearerToken: "at_x"}
+	req, _ := http.NewRequest(http.MethodGet, "http://evil.example/x", nil)
+	if err := AttachAuth(creds, req); err == nil {
+		t.Fatal("expected AttachAuth to refuse an insecure host")
+	}
+	if req.Header.Get("Authorization") != "" {
+		t.Error("credential attached to an insecure host")
+	}
+}
+
+// TestCanReExchange: only the exchange-backed disk path is re-exchangeable; an
+// injected token or an API key is a fixed credential (a 401 is a hard denial).
+func TestCanReExchange(t *testing.T) {
+	withConfigDir(t)
+
+	disk := Credentials{IdentityName: "a", EnvironmentName: "e"}
+	if !CanReExchange(disk) {
+		t.Error("disk-path creds should be re-exchangeable")
+	}
+
+	injected := Credentials{InjectedBearerToken: "at_x"}
+	if CanReExchange(injected) {
+		t.Error("injected token must NOT be re-exchangeable")
+	}
+
+	ref := IdentityRef{Identity: "k", Environment: "e"}
+	if err := SaveAPIKey(ref, "jak_key"); err != nil {
+		t.Fatalf("SaveAPIKey: %v", err)
+	}
+	apiKey := Credentials{IdentityName: "k", EnvironmentName: "e"}
+	if CanReExchange(apiKey) {
+		t.Error("API-key creds must NOT be re-exchangeable")
+	}
+}
+
+// TestInvalidateTokens_RemovesAndTolerant: invalidation deletes the cache and is a
+// no-op (nil error) when there is nothing to remove.
+func TestInvalidateTokens_RemovesAndTolerant(t *testing.T) {
+	withConfigDir(t)
+	ref := IdentityRef{Identity: "a", Environment: "e"}
+
+	if err := InvalidateTokens(ref); err != nil {
+		t.Errorf("InvalidateTokens on missing file = %v, want nil", err)
+	}
+
+	if err := SaveTokens(ref, &TokenSet{AccessToken: "tok"}); err != nil {
+		t.Fatalf("SaveTokens: %v", err)
+	}
+	if err := InvalidateTokens(ref); err != nil {
+		t.Fatalf("InvalidateTokens: %v", err)
+	}
+	if _, err := ReadTokens(ref); err == nil {
+		t.Error("token still present after InvalidateTokens")
+	}
+}
+
+// TestRegister_PostsJWKSAndParsesResult drives the RFC 7591 registration against a
+// mock /register: it asserts the JSON body shape (client_name + jwks) and that a
+// 201 client_id/status is parsed.
+func TestRegister_PostsJWKSAndParsesResult(t *testing.T) {
+	var gotPath string
+	var body struct {
+		ClientName string `json:"client_name"`
+		Jwks       JWKS   `json:"jwks"`
+	}
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"client_id": "client_123", "status": "pending"})
+	}))
+	defer srv.Close()
+
+	// httptest TLS uses a self-signed cert; point the package client at the
+	// server's own client so the handshake verifies.
+	old := httpClient
+	httpClient = srv.Client()
+	defer func() { httpClient = old }()
+
+	pub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := Register(srv.URL, "my-agent", PublicKeyToJWKS(pub))
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if gotPath != "/register" {
+		t.Errorf("path = %q, want /register", gotPath)
+	}
+	if body.ClientName != "my-agent" || len(body.Jwks.Keys) != 1 {
+		t.Errorf("unexpected request body: %+v", body)
+	}
+	if res.ClientID != "client_123" || res.Status != "pending" {
+		t.Errorf("result = %+v, want client_123/pending", res)
+	}
+}
+
+// TestRegister_RefusesInsecureHost: registration publishes state + returns a
+// client_id we sign as, so it holds the same TLS guard as the token endpoint.
+func TestRegister_RefusesInsecureHost(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	if _, err := Register("http://evil.example", "a", PublicKeyToJWKS(pub)); err == nil {
+		t.Error("Register on an insecure host should be refused")
+	}
+}
+
+// TestRegister_Non201IsError: a non-201 surfaces the problem detail.
+func TestRegister_Non201IsError(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": "already registered"})
+	}))
+	defer srv.Close()
+	old := httpClient
+	httpClient = srv.Client()
+	defer func() { httpClient = old }()
+
+	pub, _, _ := ed25519.GenerateKey(nil)
+	_, err := Register(srv.URL, "a", PublicKeyToJWKS(pub))
+	if err == nil {
+		t.Fatal("expected an error for a non-201 registration")
+	}
+}

--- a/cli/client/auth/tokens.go
+++ b/cli/client/auth/tokens.go
@@ -60,6 +60,23 @@ func ReadTokens(ref IdentityRef) (*TokenSet, error) {
 	return &tokens, nil
 }
 
+// InvalidateTokens removes the cached token for ref so the next request forces a
+// fresh RFC 7523 exchange. It is used by the response-side 401 policy (impl/4.2 /
+// 13 §5): a server-rejected token (revoked, rotated signing key, clock drift the
+// backend won't tolerate) looks valid on disk, so we must actively discard it
+// before retrying rather than trust our own expiry math. A missing file is not an
+// error — there is simply nothing to invalidate.
+func InvalidateTokens(ref IdentityRef) error {
+	path, err := getTokenPath(ref)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("invalidating token state %s: %w", path, err)
+	}
+	return nil
+}
+
 // SaveTokens writes the token cache for ref (0600).
 //
 // Concurrency: no lock. Two processes sharing the same identity+environment that

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -70,9 +70,7 @@ func (c Config) credentials() auth.Credentials {
 // clearer than a reflective bridge.
 func controlOptions(c Config) []control.ClientOption {
 	opts := make([]control.ClientOption, 0, 2+len(c.Editors))
-	if c.HTTPClient != nil {
-		opts = append(opts, control.WithHTTPClient(c.HTTPClient))
-	}
+	opts = append(opts, control.WithHTTPClient(c.httpClient()))
 	opts = append(opts, control.WithRequestEditorFn(auth.RequestEditor(c.credentials())))
 	for _, e := range c.Editors {
 		opts = append(opts, control.WithRequestEditorFn(control.RequestEditorFn(e)))
@@ -82,14 +80,28 @@ func controlOptions(c Config) []control.ClientOption {
 
 func brokerOptions(c Config) []broker.ClientOption {
 	opts := make([]broker.ClientOption, 0, 2+len(c.Editors))
-	if c.HTTPClient != nil {
-		opts = append(opts, broker.WithHTTPClient(c.HTTPClient))
-	}
+	opts = append(opts, broker.WithHTTPClient(c.httpClient()))
 	opts = append(opts, broker.WithRequestEditorFn(auth.RequestEditor(c.credentials())))
 	for _, e := range c.Editors {
 		opts = append(opts, broker.WithRequestEditorFn(broker.RequestEditorFn(e)))
 	}
 	return opts
+}
+
+// httpClient returns the *http.Client both planes share, with the SDK-level
+// response policy (401 re-exchange, 429 Retry-After, bounded 5xx/transport
+// backoff — 13 §5) wrapped around the caller's transport. A caller-supplied
+// HTTPClient is preserved (timeouts, custom CA pool, test doubles); only its
+// transport is decorated. When no client is supplied we default one but leave its
+// Timeout zero so the generated per-call contexts govern deadlines.
+func (c Config) httpClient() *http.Client {
+	hc := c.HTTPClient
+	if hc == nil {
+		hc = &http.Client{}
+	}
+	wrapped := *hc
+	wrapped.Transport = newRetryTransport(hc.Transport, c.credentials())
+	return &wrapped
 }
 
 // NewControl builds the strictly-typed control-plane client, authenticated for the

--- a/cli/client/transport.go
+++ b/cli/client/transport.go
@@ -1,0 +1,217 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/jentic/jentic-one/cli/client/auth"
+)
+
+// Retry/idempotency policy knobs (13 §5). Package-level so tests can shrink the
+// waits and caps instead of sleeping real wall-clock seconds.
+var (
+	// maxIdempotentRetries bounds 5xx/transport backoff for idempotent calls.
+	maxIdempotentRetries = 3
+	// retryBaseDelay is the first backoff step; it doubles each attempt.
+	retryBaseDelay = 200 * time.Millisecond
+	// maxRetryAfter caps how long a 429 Retry-After we will honor inline. A
+	// server asking us to wait longer than this surfaces the 429 to the caller
+	// instead (the wait-capable commands manage their own budget via --timeout).
+	maxRetryAfter = 30 * time.Second
+)
+
+// retryTransport implements the SDK-level response policy from 13 §5:
+//
+//   - 401 → exactly one token re-exchange, then one retry, then surface. Only for
+//     re-exchangeable credentials (the JWT-bearer disk path); injected tokens and
+//     API keys are fixed, so a 401 on those is a hard denial we do not loop on.
+//   - 429 → honor Retry-After up to maxRetryAfter, then one retry; otherwise
+//     surface the 429 unchanged.
+//   - 5xx / transport error → bounded backoff, but for IDEMPOTENT requests only
+//     (GET/HEAD, or a POST carrying an Idempotency-Key). A plain POST is never
+//     blind-retried.
+//
+// It wraps a base RoundTripper and re-stamps auth via auth.AttachAuth on the 401
+// retry so the fresh token actually lands on the resent request (the generated
+// client applies editors ONCE, before the first RoundTrip).
+type retryTransport struct {
+	base  http.RoundTripper
+	creds auth.Credentials
+}
+
+// newRetryTransport wraps base with the response policy for creds. A nil base
+// uses http.DefaultTransport.
+func newRetryTransport(base http.RoundTripper, creds auth.Credentials) *retryTransport {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &retryTransport{base: base, creds: creds}
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Buffer the body once so we can safely resend it on any retry. A nil GetBody
+	// (streaming body) means we cannot rewind, so such requests get exactly one
+	// attempt regardless of status.
+	body, canRewind, err := bufferBody(req)
+	if err != nil {
+		return nil, err
+	}
+
+	idempotent := isIdempotent(req)
+	triedReauth := false
+	delay := retryBaseDelay
+
+	for attempt := 0; ; attempt++ {
+		rewind(req, body, canRewind)
+
+		resp, rtErr := t.base.RoundTrip(req)
+
+		// Transport error (no response): bounded backoff for idempotent calls only.
+		if rtErr != nil {
+			if idempotent && canRewind && attempt < maxIdempotentRetries {
+				if !sleepCtx(req.Context(), delay) {
+					return nil, rtErr
+				}
+				delay *= 2
+				continue
+			}
+			return nil, rtErr
+		}
+
+		switch {
+		// 401: one re-exchange + retry, only for re-exchangeable creds and a
+		// rewindable body. Discard the body before retrying to free the conn.
+		case resp.StatusCode == http.StatusUnauthorized &&
+			!triedReauth && canRewind && auth.CanReExchange(t.creds):
+			triedReauth = true
+			drain(resp)
+			// Force a fresh token: the on-disk one looked valid to us but the
+			// server rejected it (revoked/rotated). Then re-stamp auth so the
+			// resent request carries the new bearer.
+			_ = auth.InvalidateTokens(t.creds.IdentityRef())
+			if aerr := auth.AttachAuth(t.creds, req); aerr != nil {
+				//nolint:nilerr // deliberate: if re-auth fails we surface the ORIGINAL 401 response to the caller, not the re-auth error.
+				return resp, nil
+			}
+			continue
+
+		// 429: honor Retry-After within budget, then retry once per hint.
+		case resp.StatusCode == http.StatusTooManyRequests:
+			wait, ok := retryAfter(resp)
+			if !ok || wait > maxRetryAfter || !canRewind {
+				return resp, nil // surface the 429 to the caller
+			}
+			drain(resp)
+			if !sleepCtx(req.Context(), wait) {
+				return resp, nil
+			}
+			// A single Retry-After-driven retry; further 429s surface.
+			continue
+
+		// 5xx: bounded backoff for idempotent calls only.
+		case resp.StatusCode >= 500 && idempotent && canRewind && attempt < maxIdempotentRetries:
+			drain(resp)
+			if !sleepCtx(req.Context(), delay) {
+				// Context cancelled mid-backoff: re-issue once to get a final
+				// response/error rather than fabricating one.
+				rewind(req, body, canRewind)
+				return t.base.RoundTrip(req)
+			}
+			delay *= 2
+			continue
+
+		default:
+			return resp, nil
+		}
+	}
+}
+
+// isIdempotent reports whether req may be safely retried. GET/HEAD are idempotent
+// by method; a POST/PUT is retry-safe only when it carries an Idempotency-Key
+// (13 §5) — the broker dedupes on that header, so a resend cannot double-execute.
+func isIdempotent(req *http.Request) bool {
+	switch req.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	}
+	return req.Header.Get("Idempotency-Key") != ""
+}
+
+// bufferBody reads req.Body into memory so retries can resend it. Returns
+// canRewind=false for a bodyless request or one whose body cannot be rewound.
+func bufferBody(req *http.Request) (buf []byte, canRewind bool, err error) {
+	if req.Body == nil || req.Body == http.NoBody {
+		return nil, true, nil
+	}
+	data, err := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+	if err != nil {
+		return nil, false, err
+	}
+	return data, true, nil
+}
+
+// rewind resets req.Body to a fresh reader over buf before each attempt.
+func rewind(req *http.Request, buf []byte, canRewind bool) {
+	if !canRewind {
+		return
+	}
+	if buf == nil {
+		req.Body = http.NoBody
+		return
+	}
+	req.Body = io.NopCloser(bytes.NewReader(buf))
+	req.ContentLength = int64(len(buf))
+}
+
+// retryAfter parses a Retry-After header (delta-seconds or HTTP-date).
+func retryAfter(resp *http.Response) (time.Duration, bool) {
+	v := resp.Header.Get("Retry-After")
+	if v == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs < 0 {
+			return 0, false
+		}
+		return time.Duration(secs) * time.Second, true
+	}
+	if when, err := http.ParseTime(v); err == nil {
+		d := time.Until(when)
+		if d < 0 {
+			d = 0
+		}
+		return d, true
+	}
+	return 0, false
+}
+
+// drain reads and closes a response body so the connection can be reused.
+func drain(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+	_ = resp.Body.Close()
+}
+
+// sleepCtx waits for d or until ctx is done; it returns false if ctx was
+// cancelled first (so the caller stops retrying).
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	if ctx == nil {
+		time.Sleep(d)
+		return true
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}

--- a/cli/client/transport_test.go
+++ b/cli/client/transport_test.go
@@ -1,0 +1,255 @@
+package client
+
+import (
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jentic/jentic-one/cli/client/auth"
+)
+
+// withClientConfigDir isolates the XDG config/state dirs so token/key files land
+// in a temp location for the duration of the test.
+func withClientConfigDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "state"))
+}
+
+// fakeRT is a scripted RoundTripper: it returns the next scripted response/error
+// per call and records how many times it was invoked.
+type fakeRT struct {
+	calls   int32
+	respond func(attempt int, req *http.Request) (*http.Response, error)
+}
+
+func (f *fakeRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	n := int(atomic.AddInt32(&f.calls, 1))
+	return f.respond(n-1, req)
+}
+
+func resp(status int, hdr map[string]string) *http.Response {
+	h := http.Header{}
+	for k, v := range hdr {
+		h.Set(k, v)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader("{}")),
+	}
+}
+
+// shrinkRetryKnobs makes backoff instant so tests don't sleep real seconds.
+func shrinkRetryKnobs(t *testing.T) {
+	t.Helper()
+	oldDelay, oldAfter := retryBaseDelay, maxRetryAfter
+	retryBaseDelay = time.Millisecond
+	maxRetryAfter = 5 * time.Second
+	t.Cleanup(func() { retryBaseDelay, maxRetryAfter = oldDelay, oldAfter })
+}
+
+func newReq(t *testing.T, method, url, body string) *http.Request {
+	t.Helper()
+	var r io.Reader
+	if body != "" {
+		r = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
+}
+
+// closeResp drains and closes a response body so the bodyclose linter is
+// satisfied and connections are freed. Safe on nil.
+func closeResp(r *http.Response) {
+	if r != nil && r.Body != nil {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+	}
+}
+
+// TestRetry_5xxIdempotentRetriesThenSurfaces: a GET retries on 500 up to the cap
+// and returns the final response.
+func TestRetry_5xxIdempotentRetriesThenSurfaces(t *testing.T) {
+	shrinkRetryKnobs(t)
+	fake := &fakeRT{respond: func(_ int, _ *http.Request) (*http.Response, error) {
+		return resp(http.StatusInternalServerError, nil), nil
+	}}
+	rt := newRetryTransport(fake, auth.Credentials{InjectedBearerToken: "at_x"})
+
+	r, err := rt.RoundTrip(newReq(t, http.MethodGet, "https://x.test/thing", ""))
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer closeResp(r)
+	if r.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", r.StatusCode)
+	}
+	// 1 initial + maxIdempotentRetries retries.
+	if got := int(fake.calls); got != maxIdempotentRetries+1 {
+		t.Errorf("calls = %d, want %d", got, maxIdempotentRetries+1)
+	}
+}
+
+// TestRetry_5xxNonIdempotentNotRetried: a plain POST (no Idempotency-Key) is never
+// blind-retried on 500.
+func TestRetry_5xxNonIdempotentNotRetried(t *testing.T) {
+	shrinkRetryKnobs(t)
+	fake := &fakeRT{respond: func(_ int, _ *http.Request) (*http.Response, error) {
+		return resp(http.StatusBadGateway, nil), nil
+	}}
+	rt := newRetryTransport(fake, auth.Credentials{InjectedBearerToken: "at_x"})
+
+	r, err := rt.RoundTrip(newReq(t, http.MethodPost, "https://x.test/exec", `{"a":1}`))
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	closeResp(r)
+	if got := int(fake.calls); got != 1 {
+		t.Errorf("plain POST retried on 5xx: calls = %d, want 1", got)
+	}
+}
+
+// TestRetry_5xxPostWithIdempotencyKeyRetried: a POST carrying an Idempotency-Key
+// IS retry-safe (the broker dedupes on it).
+func TestRetry_5xxPostWithIdempotencyKeyRetried(t *testing.T) {
+	shrinkRetryKnobs(t)
+	fake := &fakeRT{respond: func(attempt int, _ *http.Request) (*http.Response, error) {
+		if attempt == 0 {
+			return resp(http.StatusServiceUnavailable, nil), nil
+		}
+		return resp(http.StatusOK, nil), nil
+	}}
+	rt := newRetryTransport(fake, auth.Credentials{InjectedBearerToken: "at_x"})
+
+	req := newReq(t, http.MethodPost, "https://x.test/exec", `{"a":1}`)
+	req.Header.Set("Idempotency-Key", "key-1")
+	r, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer closeResp(r)
+	if r.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 after retry", r.StatusCode)
+	}
+	if got := int(fake.calls); got != 2 {
+		t.Errorf("calls = %d, want 2", got)
+	}
+}
+
+// TestRetry_429HonorsRetryAfterWithinBudget: a 429 with a small Retry-After is
+// waited out and retried once.
+func TestRetry_429HonorsRetryAfterWithinBudget(t *testing.T) {
+	shrinkRetryKnobs(t)
+	fake := &fakeRT{respond: func(attempt int, _ *http.Request) (*http.Response, error) {
+		if attempt == 0 {
+			return resp(http.StatusTooManyRequests, map[string]string{"Retry-After": "0"}), nil
+		}
+		return resp(http.StatusOK, nil), nil
+	}}
+	rt := newRetryTransport(fake, auth.Credentials{InjectedBearerToken: "at_x"})
+
+	r, err := rt.RoundTrip(newReq(t, http.MethodGet, "https://x.test/thing", ""))
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer closeResp(r)
+	if r.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", r.StatusCode)
+	}
+	if got := int(fake.calls); got != 2 {
+		t.Errorf("calls = %d, want 2", got)
+	}
+}
+
+// TestRetry_429OverBudgetSurfaces: a Retry-After beyond the cap is surfaced, not
+// waited on.
+func TestRetry_429OverBudgetSurfaces(t *testing.T) {
+	shrinkRetryKnobs(t) // maxRetryAfter = 5s
+	fake := &fakeRT{respond: func(_ int, _ *http.Request) (*http.Response, error) {
+		return resp(http.StatusTooManyRequests, map[string]string{"Retry-After": "3600"}), nil
+	}}
+	rt := newRetryTransport(fake, auth.Credentials{InjectedBearerToken: "at_x"})
+
+	r, err := rt.RoundTrip(newReq(t, http.MethodGet, "https://x.test/thing", ""))
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer closeResp(r)
+	if r.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429 surfaced", r.StatusCode)
+	}
+	if got := int(fake.calls); got != 1 {
+		t.Errorf("calls = %d, want 1 (no wait)", got)
+	}
+}
+
+// TestRetry_401InvalidatesTokenForExchangeableCreds: a 401 on the disk
+// (JWT-bearer) path invalidates the cached token so the NEXT request re-exchanges.
+// Here the stub base URL is unresolvable, so the inline re-exchange fails and the
+// transport surfaces the original 401 — but the invalidation (the important state
+// change) must still have happened exactly once.
+func TestRetry_401InvalidatesTokenForExchangeableCreds(t *testing.T) {
+	shrinkRetryKnobs(t)
+	withClientConfigDir(t)
+
+	ref := auth.IdentityRef{Identity: "a", Environment: "e"}
+	if err := auth.SaveTokens(ref, &auth.TokenSet{AccessToken: "tok-old", ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+		t.Fatalf("SaveTokens: %v", err)
+	}
+
+	fake := &fakeRT{respond: func(_ int, _ *http.Request) (*http.Response, error) {
+		return resp(http.StatusUnauthorized, nil), nil
+	}}
+	// base URL points at an unresolvable host so the re-exchange fails fast; the
+	// policy then surfaces the 401 rather than looping.
+	rt := newRetryTransport(fake, auth.Credentials{
+		IdentityName:    "a",
+		EnvironmentName: "e",
+		BaseURL:         "https://nonexistent.invalid",
+	})
+
+	req := newReq(t, http.MethodGet, "https://nonexistent.invalid/thing", "")
+	req.Header.Set("Authorization", "Bearer tok-old")
+	r, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer closeResp(r)
+	if r.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 surfaced after failed re-exchange", r.StatusCode)
+	}
+	if _, rerr := auth.ReadTokens(ref); rerr == nil {
+		t.Error("token should have been invalidated by the 401 branch")
+	}
+}
+
+// TestRetry_401NotRetriedForFixedCreds: an injected token (or API key) is a fixed
+// credential — a 401 is a hard denial and must NOT loop.
+func TestRetry_401NotRetriedForFixedCreds(t *testing.T) {
+	shrinkRetryKnobs(t)
+	fake := &fakeRT{respond: func(_ int, _ *http.Request) (*http.Response, error) {
+		return resp(http.StatusUnauthorized, nil), nil
+	}}
+	rt := newRetryTransport(fake, auth.Credentials{InjectedBearerToken: "at_x"})
+
+	r, err := rt.RoundTrip(newReq(t, http.MethodGet, "https://x.test/thing", ""))
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer closeResp(r)
+	if r.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", r.StatusCode)
+	}
+	if got := int(fake.calls); got != 1 {
+		t.Errorf("fixed-cred 401 retried: calls = %d, want 1", got)
+	}
+}

--- a/cli/internal/cli/clictx/client.go
+++ b/cli/internal/cli/clictx/client.go
@@ -1,0 +1,50 @@
+package clictx
+
+// client.go is the CLI adapter (impl/4.2 §3b): it translates the Cobra-resolved
+// ActiveState into the SDK's UX-free client.Config and constructs the generated,
+// authenticated plane clients. It lives in the leaf clictx package so command
+// subpackages can import it without cycling back into the api command root.
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jentic/jentic-one/cli/client"
+	"github.com/jentic/jentic-one/cli/client/generated/broker"
+	"github.com/jentic/jentic-one/cli/client/generated/control"
+)
+
+// configFromState maps the CLI's resolved ActiveState onto the SDK's UX-free
+// Config. ActiveState embeds *config.ResolvedState, so the SDK fields (BaseURL,
+// BrokerURL, IdentityName, …) are promoted and read through the same value.
+func configFromState(state *ActiveState) client.Config {
+	return client.Config{
+		ControlBaseURL:      state.BaseURL,
+		BrokerBaseURL:       state.BrokerURL,
+		IdentityName:        state.IdentityName,
+		EnvironmentName:     state.EnvironmentName,
+		InjectedBearerToken: state.InjectedBearerToken,
+	}
+}
+
+// GetControlClient is the single constructor every Control Plane command uses. It
+// pulls the ActiveState the root interceptor injected and delegates to the SDK, so
+// token state, API-key credentials, and the file-less override are all handled
+// transparently and identically to a third-party SDK consumer.
+func GetControlClient(ctx context.Context) (*control.ClientWithResponses, error) {
+	state := FromContext(ctx)
+	if state == nil {
+		return nil, errors.New("no active state in context (was the root PersistentPreRunE run?)")
+	}
+	return client.NewControl(configFromState(state))
+}
+
+// GetBrokerClient is the Data Plane counterpart. The Env's broker_url must be set
+// (the SDK errors otherwise); it is NEVER derived from the control base URL.
+func GetBrokerClient(ctx context.Context) (*broker.ClientWithResponses, error) {
+	state := FromContext(ctx)
+	if state == nil {
+		return nil, errors.New("no active state in context (was the root PersistentPreRunE run?)")
+	}
+	return client.NewBroker(configFromState(state))
+}

--- a/cli/internal/cli/clictx/client_test.go
+++ b/cli/internal/cli/clictx/client_test.go
@@ -1,0 +1,72 @@
+package clictx
+
+import (
+	"context"
+	"testing"
+
+	sdkconfig "github.com/jentic/jentic-one/cli/client/config"
+)
+
+// TestConfigFromState_MapsResolvedState verifies the ActiveState -> client.Config
+// projection carries the control/broker URLs and identity/environment through.
+func TestConfigFromState_MapsResolvedState(t *testing.T) {
+	state := &ActiveState{
+		ResolvedState: &sdkconfig.ResolvedState{
+			IdentityName:        "ci",
+			EnvironmentName:     "prod",
+			BaseURL:             "https://ctl.example",
+			BrokerURL:           "https://brk.example",
+			InjectedBearerToken: "at_x",
+		},
+		Mode: ModeAgent,
+	}
+	cfg := configFromState(state)
+	if cfg.ControlBaseURL != "https://ctl.example" || cfg.BrokerBaseURL != "https://brk.example" {
+		t.Errorf("urls = %q/%q", cfg.ControlBaseURL, cfg.BrokerBaseURL)
+	}
+	if cfg.IdentityName != "ci" || cfg.EnvironmentName != "prod" {
+		t.Errorf("identity/env = %q/%q", cfg.IdentityName, cfg.EnvironmentName)
+	}
+	if cfg.InjectedBearerToken != "at_x" {
+		t.Errorf("injected token = %q", cfg.InjectedBearerToken)
+	}
+}
+
+// TestGetControlClient_RequiresState: without an ActiveState in context (the root
+// interceptor never ran) the adapter errors rather than building a half-configured
+// client.
+func TestGetControlClient_RequiresState(t *testing.T) {
+	if _, err := GetControlClient(context.Background()); err == nil {
+		t.Fatal("expected an error with no ActiveState in context")
+	}
+}
+
+// TestGetControlClient_BuildsWithState: with a control URL present the adapter
+// constructs a client.
+func TestGetControlClient_BuildsWithState(t *testing.T) {
+	state := &ActiveState{
+		ResolvedState: &sdkconfig.ResolvedState{BaseURL: "https://ctl.example"},
+		Mode:          ModeHuman,
+	}
+	ctx := WithActiveState(context.Background(), state)
+	c, err := GetControlClient(ctx)
+	if err != nil {
+		t.Fatalf("GetControlClient: %v", err)
+	}
+	if c == nil {
+		t.Fatal("nil control client")
+	}
+}
+
+// TestGetBrokerClient_RequiresBrokerURL: the broker URL is never derived from the
+// control URL, so a state without a broker_url errors.
+func TestGetBrokerClient_RequiresBrokerURL(t *testing.T) {
+	state := &ActiveState{
+		ResolvedState: &sdkconfig.ResolvedState{BaseURL: "https://ctl.example"},
+		Mode:          ModeHuman,
+	}
+	ctx := WithActiveState(context.Background(), state)
+	if _, err := GetBrokerClient(ctx); err == nil {
+		t.Fatal("expected GetBrokerClient to require a broker URL")
+	}
+}

--- a/cli/internal/cmd/context_cmd_test.go
+++ b/cli/internal/cmd/context_cmd_test.go
@@ -17,6 +17,10 @@ func withXDG(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
 	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "state"))
+	// Isolate the legacy ~/.jentic root too: clictx's legacy-read adapter resolves
+	// it via $JENTIC_HOME, so without this a developer's real ~/.jentic would leak
+	// into command tests (e.g. resolving a stray default identity/base URL).
+	t.Setenv("JENTIC_HOME", filepath.Join(dir, "jentic-home"))
 	t.Setenv("JENTIC_BASE_URL", "")
 	t.Setenv("JENTIC_BEARER_TOKEN", "")
 	t.Setenv("JENTIC_MODE", "human")

--- a/cli/internal/cmd/identity.go
+++ b/cli/internal/cmd/identity.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"crypto/ed25519"
 	"fmt"
 	"sort"
 
@@ -8,6 +9,7 @@ import (
 
 	"github.com/jentic/jentic-one/cli/client/auth"
 	"github.com/jentic/jentic-one/cli/client/config"
+	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
 	"github.com/jentic/jentic-one/cli/internal/cli/ux"
 )
 
@@ -32,7 +34,118 @@ func newIdentityCmd(app *App) *cobra.Command {
 	}
 	cmd.AddCommand(fenced(newIdentityAddCmd(app)))
 	cmd.AddCommand(newIdentityListCmd(app)) // read-only: not fenced
+	cmd.AddCommand(newIdentityRegisterCmd(app))
 	cmd.AddCommand(fenced(newIdentityDeleteCmd(app)))
+	return cmd
+}
+
+// newIdentityRegisterCmd implements `jentic identity register` (Phase 4.1 §2):
+// the active identity registers its environment-scoped Ed25519 public key with the
+// active environment via RFC 7591 Dynamic Client Registration, and the returned
+// client_id + status ("pending" until an operator approves) are persisted per
+// (identity, environment) in config.yaml. A subsequent token exchange (the auth
+// middleware) signs assertions with that exact key, scoped to that environment.
+//
+// This is the deliberate FENCING CARVE-OUT: registration is the one management-
+// shaped step an agent legitimately performs for its OWN provisioned identity
+// during autonomous bootstrap, so it is bootstrap-safe rather than fenced
+// (07_security_and_agent_isolation; impl/1.3 §5). It never switches contexts or
+// mints another identity.
+func newIdentityRegisterCmd(_ *App) *cobra.Command {
+	var name string
+	cmd := bootstrapSafe(&cobra.Command{
+		Use:   "register",
+		Short: "Register the active identity's key with the active environment",
+		Long: "register generates an environment-scoped Ed25519 key (if absent),\n" +
+			"performs RFC 7591 Dynamic Client Registration, and records the returned\n" +
+			"client_id + status. The agent is 'pending' until an operator approves it;\n" +
+			"token exchange then succeeds automatically. This is the V2 successor to the\n" +
+			"legacy `jentic register` and operates on the resolved active context.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			aud := ux.FromContext(cmd.Context())
+			state := clictx.FromContext(cmd.Context())
+			if state == nil || state.ResolvedState == nil || state.IdentityName == "" || state.EnvironmentName == "" {
+				return reportCoded(aud, &ux.CodedError{
+					Code:       ux.CodeResolveFailed,
+					Msg:        "no active identity/environment to register",
+					Actionable: "Create and select a context first (`jentic context create`, `jentic context use`).",
+				})
+			}
+			if state.BaseURL == "" {
+				return reportCoded(aud, &ux.CodedError{
+					Code:       ux.CodeResolveFailed,
+					Msg:        fmt.Sprintf("environment %q has no base_url", state.EnvironmentName),
+					Actionable: "Set it with `jentic env add` / edit the environment.",
+				})
+			}
+
+			ref := auth.IdentityRef{Identity: state.IdentityName, Environment: state.EnvironmentName}
+
+			// Local-only, non-destructive: mint the env-scoped key if this is the
+			// first registration for the pair. Never contacts the server.
+			priv, err := auth.GetOrGenerateKey(ref)
+			if err != nil {
+				return reportCoded(aud, err)
+			}
+			pub, ok := priv.Public().(ed25519.PublicKey)
+			if !ok {
+				return reportCoded(aud, &ux.CodedError{Code: ux.CodeInternalError, Msg: "env-scoped key is not Ed25519"})
+			}
+
+			clientName := name
+			if clientName == "" {
+				clientName = state.IdentityName
+			}
+			reg, err := auth.Register(state.BaseURL, clientName, auth.PublicKeyToJWKS(pub))
+			if err != nil {
+				return reportCoded(aud, err)
+			}
+
+			if err := config.MutateConfig(func(cfg *config.Config) error {
+				ident := cfg.Identities[state.IdentityName]
+				if ident.Environments == nil {
+					ident.Environments = make(map[string]config.EnvRegState)
+				}
+				status := reg.Status
+				if status == "" {
+					status = "pending"
+				}
+				ident.Environments[state.EnvironmentName] = config.EnvRegState{
+					ClientID: reg.ClientID,
+					Status:   status,
+				}
+				cfg.Identities[state.IdentityName] = ident
+				return nil
+			}); err != nil {
+				return reportCoded(aud, err)
+			}
+
+			status := reg.Status
+			if status == "" {
+				status = "pending"
+			}
+			renderStatus := ux.StatusPending
+			msg := "Agent registered. Operator approval required before use."
+			if status == "approved" {
+				renderStatus = ux.StatusRegistered
+				msg = "Agent registered and approved."
+			}
+			aud.Render(ux.Result{
+				Status:   renderStatus,
+				Resource: "identity",
+				Name:     state.IdentityName,
+				ID:       reg.ClientID,
+				Message:  msg,
+				Fields: map[string]any{
+					"environment": state.EnvironmentName,
+					"status":      status,
+				},
+			})
+			return nil
+		},
+	})
+	cmd.Flags().StringVar(&name, "name", "", "Client name shown to the approving operator (default: identity name)")
 	return cmd
 }
 

--- a/cli/internal/cmd/identity_register_test.go
+++ b/cli/internal/cmd/identity_register_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jentic/jentic-one/cli/client/auth"
+	sdkconfig "github.com/jentic/jentic-one/cli/client/config"
+)
+
+// TestIdentityRegister_PersistsClientIDAndStatus drives `jentic identity register`
+// end-to-end against a mock /register (loopback http is allowed by the transport
+// guard). It asserts the returned client_id + status land in config.yaml under the
+// active (identity, environment) pair and that an env-scoped key was minted.
+func TestIdentityRegister_PersistsClientIDAndStatus(t *testing.T) {
+	withXDG(t)
+
+	var gotBody struct {
+		ClientName string    `json:"client_name"`
+		Jwks       auth.JWKS `json:"jwks"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/register" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"client_id": "client_abc", "status": "pending"})
+	}))
+	defer srv.Close()
+
+	if err := runJentic(t, "env", "add", "local", "--url", srv.URL); err != nil {
+		t.Fatalf("env add: %v", err)
+	}
+	if err := runJentic(t, "identity", "add", "agent1", "--type", "agent"); err != nil {
+		t.Fatalf("identity add: %v", err)
+	}
+	if err := runJentic(t, "context", "create", "c1", "--env", "local", "--identity", "agent1"); err != nil {
+		t.Fatalf("context create: %v", err)
+	}
+	if err := runJentic(t, "context", "use", "c1"); err != nil {
+		t.Fatalf("context use: %v", err)
+	}
+
+	if err := runJentic(t, "identity", "register"); err != nil {
+		t.Fatalf("identity register: %v", err)
+	}
+
+	if gotBody.ClientName != "agent1" || len(gotBody.Jwks.Keys) != 1 {
+		t.Errorf("register request body = %+v", gotBody)
+	}
+
+	cfg, err := sdkconfig.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg, ok := cfg.Identities["agent1"].Environments["local"]
+	if !ok {
+		t.Fatal("no registration state persisted for agent1/local")
+	}
+	if reg.ClientID != "client_abc" || reg.Status != "pending" {
+		t.Errorf("registration state = %+v, want client_abc/pending", reg)
+	}
+}
+
+// TestIdentityRegister_RequiresActiveContext: with no active context there is no
+// identity/environment to register, so the command fails cleanly.
+func TestIdentityRegister_RequiresActiveContext(t *testing.T) {
+	withXDG(t)
+	if err := runJentic(t, "identity", "register"); err == nil {
+		t.Fatal("expected register to fail with no active context")
+	}
+}

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -739,6 +739,35 @@
               ]
             },
             {
+              "name": "register",
+              "path": "jentic identity register",
+              "use": "register",
+              "short": "Register the active identity's key with the active environment",
+              "long": "register generates an environment-scoped Ed25519 key (if absent),\nperforms RFC 7591 Dynamic Client Registration, and records the returned\nclient_id + status. The agent is 'pending' until an operator approves it;\ntoken exchange then succeeds automatically. This is the V2 successor to the\nlegacy `jentic register` and operates on the resolved active context.",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "name",
+                  "type": "string",
+                  "usage": "Client name shown to the approving operator (default: identity name)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                }
+              ]
+            },
+            {
               "name": "delete",
               "path": "jentic identity delete",
               "use": "delete \u003cname\u003e",


### PR DESCRIPTION
Stacked on #986 (Phase 3). Part of the CLI-V2 rewrite. Plan: `jentic-one-plans` cli-v2 Phase 4 (`03_identity_roaming.md`, `impl/4.1`, `impl/4.2`, `13_agent_machine_contract.md` §4-5).

## Scope

Phase 4 is **Auth Hardening applied to the stack lifted in Phase 1**. Items 1-3 already shipped with that lift — env-scoped `<identity>_<env>.key`, the F1/F3 `requireSecureHost` transport guard (token endpoint + request editor), and the F4 renewal-skew clamp (`min(30s, lifetime/2)`) + 270s assertion TTL. This PR adds the remaining deltas.

### `jentic identity register` (item 1)
- RFC 7591 Dynamic Client Registration for the **active** identity × environment (resolved from the context, not flags).
- Generates the env-scoped Ed25519 key lazily if absent (local-only, non-destructive), POSTs the public JWKS to `/register`, and persists `client_id` + `status` per `(identity, environment)` in `config.yaml` via `MutateConfig`.
- Hand-rolled POST (not a generated call): `/register` and `/oauth/token` are auth-server routes **not** in the control-plane OpenAPI surface — this matches the shipped V1 `internal/authclient` contract. Held to the same TLS/loopback guard as the token endpoint.
- **Fencing carve-out**: bootstrap-safe, not fenced — an agent legitimately registers its OWN provisioned identity during autonomous bootstrap. Never switches contexts or mints another identity.

### API-key credential first-class in the flow (item 4)
- `AttachAuth` now presents a stored `jak_*` key as `Authorization: Bearer jak_...` **verbatim** (no exchange/minting), ahead of the OAuth path. Confirmed against the backend (`shared/web/auth.py`, `shared/auth/api_key_resolver.py`): the backend prefix-dispatches on the key, and V1 (`agentauth.Session.ValidToken` → `httpx`) already sends it on `Authorization: Bearer`.
- Presence of the on-disk credential is the signal; a read miss falls through to the exchange. Injected token still wins over an API key.

### SDK response-side policy (item 5, `13` §5)
A `retryTransport` wrapping both planes' HTTP client:
- **401** → exactly one token re-exchange + one retry, and **only** for re-exchangeable creds (the JWT-bearer disk path). Injected tokens and API keys are fixed — a 401 is a hard denial, not looped. On 401 it invalidates the cached token (server rejected what looked valid to us) and re-stamps auth via the shared `AttachAuth`.
- **429** → honor `Retry-After` within a bounded budget (`maxRetryAfter`), else surface the 429.
- **5xx / transport error** → bounded backoff for **idempotent** calls only: GET/HEAD, or a POST carrying an `Idempotency-Key` (the broker dedupes on it). A plain POST is never blind-retried. Bodies are buffered so retries can resend.

### Plumbing
- `clictx.GetControlClient`/`GetBrokerClient` map the resolved `ActiveState` → `client.Config` (broker URL never derived from control URL).
- `auth.InvalidateTokens`, `auth.AttachAuth`, `auth.CanReExchange`, `auth.Register`/`RegistrationResult` added; `RequestEditor` now delegates to `AttachAuth` so the editor and the 401-retry path can never disagree on which credential to present.

## Notes / deferred
- The `X-Jentic-Session-Id` telemetry editor and `Idempotency-Key` *emission* by `jentic execute` are Phase 5; this PR only makes the transport retry-aware of an Idempotency-Key when present.
- Test harness: `withXDG` now isolates `$JENTIC_HOME` so the legacy-read adapter can't pull a developer's real `~/.jentic` into command tests (latent flake, fixed here).

## Test plan
- [x] `go test -race ./...` (register mock DCR, PublicKeyToJWKS shape, API-key-in-flow precedence + transport guard, CanReExchange, InvalidateTokens, retry policy: 5xx idempotent/non-idempotent/idempotency-key, 429 within/over budget, 401 exchangeable/fixed, clictx adapter)
- [x] `make test-arch` (1C fencing, 1E mutator lock), `make test-golden`
- [x] `make check-cli-gen` (no codegen drift)
- [x] `golangci-lint run ./...` (0 issues), `go vet ./...`
- [x] `ui/public/cli-reference.json` regenerated (register entry; drift test green)
- [ ] CI green on the stacked PR

Made with [Cursor](https://cursor.com)