### PR TITLE
ci(docker): CVE-gate the app image and automate base digest freshness

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,23 @@ updates:
       python:
         patterns: ["*"]
 
+  # The Docker base images are digest-pinned (ARG defaults in
+  # deploy/docker/python-base.Dockerfile) for reproducible builds; this
+  # keeps those digests fresh so the published image doesn't accumulate
+  # already-patched base CVEs between manual bumps. The image-scan CI job
+  # (ci.yml) is the enforcement half: it fails on fixable HIGH/CRITICAL.
+  - package-ecosystem: "docker"
+    directory: "/deploy/docker"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 5
+    groups:
+      docker-bases:
+        patterns: ["*"]
+
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       cli: ${{ steps.filter.outputs.cli }}
       openapi-client: ${{ steps.filter.outputs.openapi-client }}
       installer: ${{ steps.filter.outputs.installer }}
+      docker-image: ${{ steps.filter.outputs.docker-image }}
     steps:
       - uses: actions/checkout@v7
 
@@ -97,6 +98,16 @@ jobs:
               - 'src/jentic_one/admin/web/app.py'
               - 'src/jentic_one/shared/web/app_factory.py'
               - 'scripts/spa_packaging_smoke.*'
+            # Everything that changes the published app image's contents:
+            # the wheel (src + locked deps), the UI bundle baked into it,
+            # and the Docker build definition (base digests included).
+            docker-image:
+              - 'deploy/docker/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'src/**'
+              - 'ui/**'
+              - '.trivyignore'
 
   lint:
     name: Lint & type-check
@@ -227,7 +238,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -252,6 +263,44 @@ jobs:
           uv sync --frozen
           uv run --with pip-licenses pip-licenses \
             --fail-on="GPL-3.0-only;GPL-3.0-or-later;AGPL-3.0-only;AGPL-3.0-or-later"
+
+  # The fs scan above checks the source tree; this scans the built app image
+  # (base-image OS packages included) — the same class of finding AWS ECR /
+  # registry scanners reject on, so we fail here before a registry does.
+  # `ignore-unfixed` keeps the gate actionable: Debian-slim always carries
+  # unfixed low-priority CVEs, and a permanently red gate gets ignored.
+  # Overrides go in .trivyignore (CVE id + justification + expiry).
+  image-scan:
+    name: Image CVE scan
+    needs: changes
+    if: needs.changes.outputs.docker-image == 'true' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune -af
+
+      - uses: actions/checkout@v7
+
+      # Same recipe as the release publish job (release.yml): base stages
+      # first, then the app image that FROMs python-base:runtime/:builder.
+      - name: Build the app image
+        run: |
+          make build-base
+          docker build -f deploy/docker/app.Dockerfile -t jentic-one/app:scan .
+
+      - name: Trivy image scan (fixable HIGH/CRITICAL)
+        uses: aquasecurity/trivy-action@0.36.0
+        with:
+          scan-type: 'image'
+          image-ref: jentic-one/app:scan
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '1'
+          trivyignores: .trivyignore
 
   test-unit:
     name: Unit tests
@@ -660,7 +709,7 @@ jobs:
   ci-status:
     name: CI status
     if: always()
-    needs: [lint, openapi-client-drift, security, test-unit, test-integration, ui, ui-e2e, ui-e2e-realbackend, smoke-packaging, cli, installer]
+    needs: [lint, openapi-client-drift, security, image-scan, test-unit, test-integration, ui, ui-e2e, ui-e2e-realbackend, smoke-packaging, cli, installer]
     runs-on: ubuntu-latest
     steps:
       - name: Check job results
@@ -669,6 +718,7 @@ jobs:
             ${{ needs.lint.result }}
             ${{ needs.openapi-client-drift.result }}
             ${{ needs.security.result }}
+            ${{ needs.image-scan.result }}
             ${{ needs.test-unit.result }}
             ${{ needs.test-integration.result }}
             ${{ needs.ui.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,9 @@ jobs:
 
   lint:
     name: Lint & type-check
+    # `needs: changes` is layout-only (lint always runs): it aligns lint and
+    # both Security scans into the same wave of the workflow graph.
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -228,6 +231,9 @@ jobs:
 
   security:
     name: Security / source scan
+    # `needs: changes` is layout-only (this scan always runs): it aligns the
+    # two Security scans and lint into the same wave of the workflow graph.
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
       cli: ${{ steps.filter.outputs.cli }}
       openapi-client: ${{ steps.filter.outputs.openapi-client }}
       installer: ${{ steps.filter.outputs.installer }}
-      docker-image: ${{ steps.filter.outputs.docker-image }}
     steps:
       - uses: actions/checkout@v7
 
@@ -98,22 +97,9 @@ jobs:
               - 'src/jentic_one/admin/web/app.py'
               - 'src/jentic_one/shared/web/app_factory.py'
               - 'scripts/spa_packaging_smoke.*'
-            # Everything that changes the published app image's contents:
-            # the wheel (src + locked deps), the UI bundle baked into it,
-            # and the Docker build definition (base digests included).
-            docker-image:
-              - 'deploy/docker/**'
-              - 'pyproject.toml'
-              - 'uv.lock'
-              - 'src/**'
-              - 'ui/**'
-              - '.trivyignore'
 
   lint:
     name: Lint & type-check
-    # `needs: changes` is layout-only (lint always runs): it aligns lint and
-    # both Security scans into the same wave of the workflow graph.
-    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -230,10 +216,7 @@ jobs:
           echo "Generated UI client is in sync with ui/openapi.json."
 
   security:
-    name: Security / source scan
-    # `needs: changes` is layout-only (this scan always runs): it aligns the
-    # two Security scans and lint into the same wave of the workflow graph.
-    needs: changes
+    name: Security scan
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space
@@ -270,29 +253,14 @@ jobs:
           uv run --with pip-licenses pip-licenses \
             --fail-on="GPL-3.0-only;GPL-3.0-or-later;AGPL-3.0-only;AGPL-3.0-or-later"
 
-  # The fs scan above checks the source tree; this scans the built app image
-  # (base-image OS packages included) — the same class of finding AWS ECR /
-  # registry scanners reject on, so we fail here before a registry does.
-  # `ignore-unfixed` keeps the gate actionable: Debian-slim always carries
-  # unfixed low-priority CVEs, and a permanently red gate gets ignored.
-  # Overrides go in .trivyignore (CVE id + justification + expiry).
-  image-scan:
-    name: Security / image scan
-    needs: changes
-    if: needs.changes.outputs.docker-image == 'true' || github.event_name == 'push'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune -af
-
-      - uses: actions/checkout@v7
-
-      # Same recipe as the release publish job (release.yml): base stages
-      # first, then the app image that FROMs python-base:runtime/:builder.
+      # The fs scan above checks the source tree; the steps below scan the
+      # BUILT app image (base-image OS packages included) — the same class of
+      # finding AWS ECR / registry scanners reject on, so we fail here before
+      # a registry does. Same recipe as the release publish job (release.yml):
+      # base stages first, then the app image that FROMs python-base by tag.
+      # `ignore-unfixed` keeps the gate actionable: Debian-slim always carries
+      # unfixed low-priority CVEs, and a permanently red gate gets ignored.
+      # Overrides go in .trivyignore (CVE id + justification + expiry).
       - name: Build the app image
         run: |
           make build-base
@@ -715,7 +683,7 @@ jobs:
   ci-status:
     name: CI status
     if: always()
-    needs: [lint, openapi-client-drift, security, image-scan, test-unit, test-integration, ui, ui-e2e, ui-e2e-realbackend, smoke-packaging, cli, installer]
+    needs: [lint, openapi-client-drift, security, test-unit, test-integration, ui, ui-e2e, ui-e2e-realbackend, smoke-packaging, cli, installer]
     runs-on: ubuntu-latest
     steps:
       - name: Check job results
@@ -724,7 +692,6 @@ jobs:
             ${{ needs.lint.result }}
             ${{ needs.openapi-client-drift.result }}
             ${{ needs.security.result }}
-            ${{ needs.image-scan.result }}
             ${{ needs.test-unit.result }}
             ${{ needs.test-integration.result }}
             ${{ needs.ui.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
           echo "Generated UI client is in sync with ui/openapi.json."
 
   security:
-    name: Security scan
+    name: Security / source scan
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space
@@ -271,7 +271,7 @@ jobs:
   # unfixed low-priority CVEs, and a permanently red gate gets ignored.
   # Overrides go in .trivyignore (CVE id + justification + expiry).
   image-scan:
-    name: Image CVE scan
+    name: Security / image scan
     needs: changes
     if: needs.changes.outputs.docker-image == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -293,7 +293,7 @@ jobs:
           docker build -f deploy/docker/app.Dockerfile -t jentic-one/app:scan .
 
       - name: Trivy image scan (fixable HIGH/CRITICAL)
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'image'
           image-ref: jentic-one/app:scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,7 @@ jobs:
       # the ci.yml image-scan job — fixable HIGH/CRITICAL fail, overrides
       # live in .trivyignore (CVE id + justification + expiry).
       - name: Trivy image scan (release gate)
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'image'
           image-ref: ${{ steps.build.outputs.image }}:${{ steps.build.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,19 +159,14 @@ jobs:
       # disk (it could push — and with this job's id-token grant, even sign —
       # a malicious image as this repo's release identity). Post-hooks run in
       # reverse order, so login-action's logout also fires before the
-      # installers' post-steps.
+      # installers' post-steps. The Trivy scan below also installs a binary,
+      # which is why the login happens after build+scan, immediately before
+      # the first push.
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 
       - name: Install syft (SBOM)
         uses: anchore/sbom-action/download-syft@v0
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       # One `app` image serves every surface — the surface set is chosen at
       # runtime via JENTIC__APPS (registry,admin,control,auth vs the sole broker;
@@ -193,8 +188,8 @@ jobs:
       # are floating, so the digest is the only true pin — deploy/README.md
       # "Reproducibility" tells self-hosters to pin to it. RepoDigests is
       # filtered by our image name rather than blindly taking index 0.
-      - name: Build and push the app image (version + SHA tags)
-        id: push
+      - name: Build the app image (version + SHA tags)
+        id: build
         run: |
           set -euo pipefail
           OWNER="$(tr '[:upper:]' '[:lower:]' <<<"${GITHUB_REPOSITORY_OWNER}")"
@@ -205,6 +200,42 @@ jobs:
           docker build -f deploy/docker/app.Dockerfile \
             -t "${IMAGE}:${VERSION}" \
             -t "${IMAGE}:${SHA}" .
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+
+      # CVE gate before anything is pushed: a release must not publish an
+      # image a registry scanner (e.g. AWS ECR) would flag. Same policy as
+      # the ci.yml image-scan job — fixable HIGH/CRITICAL fail, overrides
+      # live in .trivyignore (CVE id + justification + expiry).
+      - name: Trivy image scan (release gate)
+        uses: aquasecurity/trivy-action@0.36.0
+        with:
+          scan-type: 'image'
+          image-ref: ${{ steps.build.outputs.image }}:${{ steps.build.outputs.version }}
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '1'
+          trivyignores: .trivyignore
+
+      # Login deliberately AFTER build + scan (see the installer-ordering
+      # comment above): no third-party tool runs with the registry
+      # credential on disk.
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push the app image (version + SHA tags)
+        id: push
+        env:
+          IMAGE: ${{ steps.build.outputs.image }}
+          VERSION: ${{ steps.build.outputs.version }}
+          SHA: ${{ steps.build.outputs.sha }}
+        run: |
+          set -euo pipefail
           docker push "${IMAGE}:${VERSION}"
           docker push "${IMAGE}:${SHA}"
           DIGEST="$(docker inspect --format='{{range .RepoDigests}}{{println .}}{{end}}' "${IMAGE}:${VERSION}" \

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,12 @@
+# Trivy overrides for the image/fs CVE gates (ci.yml image-scan + security,
+# release.yml publish-image).
+#
+# Policy: every entry needs all three of
+#   1. the CVE id,
+#   2. a one-line justification (why it does not apply / cannot be fixed yet),
+#   3. an expiry — a date or condition for removal, checked at review time.
+#
+# Example:
+#   # CVE-2026-XXXXX: false positive — vulnerable function not reachable from
+#   # the wheel; remove when trivy DB marks the debian package fixed (~2026-09).
+#   CVE-2026-XXXXX

--- a/deploy/docker/python-base.Dockerfile
+++ b/deploy/docker/python-base.Dockerfile
@@ -2,8 +2,8 @@
 # Pinned to a specific digest for reproducible builds.
 # To bump: `docker pull python:3.12-slim` / `node:22-slim` then update the
 # digests below (`docker buildx imagetools inspect <image>` prints them).
-ARG PYTHON_IMAGE=python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
-ARG NODE_IMAGE=node:22-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3
+ARG PYTHON_IMAGE=python:3.12-slim@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36
+ARG NODE_IMAGE=node:22-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436
 
 # UI build stage — produces ui/dist, bundled into the wheel via the
 # [tool.hatch.build.targets.wheel.force-include] "ui/dist" -> jentic_one/static.


### PR DESCRIPTION
## Summary

The published app image's base digests go stale (the pinned `python:3.12-slim` digest was a month old and carries 3 fixable HIGH CVEs, including an OpenSSL heap use-after-free), and nothing in CI scanned the *built image* — the fs-mode Trivy scan in the `security` job checks the source tree only, so base-layer OS CVEs were invisible. This adds an image-level CVE gate and the automation to keep the bases fresh, so we find what a registry scanner (e.g. AWS ECR) would find before it does. Plan: `jentic-one-plans/research/aws-marketplace-readiness-impl/` (PR 1 + PR 2).

## Changes

- `deploy/docker/python-base.Dockerfile`: bump both base digests to today's upstream (`python:3.12-slim`, `node:22-slim`).
- `.github/dependabot.yml`: new `docker` ecosystem for `deploy/docker/` — weekly grouped digest-bump PRs.
- `.github/workflows/ci.yml`: the `Security scan` job now also builds the app image and Trivy-scans it (`HIGH,CRITICAL`, `ignore-unfixed`, exit 1) — runs on every PR and push, same policy as the rest of the job; pinned both `trivy-action` usages to `v0.36.0` (was `@master`).
- `.github/workflows/release.yml`: publish-image job split into build → scan → push, so a vulnerable image fails the release before anything is pushed. GHCR login moved after the scan (the installer-before-login security posture now covers the trivy download too). Sign-before-`:latest` ordering unchanged.
- `.trivyignore` (empty): auditable override path — entries need CVE id + justification + expiry.
- Out of scope: base *upgrade* (3.13/distroless), scheduled rebuilds, ECR publishing — later plan PRs.

## Risk & rollback

- Low risk to the product: no image content change beyond fresher base digests; no config or code paths.
- The always-run `Security scan` job gets ~3-5 min slower (image build on every PR, including docs-only) — accepted deliberately for gate simplicity.
- Release-blocking behaviour is new: a fixable HIGH/CRITICAL in the base now fails the release. That is the point; escape hatch is a justified `.trivyignore` entry.
- Revert the squash commit to restore the old pipeline.

## Test plan

- `make build-base` + app image build green on the new digests (local).
- `trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 jentic-one/app:scan` → exit 0 (clean).
- Negative control: same scan against the **old** pinned digest → exit 1 (3 fixable HIGH, `CVE-2026-45447` et al.) — proves the gate fires.
- YAML of all edited files parses; commit hooks (ruff/mypy/commitlint) green.
- The extended `Security scan` job runs on this PR itself.