### PR TITLE
fix(config): coerce indexed env vars into lists

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1567,7 +1567,7 @@
         "filename": "tests/unit/test_config.py",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 237
+        "line_number": 279
       }
     ],
     "tests/web/admin/conftest.py": [
@@ -1802,5 +1802,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T11:35:58Z"
+  "generated_at": "2026-08-11T16:09:23Z"
 }

--- a/src/jentic_one/shared/config.py
+++ b/src/jentic_one/shared/config.py
@@ -6,7 +6,7 @@ import ipaddress
 import os
 import re
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, cast
 
 import structlog
 import yaml
@@ -953,10 +953,40 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any
     return merged
 
 
+def _coerce_indexed_dicts_to_lists(value: Any) -> Any:
+    """Recursively turn digit-keyed dicts into lists.
+
+    The env convention (``JENTIC__SECTION__KEY``) can only ever build nested
+    dicts, so a *list*-valued field addressed by index —
+    ``JENTIC__AUTH__ID_SIGNING__0__KID`` — arrives as ``{"0": {"kid": ...}}``
+    rather than ``[{"kid": ...}]`` and fails validation with ``list_type``.
+
+    A dict is treated as a list when its keys are exactly the contiguous integer
+    sequence ``0..n-1`` (as strings); it's then rebuilt in index order. Any other
+    dict (real string keys, or a sparse/1-based set) is left untouched and
+    recursed into, so ordinary config is unaffected.
+    """
+    if isinstance(value, dict):
+        coerced = {k: _coerce_indexed_dicts_to_lists(v) for k, v in value.items()}
+        keys = list(coerced.keys())
+        if keys and all(k.isdigit() for k in keys):
+            ordered = sorted(keys, key=int)
+            if [int(k) for k in ordered] == list(range(len(ordered))):
+                return [coerced[k] for k in ordered]
+        return coerced
+    if isinstance(value, list):
+        return [_coerce_indexed_dicts_to_lists(item) for item in value]
+    return value
+
+
 def _env_overrides() -> dict[str, Any]:
     """Build a nested dict from JENTIC__* environment variables.
 
     Convention: JENTIC__SECTION__KEY=value → {"section": {"key": "value"}}
+
+    A numeric path segment addresses a list index, so
+    ``JENTIC__AUTH__ID_SIGNING__0__KID`` builds ``{"0": {...}}`` here and is
+    coerced to a one-element list by :func:`_coerce_indexed_dicts_to_lists`.
     """
     prefix = "JENTIC__"
     result: dict[str, Any] = {}
@@ -968,7 +998,9 @@ def _env_overrides() -> dict[str, Any]:
         for part in parts[:-1]:
             current = current.setdefault(part, {})
         current[parts[-1]] = value
-    return result
+    # Top-level keys are section names (never all-digit), so the result stays a
+    # dict; the coercion only reshapes nested indexed segments.
+    return cast("dict[str, Any]", _coerce_indexed_dicts_to_lists(result))
 
 
 def load_config(path: Path | None = None) -> AppConfig:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -23,6 +23,7 @@ from jentic_one.shared.config import (
     RuntimeConfig,
     _csv_to_list,
     _deep_merge,
+    _env_overrides,
     load_config,
 )
 
@@ -100,6 +101,47 @@ def test_env_coerces_float(config_file: Path):
     with patch.dict(os.environ, env, clear=False):
         config = load_config(config_file)
     assert config.services.request_timeout_s == 60.5
+
+
+def test_env_indexed_keys_build_list_of_models(config_file: Path):
+    # JENTIC__AUTH__ID_SIGNING__0__* addresses a list index; the env parser
+    # can only build dicts, so this exercises the digit-keyed dict -> list
+    # coercion that lets list[SigningKeyConfig] validate.
+    env = {
+        "JENTIC__AUTH__ID_SIGNING__0__KID": "k0",
+        "JENTIC__AUTH__ID_SIGNING__0__PRIVATE_KEY_PEM": "pem-zero",
+        "JENTIC__AUTH__ID_SIGNING__1__KID": "k1",
+        "JENTIC__AUTH__ID_SIGNING__1__PRIVATE_KEY_PEM": "pem-one",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        config = load_config(config_file)
+    assert [k.kid for k in config.auth.id_signing] == ["k0", "k1"]
+    assert config.auth.id_signing[0].private_key_pem.get_secret_value() == "pem-zero"
+
+
+def test_env_overrides_coerces_contiguous_digit_dict_to_list():
+    env = {
+        "JENTIC__AUTH__ID_SIGNING__0__KID": "k0",
+        "JENTIC__AUTH__ID_SIGNING__1__KID": "k1",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        overrides = _env_overrides()
+    signing = overrides["auth"]["id_signing"]
+    assert isinstance(signing, list)
+    assert [item["kid"] for item in signing] == ["k0", "k1"]
+
+
+def test_env_overrides_leaves_non_indexed_dicts_untouched():
+    # Real string keys (databases.registry) must stay a dict, and a sparse /
+    # 1-based numeric set must NOT be coerced (it isn't a valid list address).
+    env = {
+        "JENTIC__DATABASES__REGISTRY__HOST": "h",
+        "JENTIC__WIDGETS__1__NAME": "one",  # missing index 0 -> not a list
+    }
+    with patch.dict(os.environ, env, clear=False):
+        overrides = _env_overrides()
+    assert overrides["databases"]["registry"] == {"host": "h"}
+    assert overrides["widgets"] == {"1": {"name": "one"}}
 
 
 def test_numeric_password_preserved_as_string(config_file: Path):


### PR DESCRIPTION
## Summary

- `JENTIC__*` environment variables can only ever build **nested dicts**, so a
  list-valued config field addressed by index — e.g.
  `JENTIC__AUTH__ID_SIGNING__0__KID` / `..._0__PRIVATE_KEY_PEM` — arrives at the
  Pydantic model as `{"0": {...}}` and fails validation for
  `list[SigningKeyConfig]` with `Input should be a valid list [type=list_type]`.
- `_env_overrides()` now coerces any dict whose keys are exactly the contiguous
  integer sequence `0..n-1` into a list (rebuilt in index order) after assembling
  the env overrides. Non-indexed dicts (real string keys) and sparse/1-based
  numeric sets are left untouched, so ordinary config is unaffected.
- This lets `auth.id_signing` (and any other `list[...]` config) be supplied
  purely from the environment — which is exactly how the enterprise ECS
  deployment injects the ES256 ID-token signing key (SSM SecureString → env).

### Why

The enterprise QA1 control-plane failed to boot with:

```
ConfigError: 1 validation error for AppConfig
auth.id_signing
  Input should be a valid list [type=list_type, input_value={'0': {...}}, input_type=dict]
```

There was no way to express a list of models via env vars (only the `apps`
field had a bespoke CSV→list coercion). This generalises index-addressed lists.

## Test plan

- [x] `test_env_indexed_keys_build_list_of_models` — `..._0__*` / `..._1__*`
      round-trips through `load_config` into `list[SigningKeyConfig]`.
- [x] `test_env_overrides_coerces_contiguous_digit_dict_to_list` — direct
      `_env_overrides()` shape check.
- [x] `test_env_overrides_leaves_non_indexed_dicts_untouched` — string-keyed and
      sparse/1-based dicts stay dicts (no false coercion).
- [x] Full `tests/unit/test_config.py` passes (70).
- [x] `make lint` clean (ruff + format + mypy).

Made with [Cursor](https://cursor.com)