### PR TITLE
feat(ui): webhooks prototype — event destinations with HTTPS and Slack types

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -83,6 +83,7 @@ const MODULE_QUERY_KEY_ROOTS = {
 	dashboard: ['dashboard'],
 	agents: ['agents', 'service-accounts'],
 	monitor: ['monitor'],
+	webhooks: ['webhooks'],
 	docs: ['docs'],
 };
 

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -7,6 +7,7 @@ import { workspaceHandlers } from '@/modules/workspace/mocks/handlers';
 import { credentialsHandlers, credentialsE2eHooks } from '@/shared/credentials/mocks/handlers';
 import { railEventsHandlers } from '@/shared/app/rail/mocks/handlers';
 import { monitorHandlers } from '@/modules/monitor/mocks/handlers';
+import { webhooksHandlers } from '@/modules/webhooks/mocks/handlers';
 
 /**
  * Root MSW handler table.
@@ -163,6 +164,9 @@ export const handlers = [
 	// here keeps the Monitor page working in mocked dev when no other module's
 	// handler claimed the path.
 	...monitorHandlers,
+	// Webhooks (PROTOTYPE): the module has no backend surface yet, so these
+	// mocks are the only source for `/webhooks…` in mocked dev.
+	...webhooksHandlers,
 	// Extensibility seam: `handlers` is exported (not module-private) so a
 	// consumer can compose `[...handlers, ...extraHandlers]`. MSW is
 	// FIRST-MATCH-WINS, so a consumer must append at a DELIBERATE position —

--- a/ui/src/modules/webhooks/api/client.ts
+++ b/ui/src/modules/webhooks/api/client.ts
@@ -1,0 +1,150 @@
+/**
+ * Webhooks repository tier.
+ *
+ * PROTOTYPE: the platform has no webhooks backend surface yet, so there is no
+ * generated OpenAPI service to call. This repository speaks plain `fetch`
+ * against the paths the module's MSW handlers mock (`/webhooks…`), keeping the
+ * same repository shape as other modules so swapping in the generated client
+ * later only touches this file.
+ */
+import type {
+	EndpointCreateInput,
+	EndpointCreateResult,
+	EndpointPatch,
+	EventTypeDef,
+	RotateSecretResult,
+	WebhookDeliveryEntity,
+	WebhookDeliveryRow,
+	WebhookEndpointEntity,
+	WebhookEndpointRow,
+} from '@/modules/webhooks/api/types';
+import { toDeliveryEntity, toEndpointEntity } from '@/modules/webhooks/api/types';
+
+/** Module sentinel error — views catch this, never raw fetch failures. */
+export class WebhooksApiError extends Error {
+	readonly status: number | null;
+
+	constructor(message: string, status: number | null = null) {
+		super(message);
+		this.name = 'WebhooksApiError';
+		this.status = status;
+	}
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+	let res: Response;
+	try {
+		res = await fetch(path, {
+			headers: { 'Content-Type': 'application/json' },
+			...init,
+		});
+	} catch {
+		throw new WebhooksApiError('Network error while contacting the webhooks API.');
+	}
+	if (!res.ok) {
+		let detail = `Request failed (${res.status}).`;
+		try {
+			const body = (await res.json()) as { detail?: string };
+			if (body.detail) detail = body.detail;
+		} catch {
+			// non-JSON error body — keep the generic message
+		}
+		throw new WebhooksApiError(detail, res.status);
+	}
+	if (res.status === 204) return undefined as T;
+	return (await res.json()) as T;
+}
+
+export async function listEndpoints(): Promise<WebhookEndpointEntity[]> {
+	const body = await request<{ data: WebhookEndpointRow[] }>('/webhooks');
+	return body.data.map(toEndpointEntity);
+}
+
+export async function getEndpoint(id: string): Promise<WebhookEndpointEntity> {
+	const row = await request<WebhookEndpointRow>(`/webhooks/${encodeURIComponent(id)}`);
+	return toEndpointEntity(row);
+}
+
+export async function listEventTypes(): Promise<EventTypeDef[]> {
+	const body = await request<{ data: EventTypeDef[] }>('/webhooks/event-types');
+	return body.data;
+}
+
+export async function createEndpoint(input: EndpointCreateInput): Promise<EndpointCreateResult> {
+	const body = await request<{
+		endpoint: WebhookEndpointRow;
+		secret: string | null;
+		ping: EndpointCreateResult['ping'];
+	}>('/webhooks', { method: 'POST', body: JSON.stringify(input) });
+	return { endpoint: toEndpointEntity(body.endpoint), secret: body.secret, ping: body.ping };
+}
+
+export async function updateEndpoint(
+	id: string,
+	patch: EndpointPatch,
+): Promise<WebhookEndpointEntity> {
+	const row = await request<WebhookEndpointRow>(`/webhooks/${encodeURIComponent(id)}`, {
+		method: 'PATCH',
+		body: JSON.stringify(patch),
+	});
+	return toEndpointEntity(row);
+}
+
+export async function pauseEndpoint(id: string): Promise<WebhookEndpointEntity> {
+	const row = await request<WebhookEndpointRow>(`/webhooks/${encodeURIComponent(id)}/pause`, {
+		method: 'POST',
+	});
+	return toEndpointEntity(row);
+}
+
+export async function resumeEndpoint(id: string): Promise<WebhookEndpointEntity> {
+	const row = await request<WebhookEndpointRow>(`/webhooks/${encodeURIComponent(id)}/resume`, {
+		method: 'POST',
+	});
+	return toEndpointEntity(row);
+}
+
+export async function rotateEndpointSecret(id: string): Promise<RotateSecretResult> {
+	const body = await request<{ secret: string; secret_preview: string }>(
+		`/webhooks/${encodeURIComponent(id)}/rotate-secret`,
+		{ method: 'POST' },
+	);
+	return { secret: body.secret, secretPreview: body.secret_preview };
+}
+
+export async function deleteEndpoint(id: string): Promise<void> {
+	await request<void>(`/webhooks/${encodeURIComponent(id)}`, { method: 'DELETE' });
+}
+
+export async function sendTestEvent(id: string, eventType: string): Promise<WebhookDeliveryEntity> {
+	const body = await request<{ delivery: WebhookDeliveryRow }>(
+		`/webhooks/${encodeURIComponent(id)}/test`,
+		{ method: 'POST', body: JSON.stringify({ event_type: eventType }) },
+	);
+	return toDeliveryEntity(body.delivery);
+}
+
+export async function listDeliveries(
+	id: string,
+	filters: { status?: string | null; eventType?: string | null } = {},
+): Promise<WebhookDeliveryEntity[]> {
+	const q = new URLSearchParams();
+	if (filters.status) q.set('status', filters.status);
+	if (filters.eventType) q.set('event_type', filters.eventType);
+	const suffix = q.size > 0 ? `?${q.toString()}` : '';
+	const body = await request<{ data: WebhookDeliveryRow[] }>(
+		`/webhooks/${encodeURIComponent(id)}/deliveries${suffix}`,
+	);
+	return body.data.map(toDeliveryEntity);
+}
+
+export async function redeliverDelivery(
+	endpointId: string,
+	deliveryId: string,
+): Promise<WebhookDeliveryEntity> {
+	const body = await request<{ delivery: WebhookDeliveryRow }>(
+		`/webhooks/${encodeURIComponent(endpointId)}/deliveries/${encodeURIComponent(deliveryId)}/redeliver`,
+		{ method: 'POST' },
+	);
+	return toDeliveryEntity(body.delivery);
+}

--- a/ui/src/modules/webhooks/api/hooks.ts
+++ b/ui/src/modules/webhooks/api/hooks.ts
@@ -1,0 +1,242 @@
+/**
+ * Webhooks service tier — TanStack Query hooks.
+ *
+ * The only data-access path for webhooks views: components call these hooks,
+ * which call the repository (`./client`). Mutations invalidate the affected
+ * slices and toast on settle, mirroring the agents/toolkits modules.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from '@/shared/ui';
+import {
+	createEndpoint,
+	deleteEndpoint,
+	getEndpoint,
+	listDeliveries,
+	listEndpoints,
+	listEventTypes,
+	pauseEndpoint,
+	redeliverDelivery,
+	resumeEndpoint,
+	rotateEndpointSecret,
+	sendTestEvent,
+	updateEndpoint,
+} from '@/modules/webhooks/api/client';
+import type {
+	EndpointCreateInput,
+	EndpointCreateResult,
+	EndpointPatch,
+	EventTypeDef,
+	RotateSecretResult,
+	WebhookDeliveryEntity,
+	WebhookEndpointEntity,
+} from '@/modules/webhooks/api/types';
+
+const webhooksKeys = {
+	all: ['webhooks'] as const,
+	list: () => [...webhooksKeys.all, 'list'] as const,
+	detail: (id: string) => [...webhooksKeys.all, 'detail', id] as const,
+	deliveries: (id: string, status: string, eventType: string) =>
+		[...webhooksKeys.all, 'deliveries', id, status, eventType] as const,
+	deliveriesRoot: (id: string) => [...webhooksKeys.all, 'deliveries', id] as const,
+	eventTypes: ['webhooks', 'event-types'] as const,
+};
+
+function notifyError(error: unknown, fallback: string): void {
+	toast({
+		title: fallback,
+		description: error instanceof Error ? error.message : undefined,
+		variant: 'error',
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+export function useWebhookEndpoints() {
+	return useQuery<WebhookEndpointEntity[]>({
+		queryKey: webhooksKeys.list(),
+		queryFn: () => listEndpoints(),
+	});
+}
+
+export function useWebhookEndpoint(id: string | null) {
+	return useQuery<WebhookEndpointEntity>({
+		queryKey: webhooksKeys.detail(id ?? ''),
+		queryFn: () => getEndpoint(id as string),
+		enabled: id != null,
+	});
+}
+
+/** The subscribable event catalog. Small + slow-changing → cached generously. */
+export function useEventTypeCatalog() {
+	return useQuery<EventTypeDef[]>({
+		queryKey: webhooksKeys.eventTypes,
+		queryFn: () => listEventTypes(),
+		staleTime: 5 * 60 * 1000,
+	});
+}
+
+export function useWebhookDeliveries(
+	id: string | null,
+	filters: { status?: string | null; eventType?: string | null } = {},
+) {
+	const status = filters.status ?? 'all';
+	const eventType = filters.eventType ?? 'all';
+	return useQuery<WebhookDeliveryEntity[]>({
+		queryKey: webhooksKeys.deliveries(id ?? '', status, eventType),
+		queryFn: () =>
+			listDeliveries(id as string, {
+				status: status === 'all' ? null : status,
+				eventType: eventType === 'all' ? null : eventType,
+			}),
+		enabled: id != null,
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+export function useCreateEndpoint() {
+	const qc = useQueryClient();
+	return useMutation<EndpointCreateResult, Error, EndpointCreateInput>({
+		mutationFn: (input) => createEndpoint(input),
+		onSuccess: (result) => {
+			qc.setQueryData(webhooksKeys.detail(result.endpoint.id), result.endpoint);
+			qc.invalidateQueries({ queryKey: webhooksKeys.list() });
+			toast({
+				title: 'Endpoint created',
+				description: `${result.endpoint.name} is now receiving events.`,
+				variant: 'success',
+			});
+		},
+		onError: (e) => notifyError(e, 'Failed to create the endpoint.'),
+	});
+}
+
+export function useUpdateEndpoint() {
+	const qc = useQueryClient();
+	return useMutation<WebhookEndpointEntity, Error, { id: string; patch: EndpointPatch }>({
+		mutationFn: ({ id, patch }) => updateEndpoint(id, patch),
+		onSuccess: (endpoint) => {
+			qc.setQueryData(webhooksKeys.detail(endpoint.id), endpoint);
+			qc.invalidateQueries({ queryKey: webhooksKeys.list() });
+			toast({ title: 'Endpoint updated', variant: 'success' });
+		},
+		onError: (e) => notifyError(e, 'Failed to update the endpoint.'),
+	});
+}
+
+export function usePauseEndpoint() {
+	const qc = useQueryClient();
+	return useMutation<WebhookEndpointEntity, Error, string>({
+		mutationFn: (id) => pauseEndpoint(id),
+		onSuccess: (endpoint) => {
+			qc.setQueryData(webhooksKeys.detail(endpoint.id), endpoint);
+			qc.invalidateQueries({ queryKey: webhooksKeys.list() });
+			toast({
+				title: 'Deliveries paused',
+				description: 'Events fired while paused are not queued for later.',
+				variant: 'success',
+			});
+		},
+		onError: (e) => notifyError(e, 'Failed to pause the endpoint.'),
+	});
+}
+
+export function useResumeEndpoint() {
+	const qc = useQueryClient();
+	return useMutation<WebhookEndpointEntity, Error, string>({
+		mutationFn: (id) => resumeEndpoint(id),
+		onSuccess: (endpoint) => {
+			qc.setQueryData(webhooksKeys.detail(endpoint.id), endpoint);
+			qc.invalidateQueries({ queryKey: webhooksKeys.list() });
+			toast({ title: 'Deliveries resumed', variant: 'success' });
+		},
+		onError: (e) => notifyError(e, 'Failed to resume the endpoint.'),
+	});
+}
+
+export function useRotateEndpointSecret() {
+	const qc = useQueryClient();
+	return useMutation<RotateSecretResult, Error, string>({
+		mutationFn: (id) => rotateEndpointSecret(id),
+		onSuccess: (_result, id) => {
+			qc.invalidateQueries({ queryKey: webhooksKeys.detail(id) });
+			qc.invalidateQueries({ queryKey: webhooksKeys.list() });
+		},
+		onError: (e) => notifyError(e, 'Failed to rotate the signing secret.'),
+	});
+}
+
+export function useDeleteEndpoint() {
+	const qc = useQueryClient();
+	return useMutation<void, Error, string>({
+		mutationFn: (id) => deleteEndpoint(id),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: webhooksKeys.list() });
+			toast({ title: 'Endpoint deleted', variant: 'success' });
+		},
+		onError: (e) => notifyError(e, 'Failed to delete the endpoint.'),
+	});
+}
+
+export function useSendTestEvent(endpointId: string | null) {
+	const qc = useQueryClient();
+	return useMutation<WebhookDeliveryEntity, Error, string>({
+		mutationFn: (eventType) => {
+			if (!endpointId) {
+				return Promise.reject(
+					new Error('Cannot send a test event before the endpoint loads.'),
+				);
+			}
+			return sendTestEvent(endpointId, eventType);
+		},
+		onSuccess: (delivery) => {
+			if (endpointId) {
+				qc.invalidateQueries({ queryKey: webhooksKeys.deliveriesRoot(endpointId) });
+				qc.invalidateQueries({ queryKey: webhooksKeys.detail(endpointId) });
+				qc.invalidateQueries({ queryKey: webhooksKeys.list() });
+			}
+			toast({
+				title:
+					delivery.status === 'delivered' ? 'Test event delivered' : 'Test event failed',
+				description:
+					delivery.status === 'delivered'
+						? `Endpoint answered ${delivery.lastHttpStatus ?? '—'} in ${delivery.lastLatencyMs ?? '—'} ms.`
+						: (delivery.attempts[delivery.attempts.length - 1]?.error ??
+							`Endpoint answered ${delivery.lastHttpStatus ?? 'nothing'}.`),
+				variant: delivery.status === 'delivered' ? 'success' : 'error',
+			});
+		},
+		onError: (e) => notifyError(e, 'Failed to send the test event.'),
+	});
+}
+
+export function useRedeliverDelivery(endpointId: string | null) {
+	const qc = useQueryClient();
+	return useMutation<WebhookDeliveryEntity, Error, string>({
+		mutationFn: (deliveryId) => {
+			if (!endpointId) {
+				return Promise.reject(new Error('Cannot redeliver before the endpoint loads.'));
+			}
+			return redeliverDelivery(endpointId, deliveryId);
+		},
+		onSuccess: (delivery) => {
+			if (endpointId) {
+				qc.invalidateQueries({ queryKey: webhooksKeys.deliveriesRoot(endpointId) });
+				qc.invalidateQueries({ queryKey: webhooksKeys.detail(endpointId) });
+				qc.invalidateQueries({ queryKey: webhooksKeys.list() });
+			}
+			toast({
+				title:
+					delivery.status === 'delivered'
+						? 'Event redelivered'
+						: 'Redelivery attempt failed',
+				variant: delivery.status === 'delivered' ? 'success' : 'error',
+			});
+		},
+		onError: (e) => notifyError(e, 'Failed to redeliver the event.'),
+	});
+}

--- a/ui/src/modules/webhooks/api/index.ts
+++ b/ui/src/modules/webhooks/api/index.ts
@@ -1,0 +1,3 @@
+export * from '@/modules/webhooks/api/types';
+export { WebhooksApiError } from '@/modules/webhooks/api/client';
+export * from '@/modules/webhooks/api/hooks';

--- a/ui/src/modules/webhooks/api/types.ts
+++ b/ui/src/modules/webhooks/api/types.ts
@@ -1,0 +1,216 @@
+/**
+ * Webhooks module — UI entities and wire shapes.
+ *
+ * PROTOTYPE: there is no backend surface yet, so these mirror the wire shapes
+ * the mocked handlers serve (snake_case rows adapted into camelCase entities,
+ * matching the module conventions used by agents/toolkits).
+ */
+
+/**
+ * Where deliveries go (Stripe "event destination" pattern):
+ * - `https` — generic signed webhook for machines (verify + retry).
+ * - `slack` — Slack incoming webhook; events are rendered as human-readable
+ *   Block Kit messages and carry no signature (the URL itself is the secret).
+ */
+export type DestinationType = 'https' | 'slack';
+
+/** Wire status of an endpoint. `failing` is derived client-side. */
+export type EndpointWireStatus = 'active' | 'paused' | 'disabled';
+
+/** Display status — `failing` = active but with consecutive delivery failures. */
+export type EndpointDisplayStatus = 'active' | 'failing' | 'paused' | 'disabled';
+
+export interface WebhookEndpointRow {
+	id: string;
+	name: string;
+	url: string;
+	description: string | null;
+	destination_type: DestinationType;
+	status: EndpointWireStatus;
+	/** Subscribed event types; `['*']` means all events. */
+	event_types: string[];
+	/** Null for destinations without a signing secret (e.g. Slack). */
+	secret_preview: string | null;
+	consecutive_failures: number;
+	deliveries_24h: number;
+	/** 0–1 success ratio over the trailing 24 h; null when no deliveries. */
+	success_rate_24h: number | null;
+	last_delivery_at: string | null;
+	last_delivery_ok: boolean | null;
+	created_at: string;
+	updated_at: string | null;
+}
+
+export interface WebhookEndpointEntity {
+	id: string;
+	name: string;
+	url: string;
+	description: string | null;
+	destinationType: DestinationType;
+	status: EndpointDisplayStatus;
+	wireStatus: EndpointWireStatus;
+	eventTypes: string[];
+	subscribesToAll: boolean;
+	secretPreview: string | null;
+	consecutiveFailures: number;
+	deliveries24h: number;
+	successRate24h: number | null;
+	lastDeliveryAt: string | null;
+	lastDeliveryOk: boolean | null;
+	createdAt: string;
+	updatedAt: string | null;
+}
+
+/** Endpoints with this many consecutive failures render as `failing`. */
+const FAILING_THRESHOLD = 3;
+
+export function toEndpointEntity(row: WebhookEndpointRow): WebhookEndpointEntity {
+	const subscribesToAll = row.event_types.includes('*');
+	const status: EndpointDisplayStatus =
+		row.status === 'active' && row.consecutive_failures >= FAILING_THRESHOLD
+			? 'failing'
+			: row.status;
+	return {
+		id: row.id,
+		name: row.name,
+		url: row.url,
+		description: row.description,
+		destinationType: row.destination_type,
+		status,
+		wireStatus: row.status,
+		eventTypes: row.event_types,
+		subscribesToAll,
+		secretPreview: row.secret_preview,
+		consecutiveFailures: row.consecutive_failures,
+		deliveries24h: row.deliveries_24h,
+		successRate24h: row.success_rate_24h,
+		lastDeliveryAt: row.last_delivery_at,
+		lastDeliveryOk: row.last_delivery_ok,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Deliveries
+// ---------------------------------------------------------------------------
+
+export type DeliveryStatus = 'delivered' | 'pending' | 'failed' | 'exhausted';
+
+export interface DeliveryAttemptRow {
+	attempted_at: string;
+	ok: boolean;
+	http_status: number | null;
+	error: string | null;
+	latency_ms: number;
+}
+
+export interface WebhookDeliveryRow {
+	id: string;
+	endpoint_id: string;
+	event_id: string;
+	event_type: string;
+	status: DeliveryStatus;
+	attempts: DeliveryAttemptRow[];
+	next_attempt_at: string | null;
+	request_headers: Record<string, string>;
+	payload: unknown;
+	response_body: string | null;
+	is_test: boolean;
+	is_redelivery: boolean;
+	created_at: string;
+}
+
+export interface WebhookDeliveryEntity {
+	id: string;
+	endpointId: string;
+	eventId: string;
+	eventType: string;
+	status: DeliveryStatus;
+	attempts: DeliveryAttemptRow[];
+	nextAttemptAt: string | null;
+	requestHeaders: Record<string, string>;
+	payload: unknown;
+	responseBody: string | null;
+	isTest: boolean;
+	isRedelivery: boolean;
+	createdAt: string;
+	/** Latency of the most recent attempt, ms. */
+	lastLatencyMs: number | null;
+	/** HTTP status of the most recent attempt. */
+	lastHttpStatus: number | null;
+}
+
+export function toDeliveryEntity(row: WebhookDeliveryRow): WebhookDeliveryEntity {
+	const last = row.attempts.length > 0 ? row.attempts[row.attempts.length - 1] : null;
+	return {
+		id: row.id,
+		endpointId: row.endpoint_id,
+		eventId: row.event_id,
+		eventType: row.event_type,
+		status: row.status,
+		attempts: row.attempts,
+		nextAttemptAt: row.next_attempt_at,
+		requestHeaders: row.request_headers,
+		payload: row.payload,
+		responseBody: row.response_body,
+		isTest: row.is_test,
+		isRedelivery: row.is_redelivery,
+		createdAt: row.created_at,
+		lastLatencyMs: last?.latency_ms ?? null,
+		lastHttpStatus: last?.http_status ?? null,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Event catalog
+// ---------------------------------------------------------------------------
+
+/** One subscribable platform event type (mirrors `EventType` on the backend). */
+export interface EventTypeDef {
+	type: string;
+	/** Namespace group, e.g. `execution`, `credential`, `agent`. */
+	group: string;
+	description: string;
+}
+
+// ---------------------------------------------------------------------------
+// Mutation payloads / results
+// ---------------------------------------------------------------------------
+
+export interface EndpointCreateInput {
+	name: string;
+	url: string;
+	description: string | null;
+	destination_type: DestinationType;
+	event_types: string[];
+}
+
+export interface EndpointPatch {
+	name?: string;
+	url?: string;
+	description?: string | null;
+	event_types?: string[];
+}
+
+export interface PingResult {
+	ok: boolean;
+	http_status: number | null;
+	latency_ms: number;
+	error: string | null;
+}
+
+/**
+ * `POST /webhooks` result — for `https` destinations the plaintext secret is
+ * returned exactly once; Slack destinations have no signing secret (null).
+ */
+export interface EndpointCreateResult {
+	endpoint: WebhookEndpointEntity;
+	secret: string | null;
+	ping: PingResult;
+}
+
+export interface RotateSecretResult {
+	secret: string;
+	secretPreview: string;
+}

--- a/ui/src/modules/webhooks/components/CreateEndpointSheet.tsx
+++ b/ui/src/modules/webhooks/components/CreateEndpointSheet.tsx
@@ -1,0 +1,307 @@
+import { useEffect, useState } from 'react';
+import { CheckCircle2, Hash, Webhook, X, XCircle } from 'lucide-react';
+import { Button, ErrorAlert, Input, Label, SheetPrimitive, Textarea } from '@/shared/ui';
+import {
+	useCreateEndpoint,
+	useEventTypeCatalog,
+	type DestinationType,
+	type PingResult,
+} from '@/modules/webhooks/api';
+import { EventTypePicker } from '@/modules/webhooks/components/EventTypePicker';
+import { SecretReveal } from '@/modules/webhooks/components/SecretReveal';
+import { SlackMessagePreview } from '@/modules/webhooks/components/SlackMessagePreview';
+
+/**
+ * "New destination" slide-over (flow F1): destination type first (Stripe's
+ * event-destination pattern), then a form that adapts — signed HTTPS webhooks
+ * for machines, Slack incoming webhooks for humans. On success the panel shows
+ * the one-time signing secret (https only) and the automatic ping result, so
+ * reachability feedback is immediate. Draft persists across dismissals; the
+ * secret never does.
+ */
+const DESTINATION_OPTIONS: Array<{
+	type: DestinationType;
+	label: string;
+	description: string;
+	Icon: typeof Webhook;
+}> = [
+	{
+		type: 'https',
+		label: 'HTTPS endpoint',
+		description: 'Signed JSON POSTs to your own service. Verify the signature, get retries.',
+		Icon: Webhook,
+	},
+	{
+		type: 'slack',
+		label: 'Slack channel',
+		description: 'Readable messages in a channel, via a Slack incoming webhook URL.',
+		Icon: Hash,
+	},
+];
+
+export function CreateEndpointSheet({ open, onClose }: { open: boolean; onClose: () => void }) {
+	const { data: catalog = [] } = useEventTypeCatalog();
+	const create = useCreateEndpoint();
+
+	const [destination, setDestination] = useState<DestinationType>('https');
+	const [name, setName] = useState('');
+	const [url, setUrl] = useState('');
+	const [description, setDescription] = useState('');
+	const [eventTypes, setEventTypes] = useState<string[]>([]);
+	const [formError, setFormError] = useState<string | null>(null);
+	// Post-create result state — sensitive, wiped on every close.
+	const [secret, setSecret] = useState<string | null>(null);
+	const [created, setCreated] = useState(false);
+	const [ping, setPing] = useState<PingResult | null>(null);
+
+	// Transient flags are not user input — clear on every (re)open.
+	useEffect(() => {
+		if (!open) return;
+		setFormError(null);
+	}, [open]);
+
+	// Sensitive-data exception: wipe the one-time secret whenever the sheet closes.
+	useEffect(() => {
+		if (!open) {
+			setSecret(null);
+			setCreated(false);
+			setPing(null);
+		}
+	}, [open]);
+
+	const isSlack = destination === 'slack';
+
+	const validate = (): string | null => {
+		if (!name.trim()) return 'Give the destination a name.';
+		if (isSlack && !url.trim().startsWith('https://hooks.slack.com/')) {
+			return 'Paste a Slack incoming webhook URL (it starts with https://hooks.slack.com/).';
+		}
+		if (!url.trim().startsWith('https://')) return 'The endpoint URL must start with https://.';
+		if (eventTypes.length === 0) return 'Subscribe to at least one event type.';
+		return null;
+	};
+
+	const submit = () => {
+		const problem = validate();
+		setFormError(problem);
+		if (problem) return;
+		create.mutate(
+			{
+				name: name.trim(),
+				url: url.trim(),
+				description: description.trim() || null,
+				destination_type: destination,
+				event_types: eventTypes,
+			},
+			{
+				onSuccess: (result) => {
+					// Reset the draft only on the success path.
+					setName('');
+					setUrl('');
+					setDescription('');
+					setEventTypes([]);
+					setSecret(result.secret);
+					setCreated(true);
+					setPing(result.ping);
+				},
+			},
+		);
+	};
+
+	const previewEventType = eventTypes.find((t) => t !== '*');
+
+	return (
+		<SheetPrimitive open={open} onClose={onClose} ariaLabel="New webhook destination">
+			<div className="flex h-full flex-col">
+				<div className="border-border flex items-center justify-between border-b px-5 py-4">
+					<div className="flex items-center gap-2">
+						<Webhook className="text-primary h-4 w-4" aria-hidden="true" />
+						<h2 className="text-foreground text-base font-semibold">New destination</h2>
+					</div>
+					<Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
+						<X className="h-5 w-5" />
+					</Button>
+				</div>
+
+				<div className="flex-1 space-y-5 overflow-y-auto px-5 py-4">
+					{created ? (
+						<div className="space-y-4">
+							{secret ? (
+								<SecretReveal secret={secret} onConfirm={onClose} />
+							) : (
+								<div className="border-success/40 bg-success/5 rounded-lg border p-3">
+									<p className="text-foreground flex items-center gap-2 text-sm font-medium">
+										<CheckCircle2
+											className="text-success h-4 w-4"
+											aria-hidden="true"
+										/>
+										Slack destination created
+									</p>
+									<p className="text-muted-foreground mt-1 text-xs">
+										No signing secret is involved — Slack incoming webhooks are
+										unsigned, the URL itself is the credential. Keep it private.
+									</p>
+								</div>
+							)}
+							{ping && (
+								<div
+									className={
+										ping.ok
+											? 'border-success/40 bg-success/5 rounded-lg border p-3'
+											: 'border-danger/40 bg-danger/5 rounded-lg border p-3'
+									}
+								>
+									<p className="text-foreground flex items-center gap-2 text-sm font-medium">
+										{ping.ok ? (
+											<CheckCircle2
+												className="text-success h-4 w-4"
+												aria-hidden="true"
+											/>
+										) : (
+											<XCircle
+												className="text-danger h-4 w-4"
+												aria-hidden="true"
+											/>
+										)}
+										{ping.ok
+											? secret
+												? `Ping delivered — ${ping.http_status} in ${ping.latency_ms} ms`
+												: `Test message posted — ${ping.http_status} in ${ping.latency_ms} ms`
+											: secret
+												? 'Ping failed'
+												: 'Test message failed'}
+									</p>
+									{!ping.ok && (
+										<p className="text-muted-foreground mt-1 text-xs">
+											{ping.error ?? 'The destination did not answer.'}{' '}
+											Deliveries will retry automatically; check the
+											Deliveries tab.
+										</p>
+									)}
+								</div>
+							)}
+							{!secret && (
+								<div className="flex justify-end">
+									<Button onClick={onClose}>Done</Button>
+								</div>
+							)}
+						</div>
+					) : (
+						<>
+							<div className="space-y-1.5">
+								<Label>Destination type</Label>
+								<div
+									className="grid grid-cols-1 gap-2 sm:grid-cols-2"
+									role="radiogroup"
+									aria-label="Destination type"
+								>
+									{DESTINATION_OPTIONS.map(
+										({ type, label, description: desc, Icon }) => {
+											const selected = destination === type;
+											return (
+												<button
+													key={type}
+													type="button"
+													role="radio"
+													aria-checked={selected}
+													onClick={() => setDestination(type)}
+													className={`rounded-lg border p-3 text-left transition-colors ${
+														selected
+															? 'border-primary bg-primary/5'
+															: 'border-border hover:border-primary/40'
+													}`}
+												>
+													<span className="text-foreground flex items-center gap-2 text-sm font-medium">
+														<Icon
+															className={`h-4 w-4 ${selected ? 'text-primary' : 'text-muted-foreground'}`}
+															aria-hidden="true"
+														/>
+														{label}
+													</span>
+													<span className="text-muted-foreground mt-1 block text-xs">
+														{desc}
+													</span>
+												</button>
+											);
+										},
+									)}
+								</div>
+							</div>
+							<div className="space-y-1.5">
+								<Label htmlFor="webhook-name">Name</Label>
+								<Input
+									id="webhook-name"
+									value={name}
+									onChange={(e) => setName(e.target.value)}
+									placeholder={isSlack ? '#jentic-ops channel' : 'SIEM export'}
+									autoFocus
+								/>
+							</div>
+							<div className="space-y-1.5">
+								<Label htmlFor="webhook-url">
+									{isSlack ? 'Slack incoming webhook URL' : 'Endpoint URL'}
+								</Label>
+								<Input
+									id="webhook-url"
+									value={url}
+									onChange={(e) => setUrl(e.target.value)}
+									placeholder={
+										isSlack
+											? 'https://hooks.slack.com/services/T…/B…/…'
+											: 'https://example.com/hooks/jentic'
+									}
+									inputMode="url"
+								/>
+								<p className="text-muted-foreground text-xs">
+									{isSlack
+										? 'In Slack: create an app → Incoming Webhooks → pick the channel, then paste the URL here. Events arrive as formatted messages — no code needed.'
+										: 'HTTPS only. Each delivery is signed (Standard Webhooks headers) so the receiver can verify it came from this instance.'}
+								</p>
+							</div>
+							<div className="space-y-1.5">
+								<Label htmlFor="webhook-description">Description (optional)</Label>
+								<Textarea
+									id="webhook-description"
+									value={description}
+									onChange={(e) => setDescription(e.target.value)}
+									rows={2}
+									placeholder={
+										isSlack
+											? 'Who watches this channel?'
+											: 'What consumes these events?'
+									}
+								/>
+							</div>
+							<div className="space-y-1.5">
+								<Label>Events to send</Label>
+								<EventTypePicker
+									catalog={catalog}
+									value={eventTypes}
+									onChange={setEventTypes}
+								/>
+							</div>
+							{isSlack && (
+								<div className="space-y-1.5">
+									<Label>Message preview</Label>
+									<SlackMessagePreview eventType={previewEventType} />
+								</div>
+							)}
+							{formError && <ErrorAlert message={formError} />}
+						</>
+					)}
+				</div>
+
+				{!created && (
+					<div className="border-border flex justify-end gap-2 border-t px-5 py-4">
+						<Button variant="secondary" onClick={onClose}>
+							Cancel
+						</Button>
+						<Button onClick={submit} loading={create.isPending}>
+							{isSlack ? 'Connect Slack channel' : 'Create endpoint'}
+						</Button>
+					</div>
+				)}
+			</div>
+		</SheetPrimitive>
+	);
+}

--- a/ui/src/modules/webhooks/components/EventTypePicker.tsx
+++ b/ui/src/modules/webhooks/components/EventTypePicker.tsx
@@ -1,0 +1,102 @@
+import { useMemo, useState } from 'react';
+import { Filter } from 'lucide-react';
+import { Checkbox, SearchInput } from '@/shared/ui';
+import type { EventTypeDef } from '@/modules/webhooks/api';
+
+/**
+ * Grouped multi-select over the platform event catalog, with an "all events"
+ * wildcard toggle. `value` is the wire shape: `['*']` for everything, or an
+ * explicit list of event types.
+ */
+export function EventTypePicker({
+	catalog,
+	value,
+	onChange,
+}: {
+	catalog: EventTypeDef[];
+	value: string[];
+	onChange: (next: string[]) => void;
+}) {
+	const [query, setQuery] = useState('');
+	const allSelected = value.includes('*');
+	const selected = useMemo(() => new Set(value), [value]);
+
+	const groups = useMemo(() => {
+		const q = query.trim().toLowerCase();
+		const filtered = q
+			? catalog.filter(
+					(e) =>
+						e.type.toLowerCase().includes(q) || e.description.toLowerCase().includes(q),
+				)
+			: catalog;
+		const byGroup = new Map<string, EventTypeDef[]>();
+		for (const entry of filtered) {
+			const bucket = byGroup.get(entry.group) ?? [];
+			bucket.push(entry);
+			byGroup.set(entry.group, bucket);
+		}
+		return [...byGroup.entries()];
+	}, [catalog, query]);
+
+	const toggle = (type: string, checked: boolean) => {
+		const next = new Set(selected);
+		next.delete('*');
+		if (checked) next.add(type);
+		else next.delete(type);
+		onChange([...next]);
+	};
+
+	return (
+		<div className="space-y-3">
+			<Checkbox
+				checked={allSelected}
+				onChange={(checked) => onChange(checked ? ['*'] : [])}
+				ariaLabel="Subscribe to all events"
+			>
+				<span className="text-foreground font-medium">All events</span> — including event
+				types added in future releases.
+			</Checkbox>
+			{!allSelected && (
+				<>
+					<SearchInput
+						value={query}
+						onValueChange={setQuery}
+						icon={<Filter className="h-3.5 w-3.5" />}
+						placeholder="Filter event types…"
+						aria-label="Filter event types"
+						disabled={catalog.length === 0}
+					/>
+					<div className="border-border max-h-64 space-y-3 overflow-y-auto rounded-lg border p-3">
+						{groups.length === 0 && (
+							<p className="text-muted-foreground py-2 text-center text-sm">
+								No event types match.
+							</p>
+						)}
+						{groups.map(([group, entries]) => (
+							<div key={group} className="space-y-1.5">
+								<p className="text-muted-foreground font-mono text-[11px] tracking-wider uppercase">
+									{group}
+								</p>
+								{entries.map((entry) => (
+									<Checkbox
+										key={entry.type}
+										checked={selected.has(entry.type)}
+										onChange={(checked) => toggle(entry.type, checked)}
+										size="sm"
+									>
+										<span className="text-foreground font-mono text-xs">
+											{entry.type}
+										</span>{' '}
+										<span className="text-muted-foreground text-xs">
+											— {entry.description}
+										</span>
+									</Checkbox>
+								))}
+							</div>
+						))}
+					</div>
+				</>
+			)}
+		</div>
+	);
+}

--- a/ui/src/modules/webhooks/components/SecretReveal.tsx
+++ b/ui/src/modules/webhooks/components/SecretReveal.tsx
@@ -1,0 +1,44 @@
+import { Check, KeyRound } from 'lucide-react';
+import { Button, CopyButton } from '@/shared/ui';
+
+/**
+ * One-time reveal for a freshly created/rotated `whsec_…` signing secret.
+ * The plaintext is returned exactly once by the API and never retrievable
+ * again, so this panel makes copying obvious and requires an explicit
+ * acknowledgement. Owners must wipe the value on close (sensitive-data rule).
+ */
+export function SecretReveal({
+	secret,
+	onConfirm,
+	title = 'Signing secret created',
+}: {
+	secret: string;
+	onConfirm: () => void;
+	title?: string;
+}) {
+	return (
+		<div
+			className="border-success/40 bg-success/5 space-y-3 rounded-lg border p-4"
+			role="alert"
+		>
+			<div className="flex items-center gap-2">
+				<KeyRound className="text-success h-4 w-4" aria-hidden="true" />
+				<p className="text-foreground text-sm font-semibold">{title}</p>
+			</div>
+			<p className="text-muted-foreground text-xs">
+				Use this secret to verify the <code className="font-mono">webhook-signature</code>{' '}
+				header on every delivery. Copy it now — it is shown only once and cannot be
+				retrieved again.
+			</p>
+			<div className="bg-card border-border flex items-center gap-2 rounded-md border p-2">
+				<code className="text-foreground min-w-0 flex-1 truncate font-mono text-xs">
+					{secret}
+				</code>
+				<CopyButton value={secret} size="sm" />
+			</div>
+			<Button size="sm" onClick={onConfirm}>
+				<Check className="h-4 w-4" /> I&rsquo;ve saved it
+			</Button>
+		</div>
+	);
+}

--- a/ui/src/modules/webhooks/components/SlackMessagePreview.tsx
+++ b/ui/src/modules/webhooks/components/SlackMessagePreview.tsx
@@ -1,0 +1,48 @@
+/**
+ * Faux-Slack rendering of the notification a `slack` destination receives.
+ * Purely illustrative: shows operators what lands in their channel before
+ * they commit, mirroring the "message preview" pattern of Grafana contact
+ * points and Sentry Slack integrations.
+ */
+export function SlackMessagePreview({ eventType }: { eventType?: string }) {
+	const type = eventType || 'agent.self_registered';
+	const bad = type.includes('failed') || type.includes('expired') || type.startsWith('security.');
+	const emoji = bad ? '🔴' : '🟢';
+	const summary = bad
+		? 'Something needs attention — open jentic-one for details.'
+		: 'New activity on your jentic-one instance.';
+	return (
+		<div
+			className="border-border bg-surface rounded-lg border p-3"
+			aria-label="Slack message preview"
+		>
+			<div className="flex items-start gap-2.5">
+				<div
+					className="bg-primary/15 text-primary flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-sm font-bold"
+					aria-hidden="true"
+				>
+					j1
+				</div>
+				<div className="min-w-0 space-y-0.5">
+					<p className="text-foreground text-xs">
+						<span className="font-semibold">jentic-one</span>{' '}
+						<span className="bg-muted text-muted-foreground rounded px-1 py-px text-[10px] font-medium tracking-wide uppercase">
+							App
+						</span>{' '}
+						<span className="text-muted-foreground">just now</span>
+					</p>
+					<p className="text-foreground text-sm">
+						{emoji} <span className="font-semibold">{type}</span>
+					</p>
+					<p className="text-foreground text-sm">{summary}</p>
+					<p className="text-muted-foreground text-xs">
+						<span className="text-primary underline decoration-dotted">
+							View in jentic-one
+						</span>{' '}
+						· evt_00000000000000000042
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/ui/src/modules/webhooks/components/badges.tsx
+++ b/ui/src/modules/webhooks/components/badges.tsx
@@ -1,0 +1,102 @@
+import { Hash, Webhook } from 'lucide-react';
+import { Badge, type BadgeVariant } from '@/shared/ui';
+import type {
+	DeliveryStatus,
+	DestinationType,
+	EndpointDisplayStatus,
+	WebhookEndpointEntity,
+} from '@/modules/webhooks/api';
+
+/**
+ * Webhook status vocabulary — deliberately module-local. Endpoint status
+ * (`active | failing | paused | disabled`) and delivery status
+ * (`delivered | pending | failed | exhausted`) are NOT the shared
+ * `ActorStatus` union, so they don't reuse `ActorStatusBadge`.
+ */
+
+const ENDPOINT_LABEL: Record<EndpointDisplayStatus, string> = {
+	active: 'Active',
+	failing: 'Failing',
+	paused: 'Paused',
+	disabled: 'Disabled',
+};
+
+const ENDPOINT_VARIANT: Record<EndpointDisplayStatus, BadgeVariant> = {
+	active: 'success',
+	failing: 'danger',
+	paused: 'warning',
+	disabled: 'default',
+};
+
+export function EndpointStatusBadge({ status }: { status: EndpointDisplayStatus }) {
+	return (
+		<Badge variant={ENDPOINT_VARIANT[status]} dot>
+			{ENDPOINT_LABEL[status]}
+		</Badge>
+	);
+}
+
+const DELIVERY_LABEL: Record<DeliveryStatus, string> = {
+	delivered: 'Delivered',
+	pending: 'Pending',
+	failed: 'Failed',
+	exhausted: 'Exhausted',
+};
+
+const DELIVERY_VARIANT: Record<DeliveryStatus, BadgeVariant> = {
+	delivered: 'success',
+	pending: 'pending',
+	failed: 'danger',
+	exhausted: 'danger',
+};
+
+export function DeliveryStatusBadge({ status }: { status: DeliveryStatus }) {
+	return <Badge variant={DELIVERY_VARIANT[status]}>{DELIVERY_LABEL[status]}</Badge>;
+}
+
+const DESTINATION_META: Record<
+	DestinationType,
+	{ label: string; Icon: typeof Webhook; title: string }
+> = {
+	https: {
+		label: 'HTTPS',
+		Icon: Webhook,
+		title: 'Signed HTTPS webhook — for machines that verify and retry.',
+	},
+	slack: {
+		label: 'Slack',
+		Icon: Hash,
+		title: 'Slack incoming webhook — events rendered as channel messages.',
+	},
+};
+
+/** Small icon+label chip identifying where an endpoint delivers to. */
+export function DestinationBadge({ type }: { type: DestinationType }) {
+	const { label, Icon, title } = DESTINATION_META[type];
+	return (
+		<span
+			className="text-muted-foreground inline-flex items-center gap-1 text-xs"
+			title={title}
+		>
+			<Icon className="h-3.5 w-3.5" aria-hidden="true" />
+			{label}
+		</span>
+	);
+}
+
+/** Chip summary of an endpoint's subscription: "execution.completed +2". */
+export function EventTypeChips({ endpoint }: { endpoint: WebhookEndpointEntity }) {
+	if (endpoint.subscribesToAll) {
+		return <Badge variant="default">All events</Badge>;
+	}
+	const [first, ...rest] = endpoint.eventTypes;
+	if (!first) return <span className="text-muted-foreground text-xs">—</span>;
+	return (
+		<span className="inline-flex items-center gap-1.5" title={endpoint.eventTypes.join(', ')}>
+			<Badge variant="default">{first}</Badge>
+			{rest.length > 0 && (
+				<span className="text-muted-foreground font-mono text-xs">+{rest.length}</span>
+			)}
+		</span>
+	);
+}

--- a/ui/src/modules/webhooks/components/detail/DeliveriesTab.tsx
+++ b/ui/src/modules/webhooks/components/detail/DeliveriesTab.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from 'react';
+import { Inbox } from 'lucide-react';
+import {
+	DataTable,
+	EmptyState,
+	ErrorAlert,
+	SegmentedToggle,
+	Select,
+	StatusBadge,
+	type Column,
+} from '@/shared/ui';
+import {
+	useWebhookDeliveries,
+	type WebhookDeliveryEntity,
+	type WebhookEndpointEntity,
+} from '@/modules/webhooks/api';
+import { DeliveryStatusBadge } from '@/modules/webhooks/components/badges';
+import { DeliveryDetailSheet } from '@/modules/webhooks/components/detail/DeliveryDetailSheet';
+import { timeAgo } from '@/modules/webhooks/lib/format';
+
+const STATUS_OPTIONS = [
+	{ value: 'all', label: 'All' },
+	{ value: 'delivered', label: 'Delivered' },
+	{ value: 'pending', label: 'Pending' },
+	{ value: 'failed', label: 'Failed' },
+] as const;
+
+type StatusFilter = (typeof STATUS_OPTIONS)[number]['value'];
+
+/**
+ * Deliveries tab — the endpoint's delivery log with status / event-type
+ * filters; a row opens the inspector sheet (attempt timeline, payload,
+ * response, redeliver).
+ */
+export function DeliveriesTab({ endpoint }: { endpoint: WebhookEndpointEntity }) {
+	const [status, setStatus] = useState<StatusFilter>('all');
+	const [eventType, setEventType] = useState('all');
+	const [selectedId, setSelectedId] = useState<string | null>(null);
+
+	// `failed` view includes exhausted deliveries — same operator question
+	// ("what didn't arrive?"), so they share a lens rather than a 5th segment.
+	const wireStatus = status === 'failed' ? null : status === 'all' ? null : status;
+	const {
+		data: deliveries,
+		isLoading,
+		isError,
+	} = useWebhookDeliveries(endpoint.id, {
+		status: wireStatus,
+		eventType: eventType === 'all' ? null : eventType,
+	});
+
+	const rows = useMemo(() => {
+		const list = deliveries ?? [];
+		if (status === 'failed') {
+			return list.filter((d) => d.status === 'failed' || d.status === 'exhausted');
+		}
+		return list;
+	}, [deliveries, status]);
+
+	const eventTypeOptions = useMemo(() => {
+		const seen = new Set((deliveries ?? []).map((d) => d.eventType));
+		return ['all', ...[...seen].sort()];
+	}, [deliveries]);
+
+	const selected = rows.find((d) => d.id === selectedId) ?? null;
+
+	const columns: Column<WebhookDeliveryEntity>[] = [
+		{
+			key: 'event',
+			header: 'Event',
+			render: (d) => (
+				<div className="min-w-0">
+					<p className="text-foreground truncate font-mono text-xs">{d.eventType}</p>
+					<p className="text-muted-foreground truncate font-mono text-[11px]">
+						{d.eventId}
+						{d.isTest ? ' · test' : ''}
+						{d.isRedelivery ? ' · redelivery' : ''}
+					</p>
+				</div>
+			),
+		},
+		{
+			key: 'status',
+			header: 'Status',
+			render: (d) => <DeliveryStatusBadge status={d.status} />,
+		},
+		{
+			key: 'http',
+			header: 'HTTP',
+			render: (d) => <StatusBadge status={d.lastHttpStatus} />,
+		},
+		{
+			key: 'attempts',
+			header: 'Attempts',
+			render: (d) => (
+				<span className="font-mono text-xs tabular-nums">{d.attempts.length}</span>
+			),
+		},
+		{
+			key: 'latency',
+			header: 'Latency',
+			render: (d) => (
+				<span className="font-mono text-xs tabular-nums">
+					{d.lastLatencyMs != null ? `${d.lastLatencyMs} ms` : '—'}
+				</span>
+			),
+		},
+		{
+			key: 'when',
+			header: 'When',
+			render: (d) => (
+				<span className="text-muted-foreground text-xs">{timeAgo(d.createdAt)}</span>
+			),
+		},
+	];
+
+	return (
+		<div className="space-y-4">
+			<div className="flex flex-wrap items-center gap-3">
+				<SegmentedToggle
+					options={[...STATUS_OPTIONS]}
+					value={status}
+					onChange={setStatus}
+					ariaLabel="Filter deliveries by status"
+				/>
+				<Select
+					value={eventType}
+					onChange={(e) => setEventType(e.target.value)}
+					aria-label="Filter deliveries by event type"
+					className="max-w-60"
+				>
+					{eventTypeOptions.map((t) => (
+						<option key={t} value={t}>
+							{t === 'all' ? 'All event types' : t}
+						</option>
+					))}
+				</Select>
+			</div>
+
+			{isError && <ErrorAlert message="Failed to load deliveries." />}
+			{!isError && !isLoading && rows.length === 0 ? (
+				<EmptyState
+					icon={<Inbox className="h-6 w-6" />}
+					title="No deliveries"
+					description={
+						status === 'all' && eventType === 'all'
+							? 'Nothing has been delivered to this endpoint yet. Send a test event from the Overview tab to try it out.'
+							: 'No deliveries match the current filters.'
+					}
+				/>
+			) : (
+				!isError && (
+					<DataTable
+						columns={columns}
+						data={rows}
+						getRowKey={(d) => d.id}
+						isLoading={isLoading}
+						ariaLabel="Webhook deliveries"
+						onRowClick={(d) => setSelectedId(d.id)}
+						getRowLabel={(d) => `Inspect delivery ${d.id}`}
+					/>
+				)
+			)}
+
+			<DeliveryDetailSheet
+				endpointId={endpoint.id}
+				delivery={selected}
+				onClose={() => setSelectedId(null)}
+			/>
+		</div>
+	);
+}

--- a/ui/src/modules/webhooks/components/detail/DeliveryDetailSheet.tsx
+++ b/ui/src/modules/webhooks/components/detail/DeliveryDetailSheet.tsx
@@ -1,0 +1,155 @@
+import { CheckCircle2, Clock3, RotateCcw, X, XCircle } from 'lucide-react';
+import { Button, CopyButton, SheetPrimitive, StatusBadge } from '@/shared/ui';
+import { useRedeliverDelivery, type WebhookDeliveryEntity } from '@/modules/webhooks/api';
+import { DeliveryStatusBadge } from '@/modules/webhooks/components/badges';
+import { formatDateTime, prettyJson, timeUntil } from '@/modules/webhooks/lib/format';
+
+/**
+ * Delivery inspector — attempt timeline, signed request headers, payload and
+ * response, plus the redeliver action (the single most support-ticket-saving
+ * affordance per the UX research — kept prominent).
+ */
+export function DeliveryDetailSheet({
+	endpointId,
+	delivery,
+	onClose,
+}: {
+	endpointId: string;
+	delivery: WebhookDeliveryEntity | null;
+	onClose: () => void;
+}) {
+	const redeliver = useRedeliverDelivery(endpointId);
+
+	return (
+		<SheetPrimitive open={delivery != null} onClose={onClose} ariaLabel="Delivery details">
+			{delivery && (
+				<div className="flex h-full flex-col">
+					<div className="border-border flex items-start justify-between gap-3 border-b px-5 py-4">
+						<div className="min-w-0">
+							<div className="flex flex-wrap items-center gap-2">
+								<h2 className="text-foreground truncate font-mono text-sm font-semibold">
+									{delivery.eventType}
+								</h2>
+								<DeliveryStatusBadge status={delivery.status} />
+							</div>
+							<p className="text-muted-foreground mt-0.5 font-mono text-xs">
+								{delivery.id}
+								{delivery.isTest ? ' · test event' : ''}
+								{delivery.isRedelivery ? ' · redelivery' : ''}
+							</p>
+						</div>
+						<Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
+							<X className="h-5 w-5" />
+						</Button>
+					</div>
+
+					<div className="flex-1 space-y-5 overflow-y-auto px-5 py-4">
+						<section className="space-y-2">
+							<h3 className="font-heading text-foreground text-sm font-semibold">
+								Attempts
+							</h3>
+							<ol className="space-y-2">
+								{delivery.attempts.map((attempt, i) => (
+									<li
+										key={attempt.attempted_at + String(i)}
+										className="border-border/60 bg-muted/30 flex flex-wrap items-center gap-2 rounded-lg border p-2.5"
+									>
+										{attempt.ok ? (
+											<CheckCircle2
+												className="text-success h-4 w-4 shrink-0"
+												aria-hidden="true"
+											/>
+										) : (
+											<XCircle
+												className="text-danger h-4 w-4 shrink-0"
+												aria-hidden="true"
+											/>
+										)}
+										<span className="text-foreground text-xs font-medium">
+											Attempt {i + 1}
+										</span>
+										<StatusBadge status={attempt.http_status} />
+										<span className="text-muted-foreground font-mono text-xs tabular-nums">
+											{attempt.latency_ms} ms
+										</span>
+										<span className="text-muted-foreground ml-auto text-xs">
+											{formatDateTime(attempt.attempted_at)}
+										</span>
+										{attempt.error && (
+											<p className="text-danger w-full text-xs">
+												{attempt.error}
+											</p>
+										)}
+									</li>
+								))}
+								{delivery.status === 'pending' && (
+									<li className="border-border/60 text-muted-foreground flex items-center gap-2 rounded-lg border border-dashed p-2.5 text-xs">
+										<Clock3 className="h-4 w-4 shrink-0" aria-hidden="true" />
+										Next retry {timeUntil(delivery.nextAttemptAt)}
+									</li>
+								)}
+							</ol>
+						</section>
+
+						<section className="space-y-2">
+							<h3 className="font-heading text-foreground text-sm font-semibold">
+								Request headers
+							</h3>
+							<dl className="border-border/60 bg-muted/30 space-y-1 rounded-lg border p-3">
+								{Object.entries(delivery.requestHeaders).map(([k, v]) => (
+									<div
+										key={k}
+										className="flex flex-wrap gap-x-2 font-mono text-xs"
+									>
+										<dt className="text-muted-foreground">{k}:</dt>
+										<dd className="text-foreground min-w-0 break-all">{v}</dd>
+									</div>
+								))}
+							</dl>
+						</section>
+
+						<section className="space-y-2">
+							<div className="flex items-center justify-between gap-2">
+								<h3 className="font-heading text-foreground text-sm font-semibold">
+									Payload
+								</h3>
+								<CopyButton
+									value={prettyJson(delivery.payload)}
+									size="sm"
+									variant="ghost"
+									ariaLabel="Copy payload"
+								/>
+							</div>
+							<pre className="border-border/60 bg-muted/30 max-h-64 overflow-auto rounded-lg border p-3 font-mono text-xs leading-relaxed">
+								{prettyJson(delivery.payload)}
+							</pre>
+						</section>
+
+						<section className="space-y-2">
+							<h3 className="font-heading text-foreground text-sm font-semibold">
+								Response
+							</h3>
+							<pre className="border-border/60 bg-muted/30 max-h-40 overflow-auto rounded-lg border p-3 font-mono text-xs leading-relaxed">
+								{delivery.responseBody ?? 'No response body recorded.'}
+							</pre>
+						</section>
+					</div>
+
+					<div className="border-border flex items-center justify-between gap-2 border-t px-5 py-4">
+						<p className="text-muted-foreground text-xs">
+							Redelivery re-sends the original payload with a fresh timestamp and
+							signature.
+						</p>
+						<Button
+							variant={delivery.status === 'delivered' ? 'secondary' : 'primary'}
+							onClick={() => redeliver.mutate(delivery.id)}
+							loading={redeliver.isPending}
+						>
+							<RotateCcw className="h-4 w-4" /> Redeliver
+						</Button>
+					</div>
+				</div>
+			)}
+		</SheetPrimitive>
+	);
+}

--- a/ui/src/modules/webhooks/components/detail/OverviewTab.tsx
+++ b/ui/src/modules/webhooks/components/detail/OverviewTab.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react';
+import { Activity, CheckCircle2, FlaskConical, Gauge, Link2, XCircle } from 'lucide-react';
+import { Badge, Button, DetailSection, Select, StatCard } from '@/shared/ui';
+import {
+	useEventTypeCatalog,
+	useSendTestEvent,
+	type WebhookEndpointEntity,
+} from '@/modules/webhooks/api';
+import { formatDateTime, formatRate, timeAgo } from '@/modules/webhooks/lib/format';
+
+/** Overview tab — KPI strip, configuration summary, and the test-event bench. */
+export function OverviewTab({ endpoint }: { endpoint: WebhookEndpointEntity }) {
+	const { data: catalog = [] } = useEventTypeCatalog();
+	const sendTest = useSendTestEvent(endpoint.id);
+	const testableTypes = endpoint.subscribesToAll
+		? catalog.map((e) => e.type)
+		: endpoint.eventTypes;
+	const [testType, setTestType] = useState('');
+	const effectiveTestType = testType || testableTypes[0] || '';
+
+	return (
+		<div className="space-y-4">
+			<div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+				<StatCard
+					label="Deliveries (24h)"
+					value={endpoint.deliveries24h}
+					icon={<Activity className="h-4 w-4" />}
+					accent="blue"
+				/>
+				<StatCard
+					label="Success rate (24h)"
+					value={formatRate(endpoint.successRate24h)}
+					icon={<CheckCircle2 className="h-4 w-4" />}
+					accent="green"
+				/>
+				<StatCard
+					label="Consecutive failures"
+					value={endpoint.consecutiveFailures}
+					icon={<Gauge className="h-4 w-4" />}
+					accent={endpoint.consecutiveFailures > 0 ? 'danger' : 'neutral'}
+					valueClassName={endpoint.consecutiveFailures > 0 ? 'text-danger' : undefined}
+				/>
+				<StatCard
+					label="Last delivery"
+					value={timeAgo(endpoint.lastDeliveryAt)}
+					icon={
+						endpoint.lastDeliveryOk === false ? (
+							<XCircle className="h-4 w-4" />
+						) : (
+							<CheckCircle2 className="h-4 w-4" />
+						)
+					}
+					accent={endpoint.lastDeliveryOk === false ? 'danger' : 'neutral'}
+				/>
+			</div>
+
+			<DetailSection title="Configuration" icon={<Link2 className="h-4 w-4" />}>
+				<dl className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
+					<div>
+						<dt className="text-muted-foreground text-xs tracking-wider uppercase">
+							{endpoint.destinationType === 'slack'
+								? 'Slack incoming webhook URL'
+								: 'URL'}
+						</dt>
+						<dd className="text-foreground mt-0.5 font-mono text-xs break-all">
+							{endpoint.url}
+						</dd>
+					</div>
+					{endpoint.destinationType === 'slack' ? (
+						<div>
+							<dt className="text-muted-foreground text-xs tracking-wider uppercase">
+								Message format
+							</dt>
+							<dd className="text-foreground mt-0.5 text-xs">
+								Slack Block Kit — one formatted message per event.
+								<span className="text-muted-foreground">
+									{' '}
+									Unsigned; the URL is the credential.
+								</span>
+							</dd>
+						</div>
+					) : (
+						<div>
+							<dt className="text-muted-foreground text-xs tracking-wider uppercase">
+								Signing secret
+							</dt>
+							<dd className="text-foreground mt-0.5 font-mono text-xs">
+								{endpoint.secretPreview}
+								<span className="text-muted-foreground">
+									{' '}
+									— rotate it from Settings
+								</span>
+							</dd>
+						</div>
+					)}
+					<div>
+						<dt className="text-muted-foreground text-xs tracking-wider uppercase">
+							Created
+						</dt>
+						<dd className="text-foreground mt-0.5 text-xs">
+							{formatDateTime(endpoint.createdAt)}
+						</dd>
+					</div>
+					<div>
+						<dt className="text-muted-foreground text-xs tracking-wider uppercase">
+							Updated
+						</dt>
+						<dd className="text-foreground mt-0.5 text-xs">
+							{formatDateTime(endpoint.updatedAt)}
+						</dd>
+					</div>
+					<div className="sm:col-span-2">
+						<dt className="text-muted-foreground text-xs tracking-wider uppercase">
+							Subscribed events
+						</dt>
+						<dd className="mt-1.5 flex flex-wrap gap-1.5">
+							{endpoint.subscribesToAll ? (
+								<Badge variant="default">All events</Badge>
+							) : (
+								endpoint.eventTypes.map((t) => (
+									<Badge key={t} variant="default">
+										{t}
+									</Badge>
+								))
+							)}
+						</dd>
+					</div>
+					{endpoint.description && (
+						<div className="sm:col-span-2">
+							<dt className="text-muted-foreground text-xs tracking-wider uppercase">
+								Description
+							</dt>
+							<dd className="text-foreground mt-0.5 text-sm">
+								{endpoint.description}
+							</dd>
+						</div>
+					)}
+				</dl>
+			</DetailSection>
+
+			<DetailSection title="Send a test event" icon={<FlaskConical className="h-4 w-4" />}>
+				<p className="text-muted-foreground text-xs">
+					{endpoint.destinationType === 'slack'
+						? 'Posts a synthetic message of the chosen event type to the Slack channel, formatted like a real notification. The result lands in the Deliveries tab flagged as a test.'
+						: 'Sends a synthetic payload of the chosen type to the endpoint, signed like a real delivery. The result lands in the Deliveries tab flagged as a test.'}
+				</p>
+				<div className="flex flex-wrap items-center gap-2">
+					<Select
+						value={effectiveTestType}
+						onChange={(e) => setTestType(e.target.value)}
+						aria-label="Test event type"
+						className="max-w-xs"
+						disabled={testableTypes.length === 0}
+					>
+						{testableTypes.map((t) => (
+							<option key={t} value={t}>
+								{t}
+							</option>
+						))}
+					</Select>
+					<Button
+						variant="outline"
+						onClick={() => sendTest.mutate(effectiveTestType)}
+						loading={sendTest.isPending}
+						disabled={!effectiveTestType || endpoint.wireStatus !== 'active'}
+					>
+						<FlaskConical className="h-4 w-4" /> Send test event
+					</Button>
+					{endpoint.wireStatus !== 'active' && (
+						<span className="text-muted-foreground text-xs">
+							Resume deliveries to send test events.
+						</span>
+					)}
+				</div>
+			</DetailSection>
+		</div>
+	);
+}

--- a/ui/src/modules/webhooks/components/detail/SettingsTab.tsx
+++ b/ui/src/modules/webhooks/components/detail/SettingsTab.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router';
+import { KeyRound, Pencil, Save } from 'lucide-react';
+import {
+	Button,
+	DangerZone,
+	DetailSection,
+	Dialog,
+	ErrorAlert,
+	Input,
+	Label,
+	Textarea,
+} from '@/shared/ui';
+import {
+	useDeleteEndpoint,
+	useEventTypeCatalog,
+	usePauseEndpoint,
+	useResumeEndpoint,
+	useRotateEndpointSecret,
+	useUpdateEndpoint,
+	type WebhookEndpointEntity,
+} from '@/modules/webhooks/api';
+import { EventTypePicker } from '@/modules/webhooks/components/EventTypePicker';
+import { SecretReveal } from '@/modules/webhooks/components/SecretReveal';
+
+/**
+ * Settings tab — edit config (F9), pause/resume (F7), rotate the signing
+ * secret (F8, one-time reveal), and the delete danger zone.
+ */
+export function SettingsTab({ endpoint }: { endpoint: WebhookEndpointEntity }) {
+	const navigate = useNavigate();
+	const { data: catalog = [] } = useEventTypeCatalog();
+	const update = useUpdateEndpoint();
+	const pause = usePauseEndpoint();
+	const resume = useResumeEndpoint();
+	const rotate = useRotateEndpointSecret();
+	const remove = useDeleteEndpoint();
+
+	const [name, setName] = useState(endpoint.name);
+	const [url, setUrl] = useState(endpoint.url);
+	const [description, setDescription] = useState(endpoint.description ?? '');
+	const [eventTypes, setEventTypes] = useState<string[]>(endpoint.eventTypes);
+	const [formError, setFormError] = useState<string | null>(null);
+
+	// Seed-from-props syncs only when the endpoint itself changed — not on
+	// every render — so in-progress edits aren't clobbered by refetches.
+	const lastIdRef = useRef(endpoint.id);
+	useEffect(() => {
+		if (lastIdRef.current !== endpoint.id) {
+			lastIdRef.current = endpoint.id;
+			setName(endpoint.name);
+			setUrl(endpoint.url);
+			setDescription(endpoint.description ?? '');
+			setEventTypes(endpoint.eventTypes);
+		}
+	}, [endpoint]);
+
+	const [rotateConfirmOpen, setRotateConfirmOpen] = useState(false);
+	const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+	// Sensitive: the freshly rotated secret — wiped when its panel is dismissed.
+	const [rotatedSecret, setRotatedSecret] = useState<string | null>(null);
+
+	const isSlack = endpoint.destinationType === 'slack';
+
+	const save = () => {
+		if (!name.trim()) {
+			setFormError('Give the endpoint a name.');
+			return;
+		}
+		if (isSlack && !url.trim().startsWith('https://hooks.slack.com/')) {
+			setFormError(
+				'Paste a Slack incoming webhook URL (it starts with https://hooks.slack.com/).',
+			);
+			return;
+		}
+		if (!url.trim().startsWith('https://')) {
+			setFormError('The endpoint URL must start with https://.');
+			return;
+		}
+		if (eventTypes.length === 0) {
+			setFormError('Subscribe to at least one event type.');
+			return;
+		}
+		setFormError(null);
+		update.mutate({
+			id: endpoint.id,
+			patch: {
+				name: name.trim(),
+				url: url.trim(),
+				description: description.trim() || null,
+				event_types: eventTypes,
+			},
+		});
+	};
+
+	const paused = endpoint.wireStatus === 'paused';
+
+	return (
+		<div className="space-y-4">
+			<DetailSection
+				title="Endpoint settings"
+				icon={<Pencil className="h-4 w-4" />}
+				action={{
+					label: (
+						<>
+							<Save className="h-4 w-4" /> Save changes
+						</>
+					),
+					onClick: save,
+					variant: 'primary',
+					ariaLabel: `Save changes to ${endpoint.name}`,
+				}}
+			>
+				<div className="space-y-4">
+					<div className="space-y-1.5">
+						<Label htmlFor="settings-name">Name</Label>
+						<Input
+							id="settings-name"
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+						/>
+					</div>
+					<div className="space-y-1.5">
+						<Label htmlFor="settings-url">
+							{isSlack ? 'Slack incoming webhook URL' : 'Endpoint URL'}
+						</Label>
+						<Input
+							id="settings-url"
+							value={url}
+							onChange={(e) => setUrl(e.target.value)}
+							inputMode="url"
+						/>
+					</div>
+					<div className="space-y-1.5">
+						<Label htmlFor="settings-description">Description</Label>
+						<Textarea
+							id="settings-description"
+							value={description}
+							onChange={(e) => setDescription(e.target.value)}
+							rows={2}
+						/>
+					</div>
+					<div className="space-y-1.5">
+						<Label>Events to send</Label>
+						<EventTypePicker
+							catalog={catalog}
+							value={eventTypes}
+							onChange={setEventTypes}
+						/>
+					</div>
+					{formError && <ErrorAlert message={formError} />}
+				</div>
+			</DetailSection>
+
+			{/* Slack incoming webhooks are unsigned — there is no secret to manage. */}
+			{!isSlack && (
+				<DetailSection
+					title="Signing secret"
+					icon={<KeyRound className="h-4 w-4" />}
+					action={
+						rotatedSecret
+							? undefined
+							: {
+									label: 'Rotate secret',
+									onClick: () => setRotateConfirmOpen(true),
+									variant: 'secondary',
+									ariaLabel: `Rotate the signing secret of ${endpoint.name}`,
+								}
+					}
+				>
+					{rotatedSecret ? (
+						<SecretReveal
+							secret={rotatedSecret}
+							title="New signing secret"
+							onConfirm={() => setRotatedSecret(null)}
+						/>
+					) : (
+						<div className="space-y-1">
+							<code className="text-foreground font-mono text-xs">
+								{endpoint.secretPreview}
+							</code>
+							<p className="text-muted-foreground text-xs">
+								Rotation is zero-downtime: for 24 hours deliveries are signed with
+								both the old and the new secret (space-delimited in
+								<code className="font-mono"> webhook-signature</code>), then the old
+								one expires.
+							</p>
+						</div>
+					)}
+				</DetailSection>
+			)}
+
+			<DangerZone
+				actions={[
+					{
+						key: paused ? 'resume' : 'pause',
+						title: paused ? 'Resume deliveries' : 'Pause deliveries',
+						description: paused
+							? 'Start delivering events to this endpoint again.'
+							: 'Stop deliveries without deleting the endpoint. Events fired while paused are NOT queued for later.',
+						buttonLabel: paused ? 'Resume' : 'Pause',
+						ariaLabel: `${paused ? 'Resume' : 'Pause'} ${endpoint.name}`,
+						emphasis: 'outline',
+					},
+					{
+						key: 'delete',
+						title: 'Delete endpoint',
+						description:
+							'Permanently removes the endpoint and stops all deliveries. This cannot be undone.',
+						buttonLabel: 'Delete',
+						ariaLabel: `Delete ${endpoint.name}`,
+						emphasis: 'solid',
+					},
+				]}
+				pending={pause.isPending || resume.isPending || remove.isPending}
+				onAction={(key) => {
+					if (key === 'pause') pause.mutate(endpoint.id);
+					if (key === 'resume') resume.mutate(endpoint.id);
+					if (key === 'delete') setDeleteConfirmOpen(true);
+				}}
+			/>
+
+			<Dialog
+				open={rotateConfirmOpen}
+				onClose={() => setRotateConfirmOpen(false)}
+				title="Rotate signing secret?"
+				footer={
+					<>
+						<Button variant="secondary" onClick={() => setRotateConfirmOpen(false)}>
+							Cancel
+						</Button>
+						<Button
+							onClick={() =>
+								rotate.mutate(endpoint.id, {
+									onSuccess: (result) => {
+										setRotateConfirmOpen(false);
+										setRotatedSecret(result.secret);
+									},
+								})
+							}
+							loading={rotate.isPending}
+						>
+							Rotate secret
+						</Button>
+					</>
+				}
+			>
+				<p className="text-muted-foreground text-sm">
+					A new secret is generated and shown once. Deliveries carry both signatures for
+					24 hours so your receiver can migrate without downtime.
+				</p>
+			</Dialog>
+
+			<Dialog
+				open={deleteConfirmOpen}
+				onClose={() => setDeleteConfirmOpen(false)}
+				title={`Delete ${endpoint.name}?`}
+				footer={
+					<>
+						<Button variant="secondary" onClick={() => setDeleteConfirmOpen(false)}>
+							Cancel
+						</Button>
+						<Button
+							variant="danger"
+							onClick={() =>
+								remove.mutate(endpoint.id, {
+									onSuccess: () => navigate('/webhooks', { replace: true }),
+								})
+							}
+							loading={remove.isPending}
+						>
+							Delete endpoint
+						</Button>
+					</>
+				}
+			>
+				<p className="text-muted-foreground text-sm">
+					Deliveries stop immediately and the endpoint's configuration is removed. The
+					delivery history is kept in the audit trail.
+				</p>
+			</Dialog>
+		</div>
+	);
+}

--- a/ui/src/modules/webhooks/lib/format.ts
+++ b/ui/src/modules/webhooks/lib/format.ts
@@ -1,0 +1,55 @@
+/** Time / number formatting helpers local to the webhooks module. */
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/** Compact relative time — "just now", "12m ago", "3h ago", "5d ago". */
+export function timeAgo(iso: string | null): string {
+	if (!iso) return '—';
+	const delta = Date.now() - Date.parse(iso);
+	if (delta < MINUTE) return 'just now';
+	if (delta < HOUR) return `${Math.floor(delta / MINUTE)}m ago`;
+	if (delta < DAY) return `${Math.floor(delta / HOUR)}h ago`;
+	return `${Math.floor(delta / DAY)}d ago`;
+}
+
+/** "in 28m" style countdown for a pending retry. */
+export function timeUntil(iso: string | null): string {
+	if (!iso) return '—';
+	const delta = Date.parse(iso) - Date.now();
+	if (delta <= 0) return 'now';
+	if (delta < HOUR) return `in ${Math.max(1, Math.round(delta / MINUTE))}m`;
+	if (delta < DAY) return `in ${Math.round(delta / HOUR)}h`;
+	return `in ${Math.round(delta / DAY)}d`;
+}
+
+export function formatDateTime(iso: string | null): string {
+	return iso ? new Date(iso).toLocaleString() : '—';
+}
+
+/** 0–1 ratio → "98%" (or em-dash when unknown). */
+export function formatRate(rate: number | null): string {
+	return rate == null ? '—' : `${Math.round(rate * 100)}%`;
+}
+
+/** Truncate a URL for table display, masking any query string. */
+export function displayUrl(url: string): string {
+	try {
+		const u = new URL(url);
+		const base = `${u.host}${u.pathname}`;
+		const masked = u.search ? `${base}?…` : base;
+		return masked.length > 48 ? `${masked.slice(0, 47)}…` : masked;
+	} catch {
+		return url;
+	}
+}
+
+/** Pretty-print an unknown JSON payload for the inspector panes. */
+export function prettyJson(value: unknown): string {
+	try {
+		return JSON.stringify(value, null, 2);
+	} catch {
+		return String(value);
+	}
+}

--- a/ui/src/modules/webhooks/mocks/handlers.ts
+++ b/ui/src/modules/webhooks/mocks/handlers.ts
@@ -1,0 +1,612 @@
+/**
+ * Webhooks MSW handlers + in-memory store (PROTOTYPE — no backend yet).
+ *
+ * Serves the `/webhooks…` surface the module repository consumes, with a
+ * mutable store so lifecycle transitions (pause → resume, rotate, redeliver)
+ * are observable across calls. Delivery simulation is deterministic: an
+ * endpoint whose URL contains "fail" refuses deliveries; everything else
+ * succeeds. Registered additively in src/mocks/handlers.ts.
+ */
+import { http, HttpResponse } from 'msw';
+
+type WireStatus = 'active' | 'paused' | 'disabled';
+type DeliveryStatus = 'delivered' | 'pending' | 'failed' | 'exhausted';
+type DestinationType = 'https' | 'slack';
+
+interface AttemptRow {
+	attempted_at: string;
+	ok: boolean;
+	http_status: number | null;
+	error: string | null;
+	latency_ms: number;
+}
+
+interface EndpointRow {
+	id: string;
+	name: string;
+	url: string;
+	description: string | null;
+	destination_type: DestinationType;
+	status: WireStatus;
+	event_types: string[];
+	secret_preview: string | null;
+	consecutive_failures: number;
+	created_at: string;
+	updated_at: string | null;
+}
+
+interface DeliveryRow {
+	id: string;
+	endpoint_id: string;
+	event_id: string;
+	event_type: string;
+	status: DeliveryStatus;
+	attempts: AttemptRow[];
+	next_attempt_at: string | null;
+	request_headers: Record<string, string>;
+	payload: unknown;
+	response_body: string | null;
+	is_test: boolean;
+	is_redelivery: boolean;
+	created_at: string;
+}
+
+/** Subscribable event catalog — mirrors `EventType` (shared/models/events.py). */
+const EVENT_CATALOG: ReadonlyArray<{ type: string; group: string; description: string }> = [
+	{
+		type: 'execution.completed',
+		group: 'execution',
+		description: 'A brokered API call finished successfully.',
+	},
+	{ type: 'execution.failed', group: 'execution', description: 'A brokered API call failed.' },
+	{
+		type: 'execution.repeated_failure',
+		group: 'execution',
+		description: 'The same execution failed repeatedly.',
+	},
+	{
+		type: 'credential.expiring_soon',
+		group: 'credential',
+		description: 'A stored credential is close to its expiry.',
+	},
+	{
+		type: 'credential.expired',
+		group: 'credential',
+		description: 'A stored credential has expired.',
+	},
+	{
+		type: 'credential.connection_failed',
+		group: 'credential',
+		description: 'A credential connection attempt failed.',
+	},
+	{
+		type: 'credential.refresh_failed',
+		group: 'credential',
+		description: 'An OAuth credential could not be refreshed.',
+	},
+	{
+		type: 'agent.self_registered',
+		group: 'agent',
+		description: 'An agent registered itself and awaits approval.',
+	},
+	{
+		type: 'agent.registration_approved',
+		group: 'agent',
+		description: 'An operator approved an agent registration.',
+	},
+	{
+		type: 'agent.registration_denied',
+		group: 'agent',
+		description: 'An operator denied an agent registration.',
+	},
+	{
+		type: 'access_request.filed',
+		group: 'access_request',
+		description: 'An agent filed a request for API access.',
+	},
+	{
+		type: 'access_request.approved',
+		group: 'access_request',
+		description: 'An access request was approved.',
+	},
+	{
+		type: 'access_request.denied',
+		group: 'access_request',
+		description: 'An access request was denied.',
+	},
+	{
+		type: 'catalog.update_available',
+		group: 'catalog',
+		description: 'An imported API spec has an upstream update.',
+	},
+	{ type: 'import.completed', group: 'import', description: 'An API spec import finished.' },
+	{ type: 'import.failed', group: 'import', description: 'An API spec import failed.' },
+	{
+		type: 'job.failed_permanently',
+		group: 'job',
+		description: 'A background job exhausted its retries.',
+	},
+	{
+		type: 'security.unauthorized_access_attempt',
+		group: 'security',
+		description: 'A caller was rejected by authentication.',
+	},
+];
+
+const now = (offsetMin = 0) => new Date(Date.now() + offsetMin * 60_000).toISOString();
+
+let idCounter = 100;
+const nextId = (prefix: string) => `${prefix}_${String(idCounter++).padStart(21, '0')}`;
+
+function samplePayload(eventType: string, eventId: string, createdAt: string): unknown {
+	return {
+		id: eventId,
+		type: eventType,
+		created_at: createdAt,
+		data: {
+			summary: `Sample ${eventType} event`,
+			actor_id: 'agnt_active_1',
+			actor_type: 'agent',
+			trace_id: 'trc_0000000000000000000042',
+		},
+	};
+}
+
+/** Human-readable Slack Block Kit message a `slack` destination receives. */
+function slackPayload(eventType: string, eventId: string): unknown {
+	const emoji = eventType.includes('failed') || eventType.startsWith('security.') ? '🔴' : '🟢';
+	return {
+		text: `${emoji} jentic-one — ${eventType}`,
+		blocks: [
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `${emoji} *${eventType}*\nSample ${eventType} event · actor \`agnt_active_1\``,
+				},
+			},
+			{
+				type: 'context',
+				elements: [
+					{
+						type: 'mrkdwn',
+						text: `<https://jentic.local/app/events|View in jentic-one> · \`${eventId}\``,
+					},
+				],
+			},
+		],
+	};
+}
+
+function payloadFor(row: EndpointRow, eventType: string, eventId: string, createdAt: string) {
+	return row.destination_type === 'slack'
+		? slackPayload(eventType, eventId)
+		: samplePayload(eventType, eventId, createdAt);
+}
+
+function standardHeaders(deliveryId: string, at: string): Record<string, string> {
+	return {
+		'content-type': 'application/json',
+		'webhook-id': deliveryId,
+		'webhook-timestamp': String(Math.floor(Date.parse(at) / 1000)),
+		'webhook-signature': 'v1,K5oZfzN95Z9UVu1EsfQmfVNQhnkZ2pj9o9NDN/H/pI4=',
+		'user-agent': 'jentic-one-webhooks/0.1',
+	};
+}
+
+/** Slack incoming webhooks are unsigned — the URL itself is the credential. */
+function slackHeaders(): Record<string, string> {
+	return {
+		'content-type': 'application/json',
+		'user-agent': 'jentic-one-webhooks/0.1',
+	};
+}
+
+function headersFor(row: EndpointRow, deliveryId: string, at: string): Record<string, string> {
+	return row.destination_type === 'slack' ? slackHeaders() : standardHeaders(deliveryId, at);
+}
+
+/** One finished delivery, `minutesAgo` back, ok or failed. */
+function seedDelivery(
+	endpoint: EndpointRow,
+	eventType: string,
+	minutesAgo: number,
+	ok: boolean,
+	opts: { attempts?: number; pending?: boolean; test?: boolean } = {},
+): DeliveryRow {
+	const id = nextId('whd');
+	const createdAt = now(-minutesAgo);
+	const attemptCount = opts.attempts ?? 1;
+	const attempts: AttemptRow[] = [];
+	for (let i = 0; i < attemptCount; i++) {
+		const isLast = i === attemptCount - 1;
+		const attemptOk = isLast ? ok && !opts.pending : false;
+		attempts.push({
+			attempted_at: now(-minutesAgo + i * 5),
+			ok: attemptOk,
+			http_status: attemptOk ? 200 : 503,
+			error: attemptOk ? null : 'Upstream answered 503 Service Unavailable',
+			latency_ms: attemptOk ? 40 + ((i * 37) % 180) : 900 + ((i * 53) % 1200),
+		});
+	}
+	const status: DeliveryStatus = opts.pending
+		? 'pending'
+		: ok
+			? 'delivered'
+			: attemptCount >= 5
+				? 'exhausted'
+				: 'failed';
+	const okBody = endpoint.destination_type === 'slack' ? 'ok' : '{"received":true}';
+	return {
+		id,
+		endpoint_id: endpoint.id,
+		event_id: nextId('evt'),
+		event_type: eventType,
+		status,
+		attempts,
+		next_attempt_at: opts.pending ? now(30) : null,
+		request_headers: headersFor(endpoint, id, createdAt),
+		payload: payloadFor(endpoint, eventType, `evt_${id.slice(4)}`, createdAt),
+		response_body: ok && !opts.pending ? okBody : 'upstream error: service unavailable',
+		is_test: opts.test ?? false,
+		is_redelivery: false,
+		created_at: createdAt,
+	};
+}
+
+/** Mutable per-session store. */
+let endpoints: EndpointRow[] = [];
+let deliveries: DeliveryRow[] = [];
+
+function seedStore(): void {
+	const slack: EndpointRow = {
+		id: 'whe_000000000000000slack1',
+		name: '#jentic-ops Slack channel',
+		url: 'https://hooks.slack.com/services/T024BE7LD/B0G9QF2H3/XxYyZz0123456789abcdef',
+		description: 'Notifies #jentic-ops about approvals and credential problems.',
+		destination_type: 'slack',
+		status: 'active',
+		event_types: [
+			'agent.self_registered',
+			'access_request.filed',
+			'credential.expiring_soon',
+			'credential.expired',
+		],
+		secret_preview: null,
+		consecutive_failures: 0,
+		created_at: now(-60 * 24 * 12),
+		updated_at: null,
+	};
+	const siem: EndpointRow = {
+		id: 'whe_0000000000000000siem1',
+		name: 'SIEM export',
+		url: 'https://siem.acme-fail.example.com/ingest/jentic',
+		description: 'Streams every platform event into the security lake.',
+		destination_type: 'https',
+		status: 'active',
+		event_types: ['*'],
+		secret_preview: 'whsec_9f8e7d6c…',
+		consecutive_failures: 4,
+		created_at: now(-60 * 24 * 30),
+		updated_at: now(-60 * 24 * 2),
+	};
+	const staging: EndpointRow = {
+		id: 'whe_00000000000000stagin1',
+		name: 'Staging mirror',
+		url: 'https://staging.acme.dev/hooks/jentic',
+		description: null,
+		destination_type: 'https',
+		status: 'paused',
+		event_types: ['execution.completed', 'execution.failed'],
+		secret_preview: 'whsec_55aa66bb…',
+		consecutive_failures: 0,
+		created_at: now(-60 * 24 * 4),
+		updated_at: null,
+	};
+	endpoints = [slack, siem, staging];
+	deliveries = [
+		seedDelivery(slack, 'agent.self_registered', 30, true),
+		seedDelivery(slack, 'access_request.filed', 95, true),
+		seedDelivery(slack, 'credential.expiring_soon', 60 * 5, true),
+		seedDelivery(slack, 'access_request.filed', 60 * 9, true),
+		seedDelivery(slack, 'agent.self_registered', 60 * 14, true),
+		seedDelivery(slack, 'credential.expired', 60 * 30, false, { attempts: 2 }),
+		seedDelivery(slack, 'access_request.filed', 60 * 44, true),
+		seedDelivery(siem, 'execution.failed', 12, false, { attempts: 2, pending: true }),
+		seedDelivery(siem, 'execution.completed', 45, false, { attempts: 3 }),
+		seedDelivery(siem, 'security.unauthorized_access_attempt', 70, false, { attempts: 5 }),
+		seedDelivery(siem, 'execution.completed', 60 * 3, false, { attempts: 4 }),
+		seedDelivery(siem, 'toolkit.created', 60 * 26, true),
+		seedDelivery(siem, 'execution.completed', 60 * 28, true),
+		seedDelivery(siem, 'import.completed', 60 * 50, true),
+		seedDelivery(staging, 'execution.completed', 60 * 24 * 2, true),
+		seedDelivery(staging, 'execution.failed', 60 * 24 * 2 + 40, true),
+	];
+}
+
+seedStore();
+
+/** Reset hook for tests. */
+export function resetWebhooksStore(): void {
+	seedStore();
+}
+
+// ---------------------------------------------------------------------------
+// Derived stats + simulation
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function withStats(row: EndpointRow) {
+	const recent = deliveries.filter(
+		(d) => d.endpoint_id === row.id && Date.now() - Date.parse(d.created_at) < DAY_MS,
+	);
+	const settled = recent.filter((d) => d.status !== 'pending');
+	const okCount = settled.filter((d) => d.status === 'delivered').length;
+	const all = deliveries
+		.filter((d) => d.endpoint_id === row.id)
+		.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
+	const last = all[0] ?? null;
+	return {
+		...row,
+		deliveries_24h: recent.length,
+		success_rate_24h: settled.length > 0 ? okCount / settled.length : null,
+		last_delivery_at: last?.created_at ?? null,
+		last_delivery_ok: last ? last.status === 'delivered' : null,
+	};
+}
+
+/** Deterministic delivery simulation: URLs containing "fail" refuse events. */
+function endpointRefuses(row: EndpointRow): boolean {
+	return row.url.includes('fail');
+}
+
+function attemptNow(ok: boolean): AttemptRow {
+	return {
+		attempted_at: now(),
+		ok,
+		http_status: ok ? 200 : 503,
+		error: ok ? null : 'Upstream answered 503 Service Unavailable',
+		latency_ms: ok
+			? 40 + Math.floor(Math.random() * 160)
+			: 900 + Math.floor(Math.random() * 900),
+	};
+}
+
+function deliverNew(
+	row: EndpointRow,
+	eventType: string,
+	opts: { test?: boolean; redelivery?: boolean } = {},
+): DeliveryRow {
+	const ok = !endpointRefuses(row);
+	const id = nextId('whd');
+	const createdAt = now();
+	const okBody = row.destination_type === 'slack' ? 'ok' : '{"received":true}';
+	const delivery: DeliveryRow = {
+		id,
+		endpoint_id: row.id,
+		event_id: nextId('evt'),
+		event_type: eventType,
+		status: ok ? 'delivered' : 'failed',
+		attempts: [attemptNow(ok)],
+		next_attempt_at: ok ? null : now(1),
+		request_headers: headersFor(row, id, createdAt),
+		payload: payloadFor(row, eventType, `evt_${id.slice(4)}`, createdAt),
+		response_body: ok ? okBody : 'upstream error: service unavailable',
+		is_test: opts.test ?? false,
+		is_redelivery: opts.redelivery ?? false,
+		created_at: createdAt,
+	};
+	deliveries.unshift(delivery);
+	row.consecutive_failures = ok ? 0 : row.consecutive_failures + 1;
+	return delivery;
+}
+
+function notFound() {
+	return HttpResponse.json({ detail: 'Webhook endpoint not found.' }, { status: 404 });
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+export const webhooksHandlers = [
+	// Declared before `/webhooks/:id` so "event-types" is never read as an id.
+	http.get('/webhooks/event-types', () => HttpResponse.json({ data: EVENT_CATALOG })),
+
+	http.get('/webhooks', () => HttpResponse.json({ data: endpoints.map(withStats) })),
+
+	http.post('/webhooks', async ({ request }) => {
+		const body = (await request.json()) as {
+			name?: string;
+			url?: string;
+			description?: string | null;
+			destination_type?: DestinationType;
+			event_types?: string[];
+		};
+		const destinationType: DestinationType = body.destination_type ?? 'https';
+		if (!body.name?.trim() || !body.url?.trim()) {
+			return HttpResponse.json({ detail: 'Name and URL are required.' }, { status: 422 });
+		}
+		if (!body.url.startsWith('https://')) {
+			return HttpResponse.json({ detail: 'Endpoint URLs must use HTTPS.' }, { status: 422 });
+		}
+		if (destinationType === 'slack' && !body.url.startsWith('https://hooks.slack.com/')) {
+			return HttpResponse.json(
+				{ detail: 'Slack destinations need an incoming webhook URL (hooks.slack.com).' },
+				{ status: 422 },
+			);
+		}
+		if ((body.event_types ?? []).length === 0) {
+			return HttpResponse.json(
+				{ detail: 'Subscribe to at least one event type.' },
+				{ status: 422 },
+			);
+		}
+		const secretBody = Array.from({ length: 32 }, () =>
+			'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'.charAt(
+				Math.floor(Math.random() * 62),
+			),
+		).join('');
+		const row: EndpointRow = {
+			id: nextId('whe'),
+			name: body.name.trim(),
+			url: body.url.trim(),
+			description: body.description?.trim() || null,
+			destination_type: destinationType,
+			status: 'active',
+			event_types: body.event_types ?? [],
+			// Slack incoming webhooks are unsigned; only https endpoints get a secret.
+			secret_preview: destinationType === 'slack' ? null : `whsec_${secretBody.slice(0, 8)}…`,
+			consecutive_failures: 0,
+			created_at: now(),
+			updated_at: null,
+		};
+		endpoints.unshift(row);
+		// GitHub-style ping on creation for instant reachability feedback.
+		const ok = !endpointRefuses(row);
+		const ping = {
+			ok,
+			http_status: ok ? 200 : 503,
+			latency_ms: ok ? 40 + Math.floor(Math.random() * 160) : 1400,
+			error: ok ? null : 'Upstream answered 503 Service Unavailable',
+		};
+		return HttpResponse.json(
+			{
+				endpoint: withStats(row),
+				secret: destinationType === 'slack' ? null : `whsec_${secretBody}`,
+				ping,
+			},
+			{ status: 201 },
+		);
+	}),
+
+	http.get('/webhooks/:id', ({ params }) => {
+		const row = endpoints.find((e) => e.id === params.id);
+		return row ? HttpResponse.json(withStats(row)) : notFound();
+	}),
+
+	http.patch('/webhooks/:id', async ({ params, request }) => {
+		const row = endpoints.find((e) => e.id === params.id);
+		if (!row) return notFound();
+		const patch = (await request.json()) as Partial<EndpointRow>;
+		if (patch.url !== undefined && !String(patch.url).startsWith('https://')) {
+			return HttpResponse.json({ detail: 'Endpoint URLs must use HTTPS.' }, { status: 422 });
+		}
+		if (
+			patch.url !== undefined &&
+			row.destination_type === 'slack' &&
+			!String(patch.url).startsWith('https://hooks.slack.com/')
+		) {
+			return HttpResponse.json(
+				{ detail: 'Slack destinations need an incoming webhook URL (hooks.slack.com).' },
+				{ status: 422 },
+			);
+		}
+		if (patch.name !== undefined) row.name = String(patch.name);
+		if (patch.url !== undefined) row.url = String(patch.url);
+		if (patch.description !== undefined) row.description = patch.description ?? null;
+		if (patch.event_types !== undefined) row.event_types = patch.event_types;
+		row.updated_at = now();
+		return HttpResponse.json(withStats(row));
+	}),
+
+	http.post('/webhooks/:id/pause', ({ params }) => {
+		const row = endpoints.find((e) => e.id === params.id);
+		if (!row) return notFound();
+		row.status = 'paused';
+		row.updated_at = now();
+		return HttpResponse.json(withStats(row));
+	}),
+
+	http.post('/webhooks/:id/resume', ({ params }) => {
+		const row = endpoints.find((e) => e.id === params.id);
+		if (!row) return notFound();
+		row.status = 'active';
+		row.consecutive_failures = 0;
+		row.updated_at = now();
+		return HttpResponse.json(withStats(row));
+	}),
+
+	http.post('/webhooks/:id/rotate-secret', ({ params }) => {
+		const row = endpoints.find((e) => e.id === params.id);
+		if (!row) return notFound();
+		if (row.destination_type === 'slack') {
+			return HttpResponse.json(
+				{ detail: 'Slack destinations have no signing secret to rotate.' },
+				{ status: 409 },
+			);
+		}
+		const secretBody = Array.from({ length: 32 }, () =>
+			'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'.charAt(
+				Math.floor(Math.random() * 62),
+			),
+		).join('');
+		row.secret_preview = `whsec_${secretBody.slice(0, 8)}…`;
+		row.updated_at = now();
+		return HttpResponse.json({
+			secret: `whsec_${secretBody}`,
+			secret_preview: row.secret_preview,
+		});
+	}),
+
+	http.delete('/webhooks/:id', ({ params }) => {
+		const idx = endpoints.findIndex((e) => e.id === params.id);
+		if (idx === -1) return notFound();
+		endpoints.splice(idx, 1);
+		deliveries = deliveries.filter((d) => d.endpoint_id !== params.id);
+		return new HttpResponse(null, { status: 204 });
+	}),
+
+	http.post('/webhooks/:id/test', async ({ params, request }) => {
+		const row = endpoints.find((e) => e.id === params.id);
+		if (!row) return notFound();
+		const body = (await request.json()) as { event_type?: string };
+		const eventType = body.event_type ?? 'execution.completed';
+		const delivery = deliverNew(row, eventType, { test: true });
+		return HttpResponse.json({ delivery }, { status: 201 });
+	}),
+
+	http.get('/webhooks/:id/deliveries', ({ params, request }) => {
+		const row = endpoints.find((e) => e.id === params.id);
+		if (!row) return notFound();
+		const url = new URL(request.url);
+		const status = url.searchParams.get('status');
+		const eventType = url.searchParams.get('event_type');
+		const data = deliveries
+			.filter((d) => d.endpoint_id === row.id)
+			.filter((d) => (status ? d.status === status : true))
+			.filter((d) => (eventType ? d.event_type === eventType : true))
+			.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
+		return HttpResponse.json({ data });
+	}),
+
+	http.post('/webhooks/:id/deliveries/:deliveryId/redeliver', ({ params }) => {
+		const row = endpoints.find((e) => e.id === params.id);
+		if (!row) return notFound();
+		const original = deliveries.find(
+			(d) => d.id === params.deliveryId && d.endpoint_id === row.id,
+		);
+		if (!original) {
+			return HttpResponse.json({ detail: 'Delivery not found.' }, { status: 404 });
+		}
+		// Redelivery simulates the operator having fixed their receiver: it
+		// succeeds even for otherwise-failing endpoints, and resets the counter.
+		const id = nextId('whd');
+		const createdAt = now();
+		const delivery: DeliveryRow = {
+			...original,
+			id,
+			status: 'delivered',
+			attempts: [attemptNow(true)],
+			next_attempt_at: null,
+			request_headers: standardHeaders(id, createdAt),
+			response_body: '{"received":true}',
+			is_redelivery: true,
+			created_at: createdAt,
+		};
+		deliveries.unshift(delivery);
+		row.consecutive_failures = 0;
+		return HttpResponse.json({ delivery }, { status: 201 });
+	}),
+];

--- a/ui/src/modules/webhooks/pages/WebhookDetailPage.tsx
+++ b/ui/src/modules/webhooks/pages/WebhookDetailPage.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import { useParams } from 'react-router';
+import { AlertTriangle, Inbox, LayoutDashboard, Settings, Webhook } from 'lucide-react';
+import {
+	BackButton,
+	EmptyState,
+	ErrorAlert,
+	LoadingState,
+	PageHeader,
+	PageShell,
+	TabNav,
+	type TabNavOption,
+} from '@/shared/ui';
+import { useWebhookEndpoint } from '@/modules/webhooks/api';
+import { DestinationBadge, EndpointStatusBadge } from '@/modules/webhooks/components/badges';
+import { DeliveriesTab } from '@/modules/webhooks/components/detail/DeliveriesTab';
+import { OverviewTab } from '@/modules/webhooks/components/detail/OverviewTab';
+import { SettingsTab } from '@/modules/webhooks/components/detail/SettingsTab';
+import { displayUrl } from '@/modules/webhooks/lib/format';
+
+type Tab = 'overview' | 'deliveries' | 'settings';
+
+const TABS: TabNavOption<Tab>[] = [
+	{ value: 'overview', label: 'Overview', icon: <LayoutDashboard className="h-4 w-4" /> },
+	{ value: 'deliveries', label: 'Deliveries', icon: <Inbox className="h-4 w-4" /> },
+	{ value: 'settings', label: 'Settings', icon: <Settings className="h-4 w-4" /> },
+];
+
+export default function WebhookDetailPage() {
+	const { webhookId } = useParams<{ webhookId: string }>();
+	const { data: endpoint, isLoading, isError } = useWebhookEndpoint(webhookId ?? null);
+	const [tab, setTab] = useState<Tab>('overview');
+
+	if (isLoading) {
+		return (
+			<PageShell>
+				<LoadingState />
+			</PageShell>
+		);
+	}
+
+	if (isError || !endpoint) {
+		return (
+			<PageShell>
+				<BackButton to="/webhooks" label="Webhooks" />
+				{isError ? (
+					<ErrorAlert message="Failed to load this webhook endpoint." />
+				) : (
+					<EmptyState
+						icon={<Webhook className="h-6 w-6" />}
+						title="Endpoint not found"
+						description="It may have been deleted."
+					/>
+				)}
+			</PageShell>
+		);
+	}
+
+	return (
+		<PageShell>
+			<BackButton to="/webhooks" label="Webhooks" />
+			<PageHeader
+				title={endpoint.name}
+				subtitle={displayUrl(endpoint.url)}
+				actions={
+					<span className="flex items-center gap-3">
+						<DestinationBadge type={endpoint.destinationType} />
+						<EndpointStatusBadge status={endpoint.status} />
+					</span>
+				}
+			/>
+
+			{endpoint.status === 'failing' && (
+				<div
+					role="status"
+					className="border-danger/40 bg-danger/5 flex items-start gap-3 rounded-lg border p-3"
+				>
+					<AlertTriangle
+						className="text-danger mt-0.5 h-4 w-4 shrink-0"
+						aria-hidden="true"
+					/>
+					<div className="min-w-0 text-sm">
+						<p className="text-foreground font-medium">
+							{endpoint.consecutiveFailures} consecutive delivery failures
+						</p>
+						<p className="text-muted-foreground text-xs">
+							Deliveries keep failing and this endpoint will be disabled automatically
+							if that continues. Inspect the latest attempts in the Deliveries tab,
+							fix the receiver, then redeliver.
+						</p>
+					</div>
+				</div>
+			)}
+
+			<TabNav
+				options={TABS}
+				value={tab}
+				onChange={setTab}
+				ariaLabel="Endpoint sections"
+				getTabId={(v) => `webhook-tab-${v}`}
+				getControls={(v) => `webhook-panel-${v}`}
+			/>
+
+			<div id={`webhook-panel-${tab}`} role="tabpanel" aria-labelledby={`webhook-tab-${tab}`}>
+				{tab === 'overview' && <OverviewTab endpoint={endpoint} />}
+				{tab === 'deliveries' && <DeliveriesTab endpoint={endpoint} />}
+				{tab === 'settings' && <SettingsTab endpoint={endpoint} />}
+			</div>
+		</PageShell>
+	);
+}

--- a/ui/src/modules/webhooks/pages/WebhooksPage.tsx
+++ b/ui/src/modules/webhooks/pages/WebhooksPage.tsx
@@ -1,0 +1,270 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+import {
+	Activity,
+	AlertTriangle,
+	CheckCircle2,
+	Filter,
+	Plus,
+	Webhook,
+	XCircle,
+} from 'lucide-react';
+import {
+	Button,
+	DataTable,
+	EmptyState,
+	ErrorAlert,
+	PageHeader,
+	PageHelp,
+	PageShell,
+	SearchInput,
+	StatCard,
+	type Column,
+} from '@/shared/ui';
+import { useWebhookEndpoints, type WebhookEndpointEntity } from '@/modules/webhooks/api';
+import {
+	DestinationBadge,
+	EndpointStatusBadge,
+	EventTypeChips,
+} from '@/modules/webhooks/components/badges';
+import { CreateEndpointSheet } from '@/modules/webhooks/components/CreateEndpointSheet';
+import { displayUrl, formatRate, timeAgo } from '@/modules/webhooks/lib/format';
+
+function LastDeliveryCell({ endpoint }: { endpoint: WebhookEndpointEntity }) {
+	if (!endpoint.lastDeliveryAt) {
+		return <span className="text-muted-foreground text-xs">never</span>;
+	}
+	return (
+		<span className="inline-flex items-center gap-1.5 text-xs">
+			{endpoint.lastDeliveryOk ? (
+				<CheckCircle2 className="text-success h-3.5 w-3.5" aria-hidden="true" />
+			) : (
+				<XCircle className="text-danger h-3.5 w-3.5" aria-hidden="true" />
+			)}
+			{timeAgo(endpoint.lastDeliveryAt)}
+		</span>
+	);
+}
+
+export default function WebhooksPage() {
+	const navigate = useNavigate();
+	const { data: endpoints, isLoading, isError } = useWebhookEndpoints();
+	const [query, setQuery] = useState('');
+	const [createOpen, setCreateOpen] = useState(false);
+
+	const rows = useMemo(() => {
+		const list = endpoints ?? [];
+		const q = query.trim().toLowerCase();
+		if (!q) return list;
+		return list.filter(
+			(e) => e.name.toLowerCase().includes(q) || e.url.toLowerCase().includes(q),
+		);
+	}, [endpoints, query]);
+
+	const stats = useMemo(() => {
+		const list = endpoints ?? [];
+		const deliveries = list.reduce((sum, e) => sum + e.deliveries24h, 0);
+		const rated = list.filter((e) => e.successRate24h != null);
+		const weighted = rated.reduce(
+			(sum, e) => sum + (e.successRate24h ?? 0) * e.deliveries24h,
+			0,
+		);
+		const ratedVolume = rated.reduce((sum, e) => sum + e.deliveries24h, 0);
+		return {
+			endpoints: list.length,
+			deliveries,
+			successRate: ratedVolume > 0 ? weighted / ratedVolume : null,
+			failing: list.filter((e) => e.status === 'failing').length,
+		};
+	}, [endpoints]);
+
+	const columns: Column<WebhookEndpointEntity>[] = [
+		{
+			key: 'name',
+			header: 'Destination',
+			render: (e) => (
+				<div className="min-w-0">
+					<p className="text-foreground truncate text-sm font-medium">{e.name}</p>
+					<p className="text-muted-foreground truncate font-mono text-xs">
+						{displayUrl(e.url)}
+					</p>
+				</div>
+			),
+		},
+		{
+			key: 'type',
+			header: 'Type',
+			render: (e) => <DestinationBadge type={e.destinationType} />,
+		},
+		{ key: 'events', header: 'Events', render: (e) => <EventTypeChips endpoint={e} /> },
+		{
+			key: 'status',
+			header: 'Status',
+			render: (e) => <EndpointStatusBadge status={e.status} />,
+		},
+		{
+			key: 'deliveries',
+			header: 'Deliveries (24h)',
+			render: (e) => (
+				<span className="font-mono text-xs tabular-nums">
+					{e.deliveries24h}
+					<span className="text-muted-foreground">
+						{' '}
+						· {formatRate(e.successRate24h)} ok
+					</span>
+				</span>
+			),
+		},
+		{
+			key: 'last',
+			header: 'Last delivery',
+			render: (e) => <LastDeliveryCell endpoint={e} />,
+		},
+	];
+
+	return (
+		<PageShell>
+			<PageHeader
+				title="Webhooks"
+				subtitle="Push platform events to your own systems or straight into Slack — signed, retried, and inspectable."
+				actions={
+					<>
+						<Button onClick={() => setCreateOpen(true)}>
+							<Plus className="h-4 w-4" /> New destination
+						</Button>
+						<PageHelp
+							title="About Webhooks"
+							intro={
+								<p>
+									Destinations receive platform events (executions, credentials,
+									agent registrations…) without polling. HTTPS endpoints get
+									signed JSON for machines; Slack destinations get readable
+									channel messages for humans.
+								</p>
+							}
+							sections={[
+								{
+									heading: 'Verifying deliveries',
+									body: (
+										<p>
+											HTTPS deliveries carry Standard Webhooks headers
+											(webhook-id, webhook-timestamp, webhook-signature).
+											Verify the HMAC with the endpoint&rsquo;s signing secret
+											and treat webhook-id as an idempotency key. Slack
+											destinations are unsigned — the incoming webhook URL is
+											the credential.
+										</p>
+									),
+								},
+								{
+									heading: 'Failures and retries',
+									body: (
+										<p>
+											Failed deliveries retry with exponential backoff. An
+											endpoint that keeps failing is marked as such and is
+											eventually disabled — you can redeliver any event from
+											its Deliveries tab once the receiver is fixed.
+										</p>
+									),
+								},
+							]}
+						/>
+					</>
+				}
+			/>
+
+			<div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+				<StatCard
+					label="Endpoints"
+					value={stats.endpoints}
+					icon={<Webhook className="h-4 w-4" />}
+					accent="primary"
+					isLoading={isLoading}
+				/>
+				<StatCard
+					label="Deliveries (24h)"
+					value={stats.deliveries}
+					icon={<Activity className="h-4 w-4" />}
+					accent="blue"
+					isLoading={isLoading}
+				/>
+				<StatCard
+					label="Success rate (24h)"
+					value={formatRate(stats.successRate)}
+					icon={<CheckCircle2 className="h-4 w-4" />}
+					accent="green"
+					isLoading={isLoading}
+				/>
+				<StatCard
+					label="Failing endpoints"
+					value={stats.failing}
+					icon={<AlertTriangle className="h-4 w-4" />}
+					accent={stats.failing > 0 ? 'danger' : 'neutral'}
+					valueClassName={stats.failing > 0 ? 'text-danger' : undefined}
+					isLoading={isLoading}
+				/>
+			</div>
+
+			<div className="flex items-center gap-3">
+				<SearchInput
+					value={query}
+					onValueChange={setQuery}
+					icon={<Filter className="h-3.5 w-3.5" />}
+					placeholder="Filter endpoints by name or URL…"
+					aria-label="Filter endpoints"
+					className="max-w-sm flex-1"
+					disabled={(endpoints ?? []).length === 0}
+				/>
+			</div>
+
+			{isError && <ErrorAlert message="Failed to load webhook endpoints." />}
+			{!isError && !isLoading && (endpoints ?? []).length === 0 ? (
+				<EmptyState
+					icon={<Webhook className="h-6 w-6" />}
+					title="No destinations yet"
+					description="Register an HTTPS endpoint or connect a Slack channel to start receiving platform events — agent registrations, execution results, credential expiry warnings, and more."
+					action={
+						<Button onClick={() => setCreateOpen(true)}>
+							<Plus className="h-4 w-4" /> New destination
+						</Button>
+					}
+				/>
+			) : (
+				!isError && (
+					<DataTable
+						columns={columns}
+						data={rows}
+						getRowKey={(e) => e.id}
+						isLoading={isLoading}
+						emptyMessage="No endpoints match the filter."
+						ariaLabel="Webhook endpoints"
+						onRowClick={(e) => navigate(`/webhooks/${encodeURIComponent(e.id)}`)}
+						getRowLabel={(e) => `View endpoint ${e.name}`}
+						renderCard={(e) => (
+							<div className="space-y-2">
+								<div className="flex items-center justify-between gap-2">
+									<p className="text-foreground truncate text-sm font-medium">
+										{e.name}
+									</p>
+									<EndpointStatusBadge status={e.status} />
+								</div>
+								<p className="text-muted-foreground truncate font-mono text-xs">
+									{displayUrl(e.url)}
+								</p>
+								<div className="flex items-center justify-between gap-2">
+									<span className="flex items-center gap-2">
+										<DestinationBadge type={e.destinationType} />
+										<EventTypeChips endpoint={e} />
+									</span>
+									<LastDeliveryCell endpoint={e} />
+								</div>
+							</div>
+						)}
+					/>
+				)
+			)}
+
+			<CreateEndpointSheet open={createOpen} onClose={() => setCreateOpen(false)} />
+		</PageShell>
+	);
+}

--- a/ui/src/modules/webhooks/routes.tsx
+++ b/ui/src/modules/webhooks/routes.tsx
@@ -1,0 +1,13 @@
+/**
+ * Webhooks module routes. Paths are RELATIVE to the `/app` shell, so these
+ * mount at `/app/webhooks` and `/app/webhooks/:webhookId`. Registered
+ * additively into `@/shared/app/routes.ts`.
+ */
+import type { RouteObject } from 'react-router';
+import WebhooksPage from '@/modules/webhooks/pages/WebhooksPage';
+import WebhookDetailPage from '@/modules/webhooks/pages/WebhookDetailPage';
+
+export const webhooksRoutes: RouteObject[] = [
+	{ path: 'webhooks', element: <WebhooksPage /> },
+	{ path: 'webhooks/:webhookId', element: <WebhookDetailPage /> },
+];

--- a/ui/src/shared/app/nav.ts
+++ b/ui/src/shared/app/nav.ts
@@ -1,5 +1,14 @@
 import type { ComponentType } from 'react';
-import { Compass, Boxes, Bot, LayoutDashboard, LayoutGrid, KeyRound, Activity } from 'lucide-react';
+import {
+	Compass,
+	Boxes,
+	Bot,
+	LayoutDashboard,
+	LayoutGrid,
+	KeyRound,
+	Activity,
+	Webhook,
+} from 'lucide-react';
 
 /**
  * A primary-navigation entry. `order` (not array position) controls placement,
@@ -45,6 +54,7 @@ export const navItems: NavItem[] = [
 	{ id: 'toolkits', label: 'Toolkits', to: '/toolkits', order: 40, icon: Boxes },
 	{ id: 'credentials', label: 'Credentials', to: '/credentials', order: 50, icon: KeyRound },
 	{ id: 'agents', label: 'Agents', to: '/agents', order: 60, icon: Bot },
+	{ id: 'webhooks', label: 'Webhooks', to: '/webhooks', order: 65, icon: Webhook },
 	{ id: 'monitor', label: 'Monitor', to: '/monitor', order: 70, icon: Activity },
 	// NOTE: the docs portal ("API Reference", /docs) deliberately does NOT live
 	// in this registry. It's reference material, not a product destination, so

--- a/ui/src/shared/app/routes.ts
+++ b/ui/src/shared/app/routes.ts
@@ -40,6 +40,7 @@ export const ROUTES = {
 	credentials: '/credentials',
 	agents: '/agents',
 	monitor: '/monitor',
+	webhooks: '/webhooks',
 	accessRequests: '/access-requests',
 	docs: '/docs',
 } as const;
@@ -97,6 +98,7 @@ import { discoverRoutes } from '@/modules/discover/routes';
 import { workspaceRoutes } from '@/modules/workspace/routes';
 import { credentialsRoutes } from '@/modules/credentials/routes';
 import { monitorRoutes } from '@/modules/monitor/routes';
+import { webhooksRoutes } from '@/modules/webhooks/routes';
 
 export const moduleRoutes: RouteObject[] = [
 	// <-- feature route spreads go here (one `...xRoutes,` line per module) -->
@@ -107,4 +109,5 @@ export const moduleRoutes: RouteObject[] = [
 	...workspaceRoutes,
 	...credentialsRoutes,
 	...monitorRoutes,
+	...webhooksRoutes,
 ];


### PR DESCRIPTION
## Summary

UI-only prototype of outbound webhooks so operators can push platform events to their own systems without polling. The create flow starts from a **destination type** (Stripe's event-destination pattern): signed HTTPS endpoints for machines, or Slack incoming webhooks that render events as human-readable Block Kit messages — removing the middleman-lambda/Zapier step Slack would otherwise require. Research + extracted flows live in the private plans repo (`jentic-one-plans/research/webhooks-ux-flows.md`).

## Changes

- `ui/src/modules/webhooks/` — new module: list page (stat strip, destination table with Type column), detail page (Overview / Deliveries / Settings tabs, delivery inspector with attempt timeline + redeliver), create sheet with destination-type step, grouped event multi-select, Slack message preview, one-time `whsec_` secret reveal (HTTPS only) and inline ping result
- `ui/src/modules/webhooks/mocks/handlers.ts` — MSW handlers with a mutable in-memory store; per-type payloads/headers (signed envelope vs unsigned Block Kit), Slack URL validation, 409 on rotate-secret for Slack
- `ui/src/shared/app/nav.ts`, `routes.ts` — nav entry (order 65) + route spread, registered additively
- `ui/eslint.config.js` — `webhooks` added to `MODULE_QUERY_KEY_ROOTS`
- **Out of scope**: any backend surface (tables, fan-out, dispatcher, API) — the module repository speaks `fetch` against the mocked paths so a generated client can replace it in one file; no tests yet (prototype)

## Risk & rollback

- Low risk: UI-only, MSW-mocked, no backend or auth surface touched; nav/routes changes are additive. Revert the squash commit to remove.

## Test plan

- `tsc --noEmit` and `eslint src/modules/webhooks` clean
- No automated tests; manual verification via a Playwright script against `VITE_ENABLE_MSW=1 npm run dev`: create HTTPS + Slack destinations (secret reveal / no-secret paths), ping + test events, delivery inspection (Block Kit payload for Slack), pause/resume, rotate (HTTPS only), settings validation, delete

Made with [Cursor](https://cursor.com)