### PR TITLE
refactor(registry): search-strategy shadowing guard (#958) + sha-less spec_digest collision (#780)

### DIFF
--- a/src/jentic_one/registry/core/schema/api_revisions.py
+++ b/src/jentic_one/registry/core/schema/api_revisions.py
@@ -71,6 +71,11 @@ class ApiRevision(AuditableMixin, RegistryBase):
     )
     state: Mapped[str] = mapped_column(String(20), nullable=False, server_default=text("'draft'"))
     origin: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    #: sha256 of the spec content, or NULL when the source carried no sha. Must be
+    #: NULL — never '' — for sha-less specs: '' is a *value* under
+    #: uq_api_revisions_api_id_spec_digest and would collapse distinct sha-less
+    #: specs for the same api_id into one revision, whereas NULLs are distinct on
+    #: both Postgres and SQLite. Derivation lives in CreateRevisionStage (#780).
     spec_digest: Mapped[str | None] = mapped_column(String(100), nullable=True)
     #: For an overlay-origin revision: the ``spec_digest`` of the *base* revision this
     #: overlay was materialized on top of (the revision it superseded). Lets the Flow-3

--- a/src/jentic_one/registry/ingest/stages/extract_api.py
+++ b/src/jentic_one/registry/ingest/stages/extract_api.py
@@ -45,20 +45,35 @@ class CreateRevisionStage(BasePipelineStage):
     async def _run(self, ctx: PipelineContext) -> None:
         api_id = ctx.require("api_id", uuid.UUID)
         spec = ctx.specification
-        spec_digest = spec.sha or ""
-        # A prior import of identical content may have committed a revision that
-        # was later abandoned (e.g. a sibling source failed, or a subsequent
-        # stage crashed). Re-importing the same (api_id, spec_digest) would then
-        # collide with uq_api_revisions_api_id_spec_digest. Replace a leftover
-        # replaceable revision (draft/archived) so retries are idempotent.
-        await ApiRevisionRepository.delete_replaceable_by_digest(ctx.session, api_id, spec_digest)
-        # Anything still sharing the digest is an active (published/imported)
-        # revision — a genuine conflict. Surface it as a readable error before we
-        # attempt the insert, so callers see a clear message instead of a raw
-        # unique-constraint IntegrityError.
-        existing = await ApiRevisionRepository.get_by_digest(ctx.session, api_id, spec_digest)
-        if existing is not None:
-            raise DuplicateRevisionError()
+        # Domain invariant: every production IngestSpecification comes through
+        # load_specification, which digests the inline/URL bytes, so sha is
+        # always set. Assert it so a future sha-less producer fails loudly here
+        # rather than silently writing a NULL-digest revision that would confuse
+        # the Flow-3 update sweep (upstream != NULL is always "changed"). See #780.
+        assert spec.sha, "IngestSpecification reached CreateRevisionStage without a sha"
+        # An absent sha must stay NULL, never '' — the empty string is a *value*
+        # under uq_api_revisions_api_id_spec_digest, so two distinct sha-less
+        # specs would collide (and the replaceable-cleanup below would delete the
+        # OTHER spec's leftover rows). NULLs are distinct under the unique
+        # constraint on both Postgres and SQLite, so sha-less revisions coexist.
+        # See #780.
+        spec_digest = spec.sha or None
+        if spec_digest is not None:
+            # A prior import of identical content may have committed a revision that
+            # was later abandoned (e.g. a sibling source failed, or a subsequent
+            # stage crashed). Re-importing the same (api_id, spec_digest) would then
+            # collide with uq_api_revisions_api_id_spec_digest. Replace a leftover
+            # replaceable revision (draft/archived) so retries are idempotent.
+            await ApiRevisionRepository.delete_replaceable_by_digest(
+                ctx.session, api_id, spec_digest
+            )
+            # Anything still sharing the digest is an active (published/imported)
+            # revision — a genuine conflict. Surface it as a readable error before we
+            # attempt the insert, so callers see a clear message instead of a raw
+            # unique-constraint IntegrityError.
+            existing = await ApiRevisionRepository.get_by_digest(ctx.session, api_id, spec_digest)
+            if existing is not None:
+                raise DuplicateRevisionError()
         if spec.origin is not None:
             if spec.origin == ORIGIN_OVERLAY:
                 # A materialized overlay must supersede whatever revision is currently

--- a/src/jentic_one/registry/repos/revision_repo.py
+++ b/src/jentic_one/registry/repos/revision_repo.py
@@ -47,7 +47,7 @@ class ApiRevisionRepository:
         session: AsyncSession,
         *,
         api_id: uuid.UUID,
-        spec_digest: str,
+        spec_digest: str | None,
         source_type: ApiRevisionSourceType,
         source_url: str | None = None,
         source_filename: str | None = None,
@@ -76,7 +76,7 @@ class ApiRevisionRepository:
         *,
         api_id: uuid.UUID,
         origin: str,
-        spec_digest: str,
+        spec_digest: str | None,
         source_type: ApiRevisionSourceType,
         source_url: str | None = None,
         source_filename: str | None = None,
@@ -174,6 +174,10 @@ class ApiRevisionRepository:
     async def get_by_digest(
         session: AsyncSession, api_id: uuid.UUID, spec_digest: str
     ) -> ApiRevision | None:
+        # Precondition: spec_digest is a real (non-NULL) digest. A NULL digest can
+        # never match under `spec_digest == :value` (SQL `= NULL` is never true), so
+        # the sha-less case is handled upstream by skipping this lookup (#780) rather
+        # than being widened to str | None here.
         result = await session.execute(
             select(ApiRevision).where(
                 ApiRevision.api_id == api_id, ApiRevision.spec_digest == spec_digest
@@ -309,6 +313,10 @@ class ApiRevisionRepository:
         revisions are never touched — a live revision with the same content is a
         genuine conflict that must surface, not be silently overwritten. Child
         rows cascade via the ``ondelete="CASCADE"`` foreign keys.
+
+        Precondition: ``spec_digest`` is a real (non-NULL) digest. A NULL digest
+        can never match ``spec_digest == :value``, so the sha-less case is handled
+        upstream by skipping this call (#780) rather than being widened here.
         """
         result = cast(
             "CursorResult[Any]",

--- a/src/jentic_one/registry/repos/search/registry.py
+++ b/src/jentic_one/registry/repos/search/registry.py
@@ -16,8 +16,26 @@ _STRATEGIES: dict[tuple[str, str], type[SearchStrategy]] = {}
 
 
 def register_strategy[T: type[SearchStrategy]](cls: T) -> T:
-    """Class decorator that registers a SearchStrategy by (dialect, name)."""
+    """Class decorator that registers a SearchStrategy by (dialect, name).
+
+    Idempotent for an identical re-registration (same class — safe under double
+    import); raises ``ValueError`` when the key is already bound to a *different*
+    class, so an extension can't silently shadow a built-in strategy. Same
+    posture as the other registration seams: ``register_config``
+    (``shared/config.py``), ``register_telemetry_event``
+    (``shared/telemetry/events.py``), ``register_target``
+    (``migrations/targets.py``), and ``register_pipeline_stage``
+    (``registry/ingest/pipeline/stage_registry.py``).
+    """
     key = (cls.dialect, cls.name)
+    existing = _STRATEGIES.get(key)
+    if existing is not None and existing is not cls:
+        msg = (
+            f"Search strategy {key!r} is already registered by "
+            f"{existing.__module__}.{existing.__qualname__}; refusing to shadow it "
+            f"with {cls.__module__}.{cls.__qualname__}"
+        )
+        raise ValueError(msg)
     _STRATEGIES[key] = cls
     return cls
 

--- a/src/jentic_one/registry/services/import_service.py
+++ b/src/jentic_one/registry/services/import_service.py
@@ -41,18 +41,28 @@ logger = structlog.get_logger(__name__)
 
 _source_adapter: TypeAdapter[IngestSource] = TypeAdapter(IngestSource)
 
-# The unique constraint that guards one revision per (api_id, spec_digest).
+# The unique constraints whose violation means "this revision already exists".
+# Both surface as a raw IntegrityError; translate either to the readable
+# duplicate message rather than leaking a truncated SQL string.
+#   - uq_api_revisions_api_id_spec_digest: identical content re-imported.
+#   - ix_api_revisions_one_active: a concurrent import raced to become the single
+#     active (published/imported) revision for the API and lost — the digest guard
+#     can't catch this (it's keyed on api_id alone, independent of spec_digest).
 _DIGEST_CONSTRAINT = "uq_api_revisions_api_id_spec_digest"
+_ONE_ACTIVE_CONSTRAINT = "ix_api_revisions_one_active"
 
 
 def _readable_source_error(exc: Exception) -> str:
     """Map a source-level ingest failure to a message safe to show a user.
 
     Raw ``IntegrityError`` strings leak SQL and get truncated mid-word in the
-    job record; translate the duplicate-digest collision to a clear message and
-    keep other failures as their (domain) exception text.
+    job record; translate a duplicate-revision collision (same digest, or a lost
+    race for the one-active slot) to a clear message and keep other failures as
+    their (domain) exception text.
     """
-    if isinstance(exc, DatabaseIntegrityError) and _DIGEST_CONSTRAINT in exc.detail:
+    if isinstance(exc, DatabaseIntegrityError) and (
+        _DIGEST_CONSTRAINT in exc.detail or _ONE_ACTIVE_CONSTRAINT in exc.detail
+    ):
         return DuplicateRevisionError().message
     return str(exc)
 

--- a/tests/integration/registry/repos/test_revision_repo.py
+++ b/tests/integration/registry/repos/test_revision_repo.py
@@ -89,6 +89,38 @@ async def test_digest_uniqueness_constraint(registry_db: DatabaseSession, sample
             await session.commit()
 
 
+async def test_null_digests_do_not_collide(registry_db: DatabaseSession, sample_api: Api) -> None:
+    """Two sha-less revisions (spec_digest=NULL) coexist under the unique constraint (#780).
+
+    NULLs are distinct under uq_api_revisions_api_id_spec_digest on both Postgres
+    and SQLite — unlike '' (a value), which would collapse distinct sha-less specs
+    into one revision.
+    """
+    async with registry_db.session() as session:
+        first = await ApiRevisionRepository.create_draft(
+            session,
+            api_id=sample_api.id,
+            spec_digest=None,
+            source_type=ApiRevisionSourceType.INLINE,
+            created_by="usr_test",
+        )
+        second = await ApiRevisionRepository.create_draft(
+            session,
+            api_id=sample_api.id,
+            spec_digest=None,
+            source_type=ApiRevisionSourceType.INLINE,
+            created_by="usr_test",
+        )
+        await session.commit()
+
+    assert first.id != second.id
+    async with registry_db.session() as session:
+        first_loaded = await session.get(ApiRevision, first.id)
+        second_loaded = await session.get(ApiRevision, second.id)
+        assert first_loaded is not None and first_loaded.spec_digest is None
+        assert second_loaded is not None and second_loaded.spec_digest is None
+
+
 async def test_set_operation_count(
     registry_db: DatabaseSession, sample_revision: tuple[Api, ApiRevision]
 ) -> None:

--- a/tests/unit/registry/ingest/test_extract_api_spec_digest.py
+++ b/tests/unit/registry/ingest/test_extract_api_spec_digest.py
@@ -1,0 +1,99 @@
+"""Unit tests for CreateRevisionStage spec-digest derivation (#780).
+
+Two invariants are pinned here:
+
+- A production spec always carries a sha (``load_specification`` digests the
+  bytes), so the stage asserts it — a sha-less spec fails loudly rather than
+  silently persisting a NULL digest that would confuse the Flow-3 update sweep.
+- A real sha flows through unchanged as the ``spec_digest``, and the
+  duplicate/leftover-cleanup lookups run against it. The ``spec.sha or None``
+  derivation also collapses an empty-string sha to NULL, so ``''`` (a *value*
+  that would collide under ``uq_api_revisions_api_id_spec_digest``) can never
+  reach the DB.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from jentic_one.registry.ingest.models import ApiIdentifier, IngestSpecification, SpecType
+from jentic_one.registry.ingest.pipeline.ctx import PipelineContext
+from jentic_one.registry.ingest.stages.extract_api import CreateRevisionStage
+
+_STAGE_MODULE = "jentic_one.registry.ingest.stages.extract_api"
+
+
+def _ctx(sha: str | None) -> PipelineContext:
+    spec = IngestSpecification(
+        spec_type=SpecType.OPENAPI,
+        api_identifier=ApiIdentifier(vendor="acme", name="pets", version="1.0.0"),
+        sha=sha,
+        content={"openapi": "3.1.0"},
+    )
+    ctx = PipelineContext(session=object(), specification=spec, created_by="usr_test")
+    ctx.produce("api_id", uuid.uuid4(), uuid.UUID)
+    return ctx
+
+
+def _draft_revision() -> object:
+    """A minimal stand-in for an ApiRevision (only ``.id`` is read downstream)."""
+    return type("R", (), {"id": uuid.uuid4()})()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sha", ["", None])
+async def test_sha_less_spec_fails_loudly(sha: str | None) -> None:
+    """A spec with no (or empty) sha must trip the invariant assert, not persist NULL.
+
+    The ``spec.sha or None`` derivation would collapse both '' and None to NULL;
+    the assert stops that from silently producing a NULL-digest revision (which
+    would break the Flow-3 upstream-changed comparison). See #780.
+    """
+    with (
+        patch(
+            f"{_STAGE_MODULE}.ApiRevisionRepository.delete_replaceable_by_digest",
+            new_callable=AsyncMock,
+        ) as delete_replaceable,
+        patch(
+            f"{_STAGE_MODULE}.ApiRevisionRepository.create_draft",
+            new_callable=AsyncMock,
+            return_value=_draft_revision(),
+        ) as create_draft,
+        pytest.raises(AssertionError, match="without a sha"),
+    ):
+        await CreateRevisionStage()._run(_ctx(sha=sha))
+
+    delete_replaceable.assert_not_awaited()
+    create_draft.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sha_carrying_spec_runs_digest_lookups_and_passes_digest_through() -> None:
+    with (
+        patch(
+            f"{_STAGE_MODULE}.ApiRevisionRepository.delete_replaceable_by_digest",
+            new_callable=AsyncMock,
+        ) as delete_replaceable,
+        patch(
+            f"{_STAGE_MODULE}.ApiRevisionRepository.get_by_digest",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as get_by_digest,
+        patch(
+            f"{_STAGE_MODULE}.ApiRevisionRepository.create_draft",
+            new_callable=AsyncMock,
+            return_value=_draft_revision(),
+        ) as create_draft,
+    ):
+        await CreateRevisionStage()._run(_ctx(sha="sha256:abc"))
+
+    delete_replaceable.assert_awaited_once()
+    assert delete_replaceable.await_args is not None
+    _, _, deleted_digest = delete_replaceable.await_args.args
+    assert deleted_digest == "sha256:abc"
+    get_by_digest.assert_awaited_once()
+    assert create_draft.await_args is not None
+    assert create_draft.await_args.kwargs["spec_digest"] == "sha256:abc"

--- a/tests/unit/registry/search/test_strategy_registry.py
+++ b/tests/unit/registry/search/test_strategy_registry.py
@@ -2,16 +2,53 @@
 
 from __future__ import annotations
 
+import uuid
+from collections.abc import Iterator
+
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from jentic_one.registry.repos.search import (
     SearchUnsupportedError,
     resolve_strategy,
 )
 from jentic_one.registry.repos.search.postgres_lexical import PostgresLexicalStrategy
+from jentic_one.registry.repos.search.protocol import SearchCursor, SearchHit
+from jentic_one.registry.repos.search.registry import _STRATEGIES, register_strategy
 from jentic_one.registry.repos.search.sqlite_lexical import SqliteLexicalStrategy
 from jentic_one.shared.config import DatabaseConfig, SearchConfig
 from jentic_one.shared.db.backends import get_backend
+
+_TEST_KEY = ("test-dialect", "test-mode")
+
+
+class _FakeStrategy:
+    dialect = _TEST_KEY[0]
+    name = _TEST_KEY[1]
+
+    async def search_operations(
+        self,
+        session: AsyncSession,
+        *,
+        query: str,
+        api_filters: list[uuid.UUID] | None = None,
+        revision_pins: dict[uuid.UUID, uuid.UUID] | None = None,
+        limit: int = 20,
+        cursor: SearchCursor | None = None,
+    ) -> list[SearchHit]:
+        return []
+
+
+class _OtherFakeStrategy(_FakeStrategy):
+    """A different class claiming the same (dialect, name) key."""
+
+
+@pytest.fixture()
+def clean_test_key() -> Iterator[None]:
+    """Keep the process-global registry free of the test key."""
+    _STRATEGIES.pop(_TEST_KEY, None)
+    yield
+    _STRATEGIES.pop(_TEST_KEY, None)
 
 
 def test_postgres_lexical_resolves() -> None:
@@ -37,3 +74,38 @@ def test_unknown_mode_raises() -> None:
     object.__setattr__(config, "search_mode", "unknown_mode")
     with pytest.raises(SearchUnsupportedError, match="No search strategy"):
         resolve_strategy(backend, config)
+
+
+def test_register_identical_class_is_idempotent(clean_test_key: None) -> None:
+    assert register_strategy(_FakeStrategy) is _FakeStrategy
+    # Double import re-runs the decorator with the very same class — a no-op.
+    assert register_strategy(_FakeStrategy) is _FakeStrategy
+    assert _STRATEGIES[_TEST_KEY] is _FakeStrategy
+
+
+def test_register_conflicting_class_raises(clean_test_key: None) -> None:
+    register_strategy(_FakeStrategy)
+    with pytest.raises(ValueError, match="refusing to shadow"):
+        register_strategy(_OtherFakeStrategy)
+    # The original registration must survive the rejected shadowing attempt.
+    assert _STRATEGIES[_TEST_KEY] is _FakeStrategy
+
+
+def test_register_does_not_shadow_builtin_lexical() -> None:
+    """An extension can't silently replace the OSS lexical strategy (#958)."""
+
+    class _ShadowLexical(_FakeStrategy):
+        dialect = PostgresLexicalStrategy.dialect
+        name = PostgresLexicalStrategy.name
+
+    builtin_key = (PostgresLexicalStrategy.dialect, PostgresLexicalStrategy.name)
+    # Snapshot/restore the built-in entry so a future regression (guard allows the
+    # write) can't corrupt the process-global registry for later tests.
+    original = _STRATEGIES.get(builtin_key)
+    try:
+        with pytest.raises(ValueError, match="refusing to shadow"):
+            register_strategy(_ShadowLexical)
+        assert _STRATEGIES[builtin_key] is PostgresLexicalStrategy
+    finally:
+        if original is not None:
+            _STRATEGIES[builtin_key] = original

--- a/tests/unit/registry/services/test_import_error_mapping.py
+++ b/tests/unit/registry/services/test_import_error_mapping.py
@@ -23,6 +23,27 @@ def test_duplicate_digest_integrity_error_maps_to_readable_message() -> None:
     assert "sqlalchemy" not in message
 
 
+def test_one_active_index_integrity_error_maps_to_readable_message() -> None:
+    """A lost race for the single-active slot surfaces the readable duplicate message.
+
+    Two concurrent imports can both pass the (digest-keyed) duplicate guard yet
+    race to become the API's one active revision; the loser trips
+    ``ix_api_revisions_one_active`` (keyed on api_id, independent of spec_digest).
+    That must read as a duplicate, not leak a raw SQL string. See PR #1045 (F1).
+    """
+    raw = (
+        "(sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) duplicate key value "
+        'violates unique constraint "ix_api_revisions_one_active"'
+    )
+    exc = DatabaseIntegrityError(raw)
+
+    message = _readable_source_error(exc)
+
+    assert message == DuplicateRevisionError().message
+    assert "ix_api_revisions_one_active" not in message
+    assert "sqlalchemy" not in message
+
+
 def test_unrelated_integrity_error_keeps_its_text() -> None:
     """An integrity error on a different constraint is passed through unchanged."""
     exc = DatabaseIntegrityError("violates constraint uq_something_else")


### PR DESCRIPTION
## Summary

Two registry repo-layer hardening changes plus a follow-up from an 8-agent review board. `register_strategy` silently last-wins on a duplicate `(dialect, mode)` key, so an extension could shadow the OSS lexical strategy with zero signal (#958). And an absent spec sha was coerced to `''` — a *value* under `uq_api_revisions_api_id_spec_digest` — so two genuinely different sha-less specs for the same API would collide, with the leftover-cleanup path able to silently delete the other spec's rows (#780).

Retyped `fix` → `refactor`: neither is a bug broken on `main` — #780 is latent (no producer emits a sha-less spec today) and #958 has no live conflicting registrant. This is hardening, so `refactor` keeps the changelog honest.

Plan: `jentic-one-plans/issues/issues-958-779-780-registry-repo-hardening.md` (includes the review-board findings + remediation table).

## Changes

- **#958** — `registry/repos/search/registry.py`: `register_strategy` raises `ValueError` when a `(dialect, name)` key is already bound to a *different* class; idempotent for the identical class (safe under double import). Same posture as `register_config` / `register_telemetry_event` / `register_target` / `register_pipeline_stage`. Verified the enterprise overlay registers only distinct keys (`semantic`, `hybrid`).
- **#780** — `registry/ingest/stages/extract_api.py`: derive `spec_digest = spec.sha or None` (was `or ""`); skip the digest lookups when None; and `assert spec.sha` at stage entry so a future sha-less producer fails loudly instead of silently writing a NULL-digest revision (which would confuse the Flow-3 upstream-changed sweep). `create_draft`/`create_imported` in `revision_repo.py` widened to `spec_digest: str | None`; `ApiRevision.spec_digest` gains a NULL-vs-`''` field doc.
- **F1 (review board)** — `registry/services/import_service.py`: `_readable_source_error` now also maps `ix_api_revisions_one_active`. Two concurrent imports can both clear the digest guard yet race for the single active revision; the loser tripped that index and leaked a raw SQL string. This is the only *live-path* fix (also covers the sha-carrying concurrent case).
- **Enterprise follow-up** — refreshed the now-stale "Lexical coupling note" in `jentic-one-enterprise/.../search/hybrid.py` (it claimed the OSS registry *allows* overriding `(postgres, lexical)`, which #958 makes false). Shipped separately in the enterprise repo.
- **Out of scope:** #779 — investigated and **closed as not-planned**; the racy re-import branch it describes only existed on the pre-merge #757 feature branch, not on `main` (see the issue comment). Also out of scope: #965/#969 (search-seam constructor injection / registry-level composition).

## Risk & rollback

- Low risk: no schema change (column already nullable → no migration, no `make openapi`), no auth/credential surface.
- Behaviour change 1: a conflicting strategy re-registration now fails fast at import time — intended; no in-tree or enterprise-overlay conflict exists.
- Behaviour change 2 (F2, deliberate): the old `''` made sha-less *draft* re-imports idempotent via the cleanup lookup; the None path skips it. Rendered moot by `assert spec.sha` — no sha-less spec can reach the stage — so there is no live retry path to regress.
- Revert the squash commit to roll back.

## Test plan

- Unit: `tests/unit/registry/search/test_strategy_registry.py` (idempotent re-register, conflicting register raises, built-in lexical can't be shadowed — with snapshot/restore of the global registry); `tests/unit/registry/ingest/test_extract_api_spec_digest.py` (sha-less/`""` spec trips the assert; sha-carrying spec runs the lookups and passes the digest through); `tests/unit/registry/services/test_import_error_mapping.py` (both `uq_api_revisions_api_id_spec_digest` and `ix_api_revisions_one_active` map to the readable message).
- Integration: `tests/integration/registry/repos/test_revision_repo.py::test_null_digests_do_not_collide` (two NULL-digest revisions coexist), on both backends.
- Ran: `make test-fast` (2774 passed), `make test-integration` (895 passed), repo-wide `ruff` + `mypy` via pre-commit hooks.

Closes #958
Closes #780