### PR TITLE
fix(reference): key prefixed included-router routes by their full path

### DIFF
--- a/src/jentic_one/shared/web/endpoint_scopes.py
+++ b/src/jentic_one/shared/web/endpoint_scopes.py
@@ -201,14 +201,32 @@ NON_IDENTITY_AUTH: dict[tuple[str, str], str] = {
 # --- route introspection ----------------------------------------------------
 
 
-def _iter_api_routes(routes: list[Any]) -> list[APIRoute]:
-    """Flatten ``app.routes``, descending into upstream ``_IncludedRouter`` wrappers."""
-    out: list[APIRoute] = []
+def _iter_api_routes(routes: list[Any], prefix: str = "") -> list[tuple[str, APIRoute]]:
+    """Flatten ``app.routes`` into ``(prefix, route)`` pairs.
+
+    Descends into upstream ``_IncludedRouter`` wrappers, accumulating the
+    ``include_router(prefix=...)`` prefix so a route's *full* path can be
+    reconstructed. FastAPI stores each included route's ``.path`` **without** the
+    prefix its parent applied (the prefix lives on the ``_IncludedRouter`` wrapper,
+    in ``include_context.prefix``), so a naive walk keys routes by their
+    prefix-stripped path — which then fails to join to the OpenAPI document (whose
+    paths carry the full prefix). That silently dropped every prefixed
+    ``AppContainer.extra_routers`` route (e.g. an enterprise overlay's
+    ``/enterprise/admin/*`` console) from the auth map, so the endpoint reference
+    mis-classified them as public. Threading the prefix through fixes the join.
+    """
+    out: list[tuple[str, APIRoute]] = []
     for route in routes:
         if isinstance(route, APIRoute):
-            out.append(route)
+            out.append((prefix, route))
         elif _IncludedRouterType is not None and isinstance(route, _IncludedRouterType):
-            out.extend(_iter_api_routes(route.original_router.routes))
+            # The included prefix lives on the wrapper's include_context (FastAPI
+            # ≥0.138). Read it defensively: if a future refactor moves it, we fall
+            # back to no extra prefix rather than crash — the classification guard
+            # in endpoint_reference remains the loud backstop.
+            context = getattr(route, "include_context", None)
+            child_prefix = prefix + getattr(context, "prefix", "")
+            out.extend(_iter_api_routes(route.original_router.routes, child_prefix))
     return out
 
 
@@ -304,14 +322,14 @@ def build_operation_auth_map(
     stable across both the route table and the generated document.
     """
     result: dict[tuple[str, str], dict[str, Any]] = {}
-    for route in _iter_api_routes(app.routes):
+    for prefix, route in _iter_api_routes(app.routes):
         methods = {m.upper() for m in (route.methods or set())} - {"HEAD", "OPTIONS"}
         if not methods:
             continue
         has_identity, perms, actor = _route_auth(route)
 
         for method in methods:
-            key = (method, _normalise_path(route.path))
+            key = (method, _normalise_path(prefix + route.path))
             # A curated scope/actor override (or a non-identity auth note) makes an
             # operation authenticated even when no get_current_identity dependency
             # is visible (service-layer-enforced scopes, RAT-gated routes, ...).

--- a/tests/arch/test_endpoint_tree.py
+++ b/tests/arch/test_endpoint_tree.py
@@ -300,6 +300,48 @@ def test_identity_dependency_recognition_is_qualname_scoped() -> None:
     assert _closure_values(_make_impostor()) == (False, None, None)
 
 
+def test_prefixed_included_router_keyed_by_full_path() -> None:
+    """A router included under a prefix is keyed by its FULL path in the auth map.
+
+    Regression for the ``AppContainer.extra_routers`` case (e.g. an enterprise
+    overlay's ``/enterprise/admin/*`` console): ``include_router(prefix=...)`` wraps
+    the router in a FastAPI ``_IncludedRouter`` whose child routes carry only their
+    own (prefix-stripped) ``.path``. If the introspection walk drops that prefix,
+    the auth map is keyed by the stripped path, fails to join the OpenAPI document
+    (which uses the full path), and the endpoint reference mis-classifies the route
+    as public — tripping ``assert_classification_is_sound`` with a 500. The walk
+    must reconstruct the prefix so the scope is recovered under the full path.
+    """
+    from fastapi import APIRouter, FastAPI
+
+    from jentic_one.shared.web.endpoint_scopes import build_operation_auth_map
+
+    router = APIRouter()
+
+    @router.get("/toolkits/{toolkit_id}/shares", operation_id="prefixedListShares")
+    async def _list_shares(
+        toolkit_id: str,
+        _identity: object = get_current_identity(required_permissions=["toolkits:write"]),
+    ) -> dict[str, str]:
+        return {"toolkit_id": toolkit_id}
+
+    app = FastAPI()
+    app.include_router(router, prefix="/enterprise/admin")
+
+    auth_map = build_operation_auth_map(app)
+
+    full_key = ("GET", "/enterprise/admin/toolkits/{toolkit_id}/shares")
+    stripped_key = ("GET", "/toolkits/{toolkit_id}/shares")
+    assert full_key in auth_map, (
+        "prefixed included route must be keyed by its FULL path so it joins the "
+        f"OpenAPI document; got keys {sorted(auth_map)}"
+    )
+    assert stripped_key not in auth_map, "route must NOT be keyed by the prefix-stripped path"
+    entry = auth_map[full_key]
+    assert entry["authenticated"] is True
+    assert entry["scopes"] == ["toolkits:write"]
+
+
 @pytest.mark.arch
 def test_committed_reference_matches_generated() -> None:
     """docs/reference/endpoints.{md,json} must equal what the generator produces.

--- a/tests/arch/test_endpoint_tree.py
+++ b/tests/arch/test_endpoint_tree.py
@@ -16,6 +16,7 @@ import json
 from dataclasses import asdict
 
 import pytest
+from fastapi import APIRouter, FastAPI
 from tools.endpoint_tree import (
     ENDPOINTS_JSON,
     ENDPOINTS_MD,
@@ -49,6 +50,7 @@ from jentic_one.shared.web.endpoint_scopes import (
     TYPICAL_OPERATOR,
     _closure_values,
     _typical_caller,
+    build_operation_auth_map,
 )
 
 
@@ -312,10 +314,6 @@ def test_prefixed_included_router_keyed_by_full_path() -> None:
     as public — tripping ``assert_classification_is_sound`` with a 500. The walk
     must reconstruct the prefix so the scope is recovered under the full path.
     """
-    from fastapi import APIRouter, FastAPI
-
-    from jentic_one.shared.web.endpoint_scopes import build_operation_auth_map
-
     router = APIRouter()
 
     @router.get("/toolkits/{toolkit_id}/shares", operation_id="prefixedListShares")


### PR DESCRIPTION
## Summary

`GET /reference/endpoints.json` (which the docs SPA and CLI consume) returns **500** for any app that mounts a router under a prefix via `AppContainer.extra_routers` — notably an enterprise overlay's `/enterprise/admin/*` admin console. That breaks the docs page ("Couldn't load the endpoint reference").

**Root cause:** `include_router(prefix=...)` wraps the router in FastAPI's `_IncludedRouter`, whose child routes carry only their own **prefix-stripped** `.path` (the prefix lives on the wrapper's `include_context`). `_iter_api_routes` descended into the inner router and dropped that prefix, so `build_operation_auth_map` keyed the routes by the stripped path (e.g. `/toolkits/{id}/shares`). The endpoint-reference builder then looked them up by the **full** OpenAPI path (`/enterprise/admin/toolkits/{id}/shares`), missed, fell back to the spec's `security` (`[]` for these routes), and classified them **public** — tripping `assert_classification_is_sound` (undeclared public → assumed "introspection failed open") with a hard 500.

**Fix:** `_iter_api_routes` now yields `(prefix, route)` pairs, accumulating each `_IncludedRouter`'s `include_context.prefix` (read defensively so a future FastAPI refactor degrades gracefully rather than crashing) as it descends. `build_operation_auth_map` keys by `_normalise_path(prefix + route.path)`. OSS's own top-level routers are unaffected (empty prefix).

## Why it matters

The endpoint reference is the machine-readable authorization source of truth for the CLI + docs SPA. Any overlay that uses the documented `extra_routers` seam with a prefix hit this. Fixing it in OSS makes the seam correct for all consumers (no per-overlay workaround).

## Test plan

- [x] New regression test `test_prefixed_included_router_keyed_by_full_path`: a router included under a prefix is recovered under its **full** path with its scope, and **not** under the stripped path. Verified it **fails without the fix** and passes with it.
- [x] `tests/arch/test_endpoint_tree.py` + `tests/arch/test_scope_catalog.py`: **28 passed** (existing 27 + new), including the committed-reference drift test and the classification guards.
- [x] `ruff` + `mypy` clean (pre-commit hooks pass).
- [x] Verified end-to-end against the real enterprise combined app: `collect_endpoints` now succeeds and all 9 `/enterprise/admin/*` routes classify as authenticated with the correct scopes (`toolkits:write` / `credentials:write` / `org:admin`).
