### PR TITLE
cli(v2): Phase 5: Agent Features

### DIFF
--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -250,3 +250,30 @@ func NewBroker(c Config) (*broker.ClientWithResponses, error) {
 	}
 	return cli, nil
 }
+
+// BrokerTransport returns the *http.Client the broker plane uses — the caller's
+// transport decorated with the SDK response policy (429 Retry-After and bounded
+// 5xx/transport backoff for idempotent calls — 13 §5). It is the seam `jentic
+// execute` re-plumbs onto (plan.md Phase 5 item 1): execute composes the broker
+// catch-all URL itself ({scheme}://{host}/{upstreamURL}) to preserve its exact
+// METHOD:url|operation_id|METHOD:/path contract and agent_directive/exit-2
+// denial handling, but sends through THIS transport rather than a bare
+// http.Client, so it inherits the same retry/backoff every generated broker call
+// gets.
+//
+// The 401 re-exchange arm is deliberately DISABLED here (reExchange=false):
+// execute forwards its OWN agent bearer and treats a broker 401 as a recoverable
+// denial whose agent_directive body must reach the caller intact — a re-exchange
+// attempt would both be meaningless (no disk-backed identity to refresh) and
+// drain that body. 429/5xx idempotent backoff still applies.
+func BrokerTransport(c Config) *http.Client {
+	hc := c.HTTPClient
+	if hc == nil {
+		hc = &http.Client{}
+	}
+	wrapped := *hc
+	wrapped.Transport = newRetryTransport(hc.Transport, auth.Credentials{})
+	// Force CanReExchange=false without a real credential: execute owns its auth.
+	wrapped.Transport.(*retryTransport).reExchange = false
+	return &wrapped
+}

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -39,6 +39,12 @@ type Config struct {
 	IdentityName    string
 	EnvironmentName string
 
+	// SessionID, when set, is attached as X-Jentic-Session-Id on every request so
+	// the backend can group a run's executions under a client-chosen session (the
+	// server-side correlation pivot is trace_id; this is an additional grouping —
+	// impl/5.0 §1). Populated for the CLI from JENTIC_SESSION_ID via ResolvedState.
+	SessionID string
+
 	// InjectedBearerToken, when set, bypasses the on-disk key/token exchange and is
 	// attached verbatim (file-less / bring-your-own-token mode).
 	InjectedBearerToken string
@@ -64,25 +70,49 @@ func (c Config) credentials() auth.Credentials {
 	}
 }
 
+// sessionEditor attaches the X-Jentic-Session-Id header. It is appended after the
+// auth editor and only when Config.SessionID is non-empty (impl/5.0 §1). Kept as
+// the raw editor signature so it converts to each generated package's
+// RequestEditorFn at construction alongside the auth editor.
+func sessionEditor(sessionID string) RequestEditor {
+	return func(_ context.Context, req *http.Request) error {
+		req.Header.Set("X-Jentic-Session-Id", sessionID)
+		return nil
+	}
+}
+
+// editorChain is the ordered request-editor list every plane shares: auth first
+// (so a later editor can observe the Authorization header), then the optional
+// session/telemetry editor, then any caller-supplied Editors.
+func (c Config) editorChain() []RequestEditor {
+	eds := make([]RequestEditor, 0, 2+len(c.Editors))
+	eds = append(eds, auth.RequestEditor(c.credentials()))
+	if c.SessionID != "" {
+		eds = append(eds, sessionEditor(c.SessionID))
+	}
+	eds = append(eds, c.Editors...)
+	return eds
+}
+
 // controlOptions / brokerOptions assemble each plane's option slice. They are
 // nearly identical but the generated ClientOption types are distinct per package,
 // so Go generics can't unify them without an adapter; two tiny builders are
 // clearer than a reflective bridge.
 func controlOptions(c Config) []control.ClientOption {
-	opts := make([]control.ClientOption, 0, 2+len(c.Editors))
+	eds := c.editorChain()
+	opts := make([]control.ClientOption, 0, 1+len(eds))
 	opts = append(opts, control.WithHTTPClient(c.httpClient()))
-	opts = append(opts, control.WithRequestEditorFn(auth.RequestEditor(c.credentials())))
-	for _, e := range c.Editors {
+	for _, e := range eds {
 		opts = append(opts, control.WithRequestEditorFn(control.RequestEditorFn(e)))
 	}
 	return opts
 }
 
 func brokerOptions(c Config) []broker.ClientOption {
-	opts := make([]broker.ClientOption, 0, 2+len(c.Editors))
+	eds := c.editorChain()
+	opts := make([]broker.ClientOption, 0, 1+len(eds))
 	opts = append(opts, broker.WithHTTPClient(c.httpClient()))
-	opts = append(opts, broker.WithRequestEditorFn(auth.RequestEditor(c.credentials())))
-	for _, e := range c.Editors {
+	for _, e := range eds {
 		opts = append(opts, broker.WithRequestEditorFn(broker.RequestEditorFn(e)))
 	}
 	return opts

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -11,6 +11,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -206,6 +207,30 @@ func splitKV(kv string) (key, value string, ok bool) {
 		return "", "", false
 	}
 	return strings.TrimSpace(kv[:i]), strings.TrimSpace(kv[i+1:]), true
+}
+
+// ProbeServerVersion asks the control plane for its running app version
+// (GET /system/version). It backs the backend version-negotiation path
+// (impl/5.0 §6a, plan.md Phase 5 item 9): when the CLI's embedded spec advertises
+// a route an OLDER self-hosted server doesn't serve yet, a bare 404 is
+// indistinguishable from a typo, so the passthrough probes the version once to
+// enrich the error. Returns the running version string; a probe failure returns
+// "" and an error (the caller degrades to a plain 404 rather than fabricating a
+// verdict).
+func ProbeServerVersion(ctx context.Context, raw *control.Client) (string, error) {
+	resp, err := RawControlRequest(ctx, raw, http.MethodGet, "/system/version", nil)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("version probe returned status %d", resp.StatusCode)
+	}
+	var vr control.VersionResponse
+	if derr := json.NewDecoder(resp.Body).Decode(&vr); derr != nil {
+		return "", derr
+	}
+	return vr.Current, nil
 }
 
 // NewBroker builds the strictly-typed broker-plane (execution) client. It reuses

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -13,7 +13,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 
 	"github.com/jentic/jentic-one/cli/client/auth"
 	broker "github.com/jentic/jentic-one/cli/client/generated/broker"
@@ -145,6 +147,65 @@ func NewControl(c Config) (*control.ClientWithResponses, error) {
 		return nil, fmt.Errorf("building control client: %w", err)
 	}
 	return cli, nil
+}
+
+// NewControlRaw builds a raw control-plane client (server + Doer + editor chain)
+// for the `jentic api` passthrough, which issues arbitrary METHOD/PATH requests
+// the generated per-operation methods do not cover. It shares the SAME transport
+// (retry/backoff), auth editor (incl. requireSecureHost), and session editor as
+// the typed client — the passthrough is a thin wrapper over this, never a second
+// hand-rolled transport (impl/5.0 §6a).
+func NewControlRaw(c Config) (*control.Client, error) {
+	if c.ControlBaseURL == "" {
+		return nil, errors.New("control base URL is required")
+	}
+	cli, err := control.NewClient(c.ControlBaseURL, controlOptions(c)...)
+	if err != nil {
+		return nil, fmt.Errorf("building control client: %w", err)
+	}
+	return cli, nil
+}
+
+// RawControlRequest issues an arbitrary request through raw's transport and editor
+// chain and returns the response. path is a spec-relative path (e.g.
+// "/credentials"), joined to the client's Server. extraHeaders (key=value) are
+// applied after the editor chain so a caller can override defaults. It applies
+// every configured RequestEditor (auth, session) exactly as the typed methods do,
+// so the passthrough inherits auth/redaction/session for free. The caller owns the
+// response body (close it).
+func RawControlRequest(ctx context.Context, raw *control.Client, method, path string, body io.Reader, extraHeaders ...string) (*http.Response, error) {
+	// oapi-codegen's NewClient normalizes Server with a trailing slash; join
+	// without doubling it (path is always spec-absolute, starting with '/').
+	target := strings.TrimRight(raw.Server, "/") + path
+	req, err := http.NewRequestWithContext(ctx, method, target, body)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for _, ed := range raw.RequestEditors {
+		if err := ed(ctx, req); err != nil {
+			return nil, err
+		}
+	}
+	for _, kv := range extraHeaders {
+		k, v, ok := splitKV(kv)
+		if !ok {
+			return nil, fmt.Errorf("invalid header %q; expected key=value", kv)
+		}
+		req.Header.Set(k, v)
+	}
+	return raw.Client.Do(req)
+}
+
+// splitKV splits "key=value" (value may contain further '=').
+func splitKV(kv string) (key, value string, ok bool) {
+	i := strings.IndexByte(kv, '=')
+	if i < 1 {
+		return "", "", false
+	}
+	return strings.TrimSpace(kv[:i]), strings.TrimSpace(kv[i+1:]), true
 }
 
 // NewBroker builds the strictly-typed broker-plane (execution) client. It reuses

--- a/cli/client/client_test.go
+++ b/cli/client/client_test.go
@@ -97,3 +97,42 @@ func TestEditorChain_TransportGuard(t *testing.T) {
 		t.Error("bearer was attached to an insecure request (F3 violation)")
 	}
 }
+
+// TestSessionEditor_AttachedWhenSet: X-Jentic-Session-Id rides along when
+// Config.SessionID is set, and is absent otherwise.
+func TestSessionEditor_AttachedWhenSet(t *testing.T) {
+	var captured *http.Request
+	cli, err := NewControl(Config{
+		ControlBaseURL:      "https://control.example",
+		InjectedBearerToken: "tok",
+		SessionID:           "sess-123",
+		HTTPClient:          recordingClient(&captured),
+	})
+	if err != nil {
+		t.Fatalf("NewControl: %v", err)
+	}
+	if _, err := cli.HealthWithResponse(context.Background()); err != nil {
+		t.Fatalf("HealthWithResponse: %v", err)
+	}
+	if got := captured.Header.Get("X-Jentic-Session-Id"); got != "sess-123" {
+		t.Errorf("X-Jentic-Session-Id = %q, want sess-123", got)
+	}
+}
+
+func TestSessionEditor_AbsentWhenUnset(t *testing.T) {
+	var captured *http.Request
+	cli, err := NewControl(Config{
+		ControlBaseURL:      "https://control.example",
+		InjectedBearerToken: "tok",
+		HTTPClient:          recordingClient(&captured),
+	})
+	if err != nil {
+		t.Fatalf("NewControl: %v", err)
+	}
+	if _, err := cli.HealthWithResponse(context.Background()); err != nil {
+		t.Fatalf("HealthWithResponse: %v", err)
+	}
+	if got := captured.Header.Get("X-Jentic-Session-Id"); got != "" {
+		t.Errorf("X-Jentic-Session-Id = %q, want empty", got)
+	}
+}

--- a/cli/client/generated/control/spec_embed.go
+++ b/cli/client/generated/control/spec_embed.go
@@ -1,0 +1,19 @@
+// Package control also embeds the vendored OpenAPI spec (see SpecYAML) for the
+// runtime `jentic api` passthrough. The generated client doc lives in client.go;
+// this file adds only the hand-written embed beside spec.yaml.
+package control
+
+import _ "embed"
+
+// SpecYAML is the vendored OpenAPI document this client was generated from,
+// embedded verbatim. It is EXACTLY the spec `make generate-api` copied in and
+// `check-cli-gen` pins to the SDK's commit, so the `jentic api` passthrough's
+// path allowlist, self-description (`api describe`), and the generated client
+// can never disagree about what the control plane offers (impl/5.0 §6a).
+//
+// This file is hand-written (not emitted by tools/specgen) precisely so the
+// generator never clobbers it; go:embed cannot cross the module root, so the
+// embed must live here beside spec.yaml rather than in the api command package.
+//
+//go:embed spec.yaml
+var SpecYAML []byte

--- a/cli/client/transport.go
+++ b/cli/client/transport.go
@@ -41,15 +41,21 @@ var (
 type retryTransport struct {
 	base  http.RoundTripper
 	creds auth.Credentials
+	// reExchange enables the 401→token-refresh arm. True for the SDK's typed
+	// clients (disk-backed identity to refresh); set false by BrokerTransport,
+	// where the caller (jentic execute) owns its bearer and a 401 is a denial to
+	// surface intact, not refresh.
+	reExchange bool
 }
 
 // newRetryTransport wraps base with the response policy for creds. A nil base
-// uses http.DefaultTransport.
+// uses http.DefaultTransport. The 401 re-exchange arm is enabled by default;
+// BrokerTransport flips reExchange off for the caller-owned-auth case.
 func newRetryTransport(base http.RoundTripper, creds auth.Credentials) *retryTransport {
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	return &retryTransport{base: base, creds: creds}
+	return &retryTransport{base: base, creds: creds, reExchange: true}
 }
 
 func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -86,7 +92,7 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// 401: one re-exchange + retry, only for re-exchangeable creds and a
 		// rewindable body. Discard the body before retrying to free the conn.
 		case resp.StatusCode == http.StatusUnauthorized &&
-			!triedReauth && canRewind && auth.CanReExchange(t.creds):
+			t.reExchange && !triedReauth && canRewind && auth.CanReExchange(t.creds):
 			triedReauth = true
 			drain(resp)
 			// Force a fresh token: the on-disk one looked valid to us but the

--- a/cli/client/transport_test.go
+++ b/cli/client/transport_test.go
@@ -253,3 +253,60 @@ func TestRetry_401NotRetriedForFixedCreds(t *testing.T) {
 		t.Errorf("fixed-cred 401 retried: calls = %d, want 1", got)
 	}
 }
+
+// TestBrokerTransport_401SurfacesBodyWithoutReExchange guards the jentic execute
+// re-plumb (plan.md Phase 5 item 1): BrokerTransport disables the 401 arm even
+// though empty creds would otherwise look re-exchangeable, so a broker 401 (a
+// recoverable denial) reaches execute with its agent_directive body intact and
+// exactly one attempt — never drained by a doomed re-exchange.
+func TestBrokerTransport_401SurfacesBodyWithoutReExchange(t *testing.T) {
+	shrinkRetryKnobs(t)
+	fake := &fakeRT{respond: func(_ int, _ *http.Request) (*http.Response, error) {
+		r := resp(http.StatusUnauthorized, nil)
+		r.Body = io.NopCloser(strings.NewReader(`{"agent_directive":{}}`))
+		return r, nil
+	}}
+	hc := BrokerTransport(Config{HTTPClient: &http.Client{Transport: fake}})
+
+	r, err := hc.Do(newReq(t, http.MethodGet, "https://x.test/thing", ""))
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer closeResp(r)
+	if r.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", r.StatusCode)
+	}
+	if got := int(fake.calls); got != 1 {
+		t.Errorf("broker 401 retried: calls = %d, want 1", got)
+	}
+	body, _ := io.ReadAll(r.Body)
+	if !strings.Contains(string(body), "agent_directive") {
+		t.Errorf("directive body drained by transport; got %q", body)
+	}
+}
+
+// TestBrokerTransport_5xxIdempotentStillRetries confirms the re-plumb keeps the
+// idempotent 5xx backoff arm — execute's GETs benefit from bounded retries even
+// with the 401 arm off.
+func TestBrokerTransport_5xxIdempotentStillRetries(t *testing.T) {
+	shrinkRetryKnobs(t)
+	fake := &fakeRT{respond: func(attempt int, _ *http.Request) (*http.Response, error) {
+		if attempt < 2 {
+			return resp(http.StatusServiceUnavailable, nil), nil
+		}
+		return resp(http.StatusOK, nil), nil
+	}}
+	hc := BrokerTransport(Config{HTTPClient: &http.Client{Transport: fake}})
+
+	r, err := hc.Do(newReq(t, http.MethodGet, "https://x.test/thing", ""))
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer closeResp(r)
+	if r.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 after retries", r.StatusCode)
+	}
+	if got := int(fake.calls); got != 3 {
+		t.Errorf("calls = %d, want 3 (two 503s then 200)", got)
+	}
+}

--- a/cli/internal/cli/apispec/spec.go
+++ b/cli/internal/cli/apispec/spec.go
@@ -1,0 +1,300 @@
+// Package apispec parses an OpenAPI document (the embedded vendored control spec,
+// or a --live one fetched from the server) to back the `jentic api` passthrough:
+// path-allowlist matching, operation listing, and per-operation self-description
+// (`api describe`). It reuses libopenapi — the same parser tools/specgen uses — so
+// the module carries exactly one spec-parsing dependency (impl/5.0 §6a).
+package apispec
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi/datamodel"
+	base "github.com/pb33f/libopenapi/datamodel/high/base"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
+)
+
+// Spec is a parsed OpenAPI document with a compiled route table for concrete-path
+// matching.
+type Spec struct {
+	Version string
+	routes  []route
+}
+
+// route is one templated spec path compiled to a regexp for concrete-path
+// matching plus its per-method operations.
+type route struct {
+	template string
+	re       *regexp.Regexp
+	params   []string
+	methods  map[string]*v3.Operation
+}
+
+// Operation is the self-description of a single spec operation, JSON-serializable
+// for `api describe` in agent mode.
+type Operation struct {
+	Method         string   `json:"method"`
+	Path           string   `json:"path"`
+	OperationID    string   `json:"operation_id,omitempty"`
+	Summary        string   `json:"summary,omitempty"`
+	PathParams     []Param  `json:"path_params,omitempty"`
+	QueryParams    []Param  `json:"query_params,omitempty"`
+	RequestBody    any      `json:"request_body_schema,omitempty"`
+	RequiredFields []string `json:"required_fields,omitempty"`
+	ResponseSchema any      `json:"response_schema,omitempty"`
+}
+
+// Param is a query/path parameter description.
+type Param struct {
+	Name     string `json:"name"`
+	Required bool   `json:"required"`
+	Type     string `json:"type,omitempty"`
+	Desc     string `json:"description,omitempty"`
+}
+
+// Parse builds a Spec from raw OpenAPI bytes (YAML or JSON). External $refs are
+// left unresolved (hermetic; the control spec has none that matter for our use)
+// and libopenapi's logger is silenced.
+func Parse(specBytes []byte) (*Spec, error) {
+	doc, err := libopenapi.NewDocumentWithConfiguration(specBytes, &datamodel.DocumentConfiguration{
+		SkipExternalRefResolution: true,
+		Logger:                    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("parsing spec: %w", err)
+	}
+	model, err := doc.BuildV3Model()
+	if err != nil {
+		return nil, fmt.Errorf("building spec model: %w", err)
+	}
+
+	s := &Spec{}
+	if model.Model.Info != nil {
+		s.Version = model.Model.Info.Version
+	}
+	if model.Model.Paths == nil {
+		return s, nil
+	}
+	for pair := model.Model.Paths.PathItems.First(); pair != nil; pair = pair.Next() {
+		tmpl := pair.Key()
+		item := pair.Value()
+		re, params := compilePath(tmpl)
+		r := route{template: tmpl, re: re, params: params, methods: map[string]*v3.Operation{}}
+		for op := item.GetOperations().First(); op != nil; op = op.Next() {
+			r.methods[strings.ToUpper(op.Key())] = op.Value()
+		}
+		s.routes = append(s.routes, r)
+	}
+	return s, nil
+}
+
+// pathParamRe matches an OpenAPI `{name}` path template segment.
+var pathParamRe = regexp.MustCompile(`\{([^}]+)\}`)
+
+// compilePath turns a templated spec path (/credentials/{id}) into an anchored
+// regexp that matches a concrete path (/credentials/abc), plus the ordered param
+// names. A `{param}` matches one non-slash segment; literal segments are regexp-
+// quoted so path characters like '.' are matched literally.
+func compilePath(tmpl string) (*regexp.Regexp, []string) {
+	matches := pathParamRe.FindAllStringSubmatchIndex(tmpl, -1)
+	params := make([]string, 0, len(matches))
+	var b strings.Builder
+	b.WriteString("^")
+	last := 0
+	for _, loc := range matches {
+		// loc: [matchStart, matchEnd, groupStart, groupEnd]
+		b.WriteString(regexp.QuoteMeta(tmpl[last:loc[0]])) // literal prefix
+		params = append(params, tmpl[loc[2]:loc[3]])
+		b.WriteString(`[^/]+`)
+		last = loc[1]
+	}
+	b.WriteString(regexp.QuoteMeta(tmpl[last:]))
+	b.WriteString("$")
+	return regexp.MustCompile(b.String()), params
+}
+
+// Match resolves a concrete request path + method against the spec. It ignores any
+// query string on reqPath. When multiple templated routes match, the most specific
+// wins: a static route (no path params) beats a templated one, and among templated
+// routes fewer params beats more (mirrors how HTTP routers disambiguate
+// /credentials/providers from /credentials/{id}). Returns the matched Operation
+// description, or ok=false if no route/method matches.
+func (s *Spec) Match(method, reqPath string) (*Operation, bool) {
+	method = strings.ToUpper(method)
+	pathOnly := reqPath
+	if i := strings.IndexByte(pathOnly, '?'); i >= 0 {
+		pathOnly = pathOnly[:i]
+	}
+	var best *route
+	for i := range s.routes {
+		r := &s.routes[i]
+		if !r.re.MatchString(pathOnly) {
+			continue
+		}
+		if _, ok := r.methods[method]; !ok {
+			continue
+		}
+		if best == nil || len(r.params) < len(best.params) {
+			best = r
+		}
+	}
+	if best == nil {
+		return nil, false
+	}
+	return describe(method, best.template, best.methods[method]), true
+}
+
+// HasPath reports whether any route matches reqPath (regardless of method). Used
+// to give a better error ("path exists, wrong method") than a bare not-found.
+func (s *Spec) HasPath(reqPath string) bool {
+	pathOnly := reqPath
+	if i := strings.IndexByte(pathOnly, '?'); i >= 0 {
+		pathOnly = pathOnly[:i]
+	}
+	for i := range s.routes {
+		if s.routes[i].re.MatchString(pathOnly) {
+			return true
+		}
+	}
+	return false
+}
+
+// List returns every operation (method+path+summary), sorted by path then method,
+// for `api ops`. filter, when non-empty, keeps only operations whose path,
+// operationId, or summary contains it (case-insensitive).
+func (s *Spec) List(filter string) []Operation {
+	var out []Operation
+	lf := strings.ToLower(filter)
+	for i := range s.routes {
+		r := &s.routes[i]
+		for m, op := range r.methods {
+			d := describe(m, r.template, op)
+			if lf != "" && !strings.Contains(strings.ToLower(d.Path+" "+d.OperationID+" "+d.Summary), lf) {
+				continue
+			}
+			// api ops is a shallow index; drop the heavy schema fields.
+			out = append(out, Operation{Method: d.Method, Path: d.Path, OperationID: d.OperationID, Summary: d.Summary})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Path != out[j].Path {
+			return out[i].Path < out[j].Path
+		}
+		return out[i].Method < out[j].Method
+	})
+	return out
+}
+
+// Describe returns the full self-description for a concrete method+path, or
+// ok=false if unmatched.
+func (s *Spec) Describe(method, reqPath string) (*Operation, bool) {
+	return s.Match(method, reqPath)
+}
+
+// describe extracts the params + request/response schema for one operation.
+func describe(method, tmpl string, op *v3.Operation) *Operation {
+	d := &Operation{Method: method, Path: tmpl, OperationID: op.OperationId, Summary: op.Summary}
+	for _, p := range op.Parameters {
+		param := Param{Name: p.Name, Desc: p.Description}
+		if p.Required != nil {
+			param.Required = *p.Required
+		}
+		if p.Schema != nil && p.Schema.Schema() != nil {
+			param.Type = strings.Join(p.Schema.Schema().Type, "|")
+		}
+		switch p.In {
+		case "path":
+			param.Required = true
+			d.PathParams = append(d.PathParams, param)
+		case "query":
+			d.QueryParams = append(d.QueryParams, param)
+		}
+	}
+	if op.RequestBody != nil {
+		if mt := jsonMediaType(op.RequestBody.Content); mt != nil && mt.Schema != nil && mt.Schema.Schema() != nil {
+			sch := mt.Schema.Schema()
+			d.RequestBody = schemaSummary(sch)
+			d.RequiredFields = sch.Required
+		}
+	}
+	if op.Responses != nil {
+		if resp := successResponse(op); resp != nil {
+			if mt := jsonMediaType(resp.Content); mt != nil && mt.Schema != nil && mt.Schema.Schema() != nil {
+				d.ResponseSchema = schemaSummary(mt.Schema.Schema())
+			}
+		}
+	}
+	return d
+}
+
+// jsonMediaType returns the application/json media type from a content map, if any.
+func jsonMediaType(content *orderedmap.Map[string, *v3.MediaType]) *v3.MediaType {
+	if content == nil {
+		return nil
+	}
+	for pair := content.First(); pair != nil; pair = pair.Next() {
+		if strings.Contains(pair.Key(), "json") {
+			return pair.Value()
+		}
+	}
+	return nil
+}
+
+// successResponse returns the 2xx response (preferring 200/201) for an operation.
+func successResponse(op *v3.Operation) *v3.Response {
+	codes := op.Responses.Codes
+	if codes == nil {
+		return nil
+	}
+	for _, want := range []string{"200", "201", "202"} {
+		if r, ok := codes.Get(want); ok {
+			return r
+		}
+	}
+	for pair := codes.First(); pair != nil; pair = pair.Next() {
+		if strings.HasPrefix(pair.Key(), "2") {
+			return pair.Value()
+		}
+	}
+	return nil
+}
+
+// schemaSummary renders a shallow, JSON-serializable summary of a schema: its
+// type, a one-level map of property name -> type, and required fields. It is
+// deliberately NOT a full recursive dump — `api describe` is a discovery aid, not
+// a schema exporter, and the control spec's schemas are large. A caller wanting
+// the full schema uses --live against /openapi.json directly.
+func schemaSummary(sch *base.Schema) map[string]any {
+	if sch == nil {
+		return nil
+	}
+	out := map[string]any{}
+	if len(sch.Type) > 0 {
+		out["type"] = strings.Join(sch.Type, "|")
+	}
+	if sch.Description != "" {
+		out["description"] = sch.Description
+	}
+	if len(sch.Required) > 0 {
+		out["required"] = sch.Required
+	}
+	if sch.Properties != nil && sch.Properties.Len() > 0 {
+		props := map[string]string{}
+		for pair := sch.Properties.First(); pair != nil; pair = pair.Next() {
+			ps := pair.Value()
+			t := "object"
+			if ps != nil && ps.Schema() != nil && len(ps.Schema().Type) > 0 {
+				t = strings.Join(ps.Schema().Type, "|")
+			}
+			props[pair.Key()] = t
+		}
+		out["properties"] = props
+	}
+	return out
+}

--- a/cli/internal/cli/apispec/spec_test.go
+++ b/cli/internal/cli/apispec/spec_test.go
@@ -1,0 +1,70 @@
+package apispec
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/jentic/jentic-one/cli/client/generated/control"
+)
+
+// TestParseEmbeddedControlSpec parses the real vendored control spec and exercises
+// path matching against a couple of known routes, guarding the libopenapi wiring.
+func TestParseEmbeddedControlSpec(t *testing.T) {
+	spec, err := Parse(control.SpecYAML)
+	if err != nil {
+		t.Fatalf("Parse embedded control spec: %v", err)
+	}
+	if spec.Version == "" {
+		t.Error("expected a spec info.version")
+	}
+
+	// A static route.
+	if _, ok := spec.Match("GET", "/credentials"); !ok {
+		t.Error("GET /credentials should match")
+	}
+	// A templated route with a concrete id.
+	if _, ok := spec.Match("GET", "/credentials/cred_123"); !ok {
+		t.Error("GET /credentials/{credential_id} should match a concrete id")
+	}
+	// Static route beats the templated sibling: /credentials/providers must
+	// resolve to listProviders, not getCredential.
+	if op, ok := spec.Match("GET", "/credentials/providers"); !ok || op.OperationID != "listProviders" {
+		t.Errorf("GET /credentials/providers should resolve to listProviders, got %+v (ok=%v)", op, ok)
+	}
+	// Query strings are ignored for matching.
+	if _, ok := spec.Match("GET", "/credentials?limit=10"); !ok {
+		t.Error("query string should not defeat matching")
+	}
+	// A bogus route must not match.
+	if _, ok := spec.Match("GET", "/definitely/not/a/route"); ok {
+		t.Error("bogus route should not match")
+	}
+	// HasPath distinguishes wrong-method from no-route.
+	if !spec.HasPath("/credentials") {
+		t.Error("HasPath(/credentials) should be true")
+	}
+}
+
+func TestListAndDescribe(t *testing.T) {
+	spec, err := Parse(control.SpecYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ops := spec.List("credential")
+	if len(ops) == 0 {
+		t.Fatal("expected some credential operations")
+	}
+	for _, op := range ops {
+		if op.Method == "" || op.Path == "" {
+			t.Errorf("op missing method/path: %+v", op)
+		}
+	}
+
+	d, ok := spec.Describe("GET", "/credentials")
+	if !ok {
+		t.Fatal("describe GET /credentials failed")
+	}
+	if d.Path != "/credentials" || d.Method != http.MethodGet {
+		t.Errorf("describe = %+v", d)
+	}
+}

--- a/cli/internal/cli/clictx/client.go
+++ b/cli/internal/cli/clictx/client.go
@@ -49,3 +49,15 @@ func GetBrokerClient(ctx context.Context) (*broker.ClientWithResponses, error) {
 	}
 	return client.NewBroker(configFromState(state))
 }
+
+// GetControlRawClient returns the raw control client for the `jentic api`
+// passthrough (arbitrary METHOD/PATH). It shares the identical transport + editor
+// chain as GetControlClient, so the passthrough inherits auth, session, retry, and
+// the transport guard from the SDK rather than re-implementing them.
+func GetControlRawClient(ctx context.Context) (*control.Client, error) {
+	state := FromContext(ctx)
+	if state == nil {
+		return nil, errors.New("no active state in context (was the root PersistentPreRunE run?)")
+	}
+	return client.NewControlRaw(configFromState(state))
+}

--- a/cli/internal/cli/clictx/client.go
+++ b/cli/internal/cli/clictx/client.go
@@ -24,6 +24,7 @@ func configFromState(state *ActiveState) client.Config {
 		IdentityName:        state.IdentityName,
 		EnvironmentName:     state.EnvironmentName,
 		InjectedBearerToken: state.InjectedBearerToken,
+		SessionID:           state.SessionID,
 	}
 }
 

--- a/cli/internal/cli/ux/envelope.go
+++ b/cli/internal/cli/ux/envelope.go
@@ -56,6 +56,21 @@ type Page struct {
 // HasNext reports whether another page is available.
 func (p Page) HasNext() bool { return p.NextToken != "" }
 
+// Export is the versioned envelope for bulk export commands (history export). It
+// wraps a fully-walked, filtered result set (never a single page) plus the pivot
+// it was queried by, so an agent can template a workflow from a run's real
+// executions. SchemaVersion is stamped at render time like the other envelopes.
+type Export struct {
+	SchemaVersion string `json:"schema_version"`
+	// TraceID is the correlation pivot the export was queried by (impl/5.0 §2).
+	TraceID string `json:"trace_id,omitempty"`
+	// Items is the exported records (kept as `any` so the same envelope serves any
+	// export; history passes []control.ExecutionResponse).
+	Items any `json:"items"`
+	// Count is the number of exported records after filtering.
+	Count int `json:"count"`
+}
+
 // NewPage builds a Page envelope from a typed item slice and the opaque
 // next-page cursor (empty on the last page). It is the bridge from the SDK's
 // client/paginate walk helper (whose Page[T].Next is the cursor) to the machine

--- a/cli/internal/cli/ux/plan.go
+++ b/cli/internal/cli/ux/plan.go
@@ -1,0 +1,14 @@
+package ux
+
+// Plan is the machine-readable execution plan emitted for --dry-run/--export-plan
+// (impl/5.0 §5): the operation a mutating command WOULD invoke and the hydrated
+// payload it would send, without firing the call. It runs through the same
+// redaction funnel as every other rendered value, so a plan can't leak a secret
+// in its payload. SchemaVersion is stamped at render time like the other
+// envelopes.
+type Plan struct {
+	SchemaVersion string `json:"schema_version"`
+	Operation     string `json:"operation"`
+	DryRun        bool   `json:"dry_run"`
+	Payload       any    `json:"payload,omitempty"`
+}

--- a/cli/internal/cli/ux/redact.go
+++ b/cli/internal/cli/ux/redact.go
@@ -7,6 +7,7 @@ package ux
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"reflect"
 	"regexp"
 	"strings"
@@ -229,6 +230,27 @@ func redactString(s string) string { return string(redactSensitive([]byte(s))) }
 func safeMarshal(data any) []byte       { return marshalRedacted(data, false) }
 func safeMarshalIndent(data any) []byte { return marshalRedacted(data, true) }
 
+// MarshalForFile is the exported, redacted, indented marshal for commands that
+// write an envelope to a file (e.g. `history export -o out.json`) instead of
+// through the Audience. It runs the SAME three-layer redaction funnel and
+// schema-version stamping as stdout output, so a secret can never leak just
+// because the destination is a file. Indented for human readability; still valid
+// machine JSON.
+func MarshalForFile(data any) []byte { return marshalRedacted(data, true) }
+
+// WriteJSONLine writes ONE compact, redacted JSON document followed by a newline
+// to w. It is the streaming primitive for tail-style commands (e.g.
+// `events watch`) that emit an unbounded NDJSON sequence rather than a single
+// terminal envelope — Render is for one final document, this is for a stream. It
+// runs the same redaction funnel as every other output path, so a streamed event
+// cannot leak a secret. Errors from the underlying writer are returned so the
+// caller can stop the tail (e.g. on a closed pipe).
+func WriteJSONLine(w io.Writer, v any) error {
+	line := append(safeMarshal(v), '\n')
+	_, err := w.Write(line)
+	return err
+}
+
 // currentSchemaVersion pins the machine-contract envelope shape (13 §2/§6).
 const currentSchemaVersion = "1"
 
@@ -242,6 +264,11 @@ func marshalRedacted(data any, indent bool) []byte {
 		}
 		data = v
 	case Page:
+		if v.SchemaVersion == "" {
+			v.SchemaVersion = currentSchemaVersion
+		}
+		data = v
+	case Export:
 		if v.SchemaVersion == "" {
 			v.SchemaVersion = currentSchemaVersion
 		}

--- a/cli/internal/cli/ux/redact.go
+++ b/cli/internal/cli/ux/redact.go
@@ -222,6 +222,14 @@ func redactSensitive(data []byte) []byte {
 // the byte backstop over a string. Used by every ReportError path (review M6).
 func redactString(s string) string { return string(redactSensitive([]byte(s))) }
 
+// RedactBytes is the exported byte-level backstop for command code that emits a
+// raw upstream/API body (e.g. the `jentic api` passthrough, `execute --raw`)
+// rather than a marshaled envelope. It applies the SAME free-form-string scrub as
+// every other output path so a secret in an API response can't leak to a machine
+// parser. It does NOT reshape or re-marshal the payload — the body stays the
+// API's own JSON.
+func RedactBytes(data []byte) []byte { return redactSensitive(data) }
+
 // safeMarshal / safeMarshalIndent are the single funnel every Render path uses.
 // They redact by struct tag (typed reflection), by field name (key heuristics),
 // AND by pattern (byte backstop). safeMarshal emits compact JSON (agent output);

--- a/cli/internal/cli/ux/redact.go
+++ b/cli/internal/cli/ux/redact.go
@@ -281,6 +281,11 @@ func marshalRedacted(data any, indent bool) []byte {
 			v.SchemaVersion = currentSchemaVersion
 		}
 		data = v
+	case Plan:
+		if v.SchemaVersion == "" {
+			v.SchemaVersion = currentSchemaVersion
+		}
+		data = v
 	}
 
 	// THREE-LAYER FAIL-CLOSED REDACTION (order matters):

--- a/cli/internal/cmd/access.go
+++ b/cli/internal/cmd/access.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -623,10 +624,12 @@ func (a *App) accessRequestE(cmd *cobra.Command, ident *identityOptions, opts *a
 	}
 
 	if jsonOrPretty(cmd, opts.json) {
+		absolutizeApproveURL(baseURL, req)
 		if err := writeJSON(a.Out, req); err != nil {
 			return err
 		}
 	} else {
+		absolutizeApproveURL(baseURL, req)
 		a.printRequest(req, true)
 	}
 
@@ -744,6 +747,7 @@ func (a *App) accessStatusE(cmd *cobra.Command, ident *identityOptions, id strin
 	if err != nil {
 		return err
 	}
+	absolutizeApproveURL(baseURL, req)
 	if jsonOrPretty(cmd, jsonFlag) {
 		return writeJSON(a.Out, req)
 	}
@@ -916,6 +920,28 @@ func itemSummary(it *accessclient.ItemResponse) string {
 		target = strings.Trim(vendor+"/"+name, "/")
 	}
 	return fmt.Sprintf("%s:%s %s", it.ResourceType, it.Action, target)
+}
+
+// absolutizeApproveURL rewrites a relative approve_url onto the environment's base
+// URL so the value the CLI prints (or emits as JSON) is directly openable, rather
+// than a path fragment the operator has to guess a host for (impl/5.0 §6b,
+// jentic-one#777). An already-absolute URL and an empty value are left untouched.
+func absolutizeApproveURL(baseURL string, r *accessclient.Request) {
+	if r == nil || r.ApproveURL == "" {
+		return
+	}
+	if u, err := url.Parse(r.ApproveURL); err == nil && u.IsAbs() {
+		return
+	}
+	base, err := url.Parse(strings.TrimRight(baseURL, "/"))
+	if err != nil {
+		return
+	}
+	ref, err := url.Parse(r.ApproveURL)
+	if err != nil {
+		return
+	}
+	r.ApproveURL = base.ResolveReference(ref).String()
 }
 
 func statusStyle(status string) string {

--- a/cli/internal/cmd/api.go
+++ b/cli/internal/cmd/api.go
@@ -126,6 +126,18 @@ func runAPICall(cmd *cobra.Command, app *App, opts *apiOptions, method, path str
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	// Backend version negotiation (impl/5.0 §6a): a 404 on a route the EMBEDDED
+	// spec advertises can mean "this connected server predates the route", not a
+	// typo. Probe the server version once (lazy, only on the 404) and enrich the
+	// error so the agent learns to upgrade the backend or use --live, rather than
+	// treating a real route as nonexistent. Skipped for --raw (no allowlist) and
+	// --live (the route came from the server's own spec, so a 404 is a plain 404).
+	if resp.StatusCode == http.StatusNotFound && !opts.raw && !opts.live {
+		if coded := negotiate404(cmd.Context(), raw, method, path); coded != nil {
+			return reportCoded(aud, coded)
+		}
+	}
+
 	return emitAPIResponse(app.Out, resp, opts.failOnError)
 }
 
@@ -225,6 +237,31 @@ func specSource(live bool) string {
 		return "live"
 	}
 	return "embedded"
+}
+
+// negotiate404 enriches a 404 on a route the embedded spec DOES advertise (the
+// path already passed the allowlist). It probes the connected server's version
+// once: on a successful probe, the route exists in the CLI's spec but the server
+// returned 404, so the most likely cause is a server that predates the route —
+// surfaced as RESOLVE_FAILED with details.route_unsupported_upstream=true and the
+// server version, keeping 13 §3a's closed enum untouched while adding actionable
+// detail. If the probe itself fails, we return nil so the caller emits the plain
+// 404 body rather than guessing.
+func negotiate404(ctx context.Context, raw *control.Client, method, path string) *ux.CodedError {
+	version, err := client.ProbeServerVersion(ctx, raw)
+	if err != nil || version == "" {
+		//nolint:nilerr // deliberate: a failed version probe means we can't tell whether the route is unsupported upstream, so we degrade to the plain 404 body rather than fabricating a verdict.
+		return nil
+	}
+	return &ux.CodedError{
+		Code:       ux.CodeResolveFailed,
+		Msg:        fmt.Sprintf("%s %s is in this CLI's spec but the connected server (v%s) returned 404 — the backend likely predates this route", method, path, version),
+		Actionable: "Upgrade the backend, or use --live to see and call what this server actually serves.",
+		Details: map[string]any{
+			"route_unsupported_upstream": true,
+			"server_version":             version,
+		},
+	}
 }
 
 // requireLoopbackRaw gates --raw to loopback control-plane hosts.

--- a/cli/internal/cmd/api.go
+++ b/cli/internal/cmd/api.go
@@ -1,0 +1,309 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/x/term"
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/client"
+	"github.com/jentic/jentic-one/cli/client/generated/control"
+	apispec "github.com/jentic/jentic-one/cli/internal/cli/apispec"
+	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+type apiOptions struct {
+	data        string
+	dataFile    string
+	failOnError bool
+	raw         bool
+	live        bool
+	query       []string
+	headers     []string
+}
+
+// newAPICmd is the `jentic api` passthrough: a gh-api-style authenticated escape
+// hatch to the CONTROL plane (not the broker — that is `jentic execute`). It
+// reuses the SDK transport (auth, session, retry, transport guard) and validates
+// the path against the embedded spec so it cannot be aimed at arbitrary URLs
+// (impl/5.0 §6a). Not fenced: it mutates host-visible platform state, subject to
+// the identity's server-side scopes, but never local config.
+func newAPICmd(app *App) *cobra.Command {
+	opts := &apiOptions{}
+	cmd := &cobra.Command{
+		Use:   "api <METHOD> <PATH>",
+		Short: "Authenticated passthrough to the control plane",
+		Long: "api sends an arbitrary request to the control plane, reusing the same\n" +
+			"auth, session, and transport as every other command. The PATH must match a\n" +
+			"route in the CLI's embedded OpenAPI spec (use --live to allow routes the\n" +
+			"connected server serves that this binary predates). Discover routes with\n" +
+			"`jentic api ops` and their contract with `jentic api describe`.\n\n" +
+			"Request body (mirrors `jentic execute`): -d/--data inline JSON, -d - for\n" +
+			"stdin, --data-file <path>, or auto-stdin when a body is piped/redirected.\n\n" +
+			"By default any transport-successful response (2xx or 4xx/5xx) exits 0 and\n" +
+			"the body is emitted as-is; --fail-on-error maps non-2xx to exit 1.",
+		Example: "  jentic api GET /credentials\n" +
+			"  jentic api POST /toolkits -d '{\"name\":\"clarity\"}'\n" +
+			"  jentic api POST /apis < api.json\n" +
+			"  jentic api GET \"/apis?limit=10\"",
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAPICall(cmd, app, opts, args[0], args[1])
+		},
+	}
+	cmd.Flags().StringVarP(&opts.data, "data", "d", "", "request body JSON (use - for stdin)")
+	cmd.Flags().StringVar(&opts.dataFile, "data-file", "", "read request body from this file")
+	cmd.Flags().BoolVar(&opts.failOnError, "fail-on-error", false, "exit 1 on a non-2xx response")
+	cmd.Flags().BoolVar(&opts.raw, "raw", false, "skip the spec path allowlist (loopback hosts only, for dev)")
+	cmd.Flags().BoolVar(&opts.live, "live", false, "fetch the server's /openapi.json instead of the embedded spec")
+	cmd.Flags().StringArrayVar(&opts.query, "query", nil, "query parameter as key=value (repeatable)")
+	cmd.Flags().StringArrayVar(&opts.headers, "header", nil, "extra header as key=value (repeatable)")
+
+	cmd.AddCommand(newAPIOpsCmd(app))
+	cmd.AddCommand(newAPIDescribeCmd(app))
+	return cmd
+}
+
+func runAPICall(cmd *cobra.Command, app *App, opts *apiOptions, method, path string) error {
+	aud := ux.FromContext(cmd.Context())
+	method = strings.ToUpper(method)
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	raw, err := clictx.GetControlRawClient(cmd.Context())
+	if err != nil {
+		return reportCoded(aud, err)
+	}
+
+	// Path allowlist: unless --raw (loopback only), the path must match a spec
+	// route, so the passthrough can't be aimed at arbitrary URLs.
+	if !opts.raw {
+		spec, serr := loadAPISpec(cmd.Context(), opts.live, raw)
+		if serr != nil {
+			return reportCoded(aud, asCoded(serr))
+		}
+		if _, ok := spec.Match(method, path); !ok {
+			return reportCoded(aud, unmatchedPathError(spec, method, path, opts.live))
+		}
+	} else if err := requireLoopbackRaw(raw.Server); err != nil {
+		return reportCoded(aud, err)
+	}
+
+	// Append --query params.
+	if len(opts.query) > 0 {
+		qv := url.Values{}
+		for _, kv := range opts.query {
+			k, v, ok := strings.Cut(kv, "=")
+			if !ok {
+				return reportCoded(aud, &ux.CodedError{Code: ux.CodeMissingArgument, Msg: fmt.Sprintf("invalid --query %q; expected key=value", kv)})
+			}
+			qv.Add(k, v)
+		}
+		sep := "?"
+		if strings.Contains(path, "?") {
+			sep = "&"
+		}
+		path += sep + qv.Encode()
+	}
+
+	body, berr := resolveAPIBody(opts)
+	if berr != nil {
+		return reportCoded(aud, &ux.CodedError{Code: ux.CodeMissingArgument, Msg: berr.Error()})
+	}
+
+	resp, err := client.RawControlRequest(cmd.Context(), raw, method, path, body, opts.headers...)
+	if err != nil {
+		return reportCoded(aud, &ux.CodedError{Code: ux.CodeInternalError, Msg: fmt.Sprintf("request failed: %v", err)})
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return emitAPIResponse(app.Out, resp, opts.failOnError)
+}
+
+// emitAPIResponse writes the response body verbatim to out (the payload is the
+// API's, not a CLI envelope — impl/5.0 §6a), then maps the status to an exit code:
+// exit 0 for any transport-successful response by default, or exit 1 on non-2xx
+// when --fail-on-error is set.
+func emitAPIResponse(out io.Writer, resp *http.Response, failOnError bool) error {
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &ux.CodedError{Code: ux.CodeInternalError, Msg: fmt.Sprintf("reading response: %v", err)}
+	}
+	// Pass the body through the byte-level redaction backstop before printing:
+	// even raw API data must not leak a secret to a machine parser.
+	if _, werr := out.Write(ux.RedactBytes(data)); werr != nil {
+		return werr
+	}
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		_, _ = out.Write([]byte("\n"))
+	}
+	if failOnError && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
+		return &ux.CodedError{
+			Code: ux.CodeInternalError,
+			Msg:  fmt.Sprintf("control plane returned status %d", resp.StatusCode),
+		}
+	}
+	return nil
+}
+
+// resolveAPIBody mirrors execute's body contract: -d inline, -d - / auto-stdin,
+// --data-file. Returns nil when there is no body.
+func resolveAPIBody(opts *apiOptions) (io.Reader, error) {
+	switch {
+	case opts.data == "-" || (opts.data == "" && opts.dataFile == "" && !term.IsTerminal(os.Stdin.Fd())):
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("reading stdin: %w", err)
+		}
+		if len(data) == 0 {
+			return nil, nil
+		}
+		return bytes.NewReader(data), nil
+	case opts.dataFile != "":
+		data, err := os.ReadFile(opts.dataFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", opts.dataFile, err)
+		}
+		return bytes.NewReader(data), nil
+	case opts.data != "":
+		return strings.NewReader(opts.data), nil
+	}
+	return nil, nil
+}
+
+// loadAPISpec returns the parsed spec: the embedded vendored control spec by
+// default, or the server's live /openapi.json when live is set.
+func loadAPISpec(ctx context.Context, live bool, raw *control.Client) (*apispec.Spec, error) {
+	if !live {
+		return apispec.Parse(control.SpecYAML)
+	}
+	resp, err := client.RawControlRequest(ctx, raw, http.MethodGet, "/openapi.json", nil)
+	if err != nil {
+		return nil, &ux.CodedError{Code: ux.CodeResolveFailed, Msg: fmt.Sprintf("fetching live spec: %v", err)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, &ux.CodedError{Code: ux.CodeResolveFailed, Msg: fmt.Sprintf("live spec returned status %d", resp.StatusCode)}
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, &ux.CodedError{Code: ux.CodeResolveFailed, Msg: fmt.Sprintf("reading live spec: %v", err)}
+	}
+	return apispec.Parse(data)
+}
+
+// unmatchedPathError distinguishes "path exists, wrong method" from "no such
+// route", and hints at --live when the embedded spec was used.
+func unmatchedPathError(spec *apispec.Spec, method, path string, live bool) *ux.CodedError {
+	if spec.HasPath(path) {
+		return &ux.CodedError{
+			Code: ux.CodeResolveFailed,
+			Msg:  fmt.Sprintf("method %s not allowed for %s", method, path),
+		}
+	}
+	e := &ux.CodedError{
+		Code: ux.CodeResolveFailed,
+		Msg:  fmt.Sprintf("no such route %s %s in the %s spec", method, path, specSource(live)),
+	}
+	if !live {
+		e.Actionable = "Run with --live if the connected server is newer than this CLI, or `jentic api ops` to list routes."
+	}
+	return e
+}
+
+func specSource(live bool) string {
+	if live {
+		return "live"
+	}
+	return "embedded"
+}
+
+// requireLoopbackRaw gates --raw to loopback control-plane hosts.
+func requireLoopbackRaw(server string) *ux.CodedError {
+	u, err := url.Parse(server)
+	if err != nil {
+		return &ux.CodedError{Code: ux.CodeResolveFailed, Msg: fmt.Sprintf("invalid server URL %q", server)}
+	}
+	host := u.Hostname()
+	if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+		return nil
+	}
+	return &ux.CodedError{
+		Code: ux.CodeResolveFailed,
+		Msg:  "--raw is only permitted against loopback hosts (dev use)",
+	}
+}
+
+func newAPIOpsCmd(_ *App) *cobra.Command {
+	var filter string
+	var live bool
+	cmd := &cobra.Command{
+		Use:   "ops",
+		Short: "List control-plane operations (METHOD, path, id, summary)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			aud := ux.FromContext(cmd.Context())
+			var raw *control.Client
+			if live {
+				var err error
+				if raw, err = clictx.GetControlRawClient(cmd.Context()); err != nil {
+					return reportCoded(aud, err)
+				}
+			}
+			spec, err := loadAPISpec(cmd.Context(), live, raw)
+			if err != nil {
+				return reportCoded(aud, asCoded(err))
+			}
+			aud.Render(spec.List(filter))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&filter, "filter", "", "only operations whose path/id/summary contains this substring")
+	cmd.Flags().BoolVar(&live, "live", false, "list the server's live operations instead of the embedded set")
+	return cmd
+}
+
+func newAPIDescribeCmd(_ *App) *cobra.Command {
+	var live bool
+	cmd := &cobra.Command{
+		Use:   "describe <METHOD> <PATH>",
+		Short: "Describe an operation's params and request/response schema",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			aud := ux.FromContext(cmd.Context())
+			method := strings.ToUpper(args[0])
+			path := args[1]
+			if !strings.HasPrefix(path, "/") {
+				path = "/" + path
+			}
+			var raw *control.Client
+			if live {
+				var err error
+				if raw, err = clictx.GetControlRawClient(cmd.Context()); err != nil {
+					return reportCoded(aud, err)
+				}
+			}
+			spec, err := loadAPISpec(cmd.Context(), live, raw)
+			if err != nil {
+				return reportCoded(aud, asCoded(err))
+			}
+			op, ok := spec.Describe(method, path)
+			if !ok {
+				return reportCoded(aud, unmatchedPathError(spec, method, path, live))
+			}
+			aud.Render(op)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&live, "live", false, "describe against the server's live spec instead of the embedded one")
+	return cmd
+}

--- a/cli/internal/cmd/api_test.go
+++ b/cli/internal/cmd/api_test.go
@@ -53,6 +53,29 @@ func TestAPIPassthrough_GETMatchesSpecAndEmitsBody(t *testing.T) {
 	}
 }
 
+func TestAPIPassthrough_404NegotiatesBackendVersion(t *testing.T) {
+	withXDG(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/system/version":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"current":"0.20.0","update_available":false}`))
+		default:
+			// A real spec route, but this (old) server doesn't serve it.
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	seedActiveContextTo(t, srv.URL)
+
+	// /credentials is in the embedded spec; a 404 should trigger the version probe
+	// and surface the route-unsupported-upstream hint (exit non-zero).
+	_, err := runJenticCapture(t, "api", "GET", "/credentials")
+	if err == nil {
+		t.Fatal("expected an enriched error on a 404 for a spec route")
+	}
+}
+
 func TestAPIPassthrough_RejectsUnknownPath(t *testing.T) {
 	withXDG(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/cli/internal/cmd/api_test.go
+++ b/cli/internal/cmd/api_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// runJenticCapture runs the jentic root capturing app.Out, so passthrough tests
+// can assert on the emitted body (the api command writes to app.Out, not the
+// Audience).
+func runJenticCapture(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	app := testApp(t)
+	var out bytes.Buffer
+	app.Out = &out
+	root := newAPIRootCmd(app)
+	root.SetOut(new(bytes.Buffer))
+	root.SetErr(new(bytes.Buffer))
+	root.SetArgs(args)
+	err := root.Execute()
+	return out.String(), err
+}
+
+func TestAPIPassthrough_GETMatchesSpecAndEmitsBody(t *testing.T) {
+	withXDG(t)
+
+	var gotPath, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []string{"cred_1"}})
+	}))
+	defer srv.Close()
+	seedActiveContextTo(t, srv.URL)
+
+	out, err := runJenticCapture(t, "api", "GET", "/credentials")
+	if err != nil {
+		t.Fatalf("api GET /credentials: %v", err)
+	}
+	if gotPath != "/credentials" {
+		t.Errorf("server saw path %q", gotPath)
+	}
+	if gotAuth != "Bearer test-token" {
+		t.Errorf("auth header = %q (session/auth editor should have run)", gotAuth)
+	}
+	if !strings.Contains(out, "cred_1") {
+		t.Errorf("body not emitted: %q", out)
+	}
+}
+
+func TestAPIPassthrough_RejectsUnknownPath(t *testing.T) {
+	withXDG(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("server should never be reached for a spec-rejected path")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	seedActiveContextTo(t, srv.URL)
+
+	if _, err := runJenticCapture(t, "api", "GET", "/definitely/not/a/route"); err == nil {
+		t.Fatal("expected a spec-allowlist rejection")
+	}
+}
+
+func TestAPIPassthrough_FailOnError(t *testing.T) {
+	withXDG(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"detail":"boom"}`))
+	}))
+	defer srv.Close()
+	seedActiveContextTo(t, srv.URL)
+
+	// Without --fail-on-error, a 500 is still exit 0 (body is data).
+	if _, err := runJenticCapture(t, "api", "GET", "/credentials"); err != nil {
+		t.Errorf("without --fail-on-error a 500 should not error: %v", err)
+	}
+	// With --fail-on-error, non-2xx surfaces as an error.
+	if _, err := runJenticCapture(t, "api", "GET", "/credentials", "--fail-on-error"); err == nil {
+		t.Error("expected --fail-on-error to surface the 500")
+	}
+}
+
+func TestAPIOps_RunsOfflineFromEmbeddedSpec(t *testing.T) {
+	withXDG(t)
+	// api ops works fully offline (embedded spec) — no server needed, but the
+	// interceptor still needs an active state, so point at a dummy file-less env.
+	// Render writes to real stdout (not app.Out), so we assert it simply succeeds;
+	// the listing/filtering logic itself is covered in the apispec package tests.
+	t.Setenv("JENTIC_BASE_URL", "https://control.invalid")
+	t.Setenv("JENTIC_BEARER_TOKEN", "x")
+	t.Setenv("JENTIC_MODE", "agent")
+
+	if _, err := runJenticCapture(t, "api", "ops", "--filter", "credential"); err != nil {
+		t.Fatalf("api ops: %v", err)
+	}
+}

--- a/cli/internal/cmd/apis.go
+++ b/cli/internal/cmd/apis.go
@@ -45,6 +45,7 @@ func newApisCmd(app *App) *cobra.Command {
 	cmd.AddCommand(newApisArchiveCmd(app, ident))
 	cmd.AddCommand(newApisRmCmd(app, ident))
 	cmd.AddCommand(newApisSpecCmd(app, ident))
+	cmd.AddCommand(newApisImportCmd(app))
 	return cmd
 }
 

--- a/cli/internal/cmd/apis_import.go
+++ b/cli/internal/cmd/apis_import.go
@@ -42,6 +42,9 @@ func newApisImportCmd(_ *App) *cobra.Command {
 			}
 
 			body := control.ApiImportRequest{Sources: []control.ApiImportRequest_Sources_Item{source}}
+			if maybeEmitPlan(cmd, "importApis", body) {
+				return nil
+			}
 			resp, err := client.ImportApisWithResponse(cmd.Context(), body)
 			if err != nil {
 				return reportCoded(aud, asCoded(err))
@@ -64,6 +67,7 @@ func newApisImportCmd(_ *App) *cobra.Command {
 	cmd.Flags().StringVar(&vendor, "vendor", "", "Override the vendor for the imported API")
 	cmd.Flags().StringVar(&name, "name", "", "Override the API name")
 	cmd.Flags().StringVar(&version, "version", "", "Override the API version")
+	planFlags(cmd)
 	return cmd
 }
 

--- a/cli/internal/cmd/apis_import.go
+++ b/cli/internal/cmd/apis_import.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/client/generated/control"
+	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// newApisImportCmd is `jentic apis import <file|url>` (impl/5.0 §6b,
+// jentic-one#777): submit an OpenAPI document to the catalog via POST /apis. A
+// URL is sent as a fetchable source; a local file is read and sent inline. Import
+// is asynchronous — the command reports the returned job id/status.
+//
+// This subcommand is the V2-SDK path; the sibling `apis` subcommands remain on
+// the shipped internal/apiclient path until the broader re-plumb.
+func newApisImportCmd(_ *App) *cobra.Command {
+	var vendor, name, version string
+	cmd := &cobra.Command{
+		Use:   "import <file|url>",
+		Short: "Import an OpenAPI document into the catalog",
+		Long: "import submits an OpenAPI spec to the catalog. The argument is either a\n" +
+			"local file path (read and sent inline) or an http(s) URL (sent as a\n" +
+			"fetchable source). Import is asynchronous; the command prints the job id.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			aud := ux.FromContext(cmd.Context())
+			client, err := clictx.GetControlClient(cmd.Context())
+			if err != nil {
+				return reportCoded(aud, err)
+			}
+
+			source, serr := buildImportSource(args[0], vendor, name, version)
+			if serr != nil {
+				return reportCoded(aud, &ux.CodedError{Code: ux.CodeMissingArgument, Msg: serr.Error()})
+			}
+
+			body := control.ApiImportRequest{Sources: []control.ApiImportRequest_Sources_Item{source}}
+			resp, err := client.ImportApisWithResponse(cmd.Context(), body)
+			if err != nil {
+				return reportCoded(aud, asCoded(err))
+			}
+			if resp.JSON202 == nil {
+				return reportCoded(aud, &ux.CodedError{
+					Code: ux.CodeInternalError,
+					Msg:  fmt.Sprintf("import failed (status %d)", resp.StatusCode()),
+				})
+			}
+			aud.Render(ux.Result{
+				Status:   ux.StatusCreated,
+				Resource: "api-import",
+				Message:  "Import accepted; the catalog is processing it asynchronously.",
+				Fields:   map[string]any{"response": *resp.JSON202},
+			})
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&vendor, "vendor", "", "Override the vendor for the imported API")
+	cmd.Flags().StringVar(&name, "name", "", "Override the API name")
+	cmd.Flags().StringVar(&version, "version", "", "Override the API version")
+	return cmd
+}
+
+// buildImportSource turns a file-or-URL argument into a source union item. An
+// argument parseable as an http(s) URL becomes an ApiSourceUrl; anything else is
+// treated as a local file read inline.
+func buildImportSource(arg, vendor, name, version string) (control.ApiImportRequest_Sources_Item, error) {
+	var item control.ApiImportRequest_Sources_Item
+	optPtr := func(s string) *string {
+		if s == "" {
+			return nil
+		}
+		return &s
+	}
+
+	if u, err := url.Parse(arg); err == nil && (u.Scheme == "http" || u.Scheme == "https") {
+		src := control.ApiSourceUrl{
+			Type:    control.Url,
+			Url:     arg,
+			Vendor:  optPtr(vendor),
+			ApiName: optPtr(name),
+			Version: optPtr(version),
+		}
+		if merr := item.FromApiSourceUrl(src); merr != nil {
+			return item, merr
+		}
+		return item, nil
+	}
+
+	data, err := os.ReadFile(arg) //nolint:gosec // operator-supplied path; same trust as any file arg.
+	if err != nil {
+		return item, fmt.Errorf("reading %s: %w", arg, err)
+	}
+	src := control.ApiSourceInline{
+		Type:     control.Inline,
+		Filename: filepath.Base(arg),
+		Content:  string(data),
+		Vendor:   optPtr(vendor),
+		ApiName:  optPtr(name),
+		Version:  optPtr(version),
+	}
+	if merr := item.FromApiSourceInline(src); merr != nil {
+		return item, merr
+	}
+	return item, nil
+}

--- a/cli/internal/cmd/credentials.go
+++ b/cli/internal/cmd/credentials.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/client/generated/control"
+	"github.com/jentic/jentic-one/cli/client/paginate"
+	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// newCredentialsCmd is `jentic credentials`: read-only listing/inspection of the
+// identity's credentials. The server already returns CredentialRedactedResponse
+// (no live secret); the CLI redaction funnel is belt-and-braces on top. Not
+// fenced — read-only, no local config mutation (impl/5.0 §6b, jentic-one#742).
+func newCredentialsCmd(app *App) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "credentials",
+		Aliases: []string{"creds"},
+		Short:   "List and inspect credentials (secrets are server-masked)",
+		Args:    cobra.NoArgs,
+		RunE:    func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+	}
+	cmd.AddCommand(newCredentialsListCmd(app), newCredentialsShowCmd(app))
+	return cmd
+}
+
+func newCredentialsListCmd(_ *App) *cobra.Command {
+	var vendor, cursor string
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List credentials",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			aud := ux.FromContext(cmd.Context())
+			client, err := clictx.GetControlClient(cmd.Context())
+			if err != nil {
+				return reportCoded(aud, err)
+			}
+
+			// A single-page fetch when --limit/--cursor is given; otherwise walk all.
+			if limit > 0 || cursor != "" {
+				items, next, ferr := fetchCredentialPage(cmd.Context(), client, vendor, cursor, limit)
+				if ferr != nil {
+					return reportCoded(aud, asCoded(ferr))
+				}
+				aud.Render(ux.NewPage(items, next))
+				return nil
+			}
+
+			all, aerr := paginate.All(cmd.Context(), func(ctx context.Context, cur string) (paginate.Page[control.CredentialRedactedResponse], error) {
+				items, next, ferr := fetchCredentialPage(ctx, client, vendor, cur, 0)
+				return paginate.Page[control.CredentialRedactedResponse]{Items: items, Next: next}, ferr
+			})
+			if aerr != nil {
+				return reportCoded(aud, asCoded(aerr))
+			}
+			aud.Render(ux.NewPage(all, ""))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&vendor, "vendor", "", "Filter by vendor")
+	cmd.Flags().IntVar(&limit, "limit", 0, "Fetch a single page of at most N credentials")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "Fetch the page at this opaque cursor")
+	return cmd
+}
+
+func fetchCredentialPage(ctx context.Context, client *control.ClientWithResponses, vendor, cursor string, limit int) ([]control.CredentialRedactedResponse, string, error) {
+	params := &control.ListCredentialsParams{}
+	if vendor != "" {
+		params.Vendor = &vendor
+	}
+	if cursor != "" {
+		params.Cursor = &cursor
+	}
+	if limit > 0 {
+		params.Limit = &limit
+	}
+	resp, err := client.ListCredentialsWithResponse(ctx, params)
+	if err != nil {
+		return nil, "", err
+	}
+	if resp.JSON200 == nil {
+		return nil, "", fmt.Errorf("unexpected backend response (status %d)", resp.StatusCode())
+	}
+	next := ""
+	if resp.JSON200.HasMore && resp.JSON200.NextCursor != nil {
+		next = *resp.JSON200.NextCursor
+	}
+	return resp.JSON200.Data, next, nil
+}
+
+func newCredentialsShowCmd(_ *App) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <credential_id>",
+		Short: "Show a credential (secret-masked)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			aud := ux.FromContext(cmd.Context())
+			client, err := clictx.GetControlClient(cmd.Context())
+			if err != nil {
+				return reportCoded(aud, err)
+			}
+			resp, err := client.GetCredentialWithResponse(cmd.Context(), args[0])
+			if err != nil {
+				return reportCoded(aud, asCoded(err))
+			}
+			if resp.JSON200 == nil {
+				return reportCoded(aud, &ux.CodedError{
+					Code: ux.CodeResolveFailed,
+					Msg:  fmt.Sprintf("credential %q not found (status %d)", args[0], resp.StatusCode()),
+				})
+			}
+			aud.Render(resp.JSON200)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cli/internal/cmd/curated_test.go
+++ b/cli/internal/cmd/curated_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jentic/jentic-one/cli/internal/accessclient"
+)
+
+func TestCredentialsList_WalksPages(t *testing.T) {
+	withXDG(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/credentials") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data":     []map[string]any{{"credential_id": "cred_1", "name": "k", "active": true, "provider": "static", "api": map[string]any{"name": "x", "vendor": "y", "version": "1"}, "created_at": "2026-01-01T00:00:00Z", "type": "api_key"}},
+			"has_more": false,
+		})
+	}))
+	defer srv.Close()
+	seedActiveContextTo(t, srv.URL)
+
+	if err := runJentic(t, "credentials", "list"); err != nil {
+		t.Fatalf("credentials list: %v", err)
+	}
+}
+
+func TestBuildImportSource_URLvsFile(t *testing.T) {
+	// A URL becomes an ApiSourceUrl.
+	item, err := buildImportSource("https://example.com/openapi.yaml", "acme", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src, uerr := item.AsApiSourceUrl(); uerr != nil || src.Url != "https://example.com/openapi.yaml" {
+		t.Errorf("expected ApiSourceUrl, got err=%v src=%+v", uerr, src)
+	}
+
+	// A local file becomes an ApiSourceInline with the file content.
+	dir := t.TempDir()
+	p := dir + "/spec.yaml"
+	if werr := os.WriteFile(p, []byte("openapi: 3.0.0"), 0o600); werr != nil {
+		t.Fatal(werr)
+	}
+	item, err = buildImportSource(p, "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src, ierr := item.AsApiSourceInline(); ierr != nil || src.Content != "openapi: 3.0.0" || src.Filename != "spec.yaml" {
+		t.Errorf("expected inline source, got err=%v src=%+v", ierr, src)
+	}
+
+	// A missing file is an error.
+	if _, ferr := buildImportSource(dir+"/nope.yaml", "", "", ""); ferr == nil {
+		t.Error("expected an error for a missing file")
+	}
+}
+
+func TestAbsolutizeApproveURL(t *testing.T) {
+	// Relative path is joined onto the base URL.
+	r := &accessclient.Request{ApproveURL: "/approve/arq_1"}
+	absolutizeApproveURL("https://api.example.com/", r)
+	if r.ApproveURL != "https://api.example.com/approve/arq_1" {
+		t.Errorf("relative approve_url = %q", r.ApproveURL)
+	}
+	// Already-absolute is left untouched.
+	r = &accessclient.Request{ApproveURL: "https://other.example/approve/x"}
+	absolutizeApproveURL("https://api.example.com", r)
+	if r.ApproveURL != "https://other.example/approve/x" {
+		t.Errorf("absolute approve_url should be untouched, got %q", r.ApproveURL)
+	}
+	// Empty stays empty (nil-safe).
+	r = &accessclient.Request{}
+	absolutizeApproveURL("https://api.example.com", r)
+	if r.ApproveURL != "" {
+		t.Errorf("empty approve_url should stay empty, got %q", r.ApproveURL)
+	}
+}

--- a/cli/internal/cmd/curated_test.go
+++ b/cli/internal/cmd/curated_test.go
@@ -62,6 +62,25 @@ func TestBuildImportSource_URLvsFile(t *testing.T) {
 	}
 }
 
+func TestApisImport_DryRunDoesNotCallServer(t *testing.T) {
+	withXDG(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("dry-run must not reach the server")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	seedActiveContextTo(t, srv.URL)
+
+	dir := t.TempDir()
+	p := dir + "/spec.yaml"
+	if err := os.WriteFile(p, []byte("openapi: 3.0.0"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runJentic(t, "apis", "import", p, "--dry-run"); err != nil {
+		t.Fatalf("apis import --dry-run: %v", err)
+	}
+}
+
 func TestAbsolutizeApproveURL(t *testing.T) {
 	// Relative path is joined onto the base URL.
 	r := &accessclient.Request{ApproveURL: "/approve/arq_1"}

--- a/cli/internal/cmd/doctor.go
+++ b/cli/internal/cmd/doctor.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/jentic/jentic-one/cli/internal/agentauth"
 	"github.com/jentic/jentic-one/cli/internal/config"
 	"github.com/jentic/jentic-one/cli/internal/install"
+	"github.com/jentic/jentic-one/cli/internal/localagent"
 	"github.com/jentic/jentic-one/cli/internal/proc"
 	"github.com/jentic/jentic-one/cli/internal/serverinfo"
 	"github.com/jentic/jentic-one/cli/internal/theme"
@@ -106,6 +109,7 @@ func (a *App) doctorE(ctx context.Context, opts *doctorOptions) error {
 	d.checkTooling(manifest, manifestFound)
 	d.checkServer()
 	d.checkAgent()
+	d.checkLocalAgent(cfg)
 
 	if opts.json {
 		return d.renderJSON()
@@ -281,6 +285,45 @@ func (d *doctor) checkAgent() {
 		} else {
 			d.add(section, "identity", statusWarn, "identity check failed: "+meErr.Error(), "")
 		}
+	}
+}
+
+// checkLocalAgent is the client-side sibling of jenticctl's local-agent probe
+// (5.1 §3c, plan.md Phase 5 item 6). jenticctl is deliberately absent from agent
+// hosts, so `jentic doctor` is the only self-check that can run there. It reports
+// per-session confinement prerequisites (the SAME AgentUserPrereqs probe `jentic
+// run`'s launch gate uses, so the two can never disagree) and, when this operator
+// has provisioned a dedicated agent account, warns if the agent would run under
+// the operator's own uid — the boundary the whole isolation model exists to
+// establish. It is read-only and, like the rest of doctor, keeps warnings at a
+// zero exit so it stays CI-safe.
+func (d *doctor) checkLocalAgent(cfg *config.FileConfig) {
+	const section = "Local agent"
+
+	for _, p := range localagent.AgentUserPrereqs() {
+		if p.OK {
+			d.add(section, p.Name, statusPass, "available", "")
+			continue
+		}
+		d.add(section, p.Name, statusWarn, p.Reason, p.Hint)
+	}
+
+	acct, hasAcct := cfg.AgentAccount()
+	if !hasAcct || !acct.AccountCreated {
+		return
+	}
+	// A provisioned account whose OS user cannot be resolved, or which resolves
+	// to the operator's own uid, means an agent launched here would share the
+	// operator's disk view — the isolation is nominal, not real.
+	if agentUser, err := user.Lookup(acct.User); err != nil {
+		d.add(section, "account", statusWarn, fmt.Sprintf("account %q not found on this host: %v", acct.User, err),
+			"run `jentic bootstrap` on the agent host, or `jentic reset` to clear the stale record")
+	} else if agentUser.Uid == strconv.Itoa(os.Getuid()) {
+		d.add(section, "account uid", statusWarn,
+			fmt.Sprintf("agent account %q shares this operator's uid (%s)", acct.User, agentUser.Uid),
+			"the agent would run unconfined against your files; re-provision a dedicated account with `jentic bootstrap`")
+	} else {
+		d.add(section, "account", statusPass, fmt.Sprintf("%s (uid %s)", acct.User, agentUser.Uid), "")
 	}
 }
 

--- a/cli/internal/cmd/doctor_test.go
+++ b/cli/internal/cmd/doctor_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -214,5 +215,79 @@ func TestCheckStatusString(t *testing.T) {
 		if got := s.String(); got != want {
 			t.Errorf("checkStatus(%d).String() = %q, want %q", s, got, want)
 		}
+	}
+}
+
+// The client-side self-check (5.1 §3c, plan.md Phase 5 item 6) must always render
+// the local-agent confinement prereq breakdown — jenticctl is absent from agent
+// hosts, so doctor is the only place these prereqs surface there.
+func TestDoctorReportsLocalAgentPrereqs(t *testing.T) {
+	app := testApp(t)
+	opts := offlineOpts()
+	opts.json = true
+	_ = app.doctorE(context.Background(), opts)
+
+	var report struct {
+		Checks []struct {
+			Section string `json:"section"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(app.Out.(*bytes.Buffer).Bytes(), &report); err != nil {
+		t.Fatalf("decode doctor JSON: %v", err)
+	}
+	found := false
+	for _, c := range report.Checks {
+		if c.Section == "Local agent" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("doctor is missing the \"Local agent\" section:\n%s", app.Out.(*bytes.Buffer).String())
+	}
+}
+
+// A provisioned agent account whose OS user resolves to the operator's own uid is
+// the isolation-defeating case the same-uid warning exists to catch. We seed the
+// account with the CURRENT user (guaranteed same uid) and assert a warning row.
+func TestDoctorWarnsSameUIDAgentAccount(t *testing.T) {
+	me, err := user.Current()
+	if err != nil {
+		t.Skipf("cannot resolve current user: %v", err)
+	}
+
+	app := testApp(t)
+	cfg, err := config.Load(app.Paths)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfg.SetAgentAccount(config.AgentAccount{User: me.Username, AccountCreated: true, Enabled: true})
+	if err := cfg.Save(app.Paths); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	opts := offlineOpts()
+	opts.json = true
+	_ = app.doctorE(context.Background(), opts)
+
+	var report struct {
+		Checks []struct {
+			Section string `json:"section"`
+			Name    string `json:"name"`
+			Status  string `json:"status"`
+			Detail  string `json:"detail"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(app.Out.(*bytes.Buffer).Bytes(), &report); err != nil {
+		t.Fatalf("decode doctor JSON: %v", err)
+	}
+	warned := false
+	for _, c := range report.Checks {
+		if c.Section == "Local agent" && c.Name == "account uid" {
+			warned = c.Status == "warn"
+		}
+	}
+	if !warned {
+		t.Errorf("expected a same-uid warning for agent account %q:\n%s", me.Username, app.Out.(*bytes.Buffer).String())
 	}
 }

--- a/cli/internal/cmd/events.go
+++ b/cli/internal/cmd/events.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/client/generated/control"
+	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// newEventsCmd is the `jentic events` root. Read-only; not fenced.
+func newEventsCmd(app *App) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "events",
+		Short: "Observe control-plane events",
+		Args:  cobra.NoArgs,
+		RunE:  func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+	}
+	cmd.AddCommand(newEventsWatchCmd(app))
+	return cmd
+}
+
+type eventsWatchOptions struct {
+	traceID     string
+	eventTypes  []string
+	lastEventID string
+}
+
+func newEventsWatchCmd(app *App) *cobra.Command {
+	opts := &eventsWatchOptions{}
+	cmd := &cobra.Command{
+		Use:   "watch",
+		Short: "Tail the control-plane event stream as NDJSON",
+		Long: "watch connects to the control plane's Server-Sent Events stream and emits\n" +
+			"one JSON event per line (NDJSON) until interrupted. Use --last-event-id to\n" +
+			"resume after a previously seen event (the stream also advertises the id of\n" +
+			"each event so a wrapper can persist it). Ctrl-C stops cleanly.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			aud := ux.FromContext(cmd.Context())
+			client, err := clictx.GetControlClient(cmd.Context())
+			if err != nil {
+				return reportCoded(aud, err)
+			}
+			return runEventsWatch(cmd.Context(), client, app.Out, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.traceID, "trace", "", "Only events for this trace id")
+	cmd.Flags().StringArrayVar(&opts.eventTypes, "type", nil, "Only events of these types (repeatable)")
+	cmd.Flags().StringVar(&opts.lastEventID, "last-event-id", "", "Resume after this event id")
+	return cmd
+}
+
+// runEventsWatch opens the SSE stream and forwards each event as an NDJSON line.
+// It returns nil on a clean context cancellation (Ctrl-C) — a deliberately-stopped
+// tail is success, not failure.
+func runEventsWatch(ctx context.Context, client *control.ClientWithResponses, out io.Writer, opts *eventsWatchOptions) error {
+	params := &control.StreamEventsParams{}
+	if opts.traceID != "" {
+		params.TraceId = &opts.traceID
+	}
+	if len(opts.eventTypes) > 0 {
+		types := opts.eventTypes
+		params.EventType = &types
+	}
+	if opts.lastEventID != "" {
+		params.LastEventID = &opts.lastEventID
+	}
+
+	resp, err := client.StreamEvents(ctx, params)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return &ux.CodedError{
+			Code: ux.CodeResolveFailed,
+			Msg:  fmt.Sprintf("event stream returned status %d", resp.StatusCode),
+		}
+	}
+
+	err = forwardSSE(ctx, resp.Body, out)
+	if errors.Is(err, context.Canceled) || errors.Is(err, io.EOF) {
+		return nil
+	}
+	return err
+}
+
+// forwardSSE parses a Server-Sent Events body and writes each event's `data`
+// payload as one redacted NDJSON line. It follows the SSE framing: lines starting
+// with `data:` accumulate the payload, a blank line dispatches the event, and
+// `id:`/`event:` lines are metadata (id is echoed into the emitted object so a
+// consumer can persist it for --last-event-id resume). Comment lines (`:`) and the
+// periodic keep-alive are ignored.
+func forwardSSE(ctx context.Context, body io.Reader, out io.Writer) error {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var dataLines []string
+	var eventID string
+
+	flush := func() error {
+		if len(dataLines) == 0 {
+			return nil
+		}
+		payload := strings.Join(dataLines, "\n")
+		dataLines = dataLines[:0]
+		id := eventID
+		eventID = ""
+
+		// Decode into a generic object so the redaction funnel can see field names;
+		// a payload that is not valid JSON is forwarded as a raw string field rather
+		// than dropped, so an operator still sees malformed events.
+		var obj map[string]any
+		if json.Unmarshal([]byte(payload), &obj) != nil {
+			obj = map[string]any{"raw": payload}
+		}
+		if id != "" {
+			obj["_event_id"] = id
+		}
+		return ux.WriteJSONLine(out, obj)
+	}
+
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		line := scanner.Text()
+		switch {
+		case line == "":
+			if err := flush(); err != nil {
+				return err
+			}
+		case strings.HasPrefix(line, ":"):
+			// SSE comment / keep-alive — ignore.
+		case strings.HasPrefix(line, "data:"):
+			dataLines = append(dataLines, strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+		case strings.HasPrefix(line, "id:"):
+			eventID = strings.TrimSpace(strings.TrimPrefix(line, "id:"))
+		default:
+			// event:/retry:/unknown fields — not needed for the NDJSON tail.
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	// Dispatch any trailing event with no terminating blank line.
+	return flush()
+}

--- a/cli/internal/cmd/execute.go
+++ b/cli/internal/cmd/execute.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/x/term"
+	sdkclient "github.com/jentic/jentic-one/cli/client"
 	"github.com/jentic/jentic-one/cli/internal/apiclient"
 	"github.com/jentic/jentic-one/cli/internal/config"
 	"github.com/jentic/jentic-one/cli/internal/theme"
@@ -229,8 +230,16 @@ func (a *App) executeE(cmd *cobra.Command, ident *identityOptions, opts *execute
 		req.Header.Set(strings.TrimSpace(k), strings.TrimSpace(v))
 	}
 
-	// Send phase.
-	httpClient := &http.Client{Timeout: 60 * time.Second}
+	// Send phase. Route through the SDK broker transport (client.BrokerTransport)
+	// rather than a bare http.Client so execute inherits the same response policy
+	// (401 re-exchange, 429 Retry-After, bounded 5xx/transport backoff — 13 §5)
+	// every generated broker call gets, while still composing the broker
+	// catch-all URL itself to preserve its exact contract and exit-2 denial
+	// handling (plan.md Phase 5 item 1). The 60s ceiling is carried on the base
+	// client the policy decorates.
+	httpClient := sdkclient.BrokerTransport(sdkclient.Config{
+		HTTPClient: &http.Client{Timeout: 60 * time.Second},
+	})
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		if jsonOrPretty(cmd, opts.json) {

--- a/cli/internal/cmd/history.go
+++ b/cli/internal/cmd/history.go
@@ -1,0 +1,218 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/client/generated/control"
+	"github.com/jentic/jentic-one/cli/client/paginate"
+	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// newHistoryCmd is the `jentic history` root: read-only queries over the control
+// plane's execution records (impl/5.0 §2). Not fenced — it mutates nothing.
+func newHistoryCmd(app *App) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "history",
+		Short: "Query and export execution history",
+		Long: "history reads the control plane's execution records. `export` walks a\n" +
+			"trace's executions (cursor-paginated) and emits a versioned JSON document an\n" +
+			"agent can template a workflow from.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
+	}
+	cmd.AddCommand(newHistoryExportCmd(app))
+	return cmd
+}
+
+type historyExportOptions struct {
+	trace           string
+	from            string
+	to              string
+	api             string
+	includeFailures bool
+	limit           int
+	cursor          string
+	out             string
+}
+
+func newHistoryExportCmd(_ *App) *cobra.Command {
+	opts := &historyExportOptions{}
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export the execution history of a trace",
+		Long: "export walks every execution for --trace (following cursor pagination to\n" +
+			"completion) and renders a versioned export document. Failed executions\n" +
+			"(HTTP >= 400) are excluded unless --include-failures is set. Use --limit/\n" +
+			"--cursor to fetch a single page instead of the full walk.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			aud := ux.FromContext(cmd.Context())
+			client, err := clictx.GetControlClient(cmd.Context())
+			if err != nil {
+				return reportCoded(aud, err)
+			}
+
+			from, to, terr := parseTimeWindow(opts.from, opts.to)
+			if terr != nil {
+				return reportCoded(aud, &ux.CodedError{
+					Code:       ux.CodeMissingArgument,
+					Msg:        terr.Error(),
+					Actionable: "Use RFC3339 timestamps, e.g. 2026-08-01T00:00:00Z.",
+				})
+			}
+
+			records, nextCursor, err := collectExecutions(cmd.Context(), client, opts, from, to)
+			if err != nil {
+				return reportCoded(aud, asCoded(err))
+			}
+
+			filtered := filterFailures(records, opts.includeFailures)
+
+			// A single-page fetch (--limit/--cursor) renders a Page so the caller can
+			// keep walking; a full walk renders the terminal Export envelope.
+			if opts.limit > 0 || opts.cursor != "" {
+				page := ux.NewPage(filtered, nextCursor)
+				return renderMaybeToFile(aud, opts.out, page)
+			}
+			return renderMaybeToFile(aud, opts.out, ux.Export{
+				TraceID: opts.trace,
+				Items:   filtered,
+				Count:   len(filtered),
+			})
+		},
+	}
+	cmd.Flags().StringVar(&opts.trace, "trace", "", "Trace ID to export (required)")
+	cmd.Flags().StringVar(&opts.from, "from", "", "Only executions at/after this RFC3339 time")
+	cmd.Flags().StringVar(&opts.to, "to", "", "Only executions at/before this RFC3339 time")
+	cmd.Flags().StringVar(&opts.api, "api", "", "Filter by API id")
+	cmd.Flags().BoolVar(&opts.includeFailures, "include-failures", false, "Include failed executions (HTTP >= 400)")
+	cmd.Flags().IntVar(&opts.limit, "limit", 0, "Fetch a single page of at most N records instead of the full walk")
+	cmd.Flags().StringVar(&opts.cursor, "cursor", "", "Fetch the page at this opaque cursor instead of the full walk")
+	cmd.Flags().StringVarP(&opts.out, "output", "o", "", "Write the export to this file instead of stdout")
+	mustMarkRequired(cmd, "trace")
+	return cmd
+}
+
+// collectExecutions fetches execution records for the trace. With --limit/--cursor
+// it fetches exactly one page (returning the next cursor); otherwise it walks every
+// page to completion via paginate.All.
+func collectExecutions(ctx context.Context, client *control.ClientWithResponses, opts *historyExportOptions, from, to *time.Time) ([]control.ExecutionResponse, string, error) {
+	baseParams := func(cursor *string) *control.ListExecutionsParams {
+		p := &control.ListExecutionsParams{TraceId: &opts.trace, Cursor: cursor, From: from, To: to}
+		if opts.api != "" {
+			p.Api = &opts.api
+		}
+		if opts.limit > 0 {
+			p.Limit = &opts.limit
+		}
+		return p
+	}
+	fetch := func(cursor *string) (*control.ExecutionListResponse, error) {
+		resp, err := client.ListExecutionsWithResponse(ctx, baseParams(cursor))
+		if err != nil {
+			return nil, err
+		}
+		if resp.JSON200 == nil {
+			return nil, fmt.Errorf("unexpected backend response (status %d)", resp.StatusCode())
+		}
+		return resp.JSON200, nil
+	}
+
+	// Single page: honor --cursor as the starting point.
+	if opts.limit > 0 || opts.cursor != "" {
+		var start *string
+		if opts.cursor != "" {
+			start = &opts.cursor
+		}
+		body, err := fetch(start)
+		if err != nil {
+			return nil, "", err
+		}
+		next := ""
+		if body.HasMore && body.NextCursor != nil {
+			next = *body.NextCursor
+		}
+		return body.Data, next, nil
+	}
+
+	// Full walk.
+	all, err := paginate.All(ctx, func(_ context.Context, cursor string) (paginate.Page[control.ExecutionResponse], error) {
+		var c *string
+		if cursor != "" {
+			c = &cursor
+		}
+		body, err := fetch(c)
+		if err != nil {
+			return paginate.Page[control.ExecutionResponse]{}, err
+		}
+		next := ""
+		if body.HasMore && body.NextCursor != nil {
+			next = *body.NextCursor
+		}
+		return paginate.Page[control.ExecutionResponse]{Items: body.Data, Next: next}, nil
+	})
+	return all, "", err
+}
+
+// filterFailures drops executions whose http_status is >= 400 unless include is
+// set. A nil status is "not a failure" (the field is optional in the spec).
+func filterFailures(records []control.ExecutionResponse, include bool) []control.ExecutionResponse {
+	if include {
+		return records
+	}
+	filtered := make([]control.ExecutionResponse, 0, len(records))
+	for _, r := range records {
+		if r.HttpStatus != nil && *r.HttpStatus >= 400 {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	return filtered
+}
+
+// parseTimeWindow parses optional RFC3339 --from/--to bounds.
+func parseTimeWindow(from, to string) (*time.Time, *time.Time, error) {
+	parse := func(label, s string) (*time.Time, error) {
+		if s == "" {
+			return nil, nil
+		}
+		t, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --%s time %q: %w", label, s, err)
+		}
+		return &t, nil
+	}
+	f, err := parse("from", from)
+	if err != nil {
+		return nil, nil, err
+	}
+	t, err := parse("to", to)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, t, nil
+}
+
+// renderMaybeToFile renders through the Audience (stdout) unless -o was given, in
+// which case it writes the redacted JSON document to the file. Writing to a file
+// is inherently the machine (agent) shape — a human -o still gets valid JSON.
+func renderMaybeToFile(aud ux.Audience, path string, v any) error {
+	if path == "" {
+		aud.Render(v)
+		return nil
+	}
+	data := ux.MarshalForFile(v)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return reportCoded(aud, &ux.CodedError{
+			Code: ux.CodeInternalError,
+			Msg:  fmt.Sprintf("writing export to %s: %v", path, err),
+		})
+	}
+	return nil
+}

--- a/cli/internal/cmd/history_events_test.go
+++ b/cli/internal/cmd/history_events_test.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jentic/jentic-one/cli/client/generated/control"
+)
+
+func TestFilterFailures(t *testing.T) {
+	ok := 200
+	bad := 500
+	recs := []control.ExecutionResponse{
+		{ExecutionId: "a", HttpStatus: &ok},
+		{ExecutionId: "b", HttpStatus: &bad},
+		{ExecutionId: "c", HttpStatus: nil}, // nil status => not a failure
+	}
+	got := filterFailures(recs, false)
+	if len(got) != 2 || got[0].ExecutionId != "a" || got[1].ExecutionId != "c" {
+		t.Errorf("filterFailures(exclude) = %+v", ids(got))
+	}
+	if len(filterFailures(recs, true)) != 3 {
+		t.Error("filterFailures(include) should keep everything")
+	}
+}
+
+func ids(recs []control.ExecutionResponse) []string {
+	out := make([]string, len(recs))
+	for i, r := range recs {
+		out[i] = r.ExecutionId
+	}
+	return out
+}
+
+func TestParseTimeWindow(t *testing.T) {
+	f, to, err := parseTimeWindow("2026-08-01T00:00:00Z", "")
+	if err != nil || f == nil || to != nil {
+		t.Fatalf("from-only: f=%v to=%v err=%v", f, to, err)
+	}
+	if _, _, err := parseTimeWindow("not-a-time", ""); err == nil {
+		t.Error("expected a parse error for a bad --from")
+	}
+}
+
+// TestHistoryExport_WalksAndFilters drives `jentic history export` E2E against a
+// mock control plane that returns two pages, one of which contains a failure. The
+// full walk must follow the cursor and drop the failure by default.
+func TestHistoryExport_WalksAndFilters(t *testing.T) {
+	withXDG(t)
+
+	page1 := control.ExecutionListResponse{
+		Data:       []control.ExecutionResponse{{ExecutionId: "e1", TraceId: "T"}},
+		HasMore:    true,
+		NextCursor: strptr("c2"),
+	}
+	bad := 502
+	page2 := control.ExecutionListResponse{
+		Data: []control.ExecutionResponse{
+			{ExecutionId: "e2", TraceId: "T"},
+			{ExecutionId: "e3", TraceId: "T", HttpStatus: &bad},
+		},
+		HasMore: false,
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/executions") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "c2" {
+			_ = json.NewEncoder(w).Encode(page2)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(page1)
+	}))
+	defer srv.Close()
+
+	seedActiveContextTo(t, srv.URL)
+
+	out := filepath.Join(t.TempDir(), "export.json")
+	if err := runJentic(t, "history", "export", "--trace", "T", "-o", out); err != nil {
+		t.Fatalf("history export: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		TraceID string `json:"trace_id"`
+		Count   int    `json:"count"`
+		Items   []struct {
+			ExecutionID string `json:"execution_id"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("export not valid JSON: %v\n%s", err, data)
+	}
+	if got.TraceID != "T" || got.Count != 2 {
+		t.Errorf("export = trace %q count %d (want T/2)\n%s", got.TraceID, got.Count, data)
+	}
+	for _, it := range got.Items {
+		if it.ExecutionID == "e3" {
+			t.Error("failed execution e3 should have been filtered")
+		}
+	}
+}
+
+func TestForwardSSE_EmitsNDJSONWithEventID(t *testing.T) {
+	stream := strings.Join([]string{
+		": keep-alive",
+		"id: ev-1",
+		`data: {"type":"execution.started","summary":"go"}`,
+		"",
+		`data: {"type":"execution.finished"}`,
+		"",
+	}, "\n")
+
+	var buf bytes.Buffer
+	if err := forwardSSE(context.Background(), strings.NewReader(stream), &buf); err != nil {
+		t.Fatalf("forwardSSE: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 NDJSON lines, got %d:\n%s", len(lines), buf.String())
+	}
+	var first map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
+		t.Fatalf("line 1 not JSON: %v", err)
+	}
+	if first["_event_id"] != "ev-1" || first["type"] != "execution.started" {
+		t.Errorf("first event = %+v", first)
+	}
+}
+
+func TestForwardSSE_MalformedPayloadForwardedAsRaw(t *testing.T) {
+	stream := "data: not-json\n\n"
+	var buf bytes.Buffer
+	if err := forwardSSE(context.Background(), strings.NewReader(stream), &buf); err != nil {
+		t.Fatal(err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &obj); err != nil {
+		t.Fatal(err)
+	}
+	if obj["raw"] != "not-json" {
+		t.Errorf("malformed payload not preserved: %+v", obj)
+	}
+}
+
+func strptr(s string) *string { return &s }
+
+// seedActiveContextTo points the file-less path at baseURL with an injected
+// bearer, so the SDK talks to the mock server with no key exchange or on-disk
+// context. Loopback http is permitted by the transport guard. Mode is forced to
+// agent so nothing tries to prompt.
+func seedActiveContextTo(t *testing.T, baseURL string) {
+	t.Helper()
+	t.Setenv("JENTIC_BASE_URL", baseURL)
+	t.Setenv("JENTIC_BEARER_TOKEN", "test-token")
+	t.Setenv("JENTIC_MODE", "agent")
+}

--- a/cli/internal/cmd/plan.go
+++ b/cli/internal/cmd/plan.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+)
+
+// planFlags registers --dry-run/--export-plan on a mutating API-calling command
+// (impl/5.0 §5). They are LOCAL, not persistent-root flags: the shipped V1 tree
+// already has local --dry-run flags with different (file-preview) semantics on
+// bootstrap/skill, so a persistent root flag would shadow them.
+func planFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("dry-run", false, "Validate and print the request that WOULD be sent, without sending it")
+	cmd.Flags().Bool("export-plan", false, "Emit a machine-readable execution plan (implies --dry-run)")
+}
+
+// maybeEmitPlan renders the resolved request as a plan through the Audience and
+// returns true when execution should STOP (i.e. --dry-run or --export-plan was
+// set). Mutating commands call it immediately before the client call:
+//
+//	if maybeEmitPlan(cmd, "importApis", body) { return nil }
+//	// ... fire the client
+//
+// operation should mirror the generated client method the command invokes; a
+// table-driven test keeps the literal honest (impl/5.0 §5).
+func maybeEmitPlan(cmd *cobra.Command, operation string, payload any) bool {
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	exportPlan, _ := cmd.Flags().GetBool("export-plan")
+	if !dryRun && !exportPlan {
+		return false
+	}
+	ux.FromContext(cmd.Context()).Render(ux.Plan{Operation: operation, DryRun: true, Payload: payload})
+	return true
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -153,6 +153,9 @@ func newAPIRootCmd(app *App) *cobra.Command {
 	// Execution history + live events over the V2 SDK (Phase 5 items 3-4).
 	addGrouped(root, "agent", newHistoryCmd(app))
 	addGrouped(root, "agent", newEventsCmd(app))
+	// gh-api-style authenticated passthrough to the control plane, with
+	// self-description (Phase 5 item 7a). Not fenced (server-scope-gated).
+	addGrouped(root, "agent", newAPICmd(app))
 	// The agent-client commands manage and drive the local coding agent
 	// (generate its skills, launch it under isolation, tear its account down),
 	// distinct from the catalog find/run operations above.

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -146,6 +146,7 @@ func newAPIRootCmd(app *App) *cobra.Command {
 	addGrouped(root, "apis", newCatalogCmd(app))
 	addGrouped(root, "apis", newApisCmd(app))
 	addGrouped(root, "apis", newEndpointsCmd(app))
+	addGrouped(root, "apis", newCredentialsCmd(app))
 	addGrouped(root, "agent", newSearchCmd(app))
 	addGrouped(root, "agent", newInspectCmd(app))
 	addGrouped(root, "agent", newExecuteCmd(app))

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -150,6 +150,9 @@ func newAPIRootCmd(app *App) *cobra.Command {
 	addGrouped(root, "agent", newInspectCmd(app))
 	addGrouped(root, "agent", newExecuteCmd(app))
 	addGrouped(root, "agent", newAccessCmd(app))
+	// Execution history + live events over the V2 SDK (Phase 5 items 3-4).
+	addGrouped(root, "agent", newHistoryCmd(app))
+	addGrouped(root, "agent", newEventsCmd(app))
 	// The agent-client commands manage and drive the local coding agent
 	// (generate its skills, launch it under isolation, tear its account down),
 	// distinct from the catalog find/run operations above.

--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -389,70 +389,6 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   `jenticctl start` (then `jenticctl status` to confirm), and I'll retry."*
   After the restart, retry the original call and continue the task.
 
-## Advanced: the self-describing `api` loop
-
-Beyond the curated `search`/`inspect`/`execute` flow above, the CLI exposes the
-control plane directly as a `gh api`-style passthrough. Use it when no curated
-command covers what you need, or when you want to drive the API programmatically
-by **discovering** its operations rather than hard-coding paths. The loop is
-**list → describe → call**, and it is fully self-describing — you never guess a
-path or a parameter:
-
-```
-jentic api ops                       # every operation this CLI can call, with METHOD + PATH + id
-jentic api describe GET /credentials # parameters, request/response schema for one operation
-jentic api GET /credentials          # make the call (auth attached for you)
-```
-
-- `api ops` is the **allowlist** — only the operations the CLI's embedded spec
-  advertises are callable, so a typo fails locally (`unknown path`) instead of
-  wasting a round-trip. Add `--live` to list what the *connected server* actually
-  serves (useful against an older backend — see transport recovery below).
-- `api describe <METHOD> <PATH>` prints the operation's parameters and schemas
-  from the same spec `describe`/`ops` share, so what you read is exactly what the
-  call accepts.
-- Pass a body with `-d '<json>'`, `--data-file <path>`, `-d -` (read stdin), or
-  simply pipe/redirect JSON in (`… < body.json`) — the passthrough reads stdin
-  automatically when a body-bearing method has no explicit `-d`.
-- Add `--dry-run` (or `--export-plan`) to a mutating call to see the resolved
-  operation + payload **without** sending it — the plan envelope, redacted.
-- `--fail-on-error` makes a non-2xx response set a non-zero exit; by default the
-  passthrough exits 0 and hands you the body to inspect, `gh api`-style.
-
-### Reading the output (the machine contract)
-
-Every command emits a stable JSON envelope in `agent` mode (and with `--json` on
-a TTY), so you parse structure, not prose:
-
-- **Success** carries the operation's data (a `data`/`items` object, or an
-  `Export`/`Plan` envelope with a `schema_version`).
-- **Failure** is a closed-enum error object: `{"error":{"code":"…",
-  "message":"…","actionable_step":"…","details":{…}}}`. Branch on `code`, not on
-  the message text — the enum is stable, the wording is not. Codes you will meet
-  include `RESOLVE_FAILED`, `FENCED_COMMAND`, `CONFINEMENT_UNAVAILABLE`,
-  `TIMEOUT_PENDING`, and the broker denials surfaced as `agent_directive`s above.
-- **Exit codes** are the fast branch: **0** success, **1** generic error, **2**
-  broker denial / resolve failure, **3** pending timeout, **4** partial approval.
-
-### Transport-error recovery
-
-The SDK already retries transient failures for you before they ever reach your
-code: a **429** honors `Retry-After` (within budget), and **5xx / connection
-errors** get bounded backoff for **idempotent** calls (GET/HEAD, or a POST
-carrying an `Idempotency-Key`). A plain POST is never blind-retried — so if a
-non-idempotent call returns a transport error, re-send it yourself only when you
-know it is safe to repeat.
-
-A **401** is a hard denial, not a transport blip: the CLI re-mints your token
-once automatically, but if it still fails your identity needs attention (ask your
-operator) — don't loop on it.
-
-A **404 on a path `api ops` lists** means the route is in this CLI's spec but the
-**connected server is older** and doesn't serve it yet: the passthrough enriches
-that case as `RESOLVE_FAILED` with `details.route_unsupported_upstream: true` and
-the server version. Recover by upgrading the backend, or run `jentic api ops
---live` to see and call what this server actually serves.
-
 ## Quick Reference
 
 - The authoritative command + flag reference is **generated from the CLI
@@ -479,10 +415,6 @@ the server version. Recover by upgrading the backend, or run `jentic api ops
   `jentic execute <operation_id | METHOD:URL>` — discover, inspect, and call
   operations through the broker (use the full upstream URL; the broker is a
   forward proxy, not a path router).
-- `jentic api ops` → `jentic api describe <METHOD> <PATH>` →
-  `jentic api <METHOD> <PATH> [-d …]` — the self-describing control-plane
-  passthrough when no curated command fits (`--dry-run` to preview, `--live`
-  against an older backend).
 - `jentic register` / `jentic bootstrap` — operator commands that create and
   approve this identity (they block on human approval; not for autonomous use).
 - `jenticctl status` / `jenticctl start` — health-check and restart the local

--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -389,6 +389,70 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   `jenticctl start` (then `jenticctl status` to confirm), and I'll retry."*
   After the restart, retry the original call and continue the task.
 
+## Advanced: the self-describing `api` loop
+
+Beyond the curated `search`/`inspect`/`execute` flow above, the CLI exposes the
+control plane directly as a `gh api`-style passthrough. Use it when no curated
+command covers what you need, or when you want to drive the API programmatically
+by **discovering** its operations rather than hard-coding paths. The loop is
+**list → describe → call**, and it is fully self-describing — you never guess a
+path or a parameter:
+
+```
+jentic api ops                       # every operation this CLI can call, with METHOD + PATH + id
+jentic api describe GET /credentials # parameters, request/response schema for one operation
+jentic api GET /credentials          # make the call (auth attached for you)
+```
+
+- `api ops` is the **allowlist** — only the operations the CLI's embedded spec
+  advertises are callable, so a typo fails locally (`unknown path`) instead of
+  wasting a round-trip. Add `--live` to list what the *connected server* actually
+  serves (useful against an older backend — see transport recovery below).
+- `api describe <METHOD> <PATH>` prints the operation's parameters and schemas
+  from the same spec `describe`/`ops` share, so what you read is exactly what the
+  call accepts.
+- Pass a body with `-d '<json>'`, `--data-file <path>`, `-d -` (read stdin), or
+  simply pipe/redirect JSON in (`… < body.json`) — the passthrough reads stdin
+  automatically when a body-bearing method has no explicit `-d`.
+- Add `--dry-run` (or `--export-plan`) to a mutating call to see the resolved
+  operation + payload **without** sending it — the plan envelope, redacted.
+- `--fail-on-error` makes a non-2xx response set a non-zero exit; by default the
+  passthrough exits 0 and hands you the body to inspect, `gh api`-style.
+
+### Reading the output (the machine contract)
+
+Every command emits a stable JSON envelope in `agent` mode (and with `--json` on
+a TTY), so you parse structure, not prose:
+
+- **Success** carries the operation's data (a `data`/`items` object, or an
+  `Export`/`Plan` envelope with a `schema_version`).
+- **Failure** is a closed-enum error object: `{"error":{"code":"…",
+  "message":"…","actionable_step":"…","details":{…}}}`. Branch on `code`, not on
+  the message text — the enum is stable, the wording is not. Codes you will meet
+  include `RESOLVE_FAILED`, `FENCED_COMMAND`, `CONFINEMENT_UNAVAILABLE`,
+  `TIMEOUT_PENDING`, and the broker denials surfaced as `agent_directive`s above.
+- **Exit codes** are the fast branch: **0** success, **1** generic error, **2**
+  broker denial / resolve failure, **3** pending timeout, **4** partial approval.
+
+### Transport-error recovery
+
+The SDK already retries transient failures for you before they ever reach your
+code: a **429** honors `Retry-After` (within budget), and **5xx / connection
+errors** get bounded backoff for **idempotent** calls (GET/HEAD, or a POST
+carrying an `Idempotency-Key`). A plain POST is never blind-retried — so if a
+non-idempotent call returns a transport error, re-send it yourself only when you
+know it is safe to repeat.
+
+A **401** is a hard denial, not a transport blip: the CLI re-mints your token
+once automatically, but if it still fails your identity needs attention (ask your
+operator) — don't loop on it.
+
+A **404 on a path `api ops` lists** means the route is in this CLI's spec but the
+**connected server is older** and doesn't serve it yet: the passthrough enriches
+that case as `RESOLVE_FAILED` with `details.route_unsupported_upstream: true` and
+the server version. Recover by upgrading the backend, or run `jentic api ops
+--live` to see and call what this server actually serves.
+
 ## Quick Reference
 
 - The authoritative command + flag reference is **generated from the CLI
@@ -415,6 +479,10 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   `jentic execute <operation_id | METHOD:URL>` — discover, inspect, and call
   operations through the broker (use the full upstream URL; the broker is a
   forward proxy, not a path router).
+- `jentic api ops` → `jentic api describe <METHOD> <PATH>` →
+  `jentic api <METHOD> <PATH> [-d …]` — the self-describing control-plane
+  passthrough when no curated command fits (`--dry-run` to preview, `--live`
+  against an older backend).
 - `jentic register` / `jentic bootstrap` — operator commands that create and
   approve this identity (they block on human approval; not for autonomous use).
 - `jenticctl status` / `jenticctl start` — health-check and restart the local

--- a/cli/tests/arch/mutator_test.go
+++ b/cli/tests/arch/mutator_test.go
@@ -41,6 +41,7 @@ var configWriterAllowlist = map[string]bool{
 	"internal/cmd/updatenudge.go": true, // update-check timestamp (0600)
 	"internal/cmd/install.go":     true, // install writes env/compose out
 	"internal/cmd/apis.go":        true, // apis export to user-chosen -o path
+	"internal/cmd/history.go":     true, // history export to user-chosen -o path (redacted JSON, not config)
 	"internal/cmd/update.go":      true, // fetched installer script
 	"internal/cmd/uninstall.go":   true, // backup/restore moves
 }

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -2262,6 +2262,298 @@
           ]
         },
         {
+          "name": "history",
+          "path": "jentic history",
+          "use": "history",
+          "short": "Query and export execution history",
+          "long": "history reads the control plane's execution records. `export` walks a\ntrace's executions (cursor-paginated) and emits a versioned JSON document an\nagent can template a workflow from.",
+          "group_title": "Find and run operations",
+          "flags": [
+            {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            }
+          ],
+          "subcommands": [
+            {
+              "name": "export",
+              "path": "jentic history export",
+              "use": "export",
+              "short": "Export the execution history of a trace",
+              "long": "export walks every execution for --trace (following cursor pagination to\ncompletion) and renders a versioned export document. Failed executions\n(HTTP \u003e= 400) are excluded unless --include-failures is set. Use --limit/\n--cursor to fetch a single page instead of the full walk.",
+              "flags": [
+                {
+                  "name": "api",
+                  "type": "string",
+                  "usage": "Filter by API id"
+                },
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "cursor",
+                  "type": "string",
+                  "usage": "Fetch the page at this opaque cursor instead of the full walk"
+                },
+                {
+                  "name": "from",
+                  "type": "string",
+                  "usage": "Only executions at/after this RFC3339 time"
+                },
+                {
+                  "name": "include-failures",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "Include failed executions (HTTP \u003e= 400)"
+                },
+                {
+                  "name": "limit",
+                  "type": "int",
+                  "default": "0",
+                  "usage": "Fetch a single page of at most N records instead of the full walk"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "output",
+                  "shorthand": "o",
+                  "type": "string",
+                  "usage": "Write the export to this file instead of stdout"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                },
+                {
+                  "name": "to",
+                  "type": "string",
+                  "usage": "Only executions at/before this RFC3339 time"
+                },
+                {
+                  "name": "trace",
+                  "type": "string",
+                  "usage": "Trace ID to export (required)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "events",
+          "path": "jentic events",
+          "use": "events",
+          "short": "Observe control-plane events",
+          "group_title": "Find and run operations",
+          "flags": [
+            {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            }
+          ],
+          "subcommands": [
+            {
+              "name": "watch",
+              "path": "jentic events watch",
+              "use": "watch",
+              "short": "Tail the control-plane event stream as NDJSON",
+              "long": "watch connects to the control plane's Server-Sent Events stream and emits\none JSON event per line (NDJSON) until interrupted. Use --last-event-id to\nresume after a previously seen event (the stream also advertises the id of\neach event so a wrapper can persist it). Ctrl-C stops cleanly.",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "last-event-id",
+                  "type": "string",
+                  "usage": "Resume after this event id"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                },
+                {
+                  "name": "trace",
+                  "type": "string",
+                  "usage": "Only events for this trace id"
+                },
+                {
+                  "name": "type",
+                  "type": "stringArray",
+                  "default": "[]",
+                  "usage": "Only events of these types (repeatable)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "api",
+          "path": "jentic api",
+          "use": "api \u003cMETHOD\u003e \u003cPATH\u003e",
+          "short": "Authenticated passthrough to the control plane",
+          "long": "api sends an arbitrary request to the control plane, reusing the same\nauth, session, and transport as every other command. The PATH must match a\nroute in the CLI's embedded OpenAPI spec (use --live to allow routes the\nconnected server serves that this binary predates). Discover routes with\n`jentic api ops` and their contract with `jentic api describe`.\n\nRequest body (mirrors `jentic execute`): -d/--data inline JSON, -d - for\nstdin, --data-file \u003cpath\u003e, or auto-stdin when a body is piped/redirected.\n\nBy default any transport-successful response (2xx or 4xx/5xx) exits 0 and\nthe body is emitted as-is; --fail-on-error maps non-2xx to exit 1.",
+          "example": "  jentic api GET /credentials\n  jentic api POST /toolkits -d '{\"name\":\"clarity\"}'\n  jentic api POST /apis \u003c api.json\n  jentic api GET \"/apis?limit=10\"",
+          "group_title": "Find and run operations",
+          "flags": [
+            {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "data",
+              "shorthand": "d",
+              "type": "string",
+              "usage": "request body JSON (use - for stdin)"
+            },
+            {
+              "name": "data-file",
+              "type": "string",
+              "usage": "read request body from this file"
+            },
+            {
+              "name": "fail-on-error",
+              "type": "bool",
+              "default": "false",
+              "usage": "exit 1 on a non-2xx response"
+            },
+            {
+              "name": "header",
+              "type": "stringArray",
+              "default": "[]",
+              "usage": "extra header as key=value (repeatable)"
+            },
+            {
+              "name": "live",
+              "type": "bool",
+              "default": "false",
+              "usage": "fetch the server's /openapi.json instead of the embedded spec"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "query",
+              "type": "stringArray",
+              "default": "[]",
+              "usage": "query parameter as key=value (repeatable)"
+            },
+            {
+              "name": "raw",
+              "type": "bool",
+              "default": "false",
+              "usage": "skip the spec path allowlist (loopback hosts only, for dev)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            }
+          ],
+          "subcommands": [
+            {
+              "name": "ops",
+              "path": "jentic api ops",
+              "use": "ops",
+              "short": "List control-plane operations (METHOD, path, id, summary)",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "filter",
+                  "type": "string",
+                  "usage": "only operations whose path/id/summary contains this substring"
+                },
+                {
+                  "name": "live",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "list the server's live operations instead of the embedded set"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                }
+              ]
+            },
+            {
+              "name": "describe",
+              "path": "jentic api describe",
+              "use": "describe \u003cMETHOD\u003e \u003cPATH\u003e",
+              "short": "Describe an operation's params and request/response schema",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "live",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "describe against the server's live spec instead of the embedded one"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                }
+              ]
+            }
+          ]
+        },
+        {
           "name": "skill",
           "path": "jentic skill",
           "use": "skill",

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -1650,6 +1650,55 @@
                   "usage": "request YAML instead of JSON"
                 }
               ]
+            },
+            {
+              "name": "import",
+              "path": "jentic apis import",
+              "use": "import \u003cfile|url\u003e",
+              "short": "Import an OpenAPI document into the catalog",
+              "long": "import submits an OpenAPI spec to the catalog. The argument is either a\nlocal file path (read and sent inline) or an http(s) URL (sent as a\nfetchable source). Import is asynchronous; the command prints the job id.",
+              "flags": [
+                {
+                  "name": "base-url",
+                  "type": "string",
+                  "usage": "Jentic control-plane base URL"
+                },
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "name",
+                  "type": "string",
+                  "usage": "Override the API name"
+                },
+                {
+                  "name": "profile",
+                  "type": "string",
+                  "usage": "profile name (default: config default_profile)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                },
+                {
+                  "name": "vendor",
+                  "type": "string",
+                  "usage": "Override the vendor for the imported API"
+                },
+                {
+                  "name": "version",
+                  "type": "string",
+                  "usage": "Override the API version"
+                }
+              ]
             }
           ]
         },
@@ -1701,6 +1750,97 @@
               "name": "theme",
               "type": "string",
               "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            }
+          ]
+        },
+        {
+          "name": "credentials",
+          "path": "jentic credentials",
+          "use": "credentials",
+          "short": "List and inspect credentials (secrets are server-masked)",
+          "aliases": [
+            "creds"
+          ],
+          "group_title": "APIs",
+          "flags": [
+            {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            }
+          ],
+          "subcommands": [
+            {
+              "name": "list",
+              "path": "jentic credentials list",
+              "use": "list",
+              "short": "List credentials",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "cursor",
+                  "type": "string",
+                  "usage": "Fetch the page at this opaque cursor"
+                },
+                {
+                  "name": "limit",
+                  "type": "int",
+                  "default": "0",
+                  "usage": "Fetch a single page of at most N credentials"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                },
+                {
+                  "name": "vendor",
+                  "type": "string",
+                  "usage": "Filter by vendor"
+                }
+              ]
+            },
+            {
+              "name": "show",
+              "path": "jentic credentials show",
+              "use": "show \u003ccredential_id\u003e",
+              "short": "Show a credential (secret-masked)",
+              "flags": [
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                }
+              ]
             }
           ]
         },

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -1669,6 +1669,18 @@
                   "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
                 },
                 {
+                  "name": "dry-run",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "Validate and print the request that WOULD be sent, without sending it"
+                },
+                {
+                  "name": "export-plan",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "Emit a machine-readable execution plan (implies --dry-run)"
+                },
+                {
                   "name": "mode",
                   "type": "string",
                   "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"


### PR DESCRIPTION
## Summary

CLI-V2 **Phase 5 — Agent Features**, stacked on #990 (Phase 4). Adds the agent-facing surface on top of the V2 SDK/commands from earlier phases: telemetry, history/events export, a self-describing `jentic api` passthrough, curated commands, dry-run planning, backend version negotiation, the `execute` transport re-plumb, the `doctor` local-agent self-check, and the V2 agent-skill rewrite.

### Items (plan.md Phase 5)

- **Item 2 — Telemetry:** `client.Config.SessionID` + `sessionEditor` inject `X-Jentic-Session-Id` into the editor chain; mapped from `ResolvedState`/`JENTIC_SESSION_ID`.
- **Item 3 — `jentic history export`:** `--trace/--from/--to/--api/--include-failures/--limit/--cursor/-o` via generated `ListExecutions` + `paginate.All`; `ux.Export` envelope; failures excluded by default.
- **Item 4 — `jentic events watch`:** NDJSON tail of the control-plane SSE stream with `Last-Event-Id` resume.
- **Item 7a — `jentic api` passthrough:** `gh api`-style `api <METHOD> <PATH>` + `api ops` (embedded-spec allowlist) + `api describe`; `//go:embed` vendored control spec parsed with libopenapi; `-d/--data-file/-d-`/auto-stdin body; `--fail-on-error`, `--live`, loopback-gated `--raw`.
- **Item 7b — Curated commands:** `credentials list/show` (masked), `apis import <file|url>`, and `access` `approve_url` absolutization against the env base URL.
- **Item 5 — Dry-run / plan export:** `ux.Plan` + `planFlags`/`maybeEmitPlan`; `--dry-run`/`--export-plan` on mutating curated commands.
- **Item 9 — Backend version negotiation:** SDK `ProbeServerVersion`; a 404 on an embedded-spec route is enriched as `RESOLVE_FAILED` + `details.route_unsupported_upstream` + server version (probe skipped for `--raw`/`--live`).
- **Item 1 — `execute` re-plumb:** `jentic execute` now sends through `client.BrokerTransport` (shared 429/5xx idempotent backoff) instead of a bare `http.Client`, preserving its exact `METHOD:url|operation_id|METHOD:/path` contract and `agent_directive`/exit-2 denial handling. The 401 re-exchange arm is disabled on this transport (execute owns its bearer; a broker 401 is a recoverable denial whose directive body must reach the caller intact).
- **Item 6 — Local-agent isolation:** verification/port item — `run`/`reset`/`bootstrap`/the `localagent` package and its arch/CI guards (5.1 §4) carry through unchanged. New: a **`jentic doctor` "Local agent" self-check** (5.1 §3c) reporting confinement prereqs (same `AgentUserPrereqs` probe as `run`'s launch gate) and a same-uid warning for a provisioned agent account — the client-side sibling, since `jenticctl` is absent from agent hosts.
- **Item 8 — Agent skill:** extends bundled `jentic.md` with the V2 surface (the `api ops→describe→call` loop, the machine-contract envelope + closed error codes + exit taxonomy, transport-error recovery), alongside the still-default V1 flow (ship before activation).

## Test plan

- [x] `go vet ./...`
- [x] `go test -race ./...` (29 pkgs, incl. arch + golden)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make check-cli-gen` — no codegen drift
- [x] `TestCommittedCLIReferenceUpToDate` — cli-reference.json in sync