### PR TITLE
feat(helm): AWS Marketplace values + required DB password guards

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -260,36 +260,6 @@
         "line_number": 26
       }
     ],
-    "deploy/helm/jentic-one/values.yaml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/helm/jentic-one/values.yaml",
-        "hashed_secret": "f4bc54cbb2c9169457a70771dcdcf8e75aa816a9",
-        "is_verified": false,
-        "line_number": 131
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/helm/jentic-one/values.yaml",
-        "hashed_secret": "ffdbf67b6ec4759c53887c56108efe2ebe67b7bd",
-        "is_verified": false,
-        "line_number": 138
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/helm/jentic-one/values.yaml",
-        "hashed_secret": "99075eb0baa8cfda1cae029da06b57b93cc13a31",
-        "is_verified": false,
-        "line_number": 145
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "deploy/helm/jentic-one/values.yaml",
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_verified": false,
-        "line_number": 161
-      }
-    ],
     "deploy/helm/observability/values.yaml": [
       {
         "type": "Secret Keyword",
@@ -305,7 +275,7 @@
         "filename": "deploy/helm/values/local-broker.yaml",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 35
+        "line_number": 45
       }
     ],
     "deploy/helm/values/local-combined.yaml": [
@@ -314,7 +284,7 @@
         "filename": "deploy/helm/values/local-combined.yaml",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 76
+        "line_number": 86
       }
     ],
     "deploy/helm/values/local-parts.yaml": [
@@ -323,7 +293,7 @@
         "filename": "deploy/helm/values/local-parts.yaml",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 92
       }
     ],
     "docker/local-setup/docker-compose.yaml": [
@@ -1802,5 +1772,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-12T09:10:19Z"
+  "generated_at": "2026-08-13T10:46:25Z"
 }

--- a/deploy/helm/jentic-one/charts/common/templates/_db-env.tpl
+++ b/deploy/helm/jentic-one/charts/common/templates/_db-env.tpl
@@ -27,7 +27,7 @@ See deploy/README.md "Production secrets" for the migration recipe.
 - name: JENTIC__DATABASES__{{ upper $surface }}__USER
   value: {{ $db.user | quote }}
 - name: JENTIC__DATABASES__{{ upper $surface }}__PASSWORD
-  value: {{ $db.password | quote }}
+  value: {{ required (printf "global.databases.%s.password is required — set it in your values file (dev files: deploy/helm/values/local-*.yaml)" $surface) $db.password | quote }}
 - name: JENTIC__DATABASES__{{ upper $surface }}__SCHEMA_NAME
   value: {{ $db.schema_name | default $db.schema | quote }}
 {{- end }}

--- a/deploy/helm/jentic-one/values.yaml
+++ b/deploy/helm/jentic-one/values.yaml
@@ -117,32 +117,31 @@ global:
   # different registry/image can leave this off.
   security:
     allowInsecureImages: true
-  # WARNING: dev-only credential pattern.
-  # In production, do NOT set `password` here. Replace `common.db-env` in your
-  # subchart deployments with a Secret-backed `valueFrom: secretKeyRef:` block,
-  # or pass an `existingSecret` reference. See deploy/README.md
-  # "Production secrets" for the recipe.
+  # Database credentials. `password` has NO default — the chart refuses to
+  # render without one (see common.db-env), so every deployment states its
+  # credentials explicitly. Dev/kind values live in
+  # deploy/helm/values/local-*.yaml. In production, do NOT put real passwords
+  # in a values file: replace `common.db-env` in your subchart deployments
+  # with a Secret-backed `valueFrom: secretKeyRef:` block, or pass an
+  # `existingSecret` reference. See deploy/README.md "Production secrets".
   databases:
     registry:
       host: ""
       port: 5432
       name: jentic
       user: registry_user
-      password: registry_pass
       schema: registry
     control:
       host: ""
       port: 5432
       name: jentic
       user: control_user
-      password: control_pass
       schema: control
     admin:
       host: ""
       port: 5432
       name: jentic
       user: admin_user
-      password: admin_pass
       schema: admin
 
 postgresql:
@@ -158,7 +157,10 @@ postgresql:
     tag: 17.2.0-debian-12-r6
   auth:
     username: postgres
-    password: postgres
+    # No default password — set one in your values file (dev files:
+    # deploy/helm/values/local-*.yaml). Left unset, the Bitnami chart
+    # generates a random one, which breaks the pg-init scripts that the
+    # local deploys rely on.
     database: jentic
   primary:
     initdb:

--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -1,0 +1,91 @@
+# AWS Marketplace deployment values (container product listing).
+#
+# Overlay for the jentic-one umbrella chart when deploying from the AWS
+# Marketplace listing. Placeholders marked <…> are filled in when the listing
+# exists (plan PR 6): the Marketplace portal assigns the ECR registry path and
+# repository names when the product is created.
+#
+# Marketplace rule of thumb: every image a deployment pulls must come from the
+# listing's ECR registry — no docker.io / ghcr.io pulls at install time.
+
+global:
+  image:
+    # ECR registry path from the Marketplace portal, e.g.
+    # "709825985650.dkr.ecr.us-east-1.amazonaws.com/<seller>". Used as the
+    # fallback for any service without an explicit image.repository.
+    registry: "709825985650.dkr.ecr.us-east-1.amazonaws.com/<seller>"
+    # Pin per release, per the listing's deployment instructions (the
+    # Marketplace does not allow floating tags like :latest).
+    tag: ""
+
+  # Combined mode: the app pod serves registry/admin/control; only the app
+  # and broker deployments (and their shared image) exist.
+  postgresql:
+    enabled: true
+
+  # NOTE: global.observability.otel.enabled must stay false for Marketplace
+  # deploys — the sidecar image (otel/opentelemetry-collector-contrib) is
+  # pulled from docker.io, which the Marketplace disallows. Mirror it into
+  # the listing's ECR first if observability is needed.
+
+  # No database password defaults ship with the chart; set them at install:
+  #   --set global.databases.registry.password=… \
+  #   --set global.databases.control.password=…  \
+  #   --set global.databases.admin.password=…
+  # or (preferred) replace common.db-env with a Secret-backed env block —
+  # see deploy/README.md "Production secrets".
+
+# app and broker run the same jentic-one-app image, differentiated by the
+# JENTIC__APPS env each subchart sets. If the Marketplace portal provisions a
+# single ECR repository for the product, keep the explicit repository values
+# below identical; if it provisions one repo per name, drop the overrides and
+# let <global.image.registry>/<chart-name> resolve them instead.
+app:
+  enabled: true
+  image:
+    repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/<seller>/jentic-one-app"
+  # Entitlement gate wiring (plan PR 4). DO NOT uncomment until the deployed
+  # image ships the entitlement config: AppConfig rejects unknown config
+  # sections (extra="forbid"), so these env vars crash older images at boot.
+  # extraEnv:
+  #   JENTIC__ENTITLEMENT__ENABLED: "true"
+  #   JENTIC__ENTITLEMENT__PRODUCT_CODE: "<product-code from the portal>"
+
+broker:
+  enabled: true
+  image:
+    repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/<seller>/jentic-one-app"
+  # extraEnv:  # same caveat as app.extraEnv above
+  #   JENTIC__ENTITLEMENT__ENABLED: "true"
+  #   JENTIC__ENTITLEMENT__PRODUCT_CODE: "<product-code from the portal>"
+
+registry:
+  enabled: false
+admin:
+  enabled: false
+control:
+  enabled: false
+gateway:
+  enabled: false
+
+# In-cluster Postgres from the ECR-mirrored image (plan PR 6 mirrors it).
+# RDS variant: set postgresql.enabled=false, global.postgresql.enabled=false,
+# and point global.databases.*.host at the RDS endpoint instead.
+postgresql:
+  enabled: true
+  image:
+    registry: "709825985650.dkr.ecr.us-east-1.amazonaws.com"
+    repository: "<seller>/postgresql"
+    tag: "17.2.0-debian-12-r6"
+  auth:
+    username: postgres
+    # password: set at install (--set postgresql.auth.password=…) or via
+    # auth.existingSecret; no default ships with the chart.
+    database: jentic
+  # The per-surface DB roles/schemas (registry/control/admin) must exist
+  # before the app boots — create a ConfigMap from
+  # docker/local-setup/init-schemas.sql (with real passwords) and reference
+  # it here, as the local deploy tooling does:
+  # primary:
+  #   initdb:
+  #     scriptsConfigMap: "jentic-pg-init"

--- a/deploy/helm/values/local-broker.yaml
+++ b/deploy/helm/values/local-broker.yaml
@@ -27,6 +27,16 @@ control:
 global:
   postgresql:
     enabled: true
+  # Dev-only literals (must match docker/local-setup/init-schemas.sql). The
+  # umbrella chart ships no password defaults — every values file states its
+  # own. Never reuse these outside the local kind cluster.
+  databases:
+    registry:
+      password: registry_pass  # pragma: allowlist secret
+    control:
+      password: control_pass  # pragma: allowlist secret
+    admin:
+      password: admin_pass  # pragma: allowlist secret
 
 postgresql:
   enabled: true

--- a/deploy/helm/values/local-combined.yaml
+++ b/deploy/helm/values/local-combined.yaml
@@ -68,6 +68,16 @@ control:
 global:
   postgresql:
     enabled: true
+  # Dev-only literals (must match docker/local-setup/init-schemas.sql). The
+  # umbrella chart ships no password defaults — every values file states its
+  # own. Never reuse these outside the local kind cluster.
+  databases:
+    registry:
+      password: registry_pass  # pragma: allowlist secret
+    control:
+      password: control_pass  # pragma: allowlist secret
+    admin:
+      password: admin_pass  # pragma: allowlist secret
 
 postgresql:
   enabled: true

--- a/deploy/helm/values/local-parts.yaml
+++ b/deploy/helm/values/local-parts.yaml
@@ -74,6 +74,16 @@ control:
 global:
   postgresql:
     enabled: true
+  # Dev-only literals (must match docker/local-setup/init-schemas.sql). The
+  # umbrella chart ships no password defaults — every values file states its
+  # own. Never reuse these outside the local kind cluster.
+  databases:
+    registry:
+      password: registry_pass  # pragma: allowlist secret
+    control:
+      password: control_pass  # pragma: allowlist secret
+    admin:
+      password: admin_pass  # pragma: allowlist secret
 
 postgresql:
   enabled: true

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -292,6 +292,8 @@ def _skip_if_unreachable(request: pytest.FixtureRequest, base_url: str) -> None:
     exempt_modules = (
         "tests.smoke.test_env",
         "tests.smoke.test_helm_modes",
+        # Render-only helm assertions: no deployed stack needed at all.
+        "tests.smoke.test_helm_render",
         # Real-AWS SigV4 tests: the signer-level tests need only AWS env vars
         # (no deployed stack); the broker E2E test does its own reachability skip.
         "tests.smoke.test_sigv4_real_aws",

--- a/tests/smoke/test_helm_render.py
+++ b/tests/smoke/test_helm_render.py
@@ -17,6 +17,17 @@ import pytest
 CHART_DIR = Path(__file__).resolve().parents[2] / "deploy" / "helm" / "jentic-one"
 VALUES_DIR = CHART_DIR.parent / "values"
 
+DEV_PASSWORD_SETS = [
+    "--set",
+    "global.databases.registry.password=x",
+    "--set",
+    "global.databases.control.password=x",
+    "--set",
+    "global.databases.admin.password=x",
+    "--set",
+    "postgresql.auth.password=x",
+]
+
 
 def _helm_template(*args: str) -> subprocess.CompletedProcess[str]:
     if shutil.which("helm") is None:
@@ -45,3 +56,27 @@ def test_render_dev_values(values: str) -> None:
     """The committed dev values files carry their own (dev-only) passwords."""
     result = _helm_template("-f", str(VALUES_DIR / f"{values}.yaml"))
     assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.smoke
+def test_render_marketplace_images_all_ecr() -> None:
+    """Every image rendered with aws-marketplace.yaml comes from the ECR registry.
+
+    The Marketplace disallows docker.io/ghcr.io pulls at install time.
+    """
+    result = _helm_template(
+        "-f",
+        str(VALUES_DIR / "aws-marketplace.yaml"),
+        "--set",
+        "global.image.tag=0.0.0-test",
+        *DEV_PASSWORD_SETS,
+    )
+    assert result.returncode == 0, result.stderr
+    images = [
+        line.split("image:", 1)[1].strip().strip('"')
+        for line in result.stdout.splitlines()
+        if line.lstrip().startswith("image:")
+    ]
+    assert images, "no image references rendered"
+    for image in images:
+        assert image.startswith("709825985650.dkr.ecr."), f"non-ECR image rendered: {image}"

--- a/tests/smoke/test_helm_render.py
+++ b/tests/smoke/test_helm_render.py
@@ -1,0 +1,47 @@
+"""Render-only assertions for the Helm chart (no cluster required).
+
+These run inside the smoke matrix (tools.deploy ci-smoke builds the chart
+dependencies before invoking pytest), but they only shell out to
+``helm template`` — they skip cleanly when helm or the built dependencies
+are absent, so a bare local ``pytest tests/smoke`` stays green.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CHART_DIR = Path(__file__).resolve().parents[2] / "deploy" / "helm" / "jentic-one"
+VALUES_DIR = CHART_DIR.parent / "values"
+
+
+def _helm_template(*args: str) -> subprocess.CompletedProcess[str]:
+    if shutil.which("helm") is None:
+        pytest.skip("helm not installed")
+    if not list((CHART_DIR / "charts").glob("postgresql-*.tgz")):
+        pytest.skip("chart dependencies not built (run: helm dependency build)")
+    return subprocess.run(
+        ["helm", "template", "jentic", str(CHART_DIR), *args],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+@pytest.mark.smoke
+def test_render_requires_db_passwords() -> None:
+    """The chart ships no password defaults; a bare render must fail loudly."""
+    result = _helm_template()
+    assert result.returncode != 0
+    assert "password is required" in result.stderr
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("values", ["local-combined", "local-parts", "local-broker"])
+def test_render_dev_values(values: str) -> None:
+    """The committed dev values files carry their own (dev-only) passwords."""
+    result = _helm_template("-f", str(VALUES_DIR / f"{values}.yaml"))
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Prepares the Helm chart for an AWS Marketplace container listing (plan PR 5, Workstream B3+B4 of `jentic-one-plans/research/aws-marketplace-readiness-plan.md`): the chart no longer ships default database passwords (Marketplace review rejects baked-in credentials), and a new `aws-marketplace.yaml` values overlay repoints every pulled image at the listing's ECR registry. Independent of the entitlement work (plan PRs 3–4).

## Changes

- **deploy**: `common.db-env` now `required`-guards `JENTIC__DATABASES__*__PASSWORD` — rendering without a password fails loudly with a pointer to the dev values files.
- **deploy**: dropped the dev password defaults (`registry_pass`/`control_pass`/`admin_pass`, `postgresql.auth.password: postgres`) from the umbrella `values.yaml`; the same dev literals now live explicitly in `local-combined.yaml`, `local-parts.yaml`, and `local-broker.yaml` (they must match `docker/local-setup/init-schemas.sql`).
- **deploy**: new `deploy/helm/values/aws-marketplace.yaml` — combined-mode overlay with ECR placeholder registry/repos (real names come from the Marketplace portal in plan PR 6), a mirrored-Postgres block with an RDS alternative, and the entitlement env wiring **commented out** (deliberate deviation from the impl guide: `AppConfig` is `extra="forbid"`, so `JENTIC__ENTITLEMENT__*` env crashes images that predate plan PR 4 at boot).
- **tests**: `tests/smoke/test_helm_render.py` — render-only assertions (no cluster): bare render fails on the password guard, all three `local-*` files render, and the Marketplace overlay renders zero non-ECR image references. Runs in the existing smoke matrix; skips cleanly when helm/chart deps are absent.
- Out of scope: the CLI compose path (secrets are generated per-install, no equivalent problem) and mirroring the otel sidecar image (noted in the values file as "keep otel disabled for Marketplace deploys").

## Risk & rollback

- **Breaking for values files that relied on chart password defaults**: `helm template`/`install` without `global.databases.*.password` now fails at render. This includes the `deploy/terraform/envs/{dev,prod}` examples as-is — they previously deployed with the (dev-only) literals, which is exactly the exposure this closes; they now need explicit values.
- `postgresql.auth.password` also has no default; left unset, the Bitnami chart generates a random one (local values files all pin `postgres` explicitly, so kind deploys are unchanged).
- Rollback: revert the squash commit.

## Test plan

- `uv run pytest tests/smoke/test_helm_render.py -m smoke --no-cov` — 5 passed (after `helm dependency build`).
- Manual `helm template`: bare render fails with `global.databases.<surface>.password is required…`; all three `local-*` files render; the Marketplace overlay renders exactly two unique `image:` lines, both under `709825985650.dkr.ecr.…`.
- The Helm smoke matrix (`smoke-helm.yml`) triggers on this diff and deploys with the `local-*` files — a live-cluster check of the same guard.

Made with [Cursor](https://cursor.com)