### PR TITLE
fix(broker): gate background jobs on enabled apps, not DB presence

### DIFF
--- a/src/jentic_one/admin/web/app.py
+++ b/src/jentic_one/admin/web/app.py
@@ -106,7 +106,9 @@ def _make_verifier(ctx: Context) -> Any:
 
 def create_app(ctx: Context) -> FastAPI:
     """Create the admin FastAPI application for standalone deployment."""
-    app = create_surface_app(ctx, title="jentic-one-admin", routers=get_routers())
+    app = create_surface_app(
+        ctx, title="jentic-one-admin", routers=get_routers(), enabled_apps={"admin"}
+    )
     install_on_app(app, ctx)
     for exc_class, handler in get_exception_handlers():
         app.add_exception_handler(exc_class, handler)

--- a/src/jentic_one/auth/web/app.py
+++ b/src/jentic_one/auth/web/app.py
@@ -137,7 +137,9 @@ def _make_auth_verifier(ctx: Context) -> Any:
 
 def create_app(ctx: Context) -> FastAPI:
     """Create the auth FastAPI application for standalone deployment."""
-    app = create_surface_app(ctx, title="jentic-one-auth", routers=get_routers())
+    app = create_surface_app(
+        ctx, title="jentic-one-auth", routers=get_routers(), enabled_apps={"auth"}
+    )
     install_on_app(app, ctx)
     for exc_class, handler in get_exception_handlers():
         app.add_exception_handler(exc_class, handler)

--- a/src/jentic_one/broker/web/app.py
+++ b/src/jentic_one/broker/web/app.py
@@ -202,6 +202,7 @@ def create_app(ctx: Context, container: AppContainer | None = None) -> FastAPI:
         ctx,
         title="jentic-one-broker",
         routers=_routers(readiness_saturation_threshold=resilience.readiness_saturation_threshold),
+        enabled_apps={"broker"},
         extra_lifespan=broker_lifespan,
         container=container,
         include_instance_router=False,

--- a/src/jentic_one/control/web/app.py
+++ b/src/jentic_one/control/web/app.py
@@ -52,7 +52,9 @@ def get_exception_handlers() -> list[tuple[type[Exception], Any]]:
 
 def create_app(ctx: Context) -> FastAPI:
     """Create the control FastAPI application for standalone deployment."""
-    app = create_surface_app(ctx, title="jentic-one-control", routers=get_routers())
+    app = create_surface_app(
+        ctx, title="jentic-one-control", routers=get_routers(), enabled_apps={"control"}
+    )
     for exc_class, handler in get_exception_handlers():
         app.add_exception_handler(exc_class, handler)
     return app

--- a/src/jentic_one/registry/web/app.py
+++ b/src/jentic_one/registry/web/app.py
@@ -44,7 +44,9 @@ def get_exception_handlers() -> list[tuple[type[Exception], Any]]:
 
 def create_app(ctx: Context) -> FastAPI:
     """Create the registry FastAPI application for standalone deployment."""
-    app = create_surface_app(ctx, title="jentic-one-registry", routers=get_routers())
+    app = create_surface_app(
+        ctx, title="jentic-one-registry", routers=get_routers(), enabled_apps={"registry"}
+    )
     for exc_class, handler in get_exception_handlers():
         app.add_exception_handler(exc_class, handler)
     return app

--- a/src/jentic_one/shared/web/app_factory.py
+++ b/src/jentic_one/shared/web/app_factory.py
@@ -164,11 +164,22 @@ def instrument_databases(ctx: Context) -> None:
 
 def _start_worker(
     ctx: Context,
+    enabled_apps: set[str],
     *,
     upstream_executor: Any | None = None,
     credential_injector: Any | None = None,
 ) -> tuple[WorkerLoop, asyncio.Task[None]] | None:
     """Start the background worker if the admin DB is available.
+
+    ``enabled_apps`` is the set of surfaces this process actually serves (from
+    ``config.apps``). Handler registration keys off *that*, not merely which DBs
+    are reachable: a broker-only process is granted the registry DB so its
+    **synchronous** proxy can resolve specs (``SURFACE_DB_DEPS["broker"]``), but
+    it is not the registry surface and must not claim ``IMPORT`` jobs — which are
+    drawn from the shared jobs table, so a broker worker would otherwise race
+    (and win) import jobs against the control plane and run the full ingest
+    pipeline (including any registered import-time stages) with the wrong
+    service's config.
 
     ``upstream_executor`` is the broker-side ``UpstreamExecutor`` (the
     ``PipelineExecutor`` over the shared composed runner, §11 RN-0.3) and
@@ -190,7 +201,7 @@ def _start_worker(
 
     handler_registry = JobHandlerRegistry()
 
-    if ctx.has_db("registry"):
+    if "registry" in enabled_apps and ctx.has_db("registry"):
         handler_registry.register(JobKind.IMPORT, ImportHandler(ctx))
 
     if ctx.has_db("control") and upstream_executor is not None:
@@ -216,14 +227,19 @@ def _start_worker(
 
 def _start_expiry_scanner(
     ctx: Context,
+    enabled_apps: set[str],
 ) -> tuple[CredentialExpiryScanner, asyncio.Task[None]] | None:
-    """Start the credential-expiry scanner when both control + admin DBs exist.
+    """Start the credential-expiry scanner when the control surface runs it.
 
     The sweep reads OAuth token expiries from the **control** DB and writes
     ``credential.expiring_soon`` / ``credential.expired`` events into the
-    **admin** DB, so both must be present. Without either DB there is nothing to
-    scan (or nowhere to record events), so the scanner is not started.
+    **admin** DB, so both must be present. It is a control-plane background job:
+    gate it on the ``control`` surface being enabled (``config.apps``), not on
+    mere DB reachability — a broker-only process is granted the control DB to
+    resolve credentials, but must not run the control plane's expiry sweep.
     """
+    if "control" not in enabled_apps:
+        return None
     if not (ctx.has_db("control") and ctx.has_db("admin")):
         return None
     scanner = CredentialExpiryScanner(
@@ -252,14 +268,20 @@ async def _stop_expiry_scanner(
 
 def _start_catalog_update_scanner(
     ctx: Context,
+    enabled_apps: set[str],
 ) -> tuple[CatalogUpdateScanner, asyncio.Task[None]] | None:
-    """Start the Flow-3 catalog update-notify scanner when registry + admin DBs exist.
+    """Start the Flow-3 catalog update-notify scanner when the registry runs it.
 
     The sweep reads sweep candidates + check rows from the **registry** DB and emits
     ``catalog.update_available`` events into the **admin** DB, so both must be present.
-    A standalone-registry deployment (no admin DB) gets no scanner — there is nowhere
-    to record the notifications.
+    Like the import worker it is a registry-surface background job: gate it on the
+    ``registry`` surface being enabled (``config.apps``), not on DB reachability, so a
+    broker-only process (granted the registry DB for its sync-proxy spec lookups) does
+    not run it. A standalone-registry deployment (no admin DB) still gets no scanner —
+    there is nowhere to record the notifications.
     """
+    if "registry" not in enabled_apps:
+        return None
     if not (ctx.has_db("registry") and ctx.has_db("admin")):
         return None
     scanner = CatalogUpdateScanner(ctx)
@@ -391,6 +413,7 @@ def create_surface_app(
     *,
     title: str,
     routers: Sequence[tuple[APIRouter, str, list[str]]],
+    enabled_apps: set[str],
     extra_lifespan: Callable[[FastAPI], AbstractAsyncContextManager[None]] | None = None,
     container: AppContainer | None = None,
     include_instance_router: bool = True,
@@ -400,6 +423,13 @@ def create_surface_app(
     Routers are mounted without their prefix (standalone mode serves at root,
     e.g. /health rather than /broker/health — the combined-mode root app
     keeps the prefix so /broker/health, /admin/health, etc. don't collide).
+
+    ``enabled_apps`` is the set of surfaces this process serves — for a
+    standalone surface it is that one surface's name. It gates the shared
+    background jobs (import worker, catalog + expiry scanners) so they run only
+    for the surface that owns them, independent of which DBs happen to be
+    reachable (the broker is granted the registry/control DBs for its proxy +
+    credential paths, but must not run registry/control background work).
 
     ``extra_lifespan`` is an optional surface-owned async context manager entered
     after ``ctx.startup()`` and exited before ``ctx.shutdown()`` — the broker
@@ -429,11 +459,12 @@ def create_surface_app(
             # extra_lifespan) — §04 / §11 RN-0.3.
             worker_task = _start_worker(
                 ctx,
+                enabled_apps,
                 upstream_executor=getattr(app.state, "broker_upstream_executor", None),
                 credential_injector=getattr(app.state, "broker_credential_injector", None),
             )
-            scanner_task = _start_expiry_scanner(ctx)
-            catalog_scanner_task = _start_catalog_update_scanner(ctx)
+            scanner_task = _start_expiry_scanner(ctx, enabled_apps)
+            catalog_scanner_task = _start_catalog_update_scanner(ctx, enabled_apps)
             try:
                 yield
             finally:
@@ -519,9 +550,9 @@ def create_combined_app(
         await ctx.startup()
         instrument_databases(ctx)
         telemetry_handle = await _start_telemetry(ctx)
-        worker_task = _start_worker(ctx)
-        scanner_task = _start_expiry_scanner(ctx)
-        catalog_scanner_task = _start_catalog_update_scanner(ctx)
+        worker_task = _start_worker(ctx, set(apps))
+        scanner_task = _start_expiry_scanner(ctx, set(apps))
+        catalog_scanner_task = _start_catalog_update_scanner(ctx, set(apps))
         try:
             yield
         finally:

--- a/tests/unit/broker/test_injected_broker_seam.py
+++ b/tests/unit/broker/test_injected_broker_seam.py
@@ -119,6 +119,7 @@ def test_container_stashes_injected_broker_on_surface_app(ctx: Context) -> None:
         ctx,
         title="test-surface",
         routers=[],
+        enabled_apps={"broker"},
         container=container,
     )
     assert app.state.broker is broker

--- a/tests/unit/shared/web/test_app_factory_worker_gating.py
+++ b/tests/unit/shared/web/test_app_factory_worker_gating.py
@@ -1,0 +1,162 @@
+"""Background-job startup gates on the *enabled surface set*, not DB presence.
+
+The import worker + catalog/expiry scanners are surface-owned background jobs
+that draw from a **shared** jobs table. A broker-only process is granted the
+registry/control DBs (``SURFACE_DB_DEPS["broker"]``) so its synchronous proxy
+can resolve specs and inject credentials — but it must not run registry/control
+background work, or it races (and wins) ``IMPORT`` jobs against the control
+plane and runs the ingest pipeline with the wrong service's config. These tests
+pin the gate on ``enabled_apps`` (from ``config.apps``), independent of
+``has_db``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from jentic_one.shared.models.jobs import JobKind
+from jentic_one.shared.web import app_factory
+
+_AF = "jentic_one.shared.web.app_factory"
+
+
+def _ctx(*, dbs: set[str]) -> MagicMock:
+    """A Context stub whose ``has_db`` answers from an explicit DB set."""
+    ctx = MagicMock()
+    ctx.has_db.side_effect = lambda name: name in dbs
+    return ctx
+
+
+def test_import_handler_registered_only_when_registry_app_enabled() -> None:
+    """Broker has the registry DB but not the registry *app* → no IMPORT handler.
+
+    A control-plane process (registry app enabled, registry DB present) registers
+    the IMPORT handler as before.
+    """
+    with (
+        patch(f"{_AF}.WorkerLoop") as worker_loop,
+        patch(f"{_AF}.asyncio.create_task"),
+        patch(f"{_AF}.ImportHandler") as import_handler,
+    ):
+        # Broker: registry DB granted for sync-proxy spec lookup, but the broker
+        # surface — not registry — is enabled. IMPORT must NOT be registered, and
+        # with no other handler the worker must not start at all.
+        broker_ctx = _ctx(dbs={"admin", "control", "registry"})
+        result = app_factory._start_worker(
+            broker_ctx,
+            {"broker"},
+            upstream_executor=None,
+            credential_injector=None,
+        )
+        import_handler.assert_not_called()
+        assert result is None
+        worker_loop.assert_not_called()
+
+    with (
+        patch(f"{_AF}.WorkerLoop") as worker_loop,
+        patch(f"{_AF}.asyncio.create_task"),
+        patch(f"{_AF}.ImportHandler") as import_handler,
+    ):
+        registry_ctx = _ctx(dbs={"admin", "registry"})
+        result = app_factory._start_worker(registry_ctx, {"registry"})
+        import_handler.assert_called_once_with(registry_ctx)
+        assert result is not None
+        # The registry built exactly the IMPORT handler for the worker.
+        registry_arg = worker_loop.call_args.args[1]
+        assert registry_arg.kinds == {JobKind.IMPORT}
+
+
+def test_execution_handler_still_registered_for_broker() -> None:
+    """The broker's own job (EXECUTION) is unaffected by the app gate.
+
+    Gating IMPORT on the registry app must not disturb the broker: with its
+    upstream executor present and the control DB granted, EXECUTION registers and
+    the worker starts (to drain execution jobs).
+    """
+    with (
+        patch(f"{_AF}.WorkerLoop") as worker_loop,
+        patch(f"{_AF}.asyncio.create_task"),
+        patch(f"{_AF}.ImportHandler") as import_handler,
+        patch(f"{_AF}.ExecutionHandler"),
+    ):
+        broker_ctx = _ctx(dbs={"admin", "control", "registry"})
+        broker_ctx.config.broker.upstream_timeout_s = 30
+        result = app_factory._start_worker(
+            broker_ctx,
+            {"broker"},
+            upstream_executor=MagicMock(),
+            credential_injector=MagicMock(),
+        )
+        import_handler.assert_not_called()
+        assert result is not None
+        registry_arg = worker_loop.call_args.args[1]
+        assert registry_arg.kinds == {JobKind.EXECUTION}
+
+
+def test_catalog_scanner_gated_on_registry_app() -> None:
+    """Catalog update scanner runs for the registry surface, never for a broker."""
+    with (
+        patch(f"{_AF}.CatalogUpdateScanner") as scanner,
+        patch(f"{_AF}.asyncio.create_task"),
+    ):
+        broker_ctx = _ctx(dbs={"admin", "control", "registry"})
+        assert app_factory._start_catalog_update_scanner(broker_ctx, {"broker"}) is None
+        scanner.assert_not_called()
+
+    with (
+        patch(f"{_AF}.CatalogUpdateScanner") as scanner,
+        patch(f"{_AF}.asyncio.create_task"),
+    ):
+        registry_ctx = _ctx(dbs={"admin", "registry"})
+        assert app_factory._start_catalog_update_scanner(registry_ctx, {"registry"}) is not None
+        scanner.assert_called_once_with(registry_ctx)
+
+
+def test_expiry_scanner_gated_on_control_app() -> None:
+    """Credential-expiry scanner runs for the control surface, never for a broker.
+
+    The broker is granted the control DB to resolve credentials, but the expiry
+    sweep is a control-plane job.
+    """
+    with (
+        patch(f"{_AF}.CredentialExpiryScanner") as scanner,
+        patch(f"{_AF}.asyncio.create_task"),
+    ):
+        broker_ctx = _ctx(dbs={"admin", "control", "registry"})
+        assert app_factory._start_expiry_scanner(broker_ctx, {"broker"}) is None
+        scanner.assert_not_called()
+
+    with (
+        patch(f"{_AF}.CredentialExpiryScanner") as scanner,
+        patch(f"{_AF}.asyncio.create_task"),
+    ):
+        control_ctx = _ctx(dbs={"admin", "control"})
+        assert app_factory._start_expiry_scanner(control_ctx, {"control"}) is not None
+        scanner.assert_called_once()
+
+
+def test_combined_app_still_runs_all_background_jobs() -> None:
+    """Dev-combined (all surfaces in one process) keeps every background job.
+
+    The gate is per-enabled-app, not global: when registry + control are both in
+    the enabled set, IMPORT registers and both scanners start.
+    """
+    combined = {"registry", "admin", "control", "auth"}
+    with (
+        patch(f"{_AF}.WorkerLoop") as worker_loop,
+        patch(f"{_AF}.asyncio.create_task"),
+        patch(f"{_AF}.ImportHandler") as import_handler,
+    ):
+        ctx = _ctx(dbs={"admin", "registry", "control"})
+        assert app_factory._start_worker(ctx, combined) is not None
+        import_handler.assert_called_once_with(ctx)
+        assert worker_loop.call_args.args[1].kinds == {JobKind.IMPORT}
+
+    with (
+        patch(f"{_AF}.CatalogUpdateScanner"),
+        patch(f"{_AF}.CredentialExpiryScanner"),
+        patch(f"{_AF}.asyncio.create_task"),
+    ):
+        ctx = _ctx(dbs={"admin", "registry", "control"})
+        assert app_factory._start_catalog_update_scanner(ctx, combined) is not None
+        assert app_factory._start_expiry_scanner(ctx, combined) is not None


### PR DESCRIPTION
## Summary

A broker-only process (`apps: [broker]`) was running the import worker and the catalog-update / credential-expiry scanners — background jobs it has no business running. Because import jobs are drawn from a **shared** jobs table, the broker's worker raced (and could win) `IMPORT` jobs against the control plane, executing the full ingest pipeline in the wrong service (with the wrong process config). This gates those surface-owned background jobs on the **enabled surface set** (`config.apps`) instead of mere DB reachability.

The root cause: the broker is intentionally granted the registry/control DBs (via `SURFACE_DB_DEPS["broker"]`) so its **synchronous** forward-proxy can resolve specs and its execution path can inject credentials. But `_start_worker` / `_start_expiry_scanner` / `_start_catalog_update_scanner` gated startup on `has_db(...)` alone, so the broker started all of them.

## Changes

- `shared/web/app_factory.py`:
  - `_start_worker` now registers the `IMPORT` handler only when the `registry` **app** is enabled (not just when the registry DB is reachable). The broker's `EXECUTION` handler registration is unchanged.
  - `_start_catalog_update_scanner` runs only when the `registry` app is enabled.
  - `_start_expiry_scanner` runs only when the `control` app is enabled.
  - `create_surface_app` gains a required `enabled_apps: set[str]`, threaded into the three start helpers.
- Each surface's `create_app` (`registry`, `control`, `auth`, `admin`, `broker`) passes its own single-surface set; `create_combined_app` passes `set(apps)` so the dev monolith still runs everything — the gate is **per-enabled-app, not global**.
- **Out of scope:** the broker keeps the registry/control DBs and its sync-proxy registry lookup + credential injection are untouched. No config/env/DB-wiring changes.

## Risk & rollback

- Low risk, additive gating. Behaviour is unchanged for the combined dev app and for each standalone surface that owns its jobs (registry runs imports + catalog scanner; control runs the expiry scanner). The only behavioural change is that a broker-only process no longer starts these background jobs.
- No migrations, no public API shape changes, no auth/permission changes.
- Rollback: revert the squash commit.

## Test plan

- New unit tests: `tests/unit/shared/web/test_app_factory_worker_gating.py` — broker registers no `IMPORT` handler and starts no worker; broker's `EXECUTION` handler still registers; catalog scanner gated on the registry app; expiry scanner gated on the control app; combined app still runs all three.
- Updated `tests/unit/broker/test_injected_broker_seam.py` for the new `create_surface_app(enabled_apps=...)` signature.
- Ran: `pytest tests/arch tests/unit/shared/web tests/unit/broker tests/unit/registry/services/test_import_handler_lifecycle.py` → 885 passed; `ruff check` clean; `mypy` clean on `app_factory.py`.

Made with [Cursor](https://cursor.com)