### PR TITLE
fix(auth): build OIDC callback URI from canonical base URL

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1345,7 +1345,7 @@
         "filename": "tests/unit/auth/web/test_authorize_router.py",
         "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
         "is_verified": false,
-        "line_number": 17
+        "line_number": 21
       }
     ],
     "tests/unit/auth/web/test_discovery_jwks.py": [
@@ -1802,5 +1802,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-11T16:09:23Z"
+  "generated_at": "2026-08-12T09:10:19Z"
 }

--- a/src/jentic_one/auth/web/routers/authorize.py
+++ b/src/jentic_one/auth/web/routers/authorize.py
@@ -40,6 +40,23 @@ def _is_allowed_redirect_uri(redirect_uri: str, canonical_base_url: str) -> bool
     )
 
 
+def _callback_uri(request: Request, canonical_base_url: str) -> str:
+    """Build the IdP callback URI (the ``redirect_uri`` sent to the IdP).
+
+    Behind a TLS-terminating proxy (e.g. an ALB) the app sees a plain-``http``
+    request, so ``request.url_for`` would emit an ``http://`` callback that no
+    longer matches the ``https://`` URI registered with the IdP — the IdP then
+    rejects the request. When a canonical base URL is configured we therefore
+    take its scheme + host and keep only the *path* resolved by ``url_for`` (so
+    a route rename still flows through). Without a canonical base URL (local
+    dev) we fall back to the request-derived URL unchanged.
+    """
+    resolved = request.url_for("authorize_oauth_callback")
+    if not canonical_base_url:
+        return str(resolved)
+    return f"{canonical_base_url.rstrip('/')}{resolved.path}"
+
+
 def get_authorize_service(ctx: Context = Depends(get_ctx)) -> AuthorizeService:
     return AuthorizeService(ctx)
 
@@ -100,7 +117,7 @@ async def authorize_endpoint(
     if code_challenge_method != "S256":
         return _error_redirect(redirect_uri, "invalid_request", state, "only S256 is supported")
 
-    callback_uri = str(request.url_for("authorize_oauth_callback"))
+    callback_uri = _callback_uri(request, ctx.config.auth.canonical_base_url)
 
     internal_state = _sign_state(
         {
@@ -154,7 +171,7 @@ async def oauth_callback(
     nonce = params.get("nonce")
     original_state = params.get("original_state")
 
-    callback_uri = str(request.url_for("authorize_oauth_callback"))
+    callback_uri = _callback_uri(request, ctx.config.auth.canonical_base_url)
     try:
         platform_code = await authorize_svc.handle_idp_callback(
             code=code,

--- a/tests/unit/auth/web/test_authorize_router.py
+++ b/tests/unit/auth/web/test_authorize_router.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import time
+from typing import cast
+from urllib.parse import urlparse
 
 import pytest
+from fastapi import Request
 
 from jentic_one.auth.services.errors import InvalidGrantError
 from jentic_one.auth.web.routers.authorize import (
     STATE_MAX_AGE_SECONDS,
+    _callback_uri,
     _is_allowed_redirect_uri,
     _sign_state,
     _verify_state,
@@ -118,3 +122,44 @@ def test_redirect_different_port_rejected() -> None:
     assert not _is_allowed_redirect_uri(
         "https://app.example.com:9999/callback", "https://app.example.com"
     )
+
+
+class _FakeUrl:
+    """Minimal stand-in for starlette's URL: str() + .path, like url_for returns."""
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+
+    def __str__(self) -> str:
+        return self._url
+
+    @property
+    def path(self) -> str:
+        return urlparse(self._url).path
+
+
+class _FakeRequest:
+    def __init__(self, resolved: str) -> None:
+        self._resolved = resolved
+
+    def url_for(self, _name: str) -> _FakeUrl:
+        return _FakeUrl(self._resolved)
+
+
+def test_callback_uri_prefers_canonical_origin_over_request_scheme() -> None:
+    # Behind a TLS-terminating proxy the request is plain http; the callback must
+    # still carry the canonical https origin so it matches what's registered.
+    request = _FakeRequest("http://internal-host/oauth/callback")
+    result = _callback_uri(cast("Request", request), "https://app.example.com")
+    assert result == "https://app.example.com/oauth/callback"
+
+
+def test_callback_uri_keeps_resolved_path() -> None:
+    request = _FakeRequest("http://internal-host/oauth/callback")
+    result = _callback_uri(cast("Request", request), "https://app.example.com/")
+    assert result == "https://app.example.com/oauth/callback"
+
+
+def test_callback_uri_without_canonical_falls_back_to_request() -> None:
+    request = _FakeRequest("http://localhost:8000/oauth/callback")
+    assert _callback_uri(cast("Request", request), "") == "http://localhost:8000/oauth/callback"


### PR DESCRIPTION
## Summary

- The IdP `redirect_uri` (sent to Google at `/authorize` and re-sent at code
  exchange) was built with `request.url_for("authorize_oauth_callback")`, which
  derives scheme+host from the **incoming request**.
- Behind a TLS-terminating proxy (the qa1 ALB), the app sees a plain-`http`
  request, so it sent `http://…/oauth/callback` while the registered URI is
  `https://…/oauth/callback`. Google rejects the mismatch with
  **"Access blocked: this app's request is invalid"**.
- Now prefer `auth.canonical_base_url` for the callback origin and keep only the
  path resolved by `url_for` (so a future route rename still flows through).
  When no canonical base URL is configured (local dev over plain http) we fall
  back to the request-derived URL unchanged — existing behaviour preserved.

### Evidence

Probing the deployed qa1 `/authorize` showed the downgraded scheme:

```
location: https://accounts.google.com/o/oauth2/v2/auth?...&redirect_uri=
  http%3A%2F%2Fjentic-one-enterprise.qa1.eu-west-1.jenticdev.net%2Foauth%2Fcallback&...
                    ^^^^ http, but the registered URI (and canonical_base_url) is https
```

Localhost worked because there's no proxy (scheme really is http, and the
localhost redirect URI registered with Google is also http).

## Test plan

- [x] `_callback_uri` unit tests: canonical origin wins over request scheme;
      trailing slash tolerated; falls back to request URL when unset.
- [x] `tests/unit/auth/web/test_authorize_router.py` (19) pass.
- [x] `tests/web/auth/test_oidc_login_flow.py` (9) pass.
- [x] `make lint` clean (ruff + format + mypy).
- [ ] After release + enterprise pin bump + qa1 deploy: Google SSO completes
      end-to-end (no "Access blocked").

Made with [Cursor](https://cursor.com)