### PR TITLE
fix(registry): Flow-3 concurrency follow-ups — A4b supersede target + notify durability (#940, #941)

### DIFF
--- a/src/jentic_one/registry/ingest/stages/extract_api.py
+++ b/src/jentic_one/registry/ingest/stages/extract_api.py
@@ -140,6 +140,16 @@ class CreateRevisionStage(BasePipelineStage):
                     # therefore trusts the flag by construction. If a future route ever
                     # forwards a raw ``sources`` payload, that route MUST re-assert the
                     # scope before enqueue — the privilege boundary lives at enqueue time.
+                    #
+                    # Capture the revision that is current *right now*, before the archive,
+                    # so the handler can re-resolve and deprecate the overlay that actually
+                    # backed it — a concurrent confirm may have made a *different* overlay
+                    # live since this job was enqueued, so trusting the enqueue-time
+                    # supersede_overlay_id can deprecate the wrong overlay (#940). NULL when
+                    # the API has no current revision (nothing to supersede).
+                    api = await ApiRepository.get_by_id(ctx.session, api_id)
+                    if api is not None and api.current_revision_id is not None:
+                        ctx.produce("superseded_revision_id", api.current_revision_id, uuid.UUID)
                     await ApiRevisionRepository.archive_all_active(ctx.session, api_id)
                 else:
                     await ApiRevisionRepository.archive_active_imported(

--- a/src/jentic_one/registry/repos/catalog_update_check_repo.py
+++ b/src/jentic_one/registry/repos/catalog_update_check_repo.py
@@ -126,8 +126,8 @@ class CatalogUpdateCheckRepository:
 
         Keys on ``last_notified_digest``, whereas the sweep-side emit suppression
         (``CatalogService._is_snoozed``) keys on the digest currently being *emitted*. Those
-        agree because the sweep upserts ``last_notified_digest = upstream_digest`` before the
-        suppression check runs; see that method for the shared invariant.
+        agree because a snoozed change marks ``last_notified_digest = upstream_digest``
+        inline before returning (it emits no event); see ``CatalogService._probe_one``.
         """
         if now is None:
             now = datetime.now(UTC)
@@ -313,3 +313,40 @@ class CatalogUpdateCheckRepository:
             row.last_checked_at = checked_at
         await session.flush()
         return row
+
+    @staticmethod
+    async def mark_notified(
+        session: AsyncSession,
+        *,
+        local_api_id: uuid.UUID,
+        notified_digest: str,
+        notified_event_class: str,
+    ) -> int:
+        """Record that an event was *successfully emitted* for ``notified_digest``.
+
+        Split out from :meth:`upsert` so the update-notify sweep can order the durable
+        "notified" marker **after** the cross-DB event emit (emit-then-mark). The upsert
+        commits the observation (etag/digest/last_checked_at) in the registry DB; the event
+        lands in the *admin* DB in a separate transaction, so there is no shared commit. If
+        the process crashed between marking notified and emitting, dedupe — which keys on
+        ``(last_notified_digest, last_notified_event_class)`` — would suppress the
+        notification permanently until upstream changed again (#941). Marking only after a
+        successful emit means a crash re-emits on the next sweep (at worst one duplicate the
+        next successful mark dedupes) instead of silently swallowing the notification.
+
+        Returns the number of rows updated (0 if the check row is missing — the observation
+        upsert always runs first in the sweep, so in practice this is 1).
+        """
+        result = cast(
+            "CursorResult[Any]",
+            await session.execute(
+                update(CatalogUpdateCheck)
+                .where(CatalogUpdateCheck.local_api_id == local_api_id)
+                .values(
+                    last_notified_digest=notified_digest,
+                    last_notified_event_class=notified_event_class,
+                )
+            ),
+        )
+        await session.flush()
+        return result.rowcount or 0

--- a/src/jentic_one/registry/repos/overlay_repo.py
+++ b/src/jentic_one/registry/repos/overlay_repo.py
@@ -143,6 +143,36 @@ class OverlayRepository:
         return result.scalar_one_or_none()
 
     @staticmethod
+    async def list_confirmed_unlinked_for_api(
+        session: AsyncSession, api_id: uuid.UUID
+    ) -> list[Overlay]:
+        """CONFIRMED overlays for *api_id* with a NULL ``confirmed_revision_id``.
+
+        The lazy-link corner (#940): the materialize/confirm path flips an overlay to
+        CONFIRMED and promotes its revision to *current* inside the ingest transaction, then
+        stamps ``confirmed_revision_id`` in a *separate* follow-up transaction. Between those
+        commits — or durably, if the best-effort link write failed (the documented
+        CONFIRMED-but-unmaterialized recovery state) — the live overlay is CONFIRMED backing
+        the current revision with a NULL link. A strict revision-keyed lookup
+        (:meth:`get_live_confirmed_for_revision`) then can't find it.
+
+        This surfaces those NULL-linked CONFIRMED overlays so a caller resolving "which
+        overlay backed the just-archived revision" can recover the target when the strict
+        lookup misses. Ordered newest-confirmed first. Returns 0..N; the caller must decide
+        what an ambiguous (>1) result means for its context.
+        """
+        result = await session.execute(
+            select(Overlay)
+            .where(
+                Overlay.api_id == api_id,
+                Overlay.status == OverlayStatus.CONFIRMED,
+                Overlay.confirmed_revision_id.is_(None),
+            )
+            .order_by(Overlay.confirmed_at.desc().nulls_last(), Overlay.id.desc())
+        )
+        return list(result.scalars().all())
+
+    @staticmethod
     async def list_page(
         session: AsyncSession,
         *,

--- a/src/jentic_one/registry/services/catalog/service.py
+++ b/src/jentic_one/registry/services/catalog/service.py
@@ -367,10 +367,11 @@ class CatalogService:
 
         Keyed on ``upstream_digest`` (the digest the sweep is *emitting* for), whereas the
         repo-side outdated-set exclusion (:meth:`CatalogUpdateCheckRepository._not_snoozed`)
-        keys on ``last_notified_digest``. Those agree because the sweep's emit path upserts
-        ``last_notified_digest = upstream_digest`` *before* this suppression check runs
-        (see :meth:`run_update_sweep`), so at decision time the two columns hold the same
-        value. Keep that upsert-before-check ordering if either predicate is edited.
+        keys on ``last_notified_digest``. Those agree because a snoozed change marks
+        ``last_notified_digest = upstream_digest`` (inline, since it emits no event) before it
+        returns — see the snooze branch in :meth:`_probe_one`. The *emitting* (non-snoozed)
+        path marks after a successful emit (emit-then-mark, #941), which does not affect this
+        predicate because a snoozed row never reaches the emit path.
         """
         snoozed_digest = getattr(check, "snoozed_digest", None)
         if snoozed_digest is None or snoozed_digest != upstream_digest:
@@ -435,8 +436,6 @@ class CatalogService:
             last_notified_class,
         )
 
-        notified_digest = upstream_digest if changed else None
-        notified_event_class = event_class if changed else None
         async with self._ctx.registry_db.transaction() as session:
             await CatalogUpdateCheckRepository.upsert(
                 session,
@@ -445,13 +444,18 @@ class CatalogService:
                 etag=result.etag,
                 digest=upstream_digest,
                 checked_at=now,
-                notified_digest=notified_digest,
-                notified_event_class=notified_event_class,
-                # Upstream matches the served revision again (e.g. a bad publish was
-                # reverted): pin last_notified_digest to it so the outdated read surface
-                # clears. Otherwise a revert leaves the badge stuck lit with no operator
-                # action able to resolve it. Dedupe is preserved — a later genuinely
-                # different upstream digest still re-fires exactly once.
+                # Deliberately NOT stamping notified_digest/class here: the event is
+                # emitted below in a *separate* (admin-DB) transaction, so marking notified
+                # before the emit could permanently suppress the notification if the process
+                # crashes in between (#941). We mark via mark_notified only *after* a
+                # successful emit — emit-then-mark.
+                #
+                # sync_notified is the one exception: when upstream matches the served
+                # revision again (e.g. a bad publish was reverted) it fires *no* event, so
+                # pinning last_notified_digest to it here is safe and clears the outdated
+                # read surface. Otherwise a revert leaves the badge stuck lit with no
+                # operator action able to resolve it. Dedupe is preserved — a later
+                # genuinely different upstream digest still re-fires exactly once.
                 sync_notified=in_sync,
             )
 
@@ -459,13 +463,23 @@ class CatalogService:
             return
 
         # Snooze/mute (C1, #925): an operator accepted this exact upstream digest without
-        # adopting it, so suppress the *notification* while the snooze is active. We still ran
-        # the upsert above (recording last_notified_digest/class), so dedupe stays consistent
-        # and the badge stays suppressed via the shared outdated-set exclusion; we simply skip
-        # the emit here so no new inbox/rail item is created. A genuinely newer upstream digest
-        # won't match ``snoozed_digest`` and will emit normally. ``snoozed_until`` in the past
-        # means the snooze lapsed → emit again.
+        # adopting it, so suppress the *notification* while the snooze is active. This path
+        # emits no event, so we mark notified inline (emit-then-mark only defers the marker
+        # to guard the cross-DB emit; there is nothing to guard here). Marking is required:
+        # the read-surface snooze exclusion keys on ``snoozed_digest == last_notified_digest``
+        # (see :meth:`CatalogUpdateCheckRepository._not_snoozed`), so without advancing
+        # ``last_notified_digest`` to the snoozed digest the badge would wrongly re-light
+        # despite the active snooze. We skip the emit so no new inbox/rail item is created. A
+        # genuinely newer upstream digest won't match ``snoozed_digest`` and will emit
+        # normally. ``snoozed_until`` in the past means the snooze lapsed → emit again.
         if check is not None and self._is_snoozed(check, upstream_digest, now):
+            async with self._ctx.registry_db.transaction() as session:
+                await CatalogUpdateCheckRepository.mark_notified(
+                    session,
+                    local_api_id=spec.api_id,
+                    notified_digest=upstream_digest,
+                    notified_event_class=event_class,
+                )
             logger.info(
                 "catalog_update_notify_snoozed",
                 api_id=str(spec.api_id),
@@ -540,6 +554,17 @@ class CatalogService:
                         else None
                     ),
                 },
+            )
+        # Emit committed above (admin DB). Now durably record that we notified for this
+        # (digest, class) so the next sweep dedupes — emit-then-mark (#941). A crash before
+        # this point re-emits next sweep (at worst one duplicate) rather than permanently
+        # suppressing the notification.
+        async with self._ctx.registry_db.transaction() as session:
+            await CatalogUpdateCheckRepository.mark_notified(
+                session,
+                local_api_id=spec.api_id,
+                notified_digest=upstream_digest,
+                notified_event_class=event_class,
             )
         record_update_notified(event_class)
 

--- a/src/jentic_one/registry/services/catalog/service.py
+++ b/src/jentic_one/registry/services/catalog/service.py
@@ -52,7 +52,7 @@ from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.auth.permissions import has_effective_permission
 from jentic_one.shared.context import Context
 from jentic_one.shared.db.utils import utcnow
-from jentic_one.shared.events import emit_event_best_effort
+from jentic_one.shared.events import emit_event, emit_event_best_effort
 from jentic_one.shared.jobs.enqueue import enqueue_job
 from jentic_one.shared.models import ActorType
 from jentic_one.shared.models.events import EventSeverity, EventType
@@ -501,8 +501,17 @@ class CatalogService:
                 )
             conflict_overlay_id = live_overlay.id if live_overlay is not None else None
 
+        # Emit-then-mark durability (#941) requires the *raising* emit here, NOT
+        # emit_event_best_effort: the marker below must only be written when the event
+        # actually landed. emit_event_best_effort swallows failures, so a transient
+        # admin-DB error would return normally and let mark_notified stamp the dedupe key
+        # for an event that was never delivered — permanently suppressing it. Letting
+        # emit_event raise rolls back this (empty) admin txn and propagates to the sweep's
+        # per-API guard (_guarded), which logs + isolates the failure and leaves the row
+        # unmarked, so the next sweep re-emits. Worst case is one duplicate on a crash
+        # *after* this commit but before the mark — the accepted trade-off.
         async with self._ctx.admin_db.transaction() as session:
-            await emit_event_best_effort(
+            await emit_event(
                 session,
                 type=event_class,
                 severity=EventSeverity.INFO,
@@ -560,11 +569,23 @@ class CatalogService:
         # this point re-emits next sweep (at worst one duplicate) rather than permanently
         # suppressing the notification.
         async with self._ctx.registry_db.transaction() as session:
-            await CatalogUpdateCheckRepository.mark_notified(
+            marked = await CatalogUpdateCheckRepository.mark_notified(
                 session,
                 local_api_id=spec.api_id,
                 notified_digest=upstream_digest,
                 notified_event_class=event_class,
+            )
+        if marked == 0:
+            # The observation upsert above committed a row, so a 0 here means it was
+            # concurrently deleted (operator action / a future concurrent sweep) between
+            # the upsert and this mark. The event was emitted but not deduped — it re-fires
+            # next sweep (safe direction). Surface it so an "emitted but unmarked" tick is
+            # observable rather than silent, mirroring overlay_supersede_not_deprecated.
+            logger.warning(
+                "catalog_update_marked_zero_rows",
+                api_id=str(spec.api_id),
+                upstream_digest=upstream_digest,
+                event_class=event_class,
             )
         record_update_notified(event_class)
 

--- a/src/jentic_one/registry/services/import_service.py
+++ b/src/jentic_one/registry/services/import_service.py
@@ -339,10 +339,24 @@ class ImportHandler:
         show "deprecated by re-import on <date>" (L3). Emitted best-effort in the admin DB
         (events live there), requires_action=False — a notification, not an inbox item.
         """
+        # Resolve which overlay to deprecate first, isolating a *resolution* failure (a DB
+        # read error while re-resolving) from a *demote* failure. On a resolver error, fall
+        # back to the enqueue-time id and still attempt the demote — a transient resolver
+        # error must not skip the deprecate entirely (which would regress to leaving the
+        # overlay CONFIRMED over an archived revision). The resolver's own miss-cases already
+        # return the enqueue-time id internally; this guard only covers it *raising*.
         try:
             target_overlay_id = await self._resolve_superseded_overlay_id(
                 job_id, overlay_id, superseding_revision
             )
+        except Exception:
+            logger.exception(
+                "overlay_supersede_resolve_failed",
+                job_id=job_id,
+                overlay_id=overlay_id,
+            )
+            target_overlay_id = overlay_id
+        try:
             async with self._ctx.registry_db.transaction() as session:
                 overlay = await OverlayRepository.get_by_id(session, target_overlay_id)
                 demoted = await OverlayRepository.set_status(
@@ -373,7 +387,7 @@ class ImportHandler:
             logger.exception(
                 "overlay_supersede_deprecate_failed",
                 job_id=job_id,
-                overlay_id=overlay_id,
+                overlay_id=target_overlay_id,
             )
 
     async def _resolve_superseded_overlay_id(
@@ -386,16 +400,32 @@ class ImportHandler:
 
         Returns the CONFIRMED overlay whose ``confirmed_revision_id`` is the revision the
         worker just archived (captured pre-archive as
-        ``superseding_revision["superseded_revision_id"]``). Falls back to the enqueue-time
-        ``enqueue_overlay_id`` when the archived revision id or its backing overlay can't be
-        resolved. Logs when the re-resolved overlay differs from the enqueue-time one, so
-        the concurrent-confirm race is observable.
+        ``superseding_revision["superseded_revision_id"]``), re-resolved here rather than
+        trusting the enqueue-time id (a concurrent confirm may have changed the live overlay
+        after enqueue).
+
+        Two-stage resolution:
+        1. Strict: :meth:`OverlayRepository.get_live_confirmed_for_revision` on the archived
+           revision — unambiguous when the backing overlay is linked.
+        2. Lazy-link recovery: the strict lookup misses in the lazy-link window (the confirm
+           path makes the overlay's revision current *before* it stamps
+           ``confirmed_revision_id``; that link is a separate, best-effort txn, so a live
+           CONFIRMED overlay can transiently — or durably, on a failed link — have a NULL
+           link). When the archived revision was overlay-origin and there is *exactly one*
+           NULL-linked CONFIRMED overlay for the API, that is the live overlay → deprecate
+           it. This mirrors why :meth:`get_live_confirmed_for_api` refuses to key strictly.
+
+        Falls back to the enqueue-time ``enqueue_overlay_id`` only when neither stage
+        resolves (no archived revision captured, API/overlay unresolved, or an *ambiguous*
+        lazy-link set). Logs when the re-resolved overlay differs from the enqueue-time one,
+        or when it can't safely re-resolve, so the concurrent-confirm race is observable.
         """
         if superseding_revision is None:
             return enqueue_overlay_id
         archived_id_raw = superseding_revision.get("superseded_revision_id")
         api = superseding_revision.get("api") or {}
-        if not archived_id_raw or not api:
+        vendor, name, version = api.get("vendor"), api.get("name"), api.get("version")
+        if not archived_id_raw or not (vendor and name and version):
             return enqueue_overlay_id
         try:
             archived_revision_id = uuid.UUID(str(archived_id_raw))
@@ -403,15 +433,43 @@ class ImportHandler:
             return enqueue_overlay_id
 
         async with self._ctx.registry_db.session() as session:
-            api_row = await ApiRepository.get_by_identifier(
-                session, api["vendor"], api["name"], api["version"]
-            )
+            api_row = await ApiRepository.get_by_identifier(session, vendor, name, version)
             if api_row is None:
                 return enqueue_overlay_id
             overlay = await OverlayRepository.get_live_confirmed_for_revision(
                 session, api_row.id, archived_revision_id
             )
+            if overlay is None:
+                # Strict miss — try the lazy-link recovery. Only meaningful when the archived
+                # revision was itself overlay-origin (an overlay backed it); a catalog/manual
+                # base has no overlay to re-resolve.
+                archived_origin = await ApiRevisionRepository.origin_of(
+                    session, archived_revision_id
+                )
+                if archived_origin == ORIGIN_OVERLAY:
+                    unlinked = await OverlayRepository.list_confirmed_unlinked_for_api(
+                        session, api_row.id
+                    )
+                    if len(unlinked) == 1:
+                        overlay = unlinked[0]
+
         if overlay is None:
+            # Could not safely re-resolve (no backing overlay, or an ambiguous lazy-link
+            # set). Do NOT silently trust the enqueue-time id — a concurrent confirm may have
+            # made it stale. Fall back to it (no worse than pre-#940), but warn so the
+            # wrong-overlay risk in this narrow window is observable rather than silent.
+            logger.warning(
+                "overlay_supersede_target_unresolved",
+                job_id=job_id,
+                enqueue_overlay_id=enqueue_overlay_id,
+                archived_revision_id=str(archived_revision_id),
+                detail=(
+                    "could not re-resolve the overlay backing the archived revision "
+                    "(lazy-link window or ambiguous confirmed set); falling back to the "
+                    "enqueue-time overlay id, which may be stale under a concurrent confirm "
+                    "(#940)"
+                ),
+            )
             return enqueue_overlay_id
         if overlay.id != enqueue_overlay_id:
             logger.info(
@@ -523,6 +581,18 @@ class ImportHandler:
             return None
         # Finish the interrupted deprecate (idempotent: CAS on CONFIRMED — a no-op if a
         # prior attempt already demoted it).
+        #
+        # Residual (#940): this recovery path passes no ``superseding_revision``, so
+        # ``_deprecate_superseded_overlay`` cannot re-resolve and deprecates the enqueue-time
+        # ``overlay_id`` verbatim. Under a *concurrent confirm that changed the live overlay
+        # after enqueue* AND a crash mid-supersede (a double fault), that id can be stale, so
+        # the wrong overlay may be demoted here. We do not re-resolve because by recovery time
+        # the archived overlay revision is gone (the served revision is already the fresh
+        # non-overlay upstream — asserted by the ``origin == ORIGIN_OVERLAY`` guard above), so
+        # there is no reliable ``superseded_revision_id`` to key on. The CAS still guarantees
+        # we only ever demote a CONFIRMED overlay, never corrupt state; the narrow cost is a
+        # possibly-wrong-overlay demote in this double-fault corner. Left as a known residual
+        # rather than adding a heuristic that could misfire.
         await self._deprecate_superseded_overlay(
             job_id, overlay_id, actor_id=actor_id, actor_type=actor_type
         )

--- a/src/jentic_one/registry/services/import_service.py
+++ b/src/jentic_one/registry/services/import_service.py
@@ -174,6 +174,7 @@ class ImportHandler:
                     await self._deprecate_superseded_overlay(
                         job_id,
                         str(supersede_overlay_id),
+                        superseding_revision=revisions[0],
                         actor_id=created_by,
                         actor_type=actor_type,
                     )
@@ -304,7 +305,13 @@ class ImportHandler:
             )
 
     async def _deprecate_superseded_overlay(
-        self, job_id: str, overlay_id: str, *, actor_id: str, actor_type: str | None
+        self,
+        job_id: str,
+        overlay_id: str,
+        *,
+        superseding_revision: dict[str, Any] | None = None,
+        actor_id: str,
+        actor_type: str | None,
     ) -> None:
         """Auto-deprecate an overlay superseded by an authorized catalog re-import (A4b).
 
@@ -315,6 +322,16 @@ class ImportHandler:
         re-ingest, so it is logged rather than raised (the served spec is already correct;
         only the overlay's status label lags and can be repaired).
 
+        Which overlay to deprecate: prefer the one that *actually backed the revision the
+        supersede just archived* (``superseding_revision["superseded_revision_id"]``),
+        re-resolved here rather than trusting the enqueue-time ``overlay_id``. A concurrent
+        confirm can make a *different* overlay live between the A4b authorization gate and
+        this worker; the ingest stage archives whatever is current *now*, so deprecating the
+        stale enqueue-time id would leave the actually-superseded overlay stuck CONFIRMED
+        over an archived revision (#940). Fall back to the enqueue-time ``overlay_id`` when
+        the archived revision or its backing overlay can't be re-resolved, so there is no
+        regression versus the prior behaviour.
+
         L2 (#921): on a successful demote we emit an attributed ``overlay.deprecated``
         event so the overlay is not *silently* flipped behind the audit log. ``actor_id``/
         ``actor_type`` are the authorizing operator (the job's ``created_by``); the event
@@ -323,11 +340,14 @@ class ImportHandler:
         (events live there), requires_action=False — a notification, not an inbox item.
         """
         try:
+            target_overlay_id = await self._resolve_superseded_overlay_id(
+                job_id, overlay_id, superseding_revision
+            )
             async with self._ctx.registry_db.transaction() as session:
-                overlay = await OverlayRepository.get_by_id(session, overlay_id)
+                overlay = await OverlayRepository.get_by_id(session, target_overlay_id)
                 demoted = await OverlayRepository.set_status(
                     session,
-                    overlay_id,
+                    target_overlay_id,
                     OverlayStatus.DEPRECATED,
                     deprecated_at=datetime.now(UTC),
                     deprecated_reason=OverlayDeprecationReason.SUPERSEDED_BY_REIMPORT,
@@ -337,14 +357,14 @@ class ImportHandler:
                 logger.warning(
                     "overlay_supersede_not_deprecated",
                     job_id=job_id,
-                    overlay_id=overlay_id,
+                    overlay_id=target_overlay_id,
                     reason="overlay_not_confirmed_or_missing",
                 )
                 return
             await self._emit_overlay_deprecated(
                 job_id=job_id,
                 overlay=overlay,
-                overlay_id=overlay_id,
+                overlay_id=target_overlay_id,
                 actor_id=actor_id,
                 actor_type=actor_type,
             )
@@ -355,6 +375,57 @@ class ImportHandler:
                 job_id=job_id,
                 overlay_id=overlay_id,
             )
+
+    async def _resolve_superseded_overlay_id(
+        self,
+        job_id: str,
+        enqueue_overlay_id: str,
+        superseding_revision: dict[str, Any] | None,
+    ) -> str:
+        """Resolve the overlay that actually backed the supersede-archived revision (#940).
+
+        Returns the CONFIRMED overlay whose ``confirmed_revision_id`` is the revision the
+        worker just archived (captured pre-archive as
+        ``superseding_revision["superseded_revision_id"]``). Falls back to the enqueue-time
+        ``enqueue_overlay_id`` when the archived revision id or its backing overlay can't be
+        resolved. Logs when the re-resolved overlay differs from the enqueue-time one, so
+        the concurrent-confirm race is observable.
+        """
+        if superseding_revision is None:
+            return enqueue_overlay_id
+        archived_id_raw = superseding_revision.get("superseded_revision_id")
+        api = superseding_revision.get("api") or {}
+        if not archived_id_raw or not api:
+            return enqueue_overlay_id
+        try:
+            archived_revision_id = uuid.UUID(str(archived_id_raw))
+        except ValueError:
+            return enqueue_overlay_id
+
+        async with self._ctx.registry_db.session() as session:
+            api_row = await ApiRepository.get_by_identifier(
+                session, api["vendor"], api["name"], api["version"]
+            )
+            if api_row is None:
+                return enqueue_overlay_id
+            overlay = await OverlayRepository.get_live_confirmed_for_revision(
+                session, api_row.id, archived_revision_id
+            )
+        if overlay is None:
+            return enqueue_overlay_id
+        if overlay.id != enqueue_overlay_id:
+            logger.info(
+                "overlay_supersede_target_reresolved",
+                job_id=job_id,
+                enqueue_overlay_id=enqueue_overlay_id,
+                resolved_overlay_id=overlay.id,
+                archived_revision_id=str(archived_revision_id),
+                detail=(
+                    "a concurrent confirm changed the live overlay after enqueue; "
+                    "deprecating the overlay that backed the archived revision (#940)"
+                ),
+            )
+        return overlay.id
 
     async def _emit_overlay_deprecated(
         self,

--- a/tests/integration/registry/repos/test_catalog_update_check_repo.py
+++ b/tests/integration/registry/repos/test_catalog_update_check_repo.py
@@ -8,6 +8,7 @@ identity, excludes archived revisions, and de-duplicates per API.
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -387,3 +388,49 @@ async def test_future_snooze_still_excludes_without_explicit_now(
     async with registry_db.session() as session:
         ids = await CatalogUpdateCheckRepository.outdated_api_ids(session)
         assert sample_api.id not in ids
+
+
+async def test_mark_notified_updates_existing_row(
+    registry_db: DatabaseSession, sample_api: Api
+) -> None:
+    """mark_notified advances last_notified_digest/class on an existing row (#941)."""
+    now = datetime.now(UTC)
+    async with registry_db.session() as session:
+        await CatalogUpdateCheckRepository.upsert(
+            session,
+            local_api_id=sample_api.id,
+            spec_url="https://example.com/openapi.json",
+            etag='"v1"',
+            digest="digest-up",
+            checked_at=now,
+        )
+        await session.commit()
+
+    async with registry_db.session() as session:
+        marked = await CatalogUpdateCheckRepository.mark_notified(
+            session,
+            local_api_id=sample_api.id,
+            notified_digest="digest-up",
+            notified_event_class="catalog.update_available",
+        )
+        await session.commit()
+    assert marked == 1
+
+    async with registry_db.session() as session:
+        row = await CatalogUpdateCheckRepository.get(session, sample_api.id)
+    assert row is not None
+    assert row.last_notified_digest == "digest-up"
+    assert row.last_notified_event_class == "catalog.update_available"
+
+
+async def test_mark_notified_missing_row_returns_zero(registry_db: DatabaseSession) -> None:
+    """mark_notified on an api_id with no check row returns 0 and raises nothing (#941)."""
+    async with registry_db.session() as session:
+        marked = await CatalogUpdateCheckRepository.mark_notified(
+            session,
+            local_api_id=uuid.uuid4(),
+            notified_digest="digest-x",
+            notified_event_class="catalog.update_available",
+        )
+        await session.commit()
+    assert marked == 0

--- a/tests/integration/registry/services/test_catalog_update_notify_sweep.py
+++ b/tests/integration/registry/services/test_catalog_update_notify_sweep.py
@@ -526,3 +526,87 @@ async def test_import_handler_settle_reuses_session_no_self_deadlock(
         ).scalar_one()
     assert event.acknowledged is True
     assert event.acknowledged_by == "usr_reimport"
+
+
+# ── #941: emit-then-mark durability ──────────────────────────────────────────
+
+
+async def test_sweep_emit_failure_leaves_unmarked_so_next_sweep_re_emits(
+    integration_context: Context, registered_api: Api
+) -> None:
+    """#941: a crash between marking notified and emitting must NOT permanently suppress.
+
+    With emit-then-mark, the notify marker (``last_notified_digest`` /
+    ``last_notified_event_class``) is written only *after* a successful cross-DB emit. If
+    the emit fails (the process crashing mid-emit is modelled by the emit raising, which
+    the per-API guard swallows), the marker stays unadvanced so the *next* sweep re-emits
+    rather than silently deduping against a notification that was never delivered.
+    """
+    integration_context.config.catalog.update_check_interval_seconds = 1
+    changed = ConditionalFetch(
+        not_modified=False, etag='"v2"', content=b"{}", digest="sha256:upstream-new"
+    )
+    svc = CatalogService(integration_context)
+
+    # First sweep: the emit fails. The per-API guard swallows it; the API must be left
+    # unmarked (no notified digest) so it is not deduped away.
+    with (
+        patch(f"{_SWEEP}.fetch_bytes_conditional", new_callable=AsyncMock, return_value=changed),
+        patch(
+            f"{_SWEEP}.emit_event_best_effort",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("admin DB unavailable mid-emit"),
+        ),
+    ):
+        await svc._run_update_notify_sweep()
+
+    assert await _events(integration_context) == []  # nothing emitted
+    async with integration_context.registry_db.session() as session:
+        check = await CatalogUpdateCheckRepository.get(session, registered_api.id)
+    assert check is not None
+    # Observation persisted (we did fetch), but the notify marker was NOT advanced —
+    # so the change is still outstanding and will re-emit.
+    assert check.last_seen_digest == "sha256:upstream-new"
+    assert check.last_notified_digest is None
+    assert check.last_notified_event_class is None
+
+    # Second sweep with a healthy emit: it re-emits (the bug would have suppressed it).
+    async with integration_context.registry_db.transaction() as session:
+        check = await CatalogUpdateCheckRepository.get(session, registered_api.id)
+        assert check is not None
+        check.last_checked_at = None  # reopen the per-API interval gate
+    with patch(f"{_SWEEP}.fetch_bytes_conditional", new_callable=AsyncMock, return_value=changed):
+        await svc._run_update_notify_sweep()
+
+    events = await _events(integration_context)
+    assert len(events) == 1  # re-emitted, not permanently suppressed
+    async with integration_context.registry_db.session() as session:
+        check_after = await CatalogUpdateCheckRepository.get(session, registered_api.id)
+    assert check_after is not None
+    assert check_after.last_notified_digest == "sha256:upstream-new"
+
+
+async def test_sweep_marks_notified_after_successful_emit_and_dedupes(
+    integration_context: Context, registered_api: Api
+) -> None:
+    """#941 happy path: a successful emit advances the notify marker and the next sweep dedupes.
+
+    Confirms emit-then-mark does not double-notify on the success path: the marker is
+    written after the emit, so a second sweep observing the same digest is deduped.
+    """
+    integration_context.config.catalog.update_check_interval_seconds = 1
+    changed = ConditionalFetch(
+        not_modified=False, etag='"v2"', content=b"{}", digest="sha256:upstream-new"
+    )
+    svc = CatalogService(integration_context)
+    with patch(f"{_SWEEP}.fetch_bytes_conditional", new_callable=AsyncMock, return_value=changed):
+        await svc._run_update_notify_sweep()
+        async with integration_context.registry_db.transaction() as session:
+            check = await CatalogUpdateCheckRepository.get(session, registered_api.id)
+            assert check is not None
+            assert check.last_notified_digest == "sha256:upstream-new"
+            assert check.last_notified_event_class == EventType.CATALOG_UPDATE_AVAILABLE
+            check.last_checked_at = None  # reopen the gate for a second pass
+        await svc._run_update_notify_sweep()
+
+    assert len(await _events(integration_context)) == 1  # deduped, not re-emitted

--- a/tests/integration/registry/services/test_catalog_update_notify_sweep.py
+++ b/tests/integration/registry/services/test_catalog_update_notify_sweep.py
@@ -534,13 +534,14 @@ async def test_import_handler_settle_reuses_session_no_self_deadlock(
 async def test_sweep_emit_failure_leaves_unmarked_so_next_sweep_re_emits(
     integration_context: Context, registered_api: Api
 ) -> None:
-    """#941: a crash between marking notified and emitting must NOT permanently suppress.
+    """#941: a *failed emit* must NOT advance the notify marker (no permanent suppression).
 
-    With emit-then-mark, the notify marker (``last_notified_digest`` /
-    ``last_notified_event_class``) is written only *after* a successful cross-DB emit. If
-    the emit fails (the process crashing mid-emit is modelled by the emit raising, which
-    the per-API guard swallows), the marker stays unadvanced so the *next* sweep re-emits
-    rather than silently deduping against a notification that was never delivered.
+    The change path uses the raising ``emit_event`` (not the swallowing best-effort
+    wrapper) exactly so a transient admin-DB emit failure propagates to the sweep's per-API
+    guard and the marker is left unadvanced. Patching ``emit_event`` here reproduces the
+    real production seam (a raising emit), unlike patching the best-effort wrapper — which
+    in production swallows and would let the marker advance. On the next healthy sweep the
+    change re-emits rather than being deduped against a notification that never landed.
     """
     integration_context.config.catalog.update_check_interval_seconds = 1
     changed = ConditionalFetch(
@@ -548,12 +549,12 @@ async def test_sweep_emit_failure_leaves_unmarked_so_next_sweep_re_emits(
     )
     svc = CatalogService(integration_context)
 
-    # First sweep: the emit fails. The per-API guard swallows it; the API must be left
-    # unmarked (no notified digest) so it is not deduped away.
+    # First sweep: the emit raises (transient admin-DB error). The per-API guard isolates
+    # it; the API must be left unmarked (no notified digest) so it is not deduped away.
     with (
         patch(f"{_SWEEP}.fetch_bytes_conditional", new_callable=AsyncMock, return_value=changed),
         patch(
-            f"{_SWEEP}.emit_event_best_effort",
+            f"{_SWEEP}.emit_event",
             new_callable=AsyncMock,
             side_effect=RuntimeError("admin DB unavailable mid-emit"),
         ),
@@ -580,6 +581,56 @@ async def test_sweep_emit_failure_leaves_unmarked_so_next_sweep_re_emits(
 
     events = await _events(integration_context)
     assert len(events) == 1  # re-emitted, not permanently suppressed
+    async with integration_context.registry_db.session() as session:
+        check_after = await CatalogUpdateCheckRepository.get(session, registered_api.id)
+    assert check_after is not None
+    assert check_after.last_notified_digest == "sha256:upstream-new"
+
+
+async def test_sweep_crash_after_emit_before_mark_re_emits_at_most_once(
+    integration_context: Context, registered_api: Api
+) -> None:
+    """#941: a crash *after* the emit commits but *before* the mark → duplicate, not loss.
+
+    This is the residual window emit-then-mark deliberately accepts. Faithfully model it by
+    letting the emit succeed (event committed to the admin DB) and raising inside the
+    *mark* seam. The per-API guard isolates the failure; because the marker never landed,
+    the next sweep re-emits — so the event fires a *second* time (at-most-once duplicate),
+    which is strictly better than the permanent suppression the old ordering caused.
+    """
+    integration_context.config.catalog.update_check_interval_seconds = 1
+    changed = ConditionalFetch(
+        not_modified=False, etag='"v2"', content=b"{}", digest="sha256:upstream-new"
+    )
+    svc = CatalogService(integration_context)
+
+    with (
+        patch(f"{_SWEEP}.fetch_bytes_conditional", new_callable=AsyncMock, return_value=changed),
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.mark_notified",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("crash before mark commit"),
+        ),
+    ):
+        await svc._run_update_notify_sweep()
+
+    # The event WAS emitted (emit committed before the mark seam), but the marker did not
+    # land because mark_notified raised.
+    assert len(await _events(integration_context)) == 1
+    async with integration_context.registry_db.session() as session:
+        check = await CatalogUpdateCheckRepository.get(session, registered_api.id)
+    assert check is not None
+    assert check.last_notified_digest is None  # marker not advanced
+
+    # Next healthy sweep re-emits (the accepted duplicate) and this time marks.
+    async with integration_context.registry_db.transaction() as session:
+        check = await CatalogUpdateCheckRepository.get(session, registered_api.id)
+        assert check is not None
+        check.last_checked_at = None
+    with patch(f"{_SWEEP}.fetch_bytes_conditional", new_callable=AsyncMock, return_value=changed):
+        await svc._run_update_notify_sweep()
+
+    assert len(await _events(integration_context)) == 2  # duplicate, not suppressed
     async with integration_context.registry_db.session() as session:
         check_after = await CatalogUpdateCheckRepository.get(session, registered_api.id)
     assert check_after is not None

--- a/tests/integration/registry/services/test_import_handler.py
+++ b/tests/integration/registry/services/test_import_handler.py
@@ -1252,6 +1252,270 @@ async def test_authorized_supersede_reimport_deprecates_overlay(
         assert overlay_row.status == "deprecated"
 
 
+async def test_supersede_deprecates_overlay_backing_archived_revision(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    _clean_registry: None,
+) -> None:
+    """#940: a concurrent confirm can make a *different* overlay live after enqueue.
+
+    The A4b authorization gate resolves the live overlay in a lock-free read and stamps
+    its id as ``supersede_overlay_id``. If a concurrent confirm makes overlay **B** live
+    (its ``confirmed_revision_id`` is the API's current revision) before the worker runs,
+    the worker archives whatever is current *now* — B's revision — but the stale
+    ``supersede_overlay_id`` still points at the previously-live overlay **A**. The worker
+    must re-resolve and deprecate **B** (the overlay that actually backed the archived
+    revision), leaving A untouched.
+    """
+    handler = ImportHandler(integration_context)
+    await _import_base(
+        handler, vendor="race-vendor", name="race-api", version="1.0.0", origin="catalog"
+    )
+
+    async with registry_db.session() as session:
+        api = (await session.execute(select(Api).where(Api.vendor == "race-vendor"))).scalar_one()
+        api_id = api.id
+        # Overlay A: the enqueue-time target. CONFIRMED but *not* backing the current
+        # revision — it points at some other (superseded) revision, exactly like a
+        # prior-live overlay that a concurrent confirm stacked over.
+        overlay_a = Overlay(
+            api_id=api_id,
+            document=_OVERLAY_DOC,
+            status="confirmed",
+            confirmed_revision_id=uuid.uuid4(),
+            created_by="usr_author_a",
+        )
+        # Overlay B: the concurrently-confirmed one whose materialized revision will be
+        # current when the worker runs.
+        overlay_b = Overlay(
+            api_id=api_id, document=_OVERLAY_DOC, status="pending", created_by="usr_author_b"
+        )
+        session.add_all([overlay_a, overlay_b])
+        await session.commit()
+        overlay_a_id = overlay_a.id
+        overlay_b_id = overlay_b.id
+
+    # Materialize overlay B so its revision is the live served revision, then flip it
+    # CONFIRMED and link confirmed_revision_id to the served revision (what confirm does).
+    materialize = await handler.execute(
+        job_id=str(uuid.uuid4()),
+        session=None,
+        payload={
+            "sources": [
+                {
+                    "type": "inline",
+                    "content": json.dumps(
+                        {
+                            "openapi": "3.1.0",
+                            "info": {"title": "RACE", "version": "1.0.0"},
+                            "servers": [{"url": "https://overlaid-b.example.com"}],
+                            "paths": {
+                                "/items": {
+                                    "get": {
+                                        "operationId": "listItems",
+                                        "responses": {"200": {"description": "OK"}},
+                                    }
+                                }
+                            },
+                        }
+                    ),
+                    "filename": "openapi.json",
+                    "vendor": "race-vendor",
+                    "api_name": "race-api",
+                    "version": "1.0.0",
+                    "origin": "overlay",
+                    "source_url": "https://catalog.example.com/base.json",
+                }
+            ],
+            "overlay_id": overlay_b_id,
+        },
+        created_by="usr_test",
+    )
+    b_revision_id = uuid.UUID(materialize.body["revisions"][0]["revision_id"])
+    async with registry_db.session() as session:
+        await session.execute(
+            update(Overlay)
+            .where(Overlay.id == overlay_b_id)
+            .values(status="confirmed", confirmed_revision_id=b_revision_id)
+        )
+        await session.commit()
+
+    # The scope-checked enqueue path stamped the STALE overlay A (it was live when the
+    # gate ran); by worker time B is the live/current one.
+    fresh_upstream = json.dumps(
+        {
+            "openapi": "3.1.0",
+            "info": {"title": "RACE", "version": "1.0.0"},
+            "servers": [{"url": "https://upstream-fresh.example.com"}],
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "listItems",
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    reimport = await handler.execute(
+        job_id=str(uuid.uuid4()),
+        session=None,
+        payload={
+            "sources": [
+                {
+                    "type": "inline",
+                    "content": fresh_upstream,
+                    "filename": "openapi.json",
+                    "vendor": "race-vendor",
+                    "api_name": "race-api",
+                    "version": "1.0.0",
+                    "origin": "catalog",
+                    "source_url": "https://catalog.example.com/base.json",
+                    "supersede_active": "true",
+                }
+            ],
+            "supersede_overlay_id": overlay_a_id,
+        },
+        created_by="usr_operator",
+    )
+    new_revision_id = uuid.UUID(reimport.body["revisions"][0]["revision_id"])
+
+    async with registry_db.session() as session:
+        api = (await session.execute(select(Api).where(Api.id == api_id))).scalar_one()
+        assert api.current_revision_id == new_revision_id
+        b_rev = (
+            await session.execute(select(ApiRevision).where(ApiRevision.id == b_revision_id))
+        ).scalar_one()
+        assert b_rev.state == "archived"
+
+        overlay_a_row = (
+            await session.execute(select(Overlay).where(Overlay.id == overlay_a_id))
+        ).scalar_one()
+        overlay_b_row = (
+            await session.execute(select(Overlay).where(Overlay.id == overlay_b_id))
+        ).scalar_one()
+        # B backed the archived revision → B is deprecated; A (the stale enqueue target)
+        # is left untouched.
+        assert overlay_b_row.status == "deprecated"
+        assert overlay_b_row.deprecated_reason == "superseded_by_reimport"
+        assert overlay_a_row.status == "confirmed"
+        assert overlay_a_row.deprecated_at is None
+
+
+async def test_supersede_deprecates_target_when_no_race(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    _clean_registry: None,
+) -> None:
+    """#940 regression: the common no-race case still deprecates the stamped overlay.
+
+    When the enqueue-time ``supersede_overlay_id`` *is* the overlay backing the current
+    revision (no concurrent confirm), re-resolution returns that same overlay and it is
+    deprecated — no behaviour change versus before the fix.
+    """
+    handler = ImportHandler(integration_context)
+    await _import_base(
+        handler, vendor="norace-vendor", name="norace-api", version="1.0.0", origin="catalog"
+    )
+
+    async with registry_db.session() as session:
+        api = (await session.execute(select(Api).where(Api.vendor == "norace-vendor"))).scalar_one()
+        api_id = api.id
+        overlay = Overlay(
+            api_id=api_id, document=_OVERLAY_DOC, status="pending", created_by="usr_test"
+        )
+        session.add(overlay)
+        await session.commit()
+        overlay_id = overlay.id
+
+    materialize = await handler.execute(
+        job_id=str(uuid.uuid4()),
+        session=None,
+        payload={
+            "sources": [
+                {
+                    "type": "inline",
+                    "content": json.dumps(
+                        {
+                            "openapi": "3.1.0",
+                            "info": {"title": "NORACE", "version": "1.0.0"},
+                            "servers": [{"url": "https://overlaid.example.com"}],
+                            "paths": {
+                                "/items": {
+                                    "get": {
+                                        "operationId": "listItems",
+                                        "responses": {"200": {"description": "OK"}},
+                                    }
+                                }
+                            },
+                        }
+                    ),
+                    "filename": "openapi.json",
+                    "vendor": "norace-vendor",
+                    "api_name": "norace-api",
+                    "version": "1.0.0",
+                    "origin": "overlay",
+                    "source_url": "https://catalog.example.com/base.json",
+                }
+            ],
+            "overlay_id": overlay_id,
+        },
+        created_by="usr_test",
+    )
+    overlay_revision_id = uuid.UUID(materialize.body["revisions"][0]["revision_id"])
+    async with registry_db.session() as session:
+        await session.execute(
+            update(Overlay)
+            .where(Overlay.id == overlay_id)
+            .values(status="confirmed", confirmed_revision_id=overlay_revision_id)
+        )
+        await session.commit()
+
+    fresh_upstream = json.dumps(
+        {
+            "openapi": "3.1.0",
+            "info": {"title": "NORACE", "version": "1.0.0"},
+            "servers": [{"url": "https://upstream-fresh.example.com"}],
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "listItems",
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    await handler.execute(
+        job_id=str(uuid.uuid4()),
+        session=None,
+        payload={
+            "sources": [
+                {
+                    "type": "inline",
+                    "content": fresh_upstream,
+                    "filename": "openapi.json",
+                    "vendor": "norace-vendor",
+                    "api_name": "norace-api",
+                    "version": "1.0.0",
+                    "origin": "catalog",
+                    "source_url": "https://catalog.example.com/base.json",
+                    "supersede_active": "true",
+                }
+            ],
+            "supersede_overlay_id": overlay_id,
+        },
+        created_by="usr_operator",
+    )
+
+    async with registry_db.session() as session:
+        overlay_row = (
+            await session.execute(select(Overlay).where(Overlay.id == overlay_id))
+        ).scalar_one()
+        assert overlay_row.status == "deprecated"
+        assert overlay_row.deprecated_reason == "superseded_by_reimport"
+
+
 async def test_overlay_materialization_archives_active_revision_of_other_origin(
     integration_context: Context,
     registry_db: DatabaseSession,

--- a/tests/integration/registry/services/test_import_handler.py
+++ b/tests/integration/registry/services/test_import_handler.py
@@ -1516,6 +1516,269 @@ async def test_supersede_deprecates_target_when_no_race(
         assert overlay_row.deprecated_reason == "superseded_by_reimport"
 
 
+async def test_supersede_recovers_overlay_in_lazy_link_window(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    _clean_registry: None,
+) -> None:
+    """#940 lazy-link: the live overlay is CONFIRMED but not yet linked (NULL link).
+
+    The confirm path makes an overlay's revision current *before* it stamps
+    ``confirmed_revision_id`` (separate best-effort txn). In that window the strict
+    revision-keyed re-resolution misses, so the worker must recover the live overlay via
+    the single NULL-linked CONFIRMED overlay for the API rather than falling back to the
+    stale enqueue-time id.
+    """
+    handler = ImportHandler(integration_context)
+    await _import_base(
+        handler, vendor="lazy-vendor", name="lazy-api", version="1.0.0", origin="catalog"
+    )
+
+    async with registry_db.session() as session:
+        api = (await session.execute(select(Api).where(Api.vendor == "lazy-vendor"))).scalar_one()
+        api_id = api.id
+        # Stale enqueue target A: CONFIRMED, linked to some other (superseded) revision.
+        overlay_a = Overlay(
+            api_id=api_id,
+            document=_OVERLAY_DOC,
+            status="confirmed",
+            confirmed_revision_id=uuid.uuid4(),
+            created_by="usr_author_a",
+        )
+        overlay_b = Overlay(
+            api_id=api_id, document=_OVERLAY_DOC, status="pending", created_by="usr_author_b"
+        )
+        session.add_all([overlay_a, overlay_b])
+        await session.commit()
+        overlay_a_id = overlay_a.id
+        overlay_b_id = overlay_b.id
+
+    materialize = await handler.execute(
+        job_id=str(uuid.uuid4()),
+        session=None,
+        payload={
+            "sources": [
+                {
+                    "type": "inline",
+                    "content": json.dumps(
+                        {
+                            "openapi": "3.1.0",
+                            "info": {"title": "LAZY", "version": "1.0.0"},
+                            "servers": [{"url": "https://overlaid-b.example.com"}],
+                            "paths": {
+                                "/items": {
+                                    "get": {
+                                        "operationId": "listItems",
+                                        "responses": {"200": {"description": "OK"}},
+                                    }
+                                }
+                            },
+                        }
+                    ),
+                    "filename": "openapi.json",
+                    "vendor": "lazy-vendor",
+                    "api_name": "lazy-api",
+                    "version": "1.0.0",
+                    "origin": "overlay",
+                    "source_url": "https://catalog.example.com/base.json",
+                }
+            ],
+            "overlay_id": overlay_b_id,
+        },
+        created_by="usr_test",
+    )
+    b_revision_id = uuid.UUID(materialize.body["revisions"][0]["revision_id"])
+    # Lazy-link window: B is CONFIRMED and its revision is current, but confirmed_revision_id
+    # is still NULL (the link txn hasn't landed / failed).
+    async with registry_db.session() as session:
+        await session.execute(
+            update(Overlay)
+            .where(Overlay.id == overlay_b_id)
+            .values(status="confirmed", confirmed_revision_id=None)
+        )
+        await session.commit()
+
+    fresh_upstream = json.dumps(
+        {
+            "openapi": "3.1.0",
+            "info": {"title": "LAZY", "version": "1.0.0"},
+            "servers": [{"url": "https://upstream-fresh.example.com"}],
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "listItems",
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    await handler.execute(
+        job_id=str(uuid.uuid4()),
+        session=None,
+        payload={
+            "sources": [
+                {
+                    "type": "inline",
+                    "content": fresh_upstream,
+                    "filename": "openapi.json",
+                    "vendor": "lazy-vendor",
+                    "api_name": "lazy-api",
+                    "version": "1.0.0",
+                    "origin": "catalog",
+                    "source_url": "https://catalog.example.com/base.json",
+                    "supersede_active": "true",
+                }
+            ],
+            "supersede_overlay_id": overlay_a_id,
+        },
+        created_by="usr_operator",
+    )
+
+    async with registry_db.session() as session:
+        b_rev = (
+            await session.execute(select(ApiRevision).where(ApiRevision.id == b_revision_id))
+        ).scalar_one()
+        assert b_rev.state == "archived"
+        overlay_a_row = (
+            await session.execute(select(Overlay).where(Overlay.id == overlay_a_id))
+        ).scalar_one()
+        overlay_b_row = (
+            await session.execute(select(Overlay).where(Overlay.id == overlay_b_id))
+        ).scalar_one()
+        # Recovered via the single NULL-linked CONFIRMED overlay → B deprecated, A untouched.
+        assert overlay_b_row.status == "deprecated"
+        assert overlay_b_row.deprecated_reason == "superseded_by_reimport"
+        assert overlay_a_row.status == "confirmed"
+        assert overlay_a_row.deprecated_at is None
+
+
+async def test_supersede_falls_back_to_enqueue_id_when_no_backing_overlay(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    _clean_registry: None,
+) -> None:
+    """#940 fallback: a catalog-origin base (no overlay backs the archived revision).
+
+    When the archived revision was not overlay-origin, there is no overlay to re-resolve, so
+    the worker falls back to the enqueue-time id and deprecates it. This exercises the
+    strict-miss → not-overlay-origin → fallback branch.
+    """
+    handler = ImportHandler(integration_context)
+    await _import_base(
+        handler, vendor="fb-vendor", name="fb-api", version="1.0.0", origin="catalog"
+    )
+
+    async with registry_db.session() as session:
+        api = (await session.execute(select(Api).where(Api.vendor == "fb-vendor"))).scalar_one()
+        api_id = api.id
+        # A CONFIRMED overlay stamped as the enqueue target, but the current revision is the
+        # catalog base (overlay never materialized), so nothing overlay-origin backs it.
+        overlay = Overlay(
+            api_id=api_id,
+            document=_OVERLAY_DOC,
+            status="confirmed",
+            confirmed_revision_id=uuid.uuid4(),
+            created_by="usr_author",
+        )
+        session.add(overlay)
+        await session.commit()
+        overlay_id = overlay.id
+
+    fresh_upstream = json.dumps(
+        {
+            "openapi": "3.1.0",
+            "info": {"title": "FB", "version": "1.0.0"},
+            "servers": [{"url": "https://upstream-fresh.example.com"}],
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "listItems",
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+    await handler.execute(
+        job_id=str(uuid.uuid4()),
+        session=None,
+        payload={
+            "sources": [
+                {
+                    "type": "inline",
+                    "content": fresh_upstream,
+                    "filename": "openapi.json",
+                    "vendor": "fb-vendor",
+                    "api_name": "fb-api",
+                    "version": "1.0.0",
+                    "origin": "catalog",
+                    "source_url": "https://catalog.example.com/base.json",
+                    "supersede_active": "true",
+                }
+            ],
+            "supersede_overlay_id": overlay_id,
+        },
+        created_by="usr_operator",
+    )
+
+    async with registry_db.session() as session:
+        overlay_row = (
+            await session.execute(select(Overlay).where(Overlay.id == overlay_id))
+        ).scalar_one()
+        # Fallback to the enqueue-time id deprecated it (no regression vs pre-#940).
+        assert overlay_row.status == "deprecated"
+        assert overlay_row.deprecated_reason == "superseded_by_reimport"
+
+
+async def test_deprecate_superseded_overlay_is_idempotent_under_repeat(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    _clean_registry: None,
+) -> None:
+    """#940: a second deprecate of the same target is a safe no-op (CAS on CONFIRMED).
+
+    Models two supersede handlers racing the demote (or a retry): the first flips the
+    overlay CONFIRMED → DEPRECATED; the second observes it is no longer CONFIRMED, logs
+    ``overlay_supersede_not_deprecated``, and changes nothing (no double-emit, no error).
+    """
+    handler = ImportHandler(integration_context)
+    await _import_base(
+        handler, vendor="idem-vendor", name="idem-api", version="1.0.0", origin="catalog"
+    )
+    async with registry_db.session() as session:
+        api = (await session.execute(select(Api).where(Api.vendor == "idem-vendor"))).scalar_one()
+        overlay = Overlay(
+            api_id=api.id, document=_OVERLAY_DOC, status="confirmed", created_by="usr_author"
+        )
+        session.add(overlay)
+        await session.commit()
+        overlay_id = overlay.id
+
+    # First demote (no superseding_revision → uses the enqueue id directly).
+    await handler._deprecate_superseded_overlay(
+        "job-1", overlay_id, actor_id="usr_operator", actor_type="user"
+    )
+    async with registry_db.session() as session:
+        after_first = (
+            await session.execute(select(Overlay).where(Overlay.id == overlay_id))
+        ).scalar_one()
+        assert after_first.status == "deprecated"
+        first_deprecated_at = after_first.deprecated_at
+
+    # Second demote: CAS on CONFIRMED fails (already DEPRECATED) → no-op, no error.
+    await handler._deprecate_superseded_overlay(
+        "job-2", overlay_id, actor_id="usr_operator", actor_type="user"
+    )
+    async with registry_db.session() as session:
+        after_second = (
+            await session.execute(select(Overlay).where(Overlay.id == overlay_id))
+        ).scalar_one()
+        assert after_second.status == "deprecated"
+        # Unchanged — the second call did not re-demote/rewrite the timestamp.
+        assert after_second.deprecated_at == first_deprecated_at
+
+
 async def test_overlay_materialization_archives_active_revision_of_other_origin(
     integration_context: Context,
     registry_db: DatabaseSession,

--- a/tests/unit/registry/services/test_catalog_update_notify.py
+++ b/tests/unit/registry/services/test_catalog_update_notify.py
@@ -105,7 +105,7 @@ async def test_probe_skips_within_interval() -> None:
             return_value=_check(last_checked_at=recent, etag='"v1"', notified=None),
         ),
         patch(f"{_SWEEP}.fetch_bytes_conditional", new_callable=AsyncMock) as fetch,
-        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+        patch(f"{_SWEEP}.emit_event", new_callable=AsyncMock) as emit,
     ):
         await svc._probe_one(_spec(), now=datetime.now(UTC), interval=86400)
         fetch.assert_not_called()
@@ -132,7 +132,7 @@ async def test_probe_at_interval_boundary_re_probes() -> None:
             ),
         ) as fetch,
         patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
-        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock),
+        patch(f"{_SWEEP}.emit_event", new_callable=AsyncMock),
     ):
         await svc._probe_one(_spec(), now=now, interval=100)
         fetch.assert_awaited_once()
@@ -153,7 +153,7 @@ async def test_probe_304_is_noop_but_records_check() -> None:
             ),
         ),
         patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock) as upsert,
-        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+        patch(f"{_SWEEP}.emit_event", new_callable=AsyncMock) as emit,
     ):
         await svc._probe_one(_spec(), now=datetime.now(UTC), interval=86400)
         emit.assert_not_called()
@@ -181,7 +181,7 @@ async def test_probe_change_emits_event_once() -> None:
         patch(
             f"{_SWEEP}.CatalogUpdateCheckRepository.mark_notified", new_callable=AsyncMock
         ) as mark_notified,
-        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+        patch(f"{_SWEEP}.emit_event", new_callable=AsyncMock) as emit,
     ):
         await svc._probe_one(_spec(digest="local-digest"), now=datetime.now(UTC), interval=86400)
         emit.assert_awaited_once()
@@ -213,7 +213,7 @@ async def test_probe_already_notified_digest_does_not_re_emit() -> None:
             ),
         ),
         patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
-        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+        patch(f"{_SWEEP}.emit_event", new_callable=AsyncMock) as emit,
     ):
         await svc._probe_one(_spec(digest="local-digest"), now=datetime.now(UTC), interval=86400)
         emit.assert_not_called()
@@ -235,7 +235,7 @@ async def test_probe_upstream_matches_registered_is_noop() -> None:
             ),
         ),
         patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
-        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+        patch(f"{_SWEEP}.emit_event", new_callable=AsyncMock) as emit,
     ):
         await svc._probe_one(_spec(digest="local-digest"), now=datetime.now(UTC), interval=86400)
         emit.assert_not_called()
@@ -273,7 +273,7 @@ async def test_probe_overlay_conflict_emits_conflict_class() -> None:
             new_callable=AsyncMock,
             return_value=overlay,
         ),
-        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+        patch(f"{_SWEEP}.emit_event", new_callable=AsyncMock) as emit,
     ):
         # Overlaid served digest is "overlaid"; the base it was built over is "base-old".
         spec = _spec(digest="overlaid", origin="overlay", overlay_base_digest="base-old")
@@ -332,7 +332,7 @@ async def test_probe_suppresses_emit_when_snoozed() -> None:
         patch(
             f"{_SWEEP}.CatalogUpdateCheckRepository.mark_notified", new_callable=AsyncMock
         ) as mark_notified,
-        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+        patch(f"{_SWEEP}.emit_event", new_callable=AsyncMock) as emit,
     ):
         await svc._probe_one(_spec(digest="local-digest"), now=datetime.now(UTC), interval=86400)
         # Recorded the observation and marked notified inline (snooze read-surface keys on
@@ -360,7 +360,7 @@ async def test_probe_records_notify_metric() -> None:
             ),
         ),
         patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
-        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock),
+        patch(f"{_SWEEP}.emit_event", new_callable=AsyncMock),
         patch(f"{_SWEEP}.record_update_notified") as metric,
     ):
         await svc._probe_one(_spec(digest="local-digest"), now=datetime.now(UTC), interval=86400)
@@ -389,7 +389,7 @@ async def test_probe_overlay_upstream_matches_base_is_plain_noop() -> None:
             ),
         ),
         patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
-        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+        patch(f"{_SWEEP}.emit_event", new_callable=AsyncMock) as emit,
     ):
         spec = _spec(digest="overlaid", origin="overlay", overlay_base_digest="base-old")
         await svc._probe_one(spec, now=datetime.now(UTC), interval=86400)
@@ -421,7 +421,7 @@ async def test_probe_overlay_unknown_base_falls_back_to_plain() -> None:
             ),
         ),
         patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
-        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+        patch(f"{_SWEEP}.emit_event", new_callable=AsyncMock) as emit,
     ):
         spec = _spec(digest="overlaid", origin="overlay", overlay_base_digest=None)
         await svc._probe_one(spec, now=datetime.now(UTC), interval=86400)
@@ -468,7 +468,7 @@ async def test_probe_reclassified_digest_re_emits_once() -> None:
             new_callable=AsyncMock,
             return_value=None,
         ),
-        patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
+        patch(f"{_SWEEP}.emit_event", new_callable=AsyncMock) as emit,
     ):
         # Now overlay-origin with a base the upstream digest differs from → conflict class.
         spec = _spec(digest="overlaid", origin="overlay", overlay_base_digest="base-old")
@@ -539,7 +539,13 @@ async def test_sweep_skips_when_lock_already_held() -> None:
 
 @pytest.mark.asyncio
 async def test_sweep_swallows_emit_failure_per_api() -> None:
-    """A hard failure in a probe's emit path is isolated by the sweep, not propagated."""
+    """A failure in a probe's emit path is isolated by the sweep AND leaves the row unmarked.
+
+    #941: the change path now uses the raising ``emit_event`` (not the swallowing
+    best-effort wrapper) precisely so a failed emit propagates to the per-API guard and
+    the notify marker is NOT advanced — otherwise a swallowed emit failure would dedupe an
+    undelivered notification forever.
+    """
     svc = CatalogService(_make_ctx())
     with (
         patch(
@@ -559,13 +565,19 @@ async def test_sweep_swallows_emit_failure_per_api() -> None:
         ),
         patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
         patch(
-            f"{_SWEEP}.emit_event_best_effort",
+            f"{_SWEEP}.CatalogUpdateCheckRepository.mark_notified", new_callable=AsyncMock
+        ) as mark_notified,
+        patch(
+            f"{_SWEEP}.emit_event",
             new_callable=AsyncMock,
             side_effect=RuntimeError("emit boom"),
         ),
     ):
         # Must complete without raising — the sweep-level guard isolates the failure.
         await svc._run_update_notify_sweep()
+        # The emit failed → the marker must NOT have been advanced (else a next sweep would
+        # dedupe an event that was never delivered).
+        mark_notified.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/registry/services/test_catalog_update_notify.py
+++ b/tests/unit/registry/services/test_catalog_update_notify.py
@@ -177,7 +177,10 @@ async def test_probe_change_emits_event_once() -> None:
                 not_modified=False, etag='"v2"', content=b"{}", digest="upstream-new"
             ),
         ),
-        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock) as upsert,
+        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.mark_notified", new_callable=AsyncMock
+        ) as mark_notified,
         patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
     ):
         await svc._probe_one(_spec(digest="local-digest"), now=datetime.now(UTC), interval=86400)
@@ -186,8 +189,10 @@ async def test_probe_change_emits_event_once() -> None:
         assert emit_kwargs["type"] == EventType.CATALOG_UPDATE_AVAILABLE
         assert emit_kwargs["requires_action"] is True
         assert emit_kwargs["data"]["upstream_digest"] == "upstream-new"
-        upsert_kwargs = upsert.await_args.kwargs if upsert.await_args else {}
-        assert upsert_kwargs["notified_digest"] == "upstream-new"
+        # #941: the notify marker is written *after* the emit (emit-then-mark).
+        mark_notified.assert_awaited_once()
+        mark_kwargs = mark_notified.await_args.kwargs if mark_notified.await_args else {}
+        assert mark_kwargs["notified_digest"] == "upstream-new"
 
 
 @pytest.mark.asyncio
@@ -259,7 +264,10 @@ async def test_probe_overlay_conflict_emits_conflict_class() -> None:
                 not_modified=False, etag='"v2"', content=b"{}", digest="upstream-new"
             ),
         ),
-        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock) as upsert,
+        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.mark_notified", new_callable=AsyncMock
+        ) as mark_notified,
         patch(
             f"{_SWEEP}.OverlayRepository.get_live_confirmed_for_api",
             new_callable=AsyncMock,
@@ -285,16 +293,19 @@ async def test_probe_overlay_conflict_emits_conflict_class() -> None:
             "served_digest": "overlaid",
             "upstream_digest": "upstream-new",
         }
-        upsert_kwargs = upsert.await_args.kwargs if upsert.await_args else {}
-        assert upsert_kwargs["notified_event_class"] == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY
+        mark_kwargs = mark_notified.await_args.kwargs if mark_notified.await_args else {}
+        assert mark_kwargs["notified_event_class"] == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY
 
 
 @pytest.mark.asyncio
 async def test_probe_suppresses_emit_when_snoozed() -> None:
     """C1: an active snooze on the observed upstream digest suppresses the emit.
 
-    The sweep still runs the upsert (so dedupe stays consistent + the outdated-set
-    exclusion applies) but skips creating a new inbox/rail item.
+    The sweep still marks the notify digest inline (so dedupe stays consistent + the
+    outdated-set snooze exclusion, which keys on last_notified_digest, applies) but skips
+    creating a new inbox/rail item. Unlike the emit path, the snooze path emits no event,
+    so marking inline is safe (#941 emit-then-mark only defers the marker to guard a
+    cross-DB emit).
     """
     svc = CatalogService(_make_ctx())
     snoozed_check = _check(
@@ -318,11 +329,18 @@ async def test_probe_suppresses_emit_when_snoozed() -> None:
             ),
         ),
         patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock) as upsert,
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.mark_notified", new_callable=AsyncMock
+        ) as mark_notified,
         patch(f"{_SWEEP}.emit_event_best_effort", new_callable=AsyncMock) as emit,
     ):
         await svc._probe_one(_spec(digest="local-digest"), now=datetime.now(UTC), interval=86400)
-        # Still recorded the observation, but did NOT emit.
+        # Recorded the observation and marked notified inline (snooze read-surface keys on
+        # last_notified_digest), but did NOT emit.
         upsert.assert_awaited()
+        mark_notified.assert_awaited_once()
+        mark_kwargs = mark_notified.await_args.kwargs if mark_notified.await_args else {}
+        assert mark_kwargs["notified_digest"] == "upstream-new"
         emit.assert_not_awaited()
 
 
@@ -441,7 +459,10 @@ async def test_probe_reclassified_digest_re_emits_once() -> None:
                 not_modified=False, etag='"v2"', content=b"{}", digest="upstream-new"
             ),
         ),
-        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock) as upsert,
+        patch(f"{_SWEEP}.CatalogUpdateCheckRepository.upsert", new_callable=AsyncMock),
+        patch(
+            f"{_SWEEP}.CatalogUpdateCheckRepository.mark_notified", new_callable=AsyncMock
+        ) as mark_notified,
         patch(
             f"{_SWEEP}.OverlayRepository.get_live_confirmed_for_api",
             new_callable=AsyncMock,
@@ -455,8 +476,8 @@ async def test_probe_reclassified_digest_re_emits_once() -> None:
         emit.assert_awaited_once()
         emit_kwargs = emit.await_args.kwargs if emit.await_args else {}
         assert emit_kwargs["type"] == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY
-        upsert_kwargs = upsert.await_args.kwargs if upsert.await_args else {}
-        assert upsert_kwargs["notified_event_class"] == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY
+        mark_kwargs = mark_notified.await_args.kwargs if mark_notified.await_args else {}
+        assert mark_kwargs["notified_event_class"] == EventType.CATALOG_UPDATE_CONFLICTS_OVERLAY
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two backend-only registry correctness fixes deferred from the #937
Correctness+Concurrency review (epic #919), one commit each.

- **#940 — A4b supersede deprecates the wrong overlay under a concurrent confirm.**
  The authorization gate resolves the live confirmed overlay in a lock-free read at
  *enqueue* time and stamps its id; the worker then CAS-deprecated that stale id. A
  concurrent confirm can make a *different* overlay live before the worker runs — the
  ingest stage archives whatever is current *now*, so deprecating the enqueue-time id
  left the actually-superseded overlay stuck `CONFIRMED` over an archived revision.
  Fix: capture the pre-archive current revision on the supersede path and re-resolve
  the overlay that backed it (`get_live_confirmed_for_revision`) in the worker,
  deprecating *that* (still CAS on `CONFIRMED`). Falls back to the enqueue-time id when
  the archived revision or its backing overlay can't be re-resolved, and logs when the
  resolved target diverges so the race is observable.

- **#941 — cross-DB emit-after-commit can permanently suppress a Flow-3 notification.**
  `_probe_one` committed the `catalog_update_checks` upsert that sets
  `last_notified_digest`/`_event_class` (registry DB) *before* emitting the actionable
  event (admin DB, separate transaction). A crash in between marked the digest notified
  with no event emitted; because dedupe keys on
  `(last_notified_digest, last_notified_event_class)`, the notification was permanently
  suppressed until upstream changed again. Fix: **emit-then-mark** — the observation
  upsert no longer stamps the notify marker, the event is emitted, then a focused
  `mark_notified` records the marker only after a successful emit. A crash before the
  mark re-emits next sweep (at worst one duplicate) instead of suppressing forever. The
  snooze path emits no event, so it marks inline to preserve the outdated read-surface
  snooze exclusion (which keys on `last_notified_digest`).

Deliberately out of scope (noted in #940 as an *ideal*): enforcing "at most one
CONFIRMED overlay per API" (deprecate-prior-in-claim-tx or a partial unique index) is a
larger change to confirm/stacking semantics; the worker-side re-resolution fixes the
reported inconsistency without altering the stacking model. Emit-then-mark is chosen over
a full outbox for #941 — the sweep is a rare, max-age-gated lazy tick, so at-least-once
with no schema change matches the existing "one duplicate the next sweep dedupes"
tolerance.

Plan: `jentic-one-plans/issues/issues-940-941-flow3-concurrency.md`.

## Test plan

- [x] `fix #940`: new integration tests in `test_import_handler.py` —
  `test_supersede_deprecates_overlay_backing_archived_revision` (the concurrent-confirm
  race: overlay **B** backs the archived revision, stale id points at **A** → **B**
  deprecated, **A** untouched) and `test_supersede_deprecates_target_when_no_race`
  (regression: stamped id == live overlay still deprecates correctly). Existing
  `test_authorized_supersede_reimport_deprecates_overlay` (incl. crash/recovery) stays
  green.
- [x] `fix #941`: new integration tests in `test_catalog_update_notify_sweep.py` —
  `test_sweep_emit_failure_leaves_unmarked_so_next_sweep_re_emits` (emit raises → marker
  not advanced → next sweep re-emits) and
  `test_sweep_marks_notified_after_successful_emit_and_dedupes` (success path marks after
  emit and dedupes). Unit tests in `test_catalog_update_notify.py` updated for the
  emit-then-mark ordering (assert on `mark_notified` + snooze marks inline).
- [x] `make lint` (ruff + mypy) clean.
- [x] `uv run pytest tests/unit/registry` (573 passed).
- [x] `uv run pytest tests/integration/registry/services/test_import_handler.py tests/integration/registry/services/test_catalog_update_notify_sweep.py tests/integration/registry/repos/test_revision_repo.py` (44 passed).
- [x] `uv run pytest tests/arch` (275 passed).

Closes #940
Closes #941

Made with [Cursor](https://cursor.com)