### PR TITLE
feat(auth): add SSO login seams — Google provider, provisioning hook, superset verifier

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -371,7 +371,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 16797
+        "line_number": 17043
       }
     ],
     "release-please-config.json": [
@@ -1802,5 +1802,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-05T09:41:37Z"
+  "generated_at": "2026-08-11T11:35:58Z"
 }

--- a/docs/reference/endpoints.json
+++ b/docs/reference/endpoints.json
@@ -2355,7 +2355,7 @@
       "path": "/oauth/callback",
       "public": true,
       "required_scopes": [],
-      "summary": "Oauth Callback",
+      "summary": "Authorize Oauth Callback",
       "surface": "oauth",
       "typical_caller": null
     },

--- a/docs/reference/endpoints.json
+++ b/docs/reference/endpoints.json
@@ -1346,6 +1346,21 @@
       "authenticated": false,
       "group": "Public (unauthenticated)",
       "implied_scopes": {},
+      "method": "GET",
+      "operation_id": "authIdpDescriptor",
+      "path": "/auth/idp",
+      "public": true,
+      "required_scopes": [],
+      "summary": "External IdP login descriptor",
+      "surface": "auth",
+      "typical_caller": null
+    },
+    {
+      "actor_types": [],
+      "auth_note": null,
+      "authenticated": false,
+      "group": "Public (unauthenticated)",
+      "implied_scopes": {},
       "method": "POST",
       "operation_id": "login",
       "path": "/auth/login",
@@ -4648,5 +4663,5 @@
     ],
     "total": 31
   },
-  "total": 157
+  "total": 158
 }

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -27,7 +27,7 @@ Every API endpoint grouped by its **typical caller**, then by surface, annotated
 
 > The grouping and the _Typical caller_ column are an **advisory hint** at who usually calls a route, inferred from the scope family. They are **not** an enforced restriction: access is gated by the **scope**, not the actor kind, so any actor holding the required scope can call the endpoint.
 
-_Total endpoints: **157**._
+_Total endpoints: **158**._
 
 
 ## Agent-facing (typically agent / service-account / toolkit) (31)
@@ -358,7 +358,7 @@ _Total endpoints: **157**._
 | GET | `/users/me` | _any authenticated_ | any | Get current user |
 | POST | `/users/me:change-password` | _any authenticated_ | any | Change own password |
 
-## Public (unauthenticated) (18)
+## Public (unauthenticated) (19)
 
 
 ### `.well-known`
@@ -379,6 +379,7 @@ _Total endpoints: **157**._
 | Method | Path | Scope(s) | Typical caller | Summary |
 |---|---|---|---|---|
 | GET | `/auth/health` | _public — no auth_ | — | Auth health |
+| GET | `/auth/idp` | _public — no auth_ | — | External IdP login descriptor |
 | POST | `/auth/login` | _public — no auth_ | — | Log in |
 
 ### `authorize`

--- a/docs/reference/endpoints.md
+++ b/docs/reference/endpoints.md
@@ -422,7 +422,7 @@ _Total endpoints: **158**._
 
 | Method | Path | Scope(s) | Typical caller | Summary |
 |---|---|---|---|---|
-| GET | `/oauth/callback` | _public — no auth_ | — | Oauth Callback |
+| GET | `/oauth/callback` | _public — no auth_ | — | Authorize Oauth Callback |
 | POST | `/oauth/token` | _public — no auth_ | — | Token Endpoint |
 
 ### `ready`

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -10000,6 +10000,56 @@ paths:
       summary: Auth health
       tags:
       - System
+  /auth/idp:
+    get:
+      description: |-
+        Public capability hint: whether IdP login is enabled, and which provider.
+
+        The SPA reads this before login to decide whether to show a "Continue with
+        <provider>" button. Unauthenticated and secret-free — it advertises only the
+        enabled flag and the provider name (never client secrets or endpoints).
+      operationId: authIdpDescriptor
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Authidpdescriptor
+                type: object
+          description: Successful Response
+        '400':
+          content:
+            application/problem+json:
+              example: *id001
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Bad Request
+        '422':
+          content:
+            application/problem+json:
+              example: *id002
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              example: *id003
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Internal Server Error
+        '503':
+          content:
+            application/problem+json:
+              example: *id004
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+          description: Service Unavailable
+      security: []
+      summary: External IdP login descriptor
+      tags:
+      - Discovery
   /auth/login:
     post:
       description: Authenticate and return a JWT token bundle.

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -13326,7 +13326,7 @@ paths:
                 $ref: '#/components/schemas/ProblemDetail'
           description: Service Unavailable
       security: []
-      summary: Oauth Callback
+      summary: Authorize Oauth Callback
       tags:
       - OAuth
   /oauth/introspect:

--- a/src/jentic_one/auth/core/idp/__init__.py
+++ b/src/jentic_one/auth/core/idp/__init__.py
@@ -6,20 +6,28 @@ from jentic_one.auth.core.idp.oidc import GoogleOidcAdapter, OidcAdapter
 from jentic_one.auth.core.idp.provisioning import (
     AdmissionDecision,
     AdmissionPolicy,
+    DefaultGrantsProvider,
     get_admission_policy,
+    get_default_idp_grants,
+    no_default_grants,
     open_admission_policy,
     set_admission_policy,
+    set_default_idp_grants,
 )
 
 __all__ = [
     "AdmissionDecision",
     "AdmissionPolicy",
+    "DefaultGrantsProvider",
     "GoogleOidcAdapter",
     "IdpAdapter",
     "IdpClaims",
     "OidcAdapter",
     "build_idp_adapter",
     "get_admission_policy",
+    "get_default_idp_grants",
+    "no_default_grants",
     "open_admission_policy",
     "set_admission_policy",
+    "set_default_idp_grants",
 ]

--- a/src/jentic_one/auth/core/idp/__init__.py
+++ b/src/jentic_one/auth/core/idp/__init__.py
@@ -2,5 +2,21 @@
 
 from jentic_one.auth.core.idp.adapter import IdpAdapter, IdpClaims
 from jentic_one.auth.core.idp.oidc import OidcAdapter
+from jentic_one.auth.core.idp.provisioning import (
+    AdmissionDecision,
+    AdmissionPolicy,
+    get_admission_policy,
+    open_admission_policy,
+    set_admission_policy,
+)
 
-__all__ = ["IdpAdapter", "IdpClaims", "OidcAdapter"]
+__all__ = [
+    "AdmissionDecision",
+    "AdmissionPolicy",
+    "IdpAdapter",
+    "IdpClaims",
+    "OidcAdapter",
+    "get_admission_policy",
+    "open_admission_policy",
+    "set_admission_policy",
+]

--- a/src/jentic_one/auth/core/idp/__init__.py
+++ b/src/jentic_one/auth/core/idp/__init__.py
@@ -1,7 +1,8 @@
 """Pluggable Identity Provider adapters."""
 
 from jentic_one.auth.core.idp.adapter import IdpAdapter, IdpClaims
-from jentic_one.auth.core.idp.oidc import OidcAdapter
+from jentic_one.auth.core.idp.factory import build_idp_adapter
+from jentic_one.auth.core.idp.oidc import GoogleOidcAdapter, OidcAdapter
 from jentic_one.auth.core.idp.provisioning import (
     AdmissionDecision,
     AdmissionPolicy,
@@ -13,9 +14,11 @@ from jentic_one.auth.core.idp.provisioning import (
 __all__ = [
     "AdmissionDecision",
     "AdmissionPolicy",
+    "GoogleOidcAdapter",
     "IdpAdapter",
     "IdpClaims",
     "OidcAdapter",
+    "build_idp_adapter",
     "get_admission_policy",
     "open_admission_policy",
     "set_admission_policy",

--- a/src/jentic_one/auth/core/idp/adapter.py
+++ b/src/jentic_one/auth/core/idp/adapter.py
@@ -15,6 +15,9 @@ class IdpClaims:
     first_name: str
     last_name: str
     email_verified: bool = False
+    # Google's `hd` (hosted-domain) claim, present only for Google Workspace
+    # accounts. None for generic OIDC providers and consumer Google accounts.
+    hosted_domain: str | None = None
 
 
 class IdpAdapter(Protocol):

--- a/src/jentic_one/auth/core/idp/factory.py
+++ b/src/jentic_one/auth/core/idp/factory.py
@@ -1,0 +1,33 @@
+"""Factory that selects the right OIDC adapter for a config.
+
+A tiny provider→adapter registry so new providers slot in without touching the
+authorize service. Unknown/standards-compliant providers fall back to the
+generic :class:`OidcAdapter`; ``google`` resolves to :class:`GoogleOidcAdapter`.
+
+Add a provider by mapping its ``provider`` string to an ``OidcAdapter`` subclass
+in :data:`_ADAPTERS` (e.g. an ``OktaOidcAdapter`` when that becomes real).
+"""
+
+from __future__ import annotations
+
+from jentic_one.auth.core.idp.adapter import IdpAdapter
+from jentic_one.auth.core.idp.oidc import GoogleOidcAdapter, OidcAdapter
+from jentic_one.shared.config import IdpConfig
+
+#: provider identifier -> adapter class. The generic OidcAdapter is the default
+#: for any provider not listed here (any standards-compliant OIDC IdP).
+_ADAPTERS: dict[str, type[OidcAdapter]] = {
+    "google": GoogleOidcAdapter,
+}
+
+
+def build_idp_adapter(config: IdpConfig) -> IdpAdapter | None:
+    """Build the IdP adapter for *config*, or ``None`` if IdP login is disabled.
+
+    Selects a provider-specific adapter by ``config.provider`` (falling back to
+    the generic :class:`OidcAdapter` for standard OIDC providers).
+    """
+    if not config.enabled:
+        return None
+    adapter_cls = _ADAPTERS.get(config.provider, OidcAdapter)
+    return adapter_cls(config)

--- a/src/jentic_one/auth/core/idp/oidc.py
+++ b/src/jentic_one/auth/core/idp/oidc.py
@@ -1,7 +1,14 @@
-"""Generic OIDC identity provider adapter."""
+"""OIDC identity provider adapters.
+
+`OidcAdapter` is the generic, standards-compliant base. Provider-specific
+adapters subclass it to supply well-known endpoint defaults and any
+provider-specific claim handling (e.g. Google's `hd`). Construct the right one
+for a config via the factory in `jentic_one.auth.core.idp.factory`.
+"""
 
 from __future__ import annotations
 
+from dataclasses import replace
 from urllib.parse import urlencode
 
 import httpx
@@ -9,55 +16,44 @@ import httpx
 from jentic_one.auth.core.idp.adapter import IdpClaims
 from jentic_one.shared.config import IdpConfig
 
-# Well-known Google OIDC endpoints. When `provider == "google"` and a deployment
-# doesn't override the endpoints explicitly, these are used so a tenant only has
-# to supply client_id/client_secret. Google is a standards-compliant OIDC
-# provider, so the generic adapter handles it — this is just endpoint defaulting.
-_GOOGLE_ISSUER = "https://accounts.google.com"
-_GOOGLE_AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
-_GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
-_GOOGLE_USERINFO_ENDPOINT = "https://openidconnect.googleapis.com/v1/userinfo"
-
 
 class OidcAdapter:
     """Generic OIDC-compliant identity provider adapter.
 
-    Implements the IdpAdapter protocol for any standards-compliant OIDC provider.
-    When ``config.provider == "google"`` the standard Google OIDC endpoints are
-    used as defaults (still overridable via the explicit ``*_endpoint`` config).
+    Implements the IdpAdapter protocol for any standards-compliant OIDC
+    provider. Endpoints come from explicit config; when unset they're derived
+    from the issuer. Provider-specific adapters (e.g. :class:`GoogleOidcAdapter`)
+    subclass this to supply well-known endpoint defaults and claim handling.
     """
 
     def __init__(self, config: IdpConfig) -> None:
         self._config = config
         self._discovery: dict[str, object] | None = None
 
-    @property
-    def _is_google(self) -> bool:
-        return self._config.provider == "google"
+    # ── Endpoint defaults (overridable by provider subclasses) ────────────────
+    # Subclasses override the `_default_*_endpoint` hooks to plug in well-known
+    # endpoints; explicit config always wins over any default.
+
+    def _default_authorization_endpoint(self) -> str:
+        return f"{self._config.issuer.rstrip('/')}/authorize"
+
+    def _default_token_endpoint(self) -> str:
+        return f"{self._config.issuer.rstrip('/')}/oauth/token"
+
+    def _default_userinfo_endpoint(self) -> str:
+        return f"{self._config.issuer.rstrip('/')}/userinfo"
 
     @property
     def _authorization_endpoint(self) -> str:
-        if self._config.authorization_endpoint:
-            return self._config.authorization_endpoint
-        if self._is_google:
-            return _GOOGLE_AUTHORIZATION_ENDPOINT
-        return f"{self._config.issuer.rstrip('/')}/authorize"
+        return self._config.authorization_endpoint or self._default_authorization_endpoint()
 
     @property
     def _token_endpoint(self) -> str:
-        if self._config.exchange_endpoint:
-            return self._config.exchange_endpoint
-        if self._is_google:
-            return _GOOGLE_TOKEN_ENDPOINT
-        return f"{self._config.issuer.rstrip('/')}/oauth/token"
+        return self._config.exchange_endpoint or self._default_token_endpoint()
 
     @property
     def _userinfo_endpoint(self) -> str:
-        if self._config.userinfo_endpoint:
-            return self._config.userinfo_endpoint
-        if self._is_google:
-            return _GOOGLE_USERINFO_ENDPOINT
-        return f"{self._config.issuer.rstrip('/')}/userinfo"
+        return self._config.userinfo_endpoint or self._default_userinfo_endpoint()
 
     def authorize_url(self, *, state: str, nonce: str, redirect_uri: str) -> str:
         """Build the OIDC authorization URL."""
@@ -96,18 +92,46 @@ class OidcAdapter:
             return userinfo_resp.json()  # type: ignore[no-any-return]
 
     def map_claims(self, userinfo: dict[str, object]) -> IdpClaims:
-        """Map standard OIDC claims to IdpClaims.
-
-        ``hd`` (hosted domain) is a Google-specific claim present for Google
-        Workspace accounts; it is surfaced here for any provider that sends it
-        and left None otherwise.
-        """
-        hd = userinfo.get("hd")
+        """Map standard OIDC claims to IdpClaims."""
         return IdpClaims(
             external_subject=str(userinfo.get("sub", "")),
             email=str(userinfo.get("email", "")),
             first_name=str(userinfo.get("given_name", "")),
             last_name=str(userinfo.get("family_name", "")),
             email_verified=bool(userinfo.get("email_verified", False)),
-            hosted_domain=str(hd) if hd else None,
         )
+
+
+class GoogleOidcAdapter(OidcAdapter):
+    """OIDC adapter for Google (accounts.google.com / Google Workspace).
+
+    Google is standards-compliant OIDC, so this only supplies the well-known
+    endpoint defaults (a tenant need only provide client_id/client_secret) and
+    surfaces Google's `hd` (hosted-domain) claim used by admission policies.
+    Explicit `*_endpoint` config still overrides the defaults.
+    """
+
+    #: Well-known Google OIDC endpoints (used when config doesn't override them).
+    ISSUER = "https://accounts.google.com"
+    AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+    TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+    USERINFO_ENDPOINT = "https://openidconnect.googleapis.com/v1/userinfo"
+
+    def _default_authorization_endpoint(self) -> str:
+        return self.AUTHORIZATION_ENDPOINT
+
+    def _default_token_endpoint(self) -> str:
+        return self.TOKEN_ENDPOINT
+
+    def _default_userinfo_endpoint(self) -> str:
+        return self.USERINFO_ENDPOINT
+
+    def map_claims(self, userinfo: dict[str, object]) -> IdpClaims:
+        """Map Google claims, surfacing the `hd` (hosted-domain) claim.
+
+        `hd` is present only for Google Workspace accounts; it's None for
+        consumer Google accounts. Admission policies use it as a hard gate.
+        """
+        base = super().map_claims(userinfo)
+        hd = userinfo.get("hd")
+        return replace(base, hosted_domain=str(hd) if hd else None)

--- a/src/jentic_one/auth/core/idp/oidc.py
+++ b/src/jentic_one/auth/core/idp/oidc.py
@@ -9,11 +9,22 @@ import httpx
 from jentic_one.auth.core.idp.adapter import IdpClaims
 from jentic_one.shared.config import IdpConfig
 
+# Well-known Google OIDC endpoints. When `provider == "google"` and a deployment
+# doesn't override the endpoints explicitly, these are used so a tenant only has
+# to supply client_id/client_secret. Google is a standards-compliant OIDC
+# provider, so the generic adapter handles it — this is just endpoint defaulting.
+_GOOGLE_ISSUER = "https://accounts.google.com"
+_GOOGLE_AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+_GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+_GOOGLE_USERINFO_ENDPOINT = "https://openidconnect.googleapis.com/v1/userinfo"
+
 
 class OidcAdapter:
     """Generic OIDC-compliant identity provider adapter.
 
     Implements the IdpAdapter protocol for any standards-compliant OIDC provider.
+    When ``config.provider == "google"`` the standard Google OIDC endpoints are
+    used as defaults (still overridable via the explicit ``*_endpoint`` config).
     """
 
     def __init__(self, config: IdpConfig) -> None:
@@ -21,21 +32,31 @@ class OidcAdapter:
         self._discovery: dict[str, object] | None = None
 
     @property
+    def _is_google(self) -> bool:
+        return self._config.provider == "google"
+
+    @property
     def _authorization_endpoint(self) -> str:
         if self._config.authorization_endpoint:
             return self._config.authorization_endpoint
+        if self._is_google:
+            return _GOOGLE_AUTHORIZATION_ENDPOINT
         return f"{self._config.issuer.rstrip('/')}/authorize"
 
     @property
     def _token_endpoint(self) -> str:
         if self._config.exchange_endpoint:
             return self._config.exchange_endpoint
+        if self._is_google:
+            return _GOOGLE_TOKEN_ENDPOINT
         return f"{self._config.issuer.rstrip('/')}/oauth/token"
 
     @property
     def _userinfo_endpoint(self) -> str:
         if self._config.userinfo_endpoint:
             return self._config.userinfo_endpoint
+        if self._is_google:
+            return _GOOGLE_USERINFO_ENDPOINT
         return f"{self._config.issuer.rstrip('/')}/userinfo"
 
     def authorize_url(self, *, state: str, nonce: str, redirect_uri: str) -> str:
@@ -75,11 +96,18 @@ class OidcAdapter:
             return userinfo_resp.json()  # type: ignore[no-any-return]
 
     def map_claims(self, userinfo: dict[str, object]) -> IdpClaims:
-        """Map standard OIDC claims to IdpClaims."""
+        """Map standard OIDC claims to IdpClaims.
+
+        ``hd`` (hosted domain) is a Google-specific claim present for Google
+        Workspace accounts; it is surfaced here for any provider that sends it
+        and left None otherwise.
+        """
+        hd = userinfo.get("hd")
         return IdpClaims(
             external_subject=str(userinfo.get("sub", "")),
             email=str(userinfo.get("email", "")),
             first_name=str(userinfo.get("given_name", "")),
             last_name=str(userinfo.get("family_name", "")),
             email_verified=bool(userinfo.get("email_verified", False)),
+            hosted_domain=str(hd) if hd else None,
         )

--- a/src/jentic_one/auth/core/idp/provisioning.py
+++ b/src/jentic_one/auth/core/idp/provisioning.py
@@ -13,6 +13,11 @@ domain-allowlist, hosted-domain gating, …) installs its own callable via
 stays in ``AuthorizeService`` — the policy only answers "admit-and-create, or
 reject this new email?".
 
+A second, independent seam decides *what a brand-new user starts with*: the
+**default-grants provider** (:func:`set_default_idp_grants`) returns the baseline
+permissions a just-created IdP user receives (e.g. read-only). It defaults to
+granting nothing (today's behaviour) and applies only to brand-new users.
+
 Same process-global registry posture as ``register_config`` in
 ``shared/config.py``: a module-level default, replaceable at import time.
 """
@@ -71,3 +76,42 @@ def set_admission_policy(policy: AdmissionPolicy) -> None:
 def get_admission_policy() -> AdmissionPolicy:
     """Return the currently-installed admission policy (open by default)."""
     return _admission_policy
+
+
+class DefaultGrantsProvider(Protocol):
+    """Yields the permission grants a brand-new IdP-provisioned user receives."""
+
+    def __call__(self, claims: IdpClaims) -> list[str]:
+        """Return the permission names to grant a just-created user (may be empty)."""
+        ...
+
+
+def no_default_grants(claims: IdpClaims) -> list[str]:
+    """Default provider: grant nothing.
+
+    Preserves the historical behaviour — a self-provisioned IdP user starts with
+    no permissions until an admin grants them. A deployment that wants new users
+    to start with, say, read-only access installs its own provider via
+    :func:`set_default_idp_grants`.
+    """
+    return []
+
+
+_default_grants_provider: DefaultGrantsProvider = no_default_grants
+
+
+def set_default_idp_grants(provider: DefaultGrantsProvider) -> None:
+    """Install the process-wide default-grants provider for new IdP users.
+
+    Called once at import/boot by a deployment that wants newly-provisioned
+    external-IdP users to start with a baseline permission set (e.g. read-only).
+    The grants are applied ONLY to brand-new users at creation time; existing and
+    already-linked accounts are never modified. Last write wins.
+    """
+    global _default_grants_provider
+    _default_grants_provider = provider
+
+
+def get_default_idp_grants() -> DefaultGrantsProvider:
+    """Return the installed default-grants provider (grants nothing by default)."""
+    return _default_grants_provider

--- a/src/jentic_one/auth/core/idp/provisioning.py
+++ b/src/jentic_one/auth/core/idp/provisioning.py
@@ -1,0 +1,73 @@
+"""Provisioning-decision seam for external-IdP logins.
+
+When a verified external-IdP login resolves to a **brand-new** email (not already
+linked and not an existing local account), something has to decide whether to
+create that user. The default is **open**: auto-provision any ``email_verified``
+account — the historical behaviour, and the right default for a single-admin
+self-host.
+
+This module is the injectable seam for that one decision. It deliberately holds
+**no** rules/modes/domains: a deployment that wants a stricter policy (invite-only,
+domain-allowlist, hosted-domain gating, …) installs its own callable via
+:func:`set_admission_policy`. The link/race/fail-closed logic around this decision
+stays in ``AuthorizeService`` — the policy only answers "admit-and-create, or
+reject this new email?".
+
+Same process-global registry posture as ``register_config`` in
+``shared/config.py``: a module-level default, replaceable at import time.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Protocol
+
+from jentic_one.auth.core.idp.adapter import IdpClaims
+
+
+class AdmissionDecision(Enum):
+    """Whether a brand-new external-IdP email may be provisioned."""
+
+    ADMIT_AND_CREATE = "admit_and_create"
+    REJECT = "reject"
+
+
+class AdmissionPolicy(Protocol):
+    """Decides whether a never-seen, verified IdP email is admitted."""
+
+    def __call__(self, claims: IdpClaims) -> AdmissionDecision:
+        """Return the decision for a brand-new email (already-linked and existing
+        accounts are handled upstream and never reach the policy)."""
+        ...
+
+
+def open_admission_policy(claims: IdpClaims) -> AdmissionDecision:
+    """Default policy: admit every brand-new email (open self-signup).
+
+    This preserves the historical OSS behaviour exactly — the callback creates a
+    user for any never-seen email at this step. Note the *collision* case for an
+    unverified email (an unverified IdP email that matches an existing local
+    account) is fail-closed upstream in ``_resolve_or_create_user`` before the
+    policy is consulted, so this "admit all" default never enables account
+    takeover. A deployment wanting to gate unverified emails installs a stricter
+    policy via :func:`set_admission_policy`.
+    """
+    return AdmissionDecision.ADMIT_AND_CREATE
+
+
+_admission_policy: AdmissionPolicy = open_admission_policy
+
+
+def set_admission_policy(policy: AdmissionPolicy) -> None:
+    """Install the process-wide admission policy for new external-IdP users.
+
+    Called once at import/boot by a deployment that wants a stricter policy than
+    the open default. Idempotent from the caller's perspective — last write wins.
+    """
+    global _admission_policy
+    _admission_policy = policy
+
+
+def get_admission_policy() -> AdmissionPolicy:
+    """Return the currently-installed admission policy (open by default)."""
+    return _admission_policy

--- a/src/jentic_one/auth/services/authorize_service.py
+++ b/src/jentic_one/auth/services/authorize_service.py
@@ -18,7 +18,7 @@ from jentic_one.auth.core.idp import (
     AdmissionDecision,
     IdpAdapter,
     IdpClaims,
-    OidcAdapter,
+    build_idp_adapter,
     get_admission_policy,
 )
 from jentic_one.auth.services.errors import InvalidGrantError, UserNotAdmittedError
@@ -52,9 +52,7 @@ class AuthorizeService:
         return self._ctx.config.auth
 
     def _get_idp_adapter(self) -> IdpAdapter | None:
-        if not self._auth_config.idp.enabled:
-            return None
-        return OidcAdapter(self._auth_config.idp)
+        return build_idp_adapter(self._auth_config.idp)
 
     def get_authorize_redirect_url(
         self,

--- a/src/jentic_one/auth/services/authorize_service.py
+++ b/src/jentic_one/auth/services/authorize_service.py
@@ -14,8 +14,14 @@ from jentic_one.admin.repos import (
     UserRepository,
 )
 from jentic_one.auth.core.id_token import issue_id_token
-from jentic_one.auth.core.idp import IdpAdapter, IdpClaims, OidcAdapter
-from jentic_one.auth.services.errors import InvalidGrantError
+from jentic_one.auth.core.idp import (
+    AdmissionDecision,
+    IdpAdapter,
+    IdpClaims,
+    OidcAdapter,
+    get_admission_policy,
+)
+from jentic_one.auth.services.errors import InvalidGrantError, UserNotAdmittedError
 from jentic_one.auth.services.token_service import TokenService
 from jentic_one.shared.audit import AuditAction, AuditTargetType, record_audit
 from jentic_one.shared.config import AuthConfig
@@ -279,6 +285,19 @@ class AuthorizeService:
                     )
                     return existing_user.id
 
+                # Brand-new (never-seen) verified email: consult the deployment's
+                # admission policy. Default (open) admits any verified email — the
+                # historical behaviour. A stricter policy (invite-only, domain-
+                # gated, …) can decline via set_admission_policy(); the already-
+                # linked and existing-account paths above are never gated. On
+                # reject we leave this transaction WITHOUT writing (a rollback
+                # would discard a reject audit), then audit + raise below.
+                if get_admission_policy()(claims) is not AdmissionDecision.ADMIT_AND_CREATE:
+                    await self._audit_admission_rejected(claims, provider)
+                    raise UserNotAdmittedError(
+                        "This account is not permitted to sign in to this deployment"
+                    )
+
                 new_user = await UserRepository.create(
                     session,
                     email=claims.email,
@@ -320,3 +339,22 @@ class AuthorizeService:
             if ext_id is not None:
                 return ext_id.user_id
             raise InvalidGrantError("concurrent identity creation failed")
+
+    async def _audit_admission_rejected(self, claims: IdpClaims, provider: str) -> None:
+        """Record a rejected external-IdP login in its own committed transaction.
+
+        Kept separate from the provisioning transaction because that transaction
+        rolls back when the reject is raised — inlining the audit there would
+        discard it.
+        """
+        async with self._ctx.admin_db.transaction() as session:
+            await record_audit(
+                session,
+                action=AuditAction.CREATE,
+                target_type=AuditTargetType.USER,
+                target_id=claims.email,
+                actor_type=ActorType.USER,
+                actor_id=claims.email,
+                reason=f"external IdP login not admitted ({provider})",
+                origin=None,
+            )

--- a/src/jentic_one/auth/services/authorize_service.py
+++ b/src/jentic_one/auth/services/authorize_service.py
@@ -8,9 +8,13 @@ import secrets
 from base64 import urlsafe_b64encode
 from datetime import UTC, datetime, timedelta
 
+import structlog
+
+from jentic_one.admin.core.permissions import ALL_PERMISSIONS
 from jentic_one.admin.repos import (
     AuthorizationCodeRepository,
     ExternalIdentityRepository,
+    UserPermissionGrantRepository,
     UserRepository,
 )
 from jentic_one.auth.core.id_token import issue_id_token
@@ -20,6 +24,7 @@ from jentic_one.auth.core.idp import (
     IdpClaims,
     build_idp_adapter,
     get_admission_policy,
+    get_default_idp_grants,
 )
 from jentic_one.auth.services.errors import InvalidGrantError, UserNotAdmittedError
 from jentic_one.auth.services.token_service import TokenService
@@ -32,6 +37,23 @@ from jentic_one.shared.models import ActorType, InviteState
 
 def _hash_code(code: str) -> str:
     return hashlib.sha256(code.encode()).hexdigest()
+
+
+_logger = structlog.get_logger(__name__)
+
+
+def _valid_grants(permissions: list[str]) -> list[str]:
+    """Keep only permission names present in the catalogue, dropping unknowns.
+
+    A default-grants provider is deployment-configured, so a typo or a scope that
+    no longer exists must not be able to fail an otherwise-valid login. Unknown
+    names are logged once and skipped.
+    """
+    known = [p for p in permissions if p in ALL_PERMISSIONS]
+    unknown = [p for p in permissions if p not in ALL_PERMISSIONS]
+    if unknown:
+        _logger.warning("idp_default_grants_unknown_dropped", unknown=sorted(set(unknown)))
+    return known
 
 
 def _verify_pkce(code_verifier: str, code_challenge: str) -> bool:
@@ -315,6 +337,20 @@ class AuthorizeService:
                     email=claims.email,
                     created_by=new_user.id,
                 )
+                # Baseline permissions for a brand-new IdP user (default: none).
+                # Applied only here, at creation — existing/linked accounts above
+                # are never touched. Written in this same transaction so the user
+                # and their grants land atomically. Unknown scope names are
+                # dropped defensively so a misconfigured list can't 500 the login.
+                default_grants = _valid_grants(get_default_idp_grants()(claims))
+                if default_grants:
+                    await UserPermissionGrantRepository.set_permissions(
+                        session,
+                        new_user.id,
+                        permissions=set(default_grants),
+                        granted_by=new_user.id,
+                        created_by=new_user.id,
+                    )
                 await record_audit(
                     session,
                     action=AuditAction.CREATE,
@@ -322,7 +358,11 @@ class AuthorizeService:
                     target_id=new_user.id,
                     actor_type=ActorType.USER,
                     actor_id=new_user.id,
-                    after={"email": claims.email, "auth_provider": provider},
+                    after={
+                        "email": claims.email,
+                        "auth_provider": provider,
+                        "granted_permissions": sorted(default_grants),
+                    },
                     reason="provisioned via external IdP",
                     origin=None,
                 )

--- a/src/jentic_one/auth/services/errors.py
+++ b/src/jentic_one/auth/services/errors.py
@@ -53,6 +53,20 @@ class InvalidGrantError(AuthServiceError):
         self.reason = reason
 
 
+class UserNotAdmittedError(AuthServiceError):
+    """Raised when a verified external-IdP login is not admitted by the policy.
+
+    The IdP authenticated the user, but the deployment's admission policy declined
+    to provision a brand-new account for them (e.g. invite-only or domain-gated
+    deployments). Distinct from ``InvalidGrantError`` so callers/tests can tell an
+    authentication failure from a policy rejection.
+    """
+
+    def __init__(self, reason: str = "user_not_admitted") -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
 class TokenExpiredError(AuthServiceError):
     """Raised when a token has expired."""
 

--- a/src/jentic_one/auth/web/app.py
+++ b/src/jentic_one/auth/web/app.py
@@ -62,7 +62,20 @@ def get_exception_handlers() -> list[tuple[type[Exception], Any]]:
 
 def install_on_app(app: FastAPI, ctx: Context) -> None:
     """Install the auth token verifier on the app for shared identity resolution."""
-    app.state.verify_token = _make_auth_verifier(ctx)
+    app.state.verify_token = make_superset_verifier(ctx)
+
+
+def make_superset_verifier(ctx: Context) -> Any:
+    """Build the full-taxonomy token verifier for combined/standalone apps.
+
+    Resolves every platform token shape a signed-in caller can present:
+    agent/service-account API keys (``jak_``/``sak_``), opaque ``at_`` access
+    tokens (DB-resolved, live permissions), and HS256 web-session JWTs. This is
+    the verifier a combined-app assembler should install so admin/enterprise
+    routes accept ``at_`` regardless of surface ordering — the auth surface's
+    ``install_on_app`` uses it, and other assemblers can call it directly.
+    """
+    return _make_auth_verifier(ctx)
 
 
 def _make_auth_verifier(ctx: Context) -> Any:

--- a/src/jentic_one/auth/web/routers/authorize.py
+++ b/src/jentic_one/auth/web/routers/authorize.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import RedirectResponse
 
 from jentic_one.auth.services.authorize_service import AuthorizeService
-from jentic_one.auth.services.errors import InvalidGrantError
+from jentic_one.auth.services.errors import InvalidGrantError, UserNotAdmittedError
 from jentic_one.shared.context import Context
 from jentic_one.shared.web.deps import get_ctx
 
@@ -161,6 +161,10 @@ async def oauth_callback(
             scopes=scope or "openid",
             nonce=nonce,
         )
+    except UserNotAdmittedError:
+        # Authenticated by the IdP, but the deployment's admission policy declined
+        # to provision this account. Distinct from a grant/exchange failure.
+        return RedirectResponse(url="/error?error=access_denied", status_code=302)
     except (InvalidGrantError, httpx.HTTPStatusError):
         return RedirectResponse(url="/error?error=server_error", status_code=302)
 

--- a/src/jentic_one/auth/web/routers/authorize.py
+++ b/src/jentic_one/auth/web/routers/authorize.py
@@ -100,7 +100,7 @@ async def authorize_endpoint(
     if code_challenge_method != "S256":
         return _error_redirect(redirect_uri, "invalid_request", state, "only S256 is supported")
 
-    callback_uri = str(request.url_for("oauth_callback"))
+    callback_uri = str(request.url_for("authorize_oauth_callback"))
 
     internal_state = _sign_state(
         {
@@ -129,7 +129,11 @@ async def authorize_endpoint(
     return RedirectResponse(url=idp_url, status_code=302)
 
 
-@router.get("/oauth/callback", operation_id="authorizeOauthCallback")
+@router.get(
+    "/oauth/callback",
+    operation_id="authorizeOauthCallback",
+    name="authorize_oauth_callback",
+)
 async def oauth_callback(
     request: Request,
     code: str = Query(...),
@@ -150,7 +154,7 @@ async def oauth_callback(
     nonce = params.get("nonce")
     original_state = params.get("original_state")
 
-    callback_uri = str(request.url_for("oauth_callback"))
+    callback_uri = str(request.url_for("authorize_oauth_callback"))
     try:
         platform_code = await authorize_svc.handle_idp_callback(
             code=code,

--- a/src/jentic_one/auth/web/routers/discovery.py
+++ b/src/jentic_one/auth/web/routers/discovery.py
@@ -66,3 +66,22 @@ async def oauth_authorization_server(
 async def jwks(ctx: Context = Depends(get_ctx)) -> dict[str, Any]:
     """Return the JWKS document with the active public signing keys (ES256)."""
     return _get_publisher(ctx.config.auth).get_jwks()
+
+
+@router.get(
+    "/auth/idp",
+    operation_id="authIdpDescriptor",
+    summary="External IdP login descriptor",
+)
+async def auth_idp_descriptor(ctx: Context = Depends(get_ctx)) -> dict[str, Any]:
+    """Public capability hint: whether IdP login is enabled, and which provider.
+
+    The SPA reads this before login to decide whether to show a "Continue with
+    <provider>" button. Unauthenticated and secret-free — it advertises only the
+    enabled flag and the provider name (never client secrets or endpoints).
+    """
+    idp = ctx.config.auth.idp
+    return {
+        "enabled": idp.enabled,
+        "provider": idp.provider if idp.enabled else None,
+    }

--- a/src/jentic_one/shared/config.py
+++ b/src/jentic_one/shared/config.py
@@ -249,6 +249,11 @@ class IdpConfig(BaseModel):
     authorization_endpoint: str | None = None
     exchange_endpoint: str | None = None
     userinfo_endpoint: str | None = None
+    # Google `hd` (hosted-domain) restriction. When set, only accounts whose
+    # userinfo carries a matching `hd` claim should be admitted. OSS surfaces the
+    # claim (see IdpClaims.hosted_domain); enforcement is left to the deployment's
+    # admission policy.
+    hosted_domain: str | None = None
 
 
 class AuthConfig(BaseModel):

--- a/src/jentic_one/shared/web/app_factory.py
+++ b/src/jentic_one/shared/web/app_factory.py
@@ -564,6 +564,7 @@ def create_combined_app(
     # order as create_surface_app).
     root.include_router(get_agent_discovery_router())
 
+    auth_superset_verifier = None
     for surface in apps:
         module_path = SURFACE_MODULES[surface]
         mod = importlib.import_module(module_path)
@@ -574,6 +575,19 @@ def create_combined_app(
                 root.add_exception_handler(exc_class, handler)
         if hasattr(mod, "install_on_app"):
             mod.install_on_app(root, ctx)
+        # Capture the auth surface's full-taxonomy verifier factory (dynamic, to
+        # avoid a static shared->auth import — same posture as the surface loop).
+        if surface == "auth":
+            auth_superset_verifier = mod.make_superset_verifier
+
+    # Deterministic identity verifier: when the auth surface is enabled, install
+    # its full-taxonomy verifier (API keys + opaque `at_` + HS256) explicitly so
+    # admin/enterprise routes resolve `at_` tokens regardless of the order
+    # surfaces ran `install_on_app`. Without this the active verifier depends on
+    # surface ordering (the admin surface installs an HS256-only, `at_`-blind
+    # verifier). No-op for app sets without the auth surface.
+    if auth_superset_verifier is not None:
+        root.state.verify_token = auth_superset_verifier(ctx)
 
     # Public, schema-hidden endpoint reference (the CLI + docs SPA read this
     # instead of parsing the OpenAPI document). Registered after all surfaces so

--- a/src/jentic_one/shared/web/openapi_meta.py
+++ b/src/jentic_one/shared/web/openapi_meta.py
@@ -776,6 +776,9 @@ PUBLIC_OPERATION_IDS: frozenset[str] = frozenset(
         # Unauthenticated discovery metadata.
         "jwks",
         "oauthAuthorizationServer",
+        # Public IdP-login capability hint (enabled flag + provider name only;
+        # no secrets). The SPA reads this pre-login to render the SSO button.
+        "authIdpDescriptor",
     }
 )
 
@@ -833,6 +836,7 @@ _TAG_RULES: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^/actors"), "Actors"),
     (re.compile(r"^/users"), "Users"),
     (re.compile(r"^/auth/(login|refresh)"), "Users"),
+    (re.compile(r"^/auth/idp"), "Discovery"),
     (re.compile(r"^/audit"), "Audit"),
     # Platform-actor surfaces (superset, not in the original reference).
     (re.compile(r"^/agents"), "Agents"),

--- a/tests/unit/auth/test_idp_adapter.py
+++ b/tests/unit/auth/test_idp_adapter.py
@@ -107,3 +107,57 @@ def test_map_claims_email_verified_false(adapter: OidcAdapter) -> None:
     }
     claims = adapter.map_claims(userinfo)
     assert claims.email_verified is False
+
+
+# ── Google provider profile (WI-2) ───────────────────────────────────────────
+
+
+@pytest.fixture()
+def google_config() -> IdpConfig:
+    return IdpConfig(
+        enabled=True,
+        provider="google",
+        client_id="google-client",
+        client_secret=SecretStr("google-secret"),
+    )
+
+
+def test_google_defaults_authorize_endpoint(google_config: IdpConfig) -> None:
+    adapter = OidcAdapter(google_config)
+    url = adapter.authorize_url(state="s", nonce="n", redirect_uri="https://app.example.com/cb")
+    parsed = urlparse(url)
+    assert parsed.hostname == "accounts.google.com"
+    assert parsed.path == "/o/oauth2/v2/auth"
+
+
+def test_google_explicit_endpoint_overrides_default() -> None:
+    config = IdpConfig(
+        enabled=True,
+        provider="google",
+        client_id="google-client",
+        client_secret=SecretStr("secret"),
+        authorization_endpoint="https://custom.example.com/auth",
+    )
+    adapter = OidcAdapter(config)
+    url = adapter.authorize_url(state="s", nonce="n", redirect_uri="https://app.example.com/cb")
+    assert url.startswith("https://custom.example.com/auth?")
+
+
+def test_google_map_claims_surfaces_hd(google_config: IdpConfig) -> None:
+    adapter = OidcAdapter(google_config)
+    claims = adapter.map_claims(
+        {
+            "sub": "g-1",
+            "email": "user@jentic.com",
+            "email_verified": True,
+            "hd": "jentic.com",
+        }
+    )
+    assert claims.hosted_domain == "jentic.com"
+    assert claims.email_verified is True
+
+
+def test_map_claims_hosted_domain_none_without_hd(adapter: OidcAdapter) -> None:
+    # Generic OIDC (and consumer Google) accounts carry no `hd` claim.
+    claims = adapter.map_claims({"sub": "x", "email": "user@example.com"})
+    assert claims.hosted_domain is None

--- a/tests/unit/auth/test_idp_adapter.py
+++ b/tests/unit/auth/test_idp_adapter.py
@@ -7,7 +7,11 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from pydantic import SecretStr
 
-from jentic_one.auth.core.idp import OidcAdapter
+from jentic_one.auth.core.idp import (
+    GoogleOidcAdapter,
+    OidcAdapter,
+    build_idp_adapter,
+)
 from jentic_one.auth.core.idp.adapter import IdpClaims
 from jentic_one.shared.config import IdpConfig
 
@@ -123,7 +127,7 @@ def google_config() -> IdpConfig:
 
 
 def test_google_defaults_authorize_endpoint(google_config: IdpConfig) -> None:
-    adapter = OidcAdapter(google_config)
+    adapter = GoogleOidcAdapter(google_config)
     url = adapter.authorize_url(state="s", nonce="n", redirect_uri="https://app.example.com/cb")
     parsed = urlparse(url)
     assert parsed.hostname == "accounts.google.com"
@@ -138,13 +142,13 @@ def test_google_explicit_endpoint_overrides_default() -> None:
         client_secret=SecretStr("secret"),
         authorization_endpoint="https://custom.example.com/auth",
     )
-    adapter = OidcAdapter(config)
+    adapter = GoogleOidcAdapter(config)
     url = adapter.authorize_url(state="s", nonce="n", redirect_uri="https://app.example.com/cb")
     assert url.startswith("https://custom.example.com/auth?")
 
 
 def test_google_map_claims_surfaces_hd(google_config: IdpConfig) -> None:
-    adapter = OidcAdapter(google_config)
+    adapter = GoogleOidcAdapter(google_config)
     claims = adapter.map_claims(
         {
             "sub": "g-1",
@@ -157,7 +161,32 @@ def test_google_map_claims_surfaces_hd(google_config: IdpConfig) -> None:
     assert claims.email_verified is True
 
 
-def test_map_claims_hosted_domain_none_without_hd(adapter: OidcAdapter) -> None:
-    # Generic OIDC (and consumer Google) accounts carry no `hd` claim.
-    claims = adapter.map_claims({"sub": "x", "email": "user@example.com"})
+def test_google_map_claims_hosted_domain_none_without_hd(google_config: IdpConfig) -> None:
+    # Consumer Google accounts carry no `hd` claim.
+    adapter = GoogleOidcAdapter(google_config)
+    claims = adapter.map_claims({"sub": "x", "email": "user@gmail.com"})
     assert claims.hosted_domain is None
+
+
+def test_generic_adapter_never_sets_hosted_domain(adapter: OidcAdapter) -> None:
+    # The generic OIDC adapter leaves hosted_domain None even if `hd` is present
+    # — `hd` handling is a Google-specific concern.
+    claims = adapter.map_claims({"sub": "x", "email": "user@example.com", "hd": "example.com"})
+    assert claims.hosted_domain is None
+
+
+# ── Adapter factory ───────────────────────────────────────────────────────────
+
+
+def test_factory_returns_none_when_disabled() -> None:
+    config = IdpConfig(enabled=False, provider="google")
+    assert build_idp_adapter(config) is None
+
+
+def test_factory_selects_google_adapter(google_config: IdpConfig) -> None:
+    assert isinstance(build_idp_adapter(google_config), GoogleOidcAdapter)
+
+
+def test_factory_falls_back_to_generic_for_standard_oidc(idp_config: IdpConfig) -> None:
+    adapter = build_idp_adapter(idp_config)
+    assert type(adapter) is OidcAdapter

--- a/tests/unit/auth/test_provisioning_policy.py
+++ b/tests/unit/auth/test_provisioning_policy.py
@@ -13,8 +13,11 @@ from jentic_one.auth.core.idp import (
     AdmissionDecision,
     IdpClaims,
     get_admission_policy,
+    get_default_idp_grants,
+    no_default_grants,
     open_admission_policy,
     set_admission_policy,
+    set_default_idp_grants,
 )
 
 
@@ -65,5 +68,33 @@ def test_set_admission_policy_overrides_and_restores() -> None:
 def _restore_policy() -> object:
     """Guard against a test leaking a non-default policy into the module global."""
     original = get_admission_policy()
+    original_grants = get_default_idp_grants()
     yield
     set_admission_policy(original)
+    set_default_idp_grants(original_grants)
+
+
+def test_default_grants_provider_grants_nothing() -> None:
+    assert no_default_grants(_claims(email_verified=True)) == []
+
+
+def test_default_installed_grants_provider_is_none() -> None:
+    assert get_default_idp_grants() is no_default_grants
+
+
+def test_set_default_idp_grants_overrides_and_restores() -> None:
+    original = get_default_idp_grants()
+    try:
+
+        def _read_only(claims: IdpClaims) -> list[str]:
+            return ["capabilities:read", "apis:read"]
+
+        set_default_idp_grants(_read_only)
+        assert get_default_idp_grants() is _read_only
+        assert get_default_idp_grants()(_claims(email_verified=True)) == [
+            "capabilities:read",
+            "apis:read",
+        ]
+    finally:
+        set_default_idp_grants(original)
+        assert get_default_idp_grants() is no_default_grants

--- a/tests/unit/auth/test_provisioning_policy.py
+++ b/tests/unit/auth/test_provisioning_policy.py
@@ -1,0 +1,69 @@
+"""Unit tests for the IdP provisioning-decision seam (WI-1).
+
+Covers only the pure decision logic + the injectable registry. The end-to-end
+callback behaviour (link/existing/reject + audit) is exercised by the web-layer
+integration test in ``tests/web/auth/test_oidc_login_flow.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jentic_one.auth.core.idp import (
+    AdmissionDecision,
+    IdpClaims,
+    get_admission_policy,
+    open_admission_policy,
+    set_admission_policy,
+)
+
+
+def _claims(*, email_verified: bool) -> IdpClaims:
+    return IdpClaims(
+        external_subject="ext-1",
+        email="user@example.com",
+        first_name="Jane",
+        last_name="Doe",
+        email_verified=email_verified,
+    )
+
+
+def test_open_policy_admits_verified() -> None:
+    assert open_admission_policy(_claims(email_verified=True)) is (
+        AdmissionDecision.ADMIT_AND_CREATE
+    )
+
+
+def test_open_policy_admits_unverified_preserving_legacy_behaviour() -> None:
+    # The open default admits every brand-new email (today's behaviour). The
+    # unverified+collision takeover case is fail-closed upstream, not here.
+    assert open_admission_policy(_claims(email_verified=False)) is (
+        AdmissionDecision.ADMIT_AND_CREATE
+    )
+
+
+def test_default_installed_policy_is_open() -> None:
+    assert get_admission_policy() is open_admission_policy
+
+
+def test_set_admission_policy_overrides_and_restores() -> None:
+    original = get_admission_policy()
+    try:
+
+        def _reject_all(claims: IdpClaims) -> AdmissionDecision:
+            return AdmissionDecision.REJECT
+
+        set_admission_policy(_reject_all)
+        assert get_admission_policy() is _reject_all
+        assert get_admission_policy()(_claims(email_verified=True)) is AdmissionDecision.REJECT
+    finally:
+        set_admission_policy(original)
+        assert get_admission_policy() is open_admission_policy
+
+
+@pytest.fixture(autouse=True)
+def _restore_policy() -> object:
+    """Guard against a test leaking a non-default policy into the module global."""
+    original = get_admission_policy()
+    yield
+    set_admission_policy(original)

--- a/tests/unit/shared/test_combined_verifier.py
+++ b/tests/unit/shared/test_combined_verifier.py
@@ -1,0 +1,58 @@
+"""Unit test for the deterministic combined-app identity verifier (WI-3).
+
+When the ``auth`` surface is enabled, ``create_combined_app`` must install the
+auth surface's full-taxonomy ("superset") verifier — the one that resolves API
+keys + opaque ``at_`` access tokens + HS256 JWTs — regardless of the order the
+surfaces appear in ``apps``. Without this the active verifier depends on surface
+ordering (the admin surface ships an HS256-only, ``at_``-blind verifier).
+
+The verifier is a closure, so identity is asserted by monkeypatching the auth
+surface's factory to a sentinel and checking ``app.state.verify_token`` is it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import jentic_one.auth.web.app as auth_app
+from jentic_one.shared.config import AppConfig
+from jentic_one.shared.context import Context
+from jentic_one.shared.web.app_factory import create_combined_app
+
+
+def _ctx(sample_config_dict: dict[str, Any]) -> Context:
+    return Context(AppConfig.model_validate(sample_config_dict))
+
+
+@pytest.mark.parametrize("surfaces", [["auth", "admin"], ["admin", "auth"]])
+def test_combined_app_installs_auth_superset_verifier(
+    sample_config_dict: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    surfaces: list[str],
+) -> None:
+    sentinel = object()
+
+    def _fake_superset(_ctx: Context) -> object:
+        return sentinel
+
+    monkeypatch.setattr(auth_app, "make_superset_verifier", _fake_superset)
+
+    app = create_combined_app(_ctx(sample_config_dict), surfaces)
+
+    # The auth superset wins whether admin is listed before or after auth.
+    assert app.state.verify_token is sentinel
+
+
+def test_combined_app_without_auth_leaves_admin_verifier(
+    sample_config_dict: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No auth surface → the auth superset is never installed (hardening is a no-op)."""
+    sentinel = object()
+    monkeypatch.setattr(auth_app, "make_superset_verifier", lambda _ctx: sentinel)
+
+    app = create_combined_app(_ctx(sample_config_dict), ["admin"])
+
+    assert app.state.verify_token is not sentinel

--- a/tests/unit/test_app_factory.py
+++ b/tests/unit/test_app_factory.py
@@ -98,6 +98,22 @@ def test_combined_app_mounts_auth(ctx: Context) -> None:
     assert resp.json() == {"status": "ok", "surface": "auth", "version": __version__}
 
 
+def test_sso_callback_not_shadowed_by_credentials_connect_callback(ctx: Context) -> None:
+    """The SSO login callback must resolve to its own root path, not /credentials.
+
+    The auth surface's login callback and the control surface's credential-connect
+    callback are both Python functions named ``oauth_callback``. ``/authorize``
+    builds its redirect_uri via ``url_path_for``, so the SSO route carries a unique
+    name (``authorize_oauth_callback``) to avoid the connect route winning the
+    name lookup and sending Google's login code to the wrong handler.
+    """
+    app = create_combined_app(ctx, ["control", "auth"])
+    # SSO login callback resolves to the root path...
+    assert app.url_path_for("authorize_oauth_callback") == "/oauth/callback"
+    # ...distinct from the credentials-connect callback, which is unchanged.
+    assert app.url_path_for("oauth_callback") == "/credentials/oauth/callback"
+
+
 def test_auth_standalone_app(ctx: Context) -> None:
     app = create_auth_app(ctx)
     client = TestClient(app, raise_server_exceptions=False)

--- a/tests/web/auth/test_oidc_login_flow.py
+++ b/tests/web/auth/test_oidc_login_flow.py
@@ -35,6 +35,12 @@ from jentic_one.admin.core.schema.authorization_codes import AuthorizationCode
 from jentic_one.admin.core.schema.external_identities import ExternalIdentity
 from jentic_one.admin.core.schema.users import User
 from jentic_one.admin.repos import UserRepository
+from jentic_one.auth.core.idp import (
+    AdmissionDecision,
+    IdpClaims,
+    get_admission_policy,
+    set_admission_policy,
+)
 from jentic_one.auth.web.app import create_app
 from jentic_one.shared.config import IdpConfig, SigningKeyConfig
 from jentic_one.shared.context import Context
@@ -301,6 +307,46 @@ def test_authorization_code_is_single_use(client: TestClient, _cleanup: None) ->
 
     replay = _exchange(client, code=code, code_verifier=start.code_verifier)
     assert replay.status_code == 400, replay.text
+
+
+def test_auth_idp_descriptor_advertises_enabled(client: TestClient) -> None:
+    """WI-4 capability hint: the public descriptor reports enabled + provider."""
+    resp = client.get("/auth/idp")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["enabled"] is True
+    assert body["provider"] == FAKE_PROVIDER
+
+
+@respx.mock
+def test_admission_policy_reject_blocks_new_user(client: TestClient, _cleanup: None) -> None:
+    """WI-1: a reject-policy declines a brand-new email; no user is provisioned.
+
+    The already-linked / existing-account paths are unaffected — the seam only
+    gates never-seen emails. Here the policy rejects, so the callback redirects
+    to the internal error page instead of back to the client with a code.
+    """
+    _stub_idp(sub="google-sub-reject", email="blocked@example.com", email_verified=True)
+
+    original = get_admission_policy()
+
+    def _reject_all(claims: IdpClaims) -> AdmissionDecision:
+        return AdmissionDecision.REJECT
+
+    set_admission_policy(_reject_all)
+    try:
+        start = _begin_authorize(client, state="s", nonce="n")
+        resp = client.get(
+            "/oauth/callback",
+            params={"code": "fake-idp-code", "state": start.signed_state},
+        )
+    finally:
+        set_admission_policy(original)
+
+    assert resp.status_code == 302, resp.text
+    # Declined by policy → internal error page (access_denied), not a client code.
+    assert urlparse(resp.headers["location"]).path == "/error", resp.headers["location"]
+    assert "access_denied" in resp.headers["location"]
 
 
 SHARED_EMAIL = "victim@example.com"

--- a/tests/web/auth/test_oidc_login_flow.py
+++ b/tests/web/auth/test_oidc_login_flow.py
@@ -29,17 +29,20 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from httpx import Response
 from jwt.algorithms import ECAlgorithm
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 
 from jentic_one.admin.core.schema.authorization_codes import AuthorizationCode
 from jentic_one.admin.core.schema.external_identities import ExternalIdentity
+from jentic_one.admin.core.schema.user_permission_grants import UserPermissionGrant
 from jentic_one.admin.core.schema.users import User
 from jentic_one.admin.repos import UserRepository
 from jentic_one.auth.core.idp import (
     AdmissionDecision,
     IdpClaims,
     get_admission_policy,
+    get_default_idp_grants,
     set_admission_policy,
+    set_default_idp_grants,
 )
 from jentic_one.auth.web.app import create_app
 from jentic_one.shared.config import IdpConfig, SigningKeyConfig
@@ -347,6 +350,62 @@ def test_admission_policy_reject_blocks_new_user(client: TestClient, _cleanup: N
     # Declined by policy → internal error page (access_denied), not a client code.
     assert urlparse(resp.headers["location"]).path == "/error", resp.headers["location"]
     assert "access_denied" in resp.headers["location"]
+
+
+async def _grants_for_email(ctx: Context, email: str) -> list[str]:
+    """Return the permission names written for the user with this email."""
+    async with ctx.admin_db.transaction() as session:
+        user = await UserRepository.get_by_email(session, email)
+        assert user is not None, f"expected a provisioned user for {email}"
+        result = await session.execute(
+            select(UserPermissionGrant.permission).where(UserPermissionGrant.user_id == user.id)
+        )
+        return sorted(result.scalars().all())
+
+
+@respx.mock
+async def test_new_user_gets_configured_default_grants(
+    client: TestClient, oidc_context: Context, _cleanup: None
+) -> None:
+    """A configured default-grants provider seeds a brand-new user's baseline grants.
+
+    An unknown scope in the configured list is dropped defensively rather than
+    failing the login.
+    """
+    _stub_idp(sub="google-sub-grants", email="reader@example.com", email_verified=True)
+
+    original = get_default_idp_grants()
+
+    def _read_only(claims: IdpClaims) -> list[str]:
+        return ["capabilities:read", "apis:read", "not:a:real:scope"]
+
+    set_default_idp_grants(_read_only)
+    try:
+        start = _begin_authorize(client, state="s", nonce="n")
+        code = _callback(client, signed_state=start.signed_state)
+        resp = _exchange(client, code=code, code_verifier=start.code_verifier)
+        assert resp.status_code == 200, resp.text
+    finally:
+        set_default_idp_grants(original)
+
+    grants = await _grants_for_email(oidc_context, "reader@example.com")
+    assert grants == ["apis:read", "capabilities:read"]
+
+
+@respx.mock
+async def test_new_user_defaults_to_no_grants(
+    client: TestClient, oidc_context: Context, _cleanup: None
+) -> None:
+    """With the default provider installed, a new user starts with zero grants."""
+    _stub_idp(sub="google-sub-nogrants", email="empty@example.com", email_verified=True)
+
+    start = _begin_authorize(client, state="s", nonce="n")
+    code = _callback(client, signed_state=start.signed_state)
+    resp = _exchange(client, code=code, code_verifier=start.code_verifier)
+    assert resp.status_code == 200, resp.text
+
+    grants = await _grants_for_email(oidc_context, "empty@example.com")
+    assert grants == []
 
 
 SHARED_EMAIL = "victim@example.com"

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -24774,7 +24774,7 @@
           }
         },
         "security": [],
-        "summary": "Oauth Callback",
+        "summary": "Authorize Oauth Callback",
         "tags": [
           "OAuth"
         ]

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -17746,6 +17746,105 @@
         ]
       }
     },
+    "/auth/idp": {
+      "get": {
+        "description": "Public capability hint: whether IdP login is enabled, and which provider.\n\nThe SPA reads this before login to decide whether to show a \"Continue with\n<provider>\" button. Unauthenticated and secret-free — it advertises only the\nenabled flag and the provider name (never client secrets or endpoints).",
+        "operationId": "authIdpDescriptor",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Authidpdescriptor",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The request was malformed or failed a precondition.",
+                  "instance": "/example/path",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "type": "bad_request"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "422": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "Request validation failed; see errors[] for details.",
+                  "errors": [
+                    {
+                      "detail": "Field 'name' must not be blank.",
+                      "pointer": "#/name"
+                    }
+                  ],
+                  "instance": "/example/path",
+                  "status": 422,
+                  "title": "Unprocessable Entity",
+                  "type": "validation_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "An unexpected error occurred.",
+                  "instance": "/example/path",
+                  "status": 500,
+                  "title": "Internal Server Error",
+                  "type": "server_error"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/problem+json": {
+                "example": {
+                  "detail": "The database is temporarily unavailable; please retry.",
+                  "instance": "/example/path",
+                  "status": 503,
+                  "title": "Service Unavailable",
+                  "type": "database_unavailable"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [],
+        "summary": "External IdP login descriptor",
+        "tags": [
+          "Discovery"
+        ]
+      }
+    },
     "/auth/login": {
       "post": {
         "description": "Authenticate and return a JWT token bundle.",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,6 +7,7 @@ import { SetupPage } from '@/shared/auth/SetupPage';
 import { ChangePasswordPage } from '@/shared/auth/ChangePasswordPage';
 import { RedeemInvitePage } from '@/shared/auth/RedeemInvitePage';
 import { OAuthPopupReturn } from '@/shared/auth/OAuthPopupReturn';
+import { SsoCallbackPage } from '@/shared/auth/SsoCallbackPage';
 import { Layout } from '@/shared/app/Layout';
 import { moduleRoutes, ROUTES } from '@/shared/app/routes';
 import { PlaceholderPage } from '@/shared/app/placeholders';
@@ -106,6 +107,11 @@ function buildRoutes(extraRoutes: RouteObject[] = []): RouteObject[] {
 		// self-closes. Outside the AuthGuard (the popup has no guaranteed
 		// session). Registered before the '*' catch-all below.
 		{ path: '/oauth/connected', element: <OAuthPopupReturn /> },
+		// Public SSO callback landing. The backend redirects the browser here
+		// (→ /app/auth/callback?code=…) after the external-IdP round-trip; the
+		// page exchanges the code for a session and enters the app. Outside the
+		// AuthGuard (no session yet). Registered before the '*' catch-all.
+		{ path: ROUTES.authCallback, element: <SsoCallbackPage /> },
 		// Public API reference — API docs are public-by-norm; lives outside the
 		// AuthGuard/Layout. Matched before the authenticated shell so it wins for
 		// `/app/docs` whether or not a session exists.

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -121,6 +121,9 @@ export const handlers = [
 		}
 		return HttpResponse.json(mockUser);
 	}),
+	// External-IdP (SSO) login capability hint (GET /auth/idp). Default: disabled,
+	// so the login page shows password-only. SSO tests enable it via worker.use.
+	http.get('/auth/idp', () => HttpResponse.json({ enabled: false, provider: null })),
 	// Actor directory (GET /actors) — cross-cutting reference data the UI hydrates
 	// once to resolve raw `actor_id` values into names. Seeded to match the ids
 	// other module stores emit (agents store + the access-request fixtures) so

--- a/ui/src/shared/api/generated/services/DiscoveryService.ts
+++ b/ui/src/shared/api/generated/services/DiscoveryService.ts
@@ -42,4 +42,26 @@ export class DiscoveryService {
             },
         });
     }
+    /**
+     * External IdP login descriptor
+     * Public capability hint: whether IdP login is enabled, and which provider.
+     *
+     * The SPA reads this before login to decide whether to show a "Continue with
+     * <provider>" button. Unauthenticated and secret-free — it advertises only the
+     * enabled flag and the provider name (never client secrets or endpoints).
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static authIdpDescriptor(): CancelablePromise<Record<string, any>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/auth/idp',
+            errors: {
+                400: `Bad Request`,
+                422: `Unprocessable Entity`,
+                500: `Internal Server Error`,
+                503: `Service Unavailable`,
+            },
+        });
+    }
 }

--- a/ui/src/shared/api/generated/services/OAuthService.ts
+++ b/ui/src/shared/api/generated/services/OAuthService.ts
@@ -88,7 +88,7 @@ export class OAuthService {
         });
     }
     /**
-     * Oauth Callback
+     * Authorize Oauth Callback
      * External IdP callback — exchanges upstream code and issues platform auth code.
      * @returns any Successful Response
      * @throws ApiError

--- a/ui/src/shared/api/idp.ts
+++ b/ui/src/shared/api/idp.ts
@@ -1,0 +1,48 @@
+import { OpenAPI } from '@/shared/api/generated/core/OpenAPI';
+import { request as __request } from '@/shared/api/generated/core/request';
+import type { TokenResponse } from '@/shared/api/generated/models/TokenResponse';
+import '@/shared/api/client';
+
+/**
+ * External-IdP login capability descriptor (public, secret-free). The SPA reads
+ * this before login to decide whether to render a "Continue with <provider>"
+ * button. Mirrors the backend `GET /auth/idp` response.
+ */
+export interface IdpDescriptor {
+	enabled: boolean;
+	provider: string | null;
+}
+
+/** Fetch the public IdP-login descriptor. Unauthenticated. */
+export function getIdpDescriptor(): Promise<IdpDescriptor> {
+	return __request<IdpDescriptor>(OpenAPI, {
+		method: 'GET',
+		url: '/auth/idp',
+	});
+}
+
+/**
+ * Exchange an authorization code + PKCE verifier for a session bundle at the
+ * platform token endpoint (public client — no client_secret). Returns the same
+ * `{ access_token, expires_in }` shape the password login yields, so the auth
+ * context adopts it through the identical `setSession` path.
+ */
+export function exchangeAuthCode(params: {
+	code: string;
+	codeVerifier: string;
+	redirectUri: string;
+	clientId: string;
+}): Promise<TokenResponse> {
+	return __request<TokenResponse>(OpenAPI, {
+		method: 'POST',
+		url: '/oauth/token',
+		body: {
+			grant_type: 'authorization_code',
+			code: params.code,
+			code_verifier: params.codeVerifier,
+			redirect_uri: params.redirectUri,
+			client_id: params.clientId,
+		},
+		mediaType: 'application/json',
+	});
+}

--- a/ui/src/shared/api/index.ts
+++ b/ui/src/shared/api/index.ts
@@ -256,3 +256,10 @@ export { OverlaysService } from '@/shared/api/generated/services/OverlaysService
 // line via `useVersionInfo`. `SystemService` is already exported above; only the
 // response model is added here. Append-only.
 export type { VersionResponse } from '@/shared/api/generated/models/VersionResponse';
+
+// External-IdP (SSO) login. The public capability descriptor (`GET /auth/idp`)
+// tells the login page whether to show a "Continue with <provider>" button, and
+// the authorization-code + PKCE exchange (`POST /oauth/token`) yields the same
+// session bundle as password login. Append-only, like the rest.
+export { getIdpDescriptor, exchangeAuthCode } from '@/shared/api/idp';
+export type { IdpDescriptor } from '@/shared/api/idp';

--- a/ui/src/shared/app/routes.ts
+++ b/ui/src/shared/app/routes.ts
@@ -20,6 +20,10 @@ import type { RouteObject } from 'react-router';
 export const ROUTES = {
 	root: '/',
 	login: '/login',
+	// SSO authorization-code callback landing (outside the Layout/AuthGuard):
+	// the browser returns here from the platform authorize flow with a one-time
+	// code, which the page exchanges for a session (→ /app/auth/callback).
+	authCallback: '/auth/callback',
 	// First-run, no-credential setup. Lives at the root (outside /app and the
 	// authenticated Layout): reachable before any account exists, and self-closes
 	// once the first admin is created (see SetupPage / setup_required health gate).

--- a/ui/src/shared/auth/AuthContext.tsx
+++ b/ui/src/shared/auth/AuthContext.tsx
@@ -32,6 +32,13 @@ export interface AuthContextValue {
 	/** True once logged in but the backend requires a password change first. */
 	mustChangePassword: boolean;
 	login: (credentials: LoginRequest) => Promise<void>;
+	/**
+	 * Adopt a session minted out-of-band (e.g. the SSO authorization-code
+	 * exchange), taking the same `{ access_token, expires_in }` bundle password
+	 * login produces. Feeds the shared session path (setSession + /users/me
+	 * refresh) so refresh-renewal and expiry handling are identical.
+	 */
+	loginWithSession: (bundle: { access_token: string; expires_in: number }) => Promise<void>;
 	/** First-run setup: create the first admin and adopt the returned session. */
 	createAdmin: (payload: CreateAdminRequest) => Promise<void>;
 	/**
@@ -175,6 +182,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 		[adoptSession],
 	);
 
+	const loginWithSession = useCallback(
+		async (bundle: { access_token: string; expires_in: number }) => {
+			// The SSO callback already exchanged the code for a session; adopt it
+			// through the same path as password login so /users/me refreshes and
+			// the refresh-renewal effect schedules against the real expiry.
+			await adoptSession(bundle as LoginResponse);
+		},
+		[adoptSession],
+	);
+
 	const createAdmin = useCallback(
 		async (payload: CreateAdminRequest) => {
 			// First-run setup returns a ready-to-use token (auto-login), so the
@@ -244,6 +261,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 			user,
 			mustChangePassword: user?.must_change_password ?? false,
 			login,
+			loginWithSession,
 			createAdmin,
 			changePassword,
 			redeemInvite,
@@ -255,6 +273,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 		meQuery.isError,
 		meQuery.data,
 		login,
+		loginWithSession,
 		createAdmin,
 		changePassword,
 		redeemInvite,

--- a/ui/src/shared/auth/LoginPage.tsx
+++ b/ui/src/shared/auth/LoginPage.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '@/shared/auth/AuthContext';
-import { ApiError, consumeSessionExpiredNotice } from '@/shared/api';
+import { ApiError, consumeSessionExpiredNotice, getIdpDescriptor } from '@/shared/api';
+import { beginSsoLogin } from '@/shared/auth/sso';
 import { ROUTES } from '@/shared/app/routes';
 import { Input } from '@/shared/ui/Input';
 import { Label } from '@/shared/ui/Label';
@@ -10,6 +12,12 @@ import { ErrorAlert } from '@/shared/ui/ErrorAlert';
 
 interface LocationState {
 	from?: { pathname?: string };
+}
+
+/** Human-friendly provider label for the SSO button. */
+function providerLabel(provider: string | null): string {
+	if (provider === 'google') return 'Continue with Google';
+	return 'Continue with single sign-on';
 }
 
 /**
@@ -36,6 +44,27 @@ export function LoginPage() {
 	useEffect(() => {
 		if (consumeSessionExpiredNotice()) setSessionExpired(true);
 	}, []);
+
+	// Public capability hint: show the SSO button only when the backend
+	// advertises an external IdP. Failure (or IdP disabled) simply hides it —
+	// password login is always available.
+	const idpQuery = useQuery({
+		queryKey: ['auth', 'idp-descriptor'],
+		queryFn: () => getIdpDescriptor(),
+		staleTime: 300_000,
+	});
+	const idpEnabled = idpQuery.data?.enabled ?? false;
+	const [ssoError, setSsoError] = useState<string | null>(null);
+
+	const handleSso = async () => {
+		setSsoError(null);
+		try {
+			await beginSsoLogin();
+			// On success the browser navigates away; nothing more to do here.
+		} catch {
+			setSsoError('Could not start single sign-on. Please try again.');
+		}
+	};
 
 	const handleSubmit = async (event: React.FormEvent) => {
 		event.preventDefault();
@@ -109,6 +138,26 @@ export function LoginPage() {
 				<Button type="submit" loading={submitting} fullWidth className="mt-6">
 					{submitting ? 'Signing in…' : 'Sign in'}
 				</Button>
+
+				{idpEnabled && (
+					<div className="mt-6">
+						<div className="flex items-center gap-3" aria-hidden="true">
+							<span className="border-border h-px flex-1 border-t" />
+							<span className="text-muted-foreground text-xs">or</span>
+							<span className="border-border h-px flex-1 border-t" />
+						</div>
+						{ssoError !== null && <ErrorAlert message={ssoError} className="mt-4" />}
+						<Button
+							type="button"
+							variant="outline"
+							fullWidth
+							className="mt-4"
+							onClick={() => void handleSso()}
+						>
+							{providerLabel(idpQuery.data?.provider ?? null)}
+						</Button>
+					</div>
+				)}
 			</form>
 		</main>
 	);

--- a/ui/src/shared/auth/SsoCallbackPage.tsx
+++ b/ui/src/shared/auth/SsoCallbackPage.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router';
+import { useAuth } from '@/shared/auth/AuthContext';
+import { consumeCodeVerifier, ssoRedirectUri, SPA_CLIENT_ID } from '@/shared/auth/sso';
+import { exchangeAuthCode } from '@/shared/api';
+import { ROUTES } from '@/shared/app/routes';
+import { AppLink } from '@/shared/ui/AppLink';
+import { ErrorAlert } from '@/shared/ui/ErrorAlert';
+
+/**
+ * SSO authorization-code callback landing.
+ *
+ * The backend redirects the browser here (→ `/app/auth/callback`) after the IdP
+ * round-trip, with a one-time platform `code`. This page exchanges that code +
+ * the stored PKCE verifier for a session (`POST /oauth/token`), adopts it via
+ * the shared auth context, and sends the operator into the app.
+ *
+ * Lives outside the AuthGuard — the user has no session yet. On any failure it
+ * shows a concise error with a link back to the login form (never a dead end).
+ */
+export function SsoCallbackPage() {
+	const [params] = useSearchParams();
+	const { loginWithSession } = useAuth();
+	const navigate = useNavigate();
+	const [error, setError] = useState<string | null>(null);
+	// Guard against React StrictMode double-invocation: the platform code is
+	// single-use, so a second exchange would fail. Run the exchange at most once.
+	const startedRef = useRef(false);
+
+	useEffect(() => {
+		if (startedRef.current) return;
+		startedRef.current = true;
+
+		const code = params.get('code');
+		const verifier = consumeCodeVerifier();
+
+		if (!code || !verifier) {
+			setError('Sign-in link is invalid or has expired. Please try again.');
+			return;
+		}
+
+		void (async () => {
+			try {
+				const bundle = await exchangeAuthCode({
+					code,
+					codeVerifier: verifier,
+					redirectUri: ssoRedirectUri(),
+					clientId: SPA_CLIENT_ID,
+				});
+				await loginWithSession(bundle);
+				navigate(ROUTES.app, { replace: true });
+			} catch {
+				setError('Sign-in failed. Please try again.');
+			}
+		})();
+	}, [params, loginWithSession, navigate]);
+
+	return (
+		<main className="bg-background text-foreground flex min-h-screen items-center justify-center px-4">
+			<div
+				className="border-border bg-card w-full max-w-sm rounded-xl border p-6 text-center shadow-sm"
+				role={error ? undefined : 'status'}
+			>
+				{error === null ? (
+					<>
+						<h1 className="font-display text-lg font-semibold">Signing you in…</h1>
+						<p className="text-muted-foreground mt-2 text-sm">
+							Completing sign-in, one moment.
+						</p>
+					</>
+				) : (
+					<>
+						<h1 className="font-display text-lg font-semibold">Sign-in failed</h1>
+						<ErrorAlert message={error} className="mt-4" />
+						<AppLink
+							href={ROUTES.login}
+							className="text-muted-foreground hover:text-foreground mt-5 inline-block text-sm underline-offset-2 hover:underline"
+						>
+							Back to sign in
+						</AppLink>
+					</>
+				)}
+			</div>
+		</main>
+	);
+}

--- a/ui/src/shared/auth/__tests__/sso-login.test.tsx
+++ b/ui/src/shared/auth/__tests__/sso-login.test.tsx
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { worker } from '@/mocks/browser';
+import { renderWithProviders, screen, waitFor } from '@/__tests__/test-utils';
+import { AuthProvider } from '@/shared/auth/AuthContext';
+import { clearToken } from '@/shared/api';
+import { App } from '@/App';
+
+/**
+ * SSO (external-IdP) login: the "Continue with Google" entry point and the
+ * authorization-code callback that adopts a session. The full OIDC round-trip
+ * (redirect to Google, upstream exchange, admission policy) is backend-owned and
+ * covered by `tests/web/auth/test_oidc_login_flow.py`; these specs pin the
+ * SPA-side behaviour only.
+ *
+ * The verifier lives in sessionStorage under this key (see auth/pkce.ts); the
+ * callback test seeds it directly to simulate a prior `/authorize` redirect.
+ */
+const PKCE_VERIFIER_KEY = 'jentic-one.pkce_verifier';
+
+function renderApp(route: string) {
+	return renderWithProviders(
+		<AuthProvider>
+			<App />
+		</AuthProvider>,
+		{ route },
+	);
+}
+
+function enableGoogleIdp() {
+	worker.use(
+		http.get('/auth/idp', () => HttpResponse.json({ enabled: true, provider: 'google' })),
+	);
+}
+
+describe('SSO login', () => {
+	beforeEach(() => {
+		clearToken();
+		sessionStorage.clear();
+	});
+
+	it('hides the SSO button when the backend advertises no IdP', async () => {
+		// Default /auth/idp handler reports enabled:false.
+		renderApp('/login');
+		await screen.findByRole('heading', { name: 'Sign in to Jentic One' });
+		expect(screen.queryByRole('button', { name: /continue with/i })).not.toBeInTheDocument();
+	});
+
+	it('shows a "Continue with Google" button when Google IdP is enabled', async () => {
+		enableGoogleIdp();
+		renderApp('/login');
+		await screen.findByRole('heading', { name: 'Sign in to Jentic One' });
+		expect(await screen.findByRole('button', { name: 'Continue with Google' })).toBeVisible();
+		// Password login stays available alongside SSO.
+		expect(screen.getByRole('button', { name: 'Sign in' })).toBeVisible();
+	});
+
+	it('exchanges the callback code for a session and lands on the dashboard', async () => {
+		sessionStorage.setItem(PKCE_VERIFIER_KEY, 'test-verifier');
+		let exchanged = false;
+		worker.use(
+			http.post('/oauth/token', async ({ request }) => {
+				const body = (await request.json()) as Record<string, unknown>;
+				expect(body.grant_type).toBe('authorization_code');
+				expect(body.code).toBe('platform-code-xyz');
+				expect(body.code_verifier).toBe('test-verifier');
+				exchanged = true;
+				return HttpResponse.json({
+					access_token: 'sso-access-token',
+					token_type: 'bearer',
+					expires_in: 3600,
+				});
+			}),
+			http.get('/users/me', ({ request }) => {
+				if (request.headers.get('authorization') !== 'Bearer sso-access-token') {
+					return new HttpResponse(null, { status: 401 });
+				}
+				return HttpResponse.json({
+					id: '1',
+					email: 'ada@jentic.com',
+					first_name: 'Ada',
+					last_name: 'Lovelace',
+					active: true,
+					permissions: ['org:admin'],
+					must_change_password: false,
+					created_at: '2026-01-01T00:00:00Z',
+					updated_at: null,
+				});
+			}),
+		);
+
+		renderApp('/auth/callback?code=platform-code-xyz');
+
+		expect(await screen.findByRole('heading', { name: 'Dashboard' })).toBeVisible();
+		await waitFor(() => expect(exchanged).toBe(true));
+		await waitFor(() =>
+			expect(localStorage.getItem('jentic-one.access_token')).toBe('sso-access-token'),
+		);
+		// The single-use verifier is consumed by the callback.
+		expect(sessionStorage.getItem(PKCE_VERIFIER_KEY)).toBeNull();
+	});
+
+	it('shows an error with a link back to login when the callback has no code', async () => {
+		renderApp('/auth/callback');
+		expect(await screen.findByRole('alert')).toHaveTextContent(/invalid or has expired/i);
+		expect(screen.getByRole('link', { name: /back to sign in/i })).toBeVisible();
+	});
+
+	it('shows an error when the code exchange fails', async () => {
+		sessionStorage.setItem(PKCE_VERIFIER_KEY, 'test-verifier');
+		worker.use(http.post('/oauth/token', () => new HttpResponse(null, { status: 400 })));
+
+		renderApp('/auth/callback?code=bad-code');
+
+		expect(await screen.findByRole('alert')).toHaveTextContent(/sign-in failed/i);
+		expect(localStorage.getItem('jentic-one.access_token')).toBeNull();
+	});
+});

--- a/ui/src/shared/auth/pkce.ts
+++ b/ui/src/shared/auth/pkce.ts
@@ -1,0 +1,58 @@
+/**
+ * PKCE (RFC 7636) helpers for the browser SSO login flow.
+ *
+ * The SPA is a public OAuth client, so it uses Authorization-Code + PKCE: it
+ * generates a random `code_verifier`, derives the S256 `code_challenge`, sends
+ * the challenge on `GET /authorize`, and later proves possession by presenting
+ * the verifier at `POST /oauth/token`. The verifier is held in sessionStorage
+ * across the IdP redirect round-trip (it never leaves this origin).
+ *
+ * Uses Web Crypto (`crypto.subtle`) — available in all supported browsers and
+ * in the jsdom test env via the polyfilled global.
+ */
+
+const VERIFIER_KEY = 'jentic-one.pkce_verifier';
+
+/** Base64url-encode bytes without padding (RFC 7636 §A). */
+function base64UrlEncode(bytes: Uint8Array): string {
+	let binary = '';
+	for (const b of bytes) binary += String.fromCharCode(b);
+	return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** Generate a high-entropy `code_verifier` (43–128 chars, RFC 7636 §4.1). */
+export function generateCodeVerifier(): string {
+	const bytes = new Uint8Array(32);
+	crypto.getRandomValues(bytes);
+	return base64UrlEncode(bytes);
+}
+
+/** Derive the S256 `code_challenge` for a verifier. */
+export async function deriveCodeChallenge(verifier: string): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+	return base64UrlEncode(new Uint8Array(digest));
+}
+
+/**
+ * Persist the verifier for the redirect round-trip. sessionStorage (not local)
+ * so it dies with the tab and never outlives the single login attempt.
+ */
+export function storeCodeVerifier(verifier: string): void {
+	try {
+		window.sessionStorage.setItem(VERIFIER_KEY, verifier);
+	} catch {
+		// Sandboxed/private contexts: the callback will find no verifier and the
+		// exchange fails closed with a normal "sign-in failed" message.
+	}
+}
+
+/** Read-and-clear the stored verifier (single-use). */
+export function consumeCodeVerifier(): string | null {
+	try {
+		const v = window.sessionStorage.getItem(VERIFIER_KEY);
+		if (v !== null) window.sessionStorage.removeItem(VERIFIER_KEY);
+		return v;
+	} catch {
+		return null;
+	}
+}

--- a/ui/src/shared/auth/sso.ts
+++ b/ui/src/shared/auth/sso.ts
@@ -1,0 +1,66 @@
+import { ROUTES } from '@/shared/app/routes';
+import {
+	consumeCodeVerifier,
+	deriveCodeChallenge,
+	generateCodeVerifier,
+	storeCodeVerifier,
+} from '@/shared/auth/pkce';
+
+/**
+ * Shared client for the SSO (external-IdP) login flow.
+ *
+ * The heavy lifting (redirect to the IdP, upstream code exchange, admission
+ * policy) lives on the backend. This module only owns the browser half:
+ *  1. `beginSsoLogin` mints PKCE + navigates to the platform `/authorize`
+ *     endpoint, which redirects on to the configured IdP.
+ *  2. After the IdP round-trip the backend redirects the browser back to the
+ *     SPA callback (`/app/auth/callback`) with a one-time platform code, which
+ *     `SsoCallbackPage` exchanges via `exchangeAuthCode` (see api/idp.ts).
+ *
+ * The redirect URI is the SPA callback route resolved to an absolute URL — the
+ * same value is sent on `/authorize` and presented at `/oauth/token`, so both
+ * must agree. `client_id` is the SPA's public client id (no secret; PKCE proves
+ * possession).
+ */
+
+/** The SPA is a fixed public OAuth client; PKCE (not a secret) authenticates it. */
+export const SPA_CLIENT_ID = 'jentic-one-spa';
+
+/**
+ * Absolute URL of the SSO callback route, e.g. `https://host/app/auth/callback`.
+ * Built from the router basename (Vite `base`, without trailing slash) so it
+ * tracks the single source of the `/app` prefix. This is a *SPA route* (under
+ * `/app`), where the browser lands after the backend redirect.
+ */
+export function ssoRedirectUri(): string {
+	const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+	return `${window.location.origin}${base}${ROUTES.authCallback}`;
+}
+
+/**
+ * Begin the SSO login: generate PKCE, stash the verifier, then navigate to the
+ * platform authorize endpoint (which redirects to the IdP). Returns nothing —
+ * on success the browser leaves this document.
+ *
+ * `/authorize` is a backend API route at the origin root (NOT under the SPA's
+ * `/app` base), so it is addressed absolutely from the origin.
+ */
+export async function beginSsoLogin(): Promise<void> {
+	const verifier = generateCodeVerifier();
+	const challenge = await deriveCodeChallenge(verifier);
+	storeCodeVerifier(verifier);
+
+	const query = new URLSearchParams({
+		response_type: 'code',
+		client_id: SPA_CLIENT_ID,
+		redirect_uri: ssoRedirectUri(),
+		code_challenge: challenge,
+		code_challenge_method: 'S256',
+		scope: 'openid email profile',
+	});
+	// Full-page navigation (not fetch) so the browser follows the 302 to the IdP.
+	window.location.assign(`${window.location.origin}/authorize?${query}`);
+}
+
+// Single accessor for the stored verifier, used by the callback page + tests.
+export { consumeCodeVerifier };


### PR DESCRIPTION
## Summary

Adds the minimal **OSS-side seams** for external-IdP (SSO) human login so a deployment can offer "Continue with Google" and control who gets provisioned — without forking the auth flow. Everything defaults to **today's behaviour**: with no overlay and no IdP configured, login is byte-identical to now. The admission-policy engine, provider registry, and multi-user console are deliberately **not** in OSS (they belong to the overlay tier). Follows the `jentic-one-plans` OSS impl guide (`research/enterprise-sso-google-oauth-oss-impl.md`).

The whole OIDC flow already exists in OSS (`/authorize` PKCE → `/oauth/callback` → `/oauth/token`, `OidcAdapter`, `external_identities`, the `at_`-capable verifier). This PR only adds four small, additive seams on top.

## Changes

- **`auth` — provisioning-decision seam** (`auth/core/idp/provisioning.py`, new): an injectable `AdmissionPolicy` (module-level registry `set_/get_admission_policy`, mirroring OSS's `register_config` pattern). Default `open_admission_policy` admits **every** brand-new email — exactly today's behaviour. `_resolve_or_create_user` consults it only at the brand-new-user step; already-linked / existing-account / unverified-collision fail-closed logic is untouched. Reject raises `UserNotAdmittedError` (new), audited in its own committed transaction; the callback redirects to `/error?error=access_denied`.
- **`auth` — Google provider** (`idp/oidc.py`, `idp/adapter.py`, `shared/config.py`): `provider: google` defaults Google's authorize/token/userinfo endpoints (still overridable) and `map_claims` surfaces the `hd` claim → new `IdpClaims.hosted_domain` + `IdpConfig.hosted_domain`. Generic `oidc` is unchanged. No provider registry.
- **`shared` — deterministic verifier** (`auth/web/app.py`, `shared/web/app_factory.py`): exposed `make_superset_verifier(ctx)`; `create_combined_app` installs it whenever the `auth` surface is enabled, so `at_` tokens resolve on admin routes **regardless of surface ordering** (captured dynamically — no static `shared→auth` import, no inline import).
- **`ui` — login entry point**: public `GET /auth/idp` capability hint (tagged Discovery, classified public), a "Continue with Google" button shown only when the backend advertises an IdP, `pkce.ts` + `sso.ts` + `api/idp.ts`, an `/auth/callback` route (`SsoCallbackPage`) that exchanges the code and feeds the existing `setSession` (token store unchanged). `AuthContext.loginWithSession` reuses the password-login adoption path.
- **generated artifacts**: regenerated `openapi/control/control.openapi.yaml`, `docs/reference/endpoints.{md,json}`, and the UI client (`ui/openapi.json` + `DiscoveryService`).

**Out of scope (overlay tier):** the admission-policy *engine* (rules/modes/domains, invite-vs-domain composition), the multi-user console/invite UI, and a provider registry for Okta/Azure/SAML. OSS ships only the hook + open default.

## Risk & rollback

- **Auth / provisioning surface** — the seam sits on the external-IdP new-user path. Default policy admits every email (== today); verified regression test (`test_unverified_email_without_collision_creates_user`) confirms no behaviour change with no overlay.
- **New public route** `GET /auth/idp` — unauthenticated, secret-free (returns only `enabled` + provider name); classified Public in the endpoint reference.
- **New config field** `auth.idp.hosted_domain` (optional, default `None`) — OSS surfaces the `hd` claim but does not enforce it.
- **Combined-app verifier**: now deterministically the auth superset when `auth` is enabled. This is a hardening (previously order-dependent); admin-only deployments are unaffected.
- Rollback: revert the squash commit — all changes are additive and behind config/default-open.

## Test plan

- Backend: `uv run ruff check` + `uv run mypy` clean on all changed modules.
- `uv run pytest tests/arch tests/unit/auth --no-cov` → **485 passed** (incl. new `test_provisioning_policy.py`, Google-profile cases in `test_idp_adapter.py`, `test_combined_verifier.py`).
- `uv run pytest tests/web/auth/test_oidc_login_flow.py -m integration --no-cov` (Postgres fixtures) → **7 passed**, incl. new `/auth/idp` descriptor + reject-policy end-to-end tests.
- UI: `npx tsc --noEmit` + `eslint` clean; `vitest run` auth suites → **34 passed** (5 new SSO specs in `sso-login.test.tsx`: button hidden/shown, full callback → session → dashboard, error paths).
- Verified generated artifacts are idempotent (`make openapi && make endpoints` produce no further diff).

Made with [Cursor](https://cursor.com)