### PR TITLE
fix(registry): rollback base state-fidelity (#939) + auth layering guard (#938)

### DIFF
--- a/src/jentic_one/admin/core/permissions.py
+++ b/src/jentic_one/admin/core/permissions.py
@@ -7,7 +7,7 @@ re-exports it unchanged so existing ``from jentic_one.admin.core.permissions
 import …`` call sites keep working, and admin remains the documented home for
 permission concepts. Import new admin-tier code from here as before; ``shared``
 code must import from ``shared.auth.permission_catalog`` directly (enforced by the
-``test_shared_does_not_import_admin`` arch guard).
+``test_shared_does_not_import_admin_permissions`` arch guard).
 """
 
 from __future__ import annotations

--- a/src/jentic_one/admin/core/permissions.py
+++ b/src/jentic_one/admin/core/permissions.py
@@ -1,253 +1,79 @@
-"""Static permission catalogue and implication map."""
+"""Static permission catalogue and implication map (admin-tier re-export).
+
+The permission *data* now lives tier-neutrally in
+:mod:`jentic_one.shared.auth.permission_catalog` so ``shared`` callers can expand
+grants without a ``shared → admin`` layering inversion (#938). This module
+re-exports it unchanged so existing ``from jentic_one.admin.core.permissions
+import …`` call sites keep working, and admin remains the documented home for
+permission concepts. Import new admin-tier code from here as before; ``shared``
+code must import from ``shared.auth.permission_catalog`` directly (enforced by the
+``test_shared_does_not_import_admin`` arch guard).
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
-from jentic_one.shared.scopes import (
-    OWNER_ACCESS_REQUESTS_READ,
-    OWNER_AGENTS_READ,
-    OWNER_CREDENTIALS_READ,
-    OWNER_RESOURCES_READ,
-    OWNER_SERVICE_ACCOUNTS_READ,
-    OWNER_TOOLKITS_READ,
+from jentic_one.shared.auth.permission_catalog import (
+    AGENTS_READ,
+    AGENTS_WRITE,
+    ALL_PERMISSIONS,
+    APIS_READ,
+    APIS_WRITE,
+    AUDIT_READ,
+    CAPABILITIES_EXECUTE,
+    CAPABILITIES_READ,
+    CATALOG_IMPORT,
+    CONFIG_READ,
+    CONFIG_WRITE,
+    CREDENTIALS_READ,
+    CREDENTIALS_WRITE,
+    EVENTS_READ,
+    EVENTS_WRITE,
+    EXECUTIONS_READ,
+    IMPLICATION_MAP,
+    JOBS_READ,
+    JOBS_WRITE,
+    ORG_ADMIN,
+    OVERLAYS_CONFIRM,
+    SERVICE_ACCOUNTS_READ,
+    SERVICE_ACCOUNTS_WRITE,
+    TOOLKITS_READ,
+    TOOLKITS_WRITE,
+    USERS_READ,
+    USERS_WRITE,
+    Permission,
+    compute_effective,
+    compute_implies_transitive,
 )
 
-CAPABILITIES_EXECUTE = "capabilities:execute"
-CAPABILITIES_READ = "capabilities:read"
-TOOLKITS_WRITE = "toolkits:write"
-TOOLKITS_READ = "toolkits:read"
-USERS_WRITE = "users:write"
-USERS_READ = "users:read"
-JOBS_WRITE = "jobs:write"
-JOBS_READ = "jobs:read"
-EVENTS_WRITE = "events:write"
-EVENTS_READ = "events:read"
-CREDENTIALS_READ = "credentials:read"
-CREDENTIALS_WRITE = "credentials:write"
-APIS_READ = "apis:read"
-APIS_WRITE = "apis:write"
-CATALOG_IMPORT = "catalog:import"
-OVERLAYS_CONFIRM = "overlays:confirm"
-EXECUTIONS_READ = "executions:read"
-AUDIT_READ = "audit:read"
-AGENTS_READ = "agents:read"
-AGENTS_WRITE = "agents:write"
-SERVICE_ACCOUNTS_READ = "service-accounts:read"
-SERVICE_ACCOUNTS_WRITE = "service-accounts:write"
-CONFIG_READ = "config:read"
-CONFIG_WRITE = "config:write"
-ORG_ADMIN = "org:admin"
-
-
-@dataclass(frozen=True)
-class Permission:
-    """A permission entry with metadata and implications."""
-
-    name: str
-    description: str
-    implies: frozenset[str] = field(default_factory=frozenset)
-
-
-ALL_PERMISSIONS: dict[str, Permission] = {
-    ORG_ADMIN: Permission(
-        name=ORG_ADMIN,
-        description="Full organisation administrator access",
-        implies=frozenset(
-            {
-                CAPABILITIES_EXECUTE,
-                CAPABILITIES_READ,
-                TOOLKITS_WRITE,
-                TOOLKITS_READ,
-                USERS_WRITE,
-                USERS_READ,
-                JOBS_WRITE,
-                JOBS_READ,
-                EVENTS_WRITE,
-                EVENTS_READ,
-                CREDENTIALS_READ,
-                CREDENTIALS_WRITE,
-                APIS_READ,
-                APIS_WRITE,
-                CATALOG_IMPORT,
-                OVERLAYS_CONFIRM,
-                EXECUTIONS_READ,
-                AUDIT_READ,
-                AGENTS_WRITE,
-                AGENTS_READ,
-                SERVICE_ACCOUNTS_WRITE,
-                SERVICE_ACCOUNTS_READ,
-                CONFIG_WRITE,
-                CONFIG_READ,
-            }
-        ),
-    ),
-    CAPABILITIES_EXECUTE: Permission(
-        name=CAPABILITIES_EXECUTE,
-        description="Execute capabilities via the broker",
-        implies=frozenset({CAPABILITIES_READ, APIS_READ, EXECUTIONS_READ}),
-    ),
-    CAPABILITIES_READ: Permission(
-        name=CAPABILITIES_READ,
-        description="Read capability and toolkit metadata",
-    ),
-    TOOLKITS_WRITE: Permission(
-        name=TOOLKITS_WRITE,
-        description="Create, update, and delete toolkits",
-        implies=frozenset({TOOLKITS_READ}),
-    ),
-    TOOLKITS_READ: Permission(
-        name=TOOLKITS_READ,
-        description="Read toolkit configuration and status",
-    ),
-    USERS_WRITE: Permission(
-        name=USERS_WRITE,
-        description="Create, update, and disable users",
-        implies=frozenset({USERS_READ}),
-    ),
-    USERS_READ: Permission(
-        name=USERS_READ,
-        description="Read user profiles and permissions",
-    ),
-    JOBS_WRITE: Permission(
-        name=JOBS_WRITE,
-        description="Cancel and manage async jobs",
-        implies=frozenset({JOBS_READ}),
-    ),
-    JOBS_READ: Permission(
-        name=JOBS_READ,
-        description="Read job status and results",
-    ),
-    EVENTS_WRITE: Permission(
-        name=EVENTS_WRITE,
-        description="Acknowledge and manage platform events",
-        implies=frozenset({EVENTS_READ}),
-    ),
-    EVENTS_READ: Permission(
-        name=EVENTS_READ,
-        description="Read platform events",
-    ),
-    CREDENTIALS_WRITE: Permission(
-        name=CREDENTIALS_WRITE,
-        description="Create, update, and delete credentials",
-        implies=frozenset({CREDENTIALS_READ}),
-    ),
-    CREDENTIALS_READ: Permission(
-        name=CREDENTIALS_READ,
-        description="Read credential metadata",
-    ),
-    APIS_READ: Permission(
-        name=APIS_READ,
-        description="Read API definitions and metadata",
-    ),
-    APIS_WRITE: Permission(
-        name=APIS_WRITE,
-        description="Import, update, and delete API definitions and their revisions",
-        implies=frozenset({APIS_READ, CATALOG_IMPORT}),
-    ),
-    CATALOG_IMPORT: Permission(
-        name=CATALOG_IMPORT,
-        description="Import an API from the public catalog into the local registry",
-        implies=frozenset({APIS_READ}),
-    ),
-    OVERLAYS_CONFIRM: Permission(
-        name=OVERLAYS_CONFIRM,
-        description=(
-            "Confirm a pending overlay, rewriting the API's served spec "
-            "(operator action; not granted to agents by default)"
-        ),
-        implies=frozenset({APIS_READ}),
-    ),
-    EXECUTIONS_READ: Permission(
-        name=EXECUTIONS_READ,
-        description="Read execution records",
-    ),
-    AUDIT_READ: Permission(
-        name=AUDIT_READ,
-        description="Read audit log entries",
-    ),
-    AGENTS_WRITE: Permission(
-        name=AGENTS_WRITE,
-        description="Create, update, and delete agents",
-        implies=frozenset({AGENTS_READ}),
-    ),
-    AGENTS_READ: Permission(
-        name=AGENTS_READ,
-        description="Read agent configuration and status",
-    ),
-    SERVICE_ACCOUNTS_WRITE: Permission(
-        name=SERVICE_ACCOUNTS_WRITE,
-        description="Create, update, and delete service accounts",
-        implies=frozenset({SERVICE_ACCOUNTS_READ}),
-    ),
-    SERVICE_ACCOUNTS_READ: Permission(
-        name=SERVICE_ACCOUNTS_READ,
-        description="Read service account configuration and status",
-    ),
-    CONFIG_WRITE: Permission(
-        name=CONFIG_WRITE,
-        description="Create and update runtime platform configuration",
-        implies=frozenset({CONFIG_READ}),
-    ),
-    CONFIG_READ: Permission(
-        name=CONFIG_READ,
-        description="Read runtime platform configuration",
-    ),
-    OWNER_RESOURCES_READ: Permission(
-        name=OWNER_RESOURCES_READ,
-        description="Read resources owned by the agent's creator (umbrella)",
-        implies=frozenset({OWNER_CREDENTIALS_READ, OWNER_AGENTS_READ, OWNER_TOOLKITS_READ}),
-    ),
-    OWNER_CREDENTIALS_READ: Permission(
-        name=OWNER_CREDENTIALS_READ,
-        description="Read credentials owned by the agent's creator",
-    ),
-    OWNER_AGENTS_READ: Permission(
-        name=OWNER_AGENTS_READ,
-        description="Read agents owned by the agent's creator",
-    ),
-    OWNER_TOOLKITS_READ: Permission(
-        name=OWNER_TOOLKITS_READ,
-        description="Read toolkits owned by the agent's creator",
-    ),
-    OWNER_ACCESS_REQUESTS_READ: Permission(
-        name=OWNER_ACCESS_REQUESTS_READ,
-        description="Read access requests filed by or for the agent's creator",
-    ),
-    OWNER_SERVICE_ACCOUNTS_READ: Permission(
-        name=OWNER_SERVICE_ACCOUNTS_READ,
-        description="Read service accounts owned by the agent's creator",
-    ),
-}
-
-IMPLICATION_MAP: dict[str, set[str]] = {
-    perm.name: set(perm.implies) for perm in ALL_PERMISSIONS.values() if perm.implies
-}
-
-
-def compute_implies_transitive(permission_name: str) -> set[str]:
-    """Compute the full transitive closure of implied permissions."""
-    result: set[str] = set()
-    frontier = [permission_name]
-    while frontier:
-        current = frontier.pop()
-        implied = IMPLICATION_MAP.get(current, set())
-        for p in implied:
-            if p not in result:
-                result.add(p)
-                frontier.append(p)
-    return result
-
-
-def compute_effective(grants: set[str]) -> set[str]:
-    """Expand direct grants via the implication map to compute the full effective set."""
-    effective = set(grants)
-    frontier = list(grants)
-    while frontier:
-        perm = frontier.pop()
-        implied = IMPLICATION_MAP.get(perm, set())
-        for p in implied:
-            if p not in effective:
-                effective.add(p)
-                frontier.append(p)
-    return effective
+__all__ = [
+    "AGENTS_READ",
+    "AGENTS_WRITE",
+    "ALL_PERMISSIONS",
+    "APIS_READ",
+    "APIS_WRITE",
+    "AUDIT_READ",
+    "CAPABILITIES_EXECUTE",
+    "CAPABILITIES_READ",
+    "CATALOG_IMPORT",
+    "CONFIG_READ",
+    "CONFIG_WRITE",
+    "CREDENTIALS_READ",
+    "CREDENTIALS_WRITE",
+    "EVENTS_READ",
+    "EVENTS_WRITE",
+    "EXECUTIONS_READ",
+    "IMPLICATION_MAP",
+    "JOBS_READ",
+    "JOBS_WRITE",
+    "ORG_ADMIN",
+    "OVERLAYS_CONFIRM",
+    "SERVICE_ACCOUNTS_READ",
+    "SERVICE_ACCOUNTS_WRITE",
+    "TOOLKITS_READ",
+    "TOOLKITS_WRITE",
+    "USERS_READ",
+    "USERS_WRITE",
+    "Permission",
+    "compute_effective",
+    "compute_implies_transitive",
+]

--- a/src/jentic_one/registry/repos/revision_repo.py
+++ b/src/jentic_one/registry/repos/revision_repo.py
@@ -277,10 +277,23 @@ class ApiRevisionRepository:
         return result.rowcount
 
     @staticmethod
-    async def restore_archived_to_imported(session: AsyncSession, revision_id: uuid.UUID) -> int:
-        """Un-archive a revision (ARCHIVED → IMPORTED), clearing ``archived_at``.
+    async def restore_archived(session: AsyncSession, revision_id: uuid.UUID) -> int:
+        """Un-archive a revision to its *true prior state*, clearing ``archived_at``.
 
         Rollback (A5b) restores the revision an overlay superseded so it can serve again.
+        The restored state must match what the revision was before materialization archived
+        it — an overlay base can be a manually-promoted ``PUBLISHED`` revision, not only an
+        ``IMPORTED`` one (see ``archive_all_active``), and always restoring to ``IMPORTED``
+        silently drops the ``published`` label (#939).
+
+        The prior state is derived from durable provenance rather than a captured column,
+        which survives archival: ``PUBLISHED`` is only ever produced by
+        ``RevisionService.promote`` (promoting a ``DRAFT``, which ``create_draft`` leaves
+        with ``origin IS NULL``); ``IMPORTED`` is only ever produced by ``create_imported``
+        (which always sets ``origin``). So ``origin IS NULL`` ⇒ restore to ``PUBLISHED``,
+        else ``IMPORTED``. The decision is a single SQL ``CASE`` so it stays one atomic
+        UPDATE (no read-then-write race).
+
         CAS on ``state == ARCHIVED`` so only a genuinely archived revision is restored
         (rowcount 0 otherwise). The caller archives the current overlay revision *first*
         in the same txn, so the one-active partial unique index is never transiently
@@ -294,7 +307,13 @@ class ApiRevisionRepository:
                     ApiRevision.id == revision_id,
                     ApiRevision.state == ApiRevisionState.ARCHIVED,
                 )
-                .values(state=ApiRevisionState.IMPORTED, archived_at=None)
+                .values(
+                    state=case(
+                        (ApiRevision.origin.is_(None), ApiRevisionState.PUBLISHED),
+                        else_=ApiRevisionState.IMPORTED,
+                    ),
+                    archived_at=None,
+                )
                 .execution_options(synchronize_session="fetch")
             ),
         )

--- a/src/jentic_one/registry/services/overlay_service.py
+++ b/src/jentic_one/registry/services/overlay_service.py
@@ -1017,10 +1017,9 @@ class OverlayService:
                 raise OverlayStateConflictError(
                     overlay_id, overlay.status, [OverlayStatus.CONFIRMED], "rollback"
                 )
-            # 2. Restore the superseded revision (must still be archived).
-            restored = await ApiRevisionRepository.restore_archived_to_imported(
-                session, superseded_id
-            )
+            # 2. Restore the superseded revision to its true prior state (PUBLISHED vs
+            # IMPORTED, derived from provenance; #939) — must still be archived.
+            restored = await ApiRevisionRepository.restore_archived(session, superseded_id)
             if restored == 0:
                 raise OverlayRollbackTargetMissingError(
                     overlay_id,

--- a/src/jentic_one/shared/auth/permission_catalog.py
+++ b/src/jentic_one/shared/auth/permission_catalog.py
@@ -13,7 +13,7 @@ rather than reaching up into the admin tier (#938).
 so existing ``from jentic_one.admin.core.permissions import …`` call sites keep
 working unchanged; admin stays the documented home for permission *concepts*, the
 data just lives in shared. This module depends only on ``shared/scopes.py`` — no
-admin-tier import — which is what lets the ``test_shared_does_not_import_admin``
+admin-tier import — which is what lets the ``test_shared_does_not_import_admin_permissions``
 arch guard pass unconditionally.
 """
 
@@ -268,3 +268,41 @@ def compute_effective(grants: set[str]) -> set[str]:
                 effective.add(p)
                 frontier.append(p)
     return effective
+
+
+#: Public surface re-exported verbatim by the ``admin.core.permissions`` shim. The
+#: ``OWNER_*`` scope constants are intentionally excluded — their canonical home is
+#: ``shared.scopes`` and callers import them from there, not via this catalogue. Kept
+#: in sync with the shim's ``__all__`` (asserted by test_permission_catalog).
+__all__ = [
+    "AGENTS_READ",
+    "AGENTS_WRITE",
+    "ALL_PERMISSIONS",
+    "APIS_READ",
+    "APIS_WRITE",
+    "AUDIT_READ",
+    "CAPABILITIES_EXECUTE",
+    "CAPABILITIES_READ",
+    "CATALOG_IMPORT",
+    "CONFIG_READ",
+    "CONFIG_WRITE",
+    "CREDENTIALS_READ",
+    "CREDENTIALS_WRITE",
+    "EVENTS_READ",
+    "EVENTS_WRITE",
+    "EXECUTIONS_READ",
+    "IMPLICATION_MAP",
+    "JOBS_READ",
+    "JOBS_WRITE",
+    "ORG_ADMIN",
+    "OVERLAYS_CONFIRM",
+    "SERVICE_ACCOUNTS_READ",
+    "SERVICE_ACCOUNTS_WRITE",
+    "TOOLKITS_READ",
+    "TOOLKITS_WRITE",
+    "USERS_READ",
+    "USERS_WRITE",
+    "Permission",
+    "compute_effective",
+    "compute_implies_transitive",
+]

--- a/src/jentic_one/shared/auth/permission_catalog.py
+++ b/src/jentic_one/shared/auth/permission_catalog.py
@@ -1,0 +1,270 @@
+"""Static permission catalogue and implication map (tier-neutral).
+
+Home of the permission *data* — the `Permission` dataclass, the `ALL_PERMISSIONS`
+catalogue, the derived `IMPLICATION_MAP`, and the pure `compute_effective` /
+`compute_implies_transitive` expansion helpers. It lives in ``shared/auth`` (not
+``admin``) so any tier can expand grants through the implication map without a
+layering inversion: ``shared`` callers (``shared/web/deps.py``,
+``shared/web/scope_catalog.py``, ``shared/web/endpoint_scopes.py``,
+``shared/auth/permissions.py``) and non-web service callers alike import from here
+rather than reaching up into the admin tier (#938).
+
+``admin.core.permissions`` re-exports everything here for backward compatibility,
+so existing ``from jentic_one.admin.core.permissions import …`` call sites keep
+working unchanged; admin stays the documented home for permission *concepts*, the
+data just lives in shared. This module depends only on ``shared/scopes.py`` — no
+admin-tier import — which is what lets the ``test_shared_does_not_import_admin``
+arch guard pass unconditionally.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from jentic_one.shared.scopes import (
+    OWNER_ACCESS_REQUESTS_READ,
+    OWNER_AGENTS_READ,
+    OWNER_CREDENTIALS_READ,
+    OWNER_RESOURCES_READ,
+    OWNER_SERVICE_ACCOUNTS_READ,
+    OWNER_TOOLKITS_READ,
+)
+
+CAPABILITIES_EXECUTE = "capabilities:execute"
+CAPABILITIES_READ = "capabilities:read"
+TOOLKITS_WRITE = "toolkits:write"
+TOOLKITS_READ = "toolkits:read"
+USERS_WRITE = "users:write"
+USERS_READ = "users:read"
+JOBS_WRITE = "jobs:write"
+JOBS_READ = "jobs:read"
+EVENTS_WRITE = "events:write"
+EVENTS_READ = "events:read"
+CREDENTIALS_READ = "credentials:read"
+CREDENTIALS_WRITE = "credentials:write"
+APIS_READ = "apis:read"
+APIS_WRITE = "apis:write"
+CATALOG_IMPORT = "catalog:import"
+OVERLAYS_CONFIRM = "overlays:confirm"
+EXECUTIONS_READ = "executions:read"
+AUDIT_READ = "audit:read"
+AGENTS_READ = "agents:read"
+AGENTS_WRITE = "agents:write"
+SERVICE_ACCOUNTS_READ = "service-accounts:read"
+SERVICE_ACCOUNTS_WRITE = "service-accounts:write"
+CONFIG_READ = "config:read"
+CONFIG_WRITE = "config:write"
+ORG_ADMIN = "org:admin"
+
+
+@dataclass(frozen=True)
+class Permission:
+    """A permission entry with metadata and implications."""
+
+    name: str
+    description: str
+    implies: frozenset[str] = field(default_factory=frozenset)
+
+
+ALL_PERMISSIONS: dict[str, Permission] = {
+    ORG_ADMIN: Permission(
+        name=ORG_ADMIN,
+        description="Full organisation administrator access",
+        implies=frozenset(
+            {
+                CAPABILITIES_EXECUTE,
+                CAPABILITIES_READ,
+                TOOLKITS_WRITE,
+                TOOLKITS_READ,
+                USERS_WRITE,
+                USERS_READ,
+                JOBS_WRITE,
+                JOBS_READ,
+                EVENTS_WRITE,
+                EVENTS_READ,
+                CREDENTIALS_READ,
+                CREDENTIALS_WRITE,
+                APIS_READ,
+                APIS_WRITE,
+                CATALOG_IMPORT,
+                OVERLAYS_CONFIRM,
+                EXECUTIONS_READ,
+                AUDIT_READ,
+                AGENTS_WRITE,
+                AGENTS_READ,
+                SERVICE_ACCOUNTS_WRITE,
+                SERVICE_ACCOUNTS_READ,
+                CONFIG_WRITE,
+                CONFIG_READ,
+            }
+        ),
+    ),
+    CAPABILITIES_EXECUTE: Permission(
+        name=CAPABILITIES_EXECUTE,
+        description="Execute capabilities via the broker",
+        implies=frozenset({CAPABILITIES_READ, APIS_READ, EXECUTIONS_READ}),
+    ),
+    CAPABILITIES_READ: Permission(
+        name=CAPABILITIES_READ,
+        description="Read capability and toolkit metadata",
+    ),
+    TOOLKITS_WRITE: Permission(
+        name=TOOLKITS_WRITE,
+        description="Create, update, and delete toolkits",
+        implies=frozenset({TOOLKITS_READ}),
+    ),
+    TOOLKITS_READ: Permission(
+        name=TOOLKITS_READ,
+        description="Read toolkit configuration and status",
+    ),
+    USERS_WRITE: Permission(
+        name=USERS_WRITE,
+        description="Create, update, and disable users",
+        implies=frozenset({USERS_READ}),
+    ),
+    USERS_READ: Permission(
+        name=USERS_READ,
+        description="Read user profiles and permissions",
+    ),
+    JOBS_WRITE: Permission(
+        name=JOBS_WRITE,
+        description="Cancel and manage async jobs",
+        implies=frozenset({JOBS_READ}),
+    ),
+    JOBS_READ: Permission(
+        name=JOBS_READ,
+        description="Read job status and results",
+    ),
+    EVENTS_WRITE: Permission(
+        name=EVENTS_WRITE,
+        description="Acknowledge and manage platform events",
+        implies=frozenset({EVENTS_READ}),
+    ),
+    EVENTS_READ: Permission(
+        name=EVENTS_READ,
+        description="Read platform events",
+    ),
+    CREDENTIALS_WRITE: Permission(
+        name=CREDENTIALS_WRITE,
+        description="Create, update, and delete credentials",
+        implies=frozenset({CREDENTIALS_READ}),
+    ),
+    CREDENTIALS_READ: Permission(
+        name=CREDENTIALS_READ,
+        description="Read credential metadata",
+    ),
+    APIS_READ: Permission(
+        name=APIS_READ,
+        description="Read API definitions and metadata",
+    ),
+    APIS_WRITE: Permission(
+        name=APIS_WRITE,
+        description="Import, update, and delete API definitions and their revisions",
+        implies=frozenset({APIS_READ, CATALOG_IMPORT}),
+    ),
+    CATALOG_IMPORT: Permission(
+        name=CATALOG_IMPORT,
+        description="Import an API from the public catalog into the local registry",
+        implies=frozenset({APIS_READ}),
+    ),
+    OVERLAYS_CONFIRM: Permission(
+        name=OVERLAYS_CONFIRM,
+        description=(
+            "Confirm a pending overlay, rewriting the API's served spec "
+            "(operator action; not granted to agents by default)"
+        ),
+        implies=frozenset({APIS_READ}),
+    ),
+    EXECUTIONS_READ: Permission(
+        name=EXECUTIONS_READ,
+        description="Read execution records",
+    ),
+    AUDIT_READ: Permission(
+        name=AUDIT_READ,
+        description="Read audit log entries",
+    ),
+    AGENTS_WRITE: Permission(
+        name=AGENTS_WRITE,
+        description="Create, update, and delete agents",
+        implies=frozenset({AGENTS_READ}),
+    ),
+    AGENTS_READ: Permission(
+        name=AGENTS_READ,
+        description="Read agent configuration and status",
+    ),
+    SERVICE_ACCOUNTS_WRITE: Permission(
+        name=SERVICE_ACCOUNTS_WRITE,
+        description="Create, update, and delete service accounts",
+        implies=frozenset({SERVICE_ACCOUNTS_READ}),
+    ),
+    SERVICE_ACCOUNTS_READ: Permission(
+        name=SERVICE_ACCOUNTS_READ,
+        description="Read service account configuration and status",
+    ),
+    CONFIG_WRITE: Permission(
+        name=CONFIG_WRITE,
+        description="Create and update runtime platform configuration",
+        implies=frozenset({CONFIG_READ}),
+    ),
+    CONFIG_READ: Permission(
+        name=CONFIG_READ,
+        description="Read runtime platform configuration",
+    ),
+    OWNER_RESOURCES_READ: Permission(
+        name=OWNER_RESOURCES_READ,
+        description="Read resources owned by the agent's creator (umbrella)",
+        implies=frozenset({OWNER_CREDENTIALS_READ, OWNER_AGENTS_READ, OWNER_TOOLKITS_READ}),
+    ),
+    OWNER_CREDENTIALS_READ: Permission(
+        name=OWNER_CREDENTIALS_READ,
+        description="Read credentials owned by the agent's creator",
+    ),
+    OWNER_AGENTS_READ: Permission(
+        name=OWNER_AGENTS_READ,
+        description="Read agents owned by the agent's creator",
+    ),
+    OWNER_TOOLKITS_READ: Permission(
+        name=OWNER_TOOLKITS_READ,
+        description="Read toolkits owned by the agent's creator",
+    ),
+    OWNER_ACCESS_REQUESTS_READ: Permission(
+        name=OWNER_ACCESS_REQUESTS_READ,
+        description="Read access requests filed by or for the agent's creator",
+    ),
+    OWNER_SERVICE_ACCOUNTS_READ: Permission(
+        name=OWNER_SERVICE_ACCOUNTS_READ,
+        description="Read service accounts owned by the agent's creator",
+    ),
+}
+
+IMPLICATION_MAP: dict[str, set[str]] = {
+    perm.name: set(perm.implies) for perm in ALL_PERMISSIONS.values() if perm.implies
+}
+
+
+def compute_implies_transitive(permission_name: str) -> set[str]:
+    """Compute the full transitive closure of implied permissions."""
+    result: set[str] = set()
+    frontier = [permission_name]
+    while frontier:
+        current = frontier.pop()
+        implied = IMPLICATION_MAP.get(current, set())
+        for p in implied:
+            if p not in result:
+                result.add(p)
+                frontier.append(p)
+    return result
+
+
+def compute_effective(grants: set[str]) -> set[str]:
+    """Expand direct grants via the implication map to compute the full effective set."""
+    effective = set(grants)
+    frontier = list(grants)
+    while frontier:
+        perm = frontier.pop()
+        implied = IMPLICATION_MAP.get(perm, set())
+        for p in implied:
+            if p not in effective:
+                effective.add(p)
+                frontier.append(p)
+    return effective

--- a/src/jentic_one/shared/auth/permissions.py
+++ b/src/jentic_one/shared/auth/permissions.py
@@ -1,9 +1,10 @@
 """Shared permission-expansion helper.
 
-Wraps the admin implication map (``compute_effective``) so non-web callers — e.g. a
+Wraps the shared implication map (``compute_effective``) so non-web callers — e.g. a
 service that must make an authorization decision *beyond* the route's declared scope —
-can ask "does this identity effectively hold permission X?" without importing the admin
-tier directly (which the module-boundary arch rules forbid for registry/broker/control).
+can ask "does this identity effectively hold permission X?" without reaching up into the
+admin tier (the module-boundary arch rules forbid a registry/broker/control → admin
+import; the implication data now lives in ``shared.auth.permission_catalog``, #938).
 This mirrors the expansion the request guard applies in ``shared/web/deps.py``: grants
 are expanded through the static implication map (so ``org:admin`` implies everything and
 ``*:write`` implies ``*:read``) before the membership test.
@@ -13,7 +14,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from jentic_one.admin.core.permissions import compute_effective
+from jentic_one.shared.auth.permission_catalog import compute_effective
 
 
 def has_effective_permission(granted: Iterable[str], required: str) -> bool:

--- a/src/jentic_one/shared/web/deps.py
+++ b/src/jentic_one/shared/web/deps.py
@@ -8,8 +8,8 @@ from typing import Any
 from fastapi import Depends, Request
 from jentic.problem_details import Forbidden, Unauthorized
 
-from jentic_one.admin.core.permissions import compute_effective
 from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.auth.permission_catalog import compute_effective
 from jentic_one.shared.context import Context
 from jentic_one.shared.models import ActorType
 from jentic_one.shared.models.actors import Origin

--- a/src/jentic_one/shared/web/endpoint_scopes.py
+++ b/src/jentic_one/shared/web/endpoint_scopes.py
@@ -47,7 +47,7 @@ import structlog
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
 
-from jentic_one.admin.core.permissions import compute_implies_transitive
+from jentic_one.shared.auth.permission_catalog import compute_implies_transitive
 from jentic_one.shared.models.actors import ActorType
 from jentic_one.shared.scopes import AGENTS_WRITE, DEFAULT_AGENT_SCOPES
 

--- a/src/jentic_one/shared/web/scope_catalog.py
+++ b/src/jentic_one/shared/web/scope_catalog.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from jentic_one.admin.core.permissions import (
+from jentic_one.shared.auth.permission_catalog import (
     ALL_PERMISSIONS,
     ORG_ADMIN,
     compute_implies_transitive,

--- a/tests/arch/test_module_boundaries.py
+++ b/tests/arch/test_module_boundaries.py
@@ -126,6 +126,20 @@ def test_shared_does_not_import_broker(shared_source_dir: Path) -> None:
 
 
 @pytest.mark.arch
+def test_shared_does_not_import_admin_permissions(shared_source_dir: Path) -> None:
+    # The permission catalogue moved to shared.auth.permission_catalog (#938) so shared
+    # callers expand grants without a shared→admin layering inversion. Scoped to the
+    # permissions module specifically: shared jobs/events/audit machinery still references
+    # admin-tier ORM schemas (a separate, pre-existing structural coupling — admin owns
+    # those canonical schemas), which is out of scope for #938.
+    violations = _check_boundary(shared_source_dir, "jentic_one.admin.core.permissions")
+    assert not violations, (
+        "Shared imports the admin permissions module (layering inversion #938); "
+        "import from jentic_one.shared.auth.permission_catalog instead:\n" + "\n".join(violations)
+    )
+
+
+@pytest.mark.arch
 def test_auth_does_not_import_broker(auth_source_dir: Path) -> None:
     violations = _check_boundary(auth_source_dir, "jentic_one.broker")
     assert not violations, "Auth imports from broker:\n" + "\n".join(violations)

--- a/tests/integration/registry/repos/test_revision_repo.py
+++ b/tests/integration/registry/repos/test_revision_repo.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import uuid
+
 import pytest
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from jentic_one.registry.core.schema.api_revisions import ApiRevision
 from jentic_one.registry.core.schema.apis import Api
 from jentic_one.registry.repos.revision_repo import ApiRevisionRepository
 from jentic_one.shared.db.session import DatabaseSession
-from jentic_one.shared.models import ApiRevisionSourceType
+from jentic_one.shared.models import ApiRevisionSourceType, ApiRevisionState
 
 pytestmark = pytest.mark.integration
 
@@ -119,6 +122,104 @@ async def test_null_digests_do_not_collide(registry_db: DatabaseSession, sample_
         second_loaded = await session.get(ApiRevision, second.id)
         assert first_loaded is not None and first_loaded.spec_digest is None
         assert second_loaded is not None and second_loaded.spec_digest is None
+
+
+async def _archived_revision(
+    session: AsyncSession, api_id: uuid.UUID, *, origin: str | None
+) -> ApiRevision:
+    """Create a revision, drive it active then ARCHIVED, mirroring a superseded base.
+
+    ``origin=None`` stands in for a manually-promoted PUBLISHED base (``create_draft``
+    never sets origin); a non-None origin stands in for an IMPORTED/catalog base.
+    """
+    if origin is None:
+        rev = await ApiRevisionRepository.create_draft(
+            session,
+            api_id=api_id,
+            spec_digest=None,
+            source_type=ApiRevisionSourceType.INLINE,
+            created_by="usr_test",
+        )
+    else:
+        rev = await ApiRevisionRepository.create_imported(
+            session,
+            api_id=api_id,
+            origin=origin,
+            spec_digest=None,
+            source_type=ApiRevisionSourceType.INLINE,
+            created_by="usr_test",
+        )
+    await ApiRevisionRepository.set_state(session, rev.id, ApiRevisionState.ARCHIVED)
+    return rev
+
+
+async def test_restore_archived_published_base_stays_published(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """A PUBLISHED (origin-less) base restores to PUBLISHED, not IMPORTED (#939)."""
+    async with registry_db.session() as session:
+        rev = await _archived_revision(session, sample_api.id, origin=None)
+        await session.commit()
+        rev_id = rev.id
+
+    async with registry_db.session() as session:
+        rowcount = await ApiRevisionRepository.restore_archived(session, rev_id)
+        await session.commit()
+
+    assert rowcount == 1
+    async with registry_db.session() as session:
+        loaded = await session.get(ApiRevision, rev_id)
+        assert loaded is not None
+        assert loaded.state == ApiRevisionState.PUBLISHED
+        assert loaded.archived_at is None
+
+
+async def test_restore_archived_imported_base_stays_imported(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """An IMPORTED (origin-bearing) base restores to IMPORTED (#939)."""
+    async with registry_db.session() as session:
+        rev = await _archived_revision(session, sample_api.id, origin="catalog")
+        await session.commit()
+        rev_id = rev.id
+
+    async with registry_db.session() as session:
+        rowcount = await ApiRevisionRepository.restore_archived(session, rev_id)
+        await session.commit()
+
+    assert rowcount == 1
+    async with registry_db.session() as session:
+        loaded = await session.get(ApiRevision, rev_id)
+        assert loaded is not None
+        assert loaded.state == ApiRevisionState.IMPORTED
+        assert loaded.archived_at is None
+
+
+async def test_restore_archived_non_archived_is_noop(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """CAS on state==ARCHIVED: a non-archived revision is left untouched (rowcount 0)."""
+    async with registry_db.session() as session:
+        rev = await ApiRevisionRepository.create_imported(
+            session,
+            api_id=sample_api.id,
+            origin="catalog",
+            spec_digest=None,
+            source_type=ApiRevisionSourceType.INLINE,
+            created_by="usr_test",
+        )
+        await session.commit()
+        rev_id = rev.id
+
+    async with registry_db.session() as session:
+        rowcount = await ApiRevisionRepository.restore_archived(session, rev_id)
+        await session.commit()
+
+    assert rowcount == 0
+    async with registry_db.session() as session:
+        loaded = await session.get(ApiRevision, rev_id)
+        assert loaded is not None
+        assert loaded.state == ApiRevisionState.IMPORTED
 
 
 async def test_set_operation_count(

--- a/tests/integration/registry/repos/test_revision_repo.py
+++ b/tests/integration/registry/repos/test_revision_repo.py
@@ -222,6 +222,99 @@ async def test_restore_archived_non_archived_is_noop(
         assert loaded.state == ApiRevisionState.IMPORTED
 
 
+async def test_restore_archived_draft_is_noop(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """A DRAFT (origin-less, non-archived) row is left untouched — not flipped to PUBLISHED.
+
+    The dangerous branch for the state CASE: a DRAFT is ``origin IS NULL``, so if the CAS
+    on ``state == ARCHIVED`` were ever weakened, restore would wrongly promote it to
+    PUBLISHED. Pin the CAS specifically against the origin-less branch (#939).
+    """
+    async with registry_db.session() as session:
+        rev = await ApiRevisionRepository.create_draft(
+            session,
+            api_id=sample_api.id,
+            spec_digest=None,
+            source_type=ApiRevisionSourceType.INLINE,
+            created_by="usr_test",
+        )
+        await session.commit()
+        rev_id = rev.id
+
+    async with registry_db.session() as session:
+        rowcount = await ApiRevisionRepository.restore_archived(session, rev_id)
+        await session.commit()
+
+    assert rowcount == 0
+    async with registry_db.session() as session:
+        loaded = await session.get(ApiRevision, rev_id)
+        assert loaded is not None
+        assert loaded.state == ApiRevisionState.DRAFT
+
+
+async def test_restore_archived_missing_revision_returns_zero(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """A missing revision id yields rowcount 0 — the contract rollback maps to
+    OverlayRollbackTargetMissingError (#939)."""
+    async with registry_db.session() as session:
+        rowcount = await ApiRevisionRepository.restore_archived(session, uuid.uuid4())
+        await session.commit()
+    assert rowcount == 0
+
+
+async def test_state_origin_invariant_holds_for_producers(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """Guard the load-bearing invariant `restore_archived` relies on (#939).
+
+    The state CASE reconstructs prior state from `origin` (NULL ⇒ PUBLISHED, else
+    IMPORTED). That is only valid because the two revision producers correlate state and
+    origin: create_draft (the sole origin-less creator; DRAFT→PUBLISHED via promote) never
+    sets origin, and create_imported (the sole IMPORTED producer) always sets one. If a
+    future producer breaks this (e.g. an origin-less IMPORTED, or an origin-bearing row
+    that later becomes PUBLISHED), rollback would silently mis-restore. Fail loudly here.
+    """
+    async with registry_db.session() as session:
+        draft = await ApiRevisionRepository.create_draft(
+            session,
+            api_id=sample_api.id,
+            spec_digest=None,
+            source_type=ApiRevisionSourceType.INLINE,
+            created_by="usr_test",
+        )
+        # A DRAFT promoted to PUBLISHED keeps origin NULL (promote never sets origin).
+        await ApiRevisionRepository.set_state(session, draft.id, ApiRevisionState.PUBLISHED)
+        await session.commit()
+        published_id = draft.id
+
+    async with registry_db.session() as session:
+        published = await session.get(ApiRevision, published_id)
+        assert published is not None and published.state == ApiRevisionState.PUBLISHED
+        assert published.origin is None, "PUBLISHED revision must have origin IS NULL (#939)"
+        # Archive it before adding an IMPORTED row: the one-active partial unique index
+        # forbids two active (published/imported) revisions for the same api_id.
+        await ApiRevisionRepository.set_state(session, published_id, ApiRevisionState.ARCHIVED)
+        imported = await ApiRevisionRepository.create_imported(
+            session,
+            api_id=sample_api.id,
+            origin="catalog",
+            spec_digest=None,
+            source_type=ApiRevisionSourceType.INLINE,
+            created_by="usr_test",
+        )
+        await session.commit()
+        imported_id = imported.id
+
+    async with registry_db.session() as session:
+        imported_row = await session.get(ApiRevision, imported_id)
+        assert imported_row is not None and imported_row.state == ApiRevisionState.IMPORTED
+        assert imported_row.origin is not None, (
+            "IMPORTED revision must have a non-NULL origin (#939)"
+        )
+
+
 async def test_set_operation_count(
     registry_db: DatabaseSession, sample_revision: tuple[Api, ApiRevision]
 ) -> None:

--- a/tests/integration/registry/services/test_import_handler.py
+++ b/tests/integration/registry/services/test_import_handler.py
@@ -581,6 +581,98 @@ async def test_overlay_rollback_restores_superseded_revision(
         assert overlay_row.deprecated_reason == "rollback"
 
 
+async def test_overlay_rollback_restores_published_base_as_published(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    _clean_registry: None,
+) -> None:
+    """A5b + #939: a manually-PUBLISHED base is restored to PUBLISHED, not IMPORTED.
+
+    An overlay's base can be a manually-promoted PUBLISHED revision (origin-less), not
+    only an imported one. Rollback must restore it to its true prior state. Mirrors
+    test_overlay_rollback_restores_superseded_revision but marks the base PUBLISHED +
+    origin-less (as promote() would leave it) before materializing.
+    """
+    handler = ImportHandler(integration_context)
+    base_revision_id = await _import_base(
+        handler, vendor="rbp-vendor", name="rbp-api", version="1.0.0", origin="catalog"
+    )
+
+    async with registry_db.session() as session:
+        # Make the base look like a manually-promoted PUBLISHED revision: PUBLISHED
+        # state with no origin (create_draft → promote never sets origin).
+        await session.execute(
+            update(ApiRevision)
+            .where(ApiRevision.id == base_revision_id)
+            .values(state="published", origin=None)
+        )
+        api = (await session.execute(select(Api).where(Api.vendor == "rbp-vendor"))).scalar_one()
+        api_id = api.id
+        overlay = Overlay(
+            api_id=api_id, document=_OVERLAY_DOC, status="pending", created_by="usr_test"
+        )
+        session.add(overlay)
+        await session.commit()
+        overlay_id = overlay.id
+
+    await handler.execute(
+        job_id=str(uuid.uuid4()),
+        session=None,
+        payload={
+            "sources": [
+                {
+                    "type": "inline",
+                    "content": json.dumps(
+                        {
+                            "openapi": "3.1.0",
+                            "info": {"title": "RBP", "version": "1.0.0"},
+                            "servers": [{"url": "https://new.example.com"}],
+                            "paths": {
+                                "/items": {
+                                    "get": {
+                                        "operationId": "listItems",
+                                        "responses": {"200": {"description": "OK"}},
+                                    }
+                                }
+                            },
+                        }
+                    ),
+                    "filename": "openapi.json",
+                    "vendor": "rbp-vendor",
+                    "api_name": "rbp-api",
+                    "version": "1.0.0",
+                    "origin": "overlay",
+                    "source_url": "https://catalog.example.com/base.json",
+                }
+            ],
+            "overlay_id": overlay_id,
+        },
+        created_by="usr_test",
+    )
+
+    async with registry_db.session() as session:
+        await session.execute(
+            update(Overlay).where(Overlay.id == overlay_id).values(status="confirmed")
+        )
+        await session.commit()
+
+    identity = Identity(sub="usr_operator", email="op@test.local", permissions=["overlays:confirm"])
+    await OverlayService(integration_context).rollback(
+        "rbp-vendor", "rbp-api", "1.0.0", overlay_id, identity=identity
+    )
+
+    async with registry_db.session() as session:
+        api = (await session.execute(select(Api).where(Api.id == api_id))).scalar_one()
+        assert api.current_revision_id == base_revision_id
+        base_rev = (
+            await session.execute(select(ApiRevision).where(ApiRevision.id == base_revision_id))
+        ).scalar_one()
+        # The label is preserved through the archive→restore round-trip (#939): a
+        # PUBLISHED base comes back PUBLISHED, not silently demoted to IMPORTED.
+        assert base_rev.state == "published"
+        assert base_rev.archived_at is None
+
+
 async def test_overlay_rollback_conflict_when_not_live(
     integration_context: Context,
     registry_db: DatabaseSession,

--- a/tests/integration/registry/services/test_import_handler.py
+++ b/tests/integration/registry/services/test_import_handler.py
@@ -656,6 +656,16 @@ async def test_overlay_rollback_restores_published_base_as_published(
         )
         await session.commit()
 
+    # Precondition the assertion depends on: materialization must have actually archived
+    # the base. Without this, the final state=="published" check would also pass if the
+    # base were never archived/restored at all (it started PUBLISHED) — masking a broken
+    # archive→restore round-trip. See #939.
+    async with registry_db.session() as session:
+        base_rev_mid = (
+            await session.execute(select(ApiRevision).where(ApiRevision.id == base_revision_id))
+        ).scalar_one()
+        assert base_rev_mid.state == "archived"
+
     identity = Identity(sub="usr_operator", email="op@test.local", permissions=["overlays:confirm"])
     await OverlayService(integration_context).rollback(
         "rbp-vendor", "rbp-api", "1.0.0", overlay_id, identity=identity

--- a/tests/unit/shared/auth/test_permission_catalog.py
+++ b/tests/unit/shared/auth/test_permission_catalog.py
@@ -8,6 +8,8 @@ does not route through admin.
 
 from __future__ import annotations
 
+from jentic_one.admin.core import permissions as admin_perms
+from jentic_one.shared.auth import permission_catalog
 from jentic_one.shared.auth.permission_catalog import (
     ALL_PERMISSIONS,
     APIS_READ,
@@ -47,10 +49,11 @@ def test_all_permissions_is_the_shared_catalogue() -> None:
     assert ALL_PERMISSIONS[ORG_ADMIN].name == ORG_ADMIN
 
 
-def test_admin_shim_re_exports_the_same_objects() -> None:
-    # admin.core.permissions must re-export the *same* objects (identity), proving the
-    # shim is transparent for existing call sites.
-    from jentic_one.admin.core import permissions as admin_perms
-
-    assert admin_perms.ALL_PERMISSIONS is ALL_PERMISSIONS
-    assert admin_perms.compute_effective is compute_effective
+def test_admin_shim_re_exports_the_entire_public_surface() -> None:
+    # The shim's whole job is a complete, identity-preserving re-export. Assert the
+    # public surface matches AND every symbol is the *same object*, so a future dropped
+    # or diverged re-export (e.g. the unused-by-callers Permission dataclass) is caught
+    # in one place rather than only when some call site happens to break.
+    assert set(admin_perms.__all__) == set(permission_catalog.__all__)
+    for name in permission_catalog.__all__:
+        assert getattr(admin_perms, name) is getattr(permission_catalog, name), name

--- a/tests/unit/shared/auth/test_permission_catalog.py
+++ b/tests/unit/shared/auth/test_permission_catalog.py
@@ -1,0 +1,56 @@
+"""Unit tests for the shared permission catalogue (its tier-neutral home, #938).
+
+Exercises compute_effective / compute_implies_transitive imported from
+``shared.auth.permission_catalog`` directly — independent of the
+``admin.core.permissions`` re-export shim — so the shared module has coverage that
+does not route through admin.
+"""
+
+from __future__ import annotations
+
+from jentic_one.shared.auth.permission_catalog import (
+    ALL_PERMISSIONS,
+    APIS_READ,
+    CREDENTIALS_READ,
+    CREDENTIALS_WRITE,
+    ORG_ADMIN,
+    OVERLAYS_CONFIRM,
+    compute_effective,
+    compute_implies_transitive,
+)
+
+
+def test_compute_effective_empty() -> None:
+    assert compute_effective(set()) == set()
+
+
+def test_compute_effective_single_implication() -> None:
+    # credentials:write implies credentials:read.
+    assert compute_effective({CREDENTIALS_WRITE}) == {CREDENTIALS_WRITE, CREDENTIALS_READ}
+
+
+def test_compute_effective_org_admin_expands_all() -> None:
+    effective = compute_effective({ORG_ADMIN})
+    # org:admin expands to (at least) every directly-implied permission.
+    assert OVERLAYS_CONFIRM in effective
+    assert APIS_READ in effective
+
+
+def test_compute_implies_transitive_closure() -> None:
+    # overlays:confirm → apis:read (a leaf), so the transitive closure is {apis:read}.
+    assert compute_implies_transitive(OVERLAYS_CONFIRM) == {APIS_READ}
+
+
+def test_all_permissions_is_the_shared_catalogue() -> None:
+    # The catalogue is genuinely defined here (not merely re-exported from admin).
+    assert ORG_ADMIN in ALL_PERMISSIONS
+    assert ALL_PERMISSIONS[ORG_ADMIN].name == ORG_ADMIN
+
+
+def test_admin_shim_re_exports_the_same_objects() -> None:
+    # admin.core.permissions must re-export the *same* objects (identity), proving the
+    # shim is transparent for existing call sites.
+    from jentic_one.admin.core import permissions as admin_perms
+
+    assert admin_perms.ALL_PERMISSIONS is ALL_PERMISSIONS
+    assert admin_perms.compute_effective is compute_effective


### PR DESCRIPTION
Closes #939
Closes #938

## Summary

Two independent low-hanging-fruit follow-ups deferred from the #937 review board (epic #919), one commit per fix.

- **[#939](https://github.com/jentic/jentic-one/issues/939) — `fix(registry)`: rollback restores an overlay base to its *true* prior state.** `ApiRevisionRepository.restore_archived_to_imported` always restored the superseded base to `IMPORTED`. But an overlay's base can be a manually-promoted `PUBLISHED` revision (per `archive_all_active`), so a `PUBLISHED` base was silently demoted to `IMPORTED` on rollback. Renamed to `restore_archived`, restoring to the state derived from durable provenance that survives archival: `PUBLISHED` is only ever produced by `promote()` (from a `DRAFT`, which `create_draft` leaves origin-less), `IMPORTED` only by `create_imported` (always sets `origin`) — so `origin IS NULL ⇒ PUBLISHED, else IMPORTED`, decided in a single SQL `CASE` (one atomic UPDATE, no new column/migration). Index correctness was never affected (`ix_api_revisions_one_active` covers both as one active set); this is state-fidelity only.

- **[#938](https://github.com/jentic/jentic-one/issues/938) — `refactor(auth)`: kill the shared→admin permissions layering inversion + guard it.** `shared/auth/permissions.py` (and `shared/web/deps`, `scope_catalog`, `endpoint_scopes`) imported the implication logic from `admin.core.permissions` — a shared→admin inversion (admin already imports shared: latent cycle) that no arch guard prevented. The catalogue has no admin-tier dependency (only `shared/scopes.py`), so it moved to a new tier-neutral `shared.auth.permission_catalog`; `admin.core.permissions` is now a thin re-export shim (explicit `__all__`) so every existing admin-tier call site is unchanged. Added `test_shared_does_not_import_admin_permissions`.

## Notes / decisions

- **Guard scope (#938):** a *blanket* `test_shared_does_not_import_admin` is **not** achievable — `shared` has ~13 pre-existing `shared → admin` imports (jobs/events/audit machinery referencing admin-tier ORM schemas). Those are a separate, pre-existing structural coupling (admin owns those canonical schemas) and out of scope for #938, which names the *permissions* inversion specifically. The guard is scoped to `admin.core.permissions`, which is exactly the inversion the issue is about and is now genuinely gone.
- **No migration (#939):** prior state is inferred from durable `origin` rather than captured in a new column, so no schema change and no touching the (scattered) materialize/confirm/recovery write-sites.
- Plan: `jentic-one-plans/issues/issues-939-938-rollback-state-and-auth-layering.md`.

## Review board (8-agent) — addressed in follow-up commit

An 8-agent review (security, architecture, test-coverage, docs, correctness/concurrency, registry-domain, code-quality, CI/process) found no CRITICAL logic defects — correctness/concurrency and registry-domain independently confirmed the `origin`→state invariant, security confirmed the catalogue move is identity-preserving with no authz drift. Remediation applied:
- Fixed a CI failure: the new `test_permission_catalog` tripped `test_no_inline_imports` (inline import hoisted to module level).
- Fixed a stale arch-guard cross-reference in two docstrings.
- Hardened #939 tests: assert the base is actually `ARCHIVED` before rollback (so the e2e test can't pass while the round-trip is broken); added DRAFT no-op, missing-revision, and a `PUBLISHED ⟺ origin-NULL` invariant guard test.
- #938: added an explicit `__all__` to the shared module and a shim test asserting the *entire* public surface is re-exported by identity.

## Test plan

- [x] `uv run ruff check .` + `uv run ruff format --check .` + `uv run mypy` (clean; run by pre-commit hooks)
- [x] `pytest -m arch` — module-boundary (incl. new guard) + inline-import + scope-catalog guards pass
- [x] `pytest tests/unit/admin/test_permissions.py tests/unit/shared/auth` — implication behaviour through both the shared home and the admin shim
- [x] `pytest tests/integration/registry/repos/test_revision_repo.py` — `restore_archived` for published/imported/draft/non-archived/missing + invariant guard
- [x] `pytest tests/integration/registry/services/test_import_handler.py -k rollback` — end-to-end confirm→rollback proving a PUBLISHED base round-trips as PUBLISHED (with pre-rollback ARCHIVED assertion)
- 94 passed across the affected arch + integration + unit suites.

Made with [Cursor](https://cursor.com)