### PR TITLE
docs: add llms.txt, and an install-and-use section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,53 @@
 > **If `.rules/` exists, read `.rules/AGENTS.md` and use it instead of this file.**
 > Otherwise use the guidance below.
 
+## Using Jentic One (not changing it)
+
+If your task is to install Jentic One and connect an agent to it, follow this section. The
+rest of this file is for changing the codebase.
+
+**Install.** Two supported paths:
+
+1. Signed release binary, from https://github.com/jentic/jentic-one/releases/latest. Verify
+   against `checksums.txt` (signature: `checksums.txt.sig`, certificate: `checksums.txt.pem`),
+   then run `jenticctl install`. Prefer this path: it is verifiable before execution, and a
+   sandboxed agent will usually be refused permission to pipe a script to a shell.
+2. Bootstrap script:
+   `curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh`
+   This downloads a Go toolchain if none is present, clones this repository, builds `jenticctl`
+   and `jentic`, then runs `jenticctl install`. Set `JENTIC_NO_INSTALL=1` to stop after the
+   binaries are installed.
+
+**Run Jentic One on a different machine from the agent.** An agent running as the same OS user
+can read the credential database and encryption key from disk, whatever the API-level controls
+allow. See `docs/security/hardening.md` before using real credentials.
+
+**Register and reach a first call:**
+
+1. `jentic register` creates the agent identity. It then blocks, waiting for an operator to
+   approve the agent. Report this to the user: on a single-operator install they are the
+   operator, and they approve it in the UI at `/app`.
+2. The bootstrap operator login is `admin@local` / `1234`. Tell the user to change it.
+3. Import an API from https://github.com/jentic/jentic-public-apis, or register a private
+   OpenAPI description of the user's own service.
+4. Store a credential for that API, once. It is encrypted at rest and is never returned.
+5. Bind the agent to a toolkit. A rule-less binding blocks everything; the default is deny.
+6. `jentic execute GET:/get --json` runs a call through the Broker with the credential injected.
+
+**Constraints to respect:**
+
+- One governed upstream call per execution. Compose multi-step work yourself; the Broker does
+  not orchestrate.
+- A self-hosted deployment exposes no MCP endpoint. Integrate through the `jentic` CLI, the
+  skill it generates, or plain HTTP against the deployment's own API.
+- A running instance serves `/llms.txt` and `/.well-known/llms.txt` with that deployment's base
+  URL. Once an instance exists, prefer those over this file for anything at runtime.
+- Never print, log or echo a stored credential. The Broker does not return them.
+
+**If a step is blocked by your own sandbox or by network egress rules, say so and stop.** Do
+not work around a security control. Issue #994 tracks the install paths available to a
+restricted agent.
+
 ## In-repo guidance
 
 This repo's agent guidance lives in **[`CLAUDE.md`](CLAUDE.md)**. Read it first.

--- a/llms.txt
+++ b/llms.txt
@@ -19,7 +19,7 @@ A self-hosted deployment exposes no MCP endpoint. Agents integrate through the `
 Jentic One runs on one machine and the agent runs on another. Install on both with the same bootstrap:
 
 ```
-curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/tools/install.sh | sh
 ```
 
 On the host machine that is the whole command. The installer builds the two CLI binaries, `jenticctl` and `jentic`, then hands off into `jenticctl install`, which stands the deployment up through an interactive wizard. On the agent machine, run `jentic register` afterwards to create the agent identity against that deployment.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,70 @@
+# Jentic One
+
+> Jentic One is a self-hosted execution layer for AI agents. You register the APIs an agent may use and store each credential once; the agent then calls those APIs through a credential-injecting Broker, so your agent never sees your keys. Apache-2.0, public beta, runs on a laptop, a VM or Kubernetes.
+
+What an agent can do once an instance is running:
+
+- Discover operations across thousands of APIs and call them without an SDK, a client library or a key per service.
+- Reach private and internal APIs. Register your own OpenAPI description and the same credential custody, per-agent permissions and audit trail apply to services that exist only inside your network.
+- Hold its own identity. Each agent registers an Ed25519 keypair through dynamic client registration (RFC 7591/7592), so access is granted per agent rather than per machine.
+- Work inside a scope. An agent reaches only the operations it has been approved for, and asking for more is a reviewable request rather than a silent widening.
+- Leave a trail. Every call is recorded in an append-only audit log.
+
+What it does not do. Jentic One bounds what a mistaken or compromised agent can reach. It does not make an agent correct or reliable, and it does not remove the judgment call about which operations an agent should be allowed to touch at all.
+
+A self-hosted deployment exposes no MCP endpoint. Agents integrate through the `jentic` CLI and the skill it generates, or over plain HTTP against the deployment's own API. Both paths are documented below.
+
+## Install
+
+Jentic One runs on one machine and the agent runs on another. Install on both with the same bootstrap:
+
+```
+curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh
+```
+
+On the host machine that is the whole command. The installer builds the two CLI binaries, `jenticctl` and `jentic`, then hands off into `jenticctl install`, which stands the deployment up through an interactive wizard. On the agent machine, run `jentic register` afterwards to create the agent identity against that deployment.
+
+Keep the agent off the machine that runs Jentic One. An agent running as the same OS user can read the credential database and the encryption key directly off disk whatever the API-level controls say, so keep them on separate machines. The hardening guide below sets out the tiers; read it before pointing an instance at a real credential.
+
+- [tools/install.sh](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/tools/install.sh): the installer. Detects OS and architecture, provides a Go toolchain if you have none, builds only the `cli/` subtree, and installs to `~/.jentic/bin`.
+- [Installer reference](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/tools/install-README.md): every environment variable, including `JENTIC_REF` to build a specific release and `JENTIC_NO_INSTALL=1` to stop after the binaries.
+- [CLI reference](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/cli/README.md): what `jenticctl` and `jentic` each own, the full command groups, and the agent loop of `search`, `inspect`, `execute`.
+- [Deployment guide](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/deploy/README.md): Docker, Helm, Kubernetes and Terraform layouts for running it somewhere other than a laptop.
+- [Local development setup](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/development/local-setup.md): running from source with `make install`, `make dev` and `make check`.
+
+## Security
+
+- [Hardening guide](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/security/hardening.md): the threat model and a tiered set of deployment postures, from trying it out to handling production credentials. Explains why the network guarantee holds and the same-host, same-user case does not.
+- [Local agent isolation](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/security/local-agent/README.md): the options for the case where the agent must share a machine with the instance, and what each one actually buys.
+- [Credentials and toolkits](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/credentials-and-toolkits.md): how a credential is stored, encrypted and injected, and how one credential is shared across the operations of an API.
+- [SECURITY.md](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/SECURITY.md): supported versions and how to report a vulnerability.
+
+## How it works
+
+- [README](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/README.md): the architecture diagram and component table. An App control plane (Registry, Control, Admin) and a stateless Broker data plane over PostgreSQL or SQLite; both are supported production backends.
+- [Endpoint and authorization reference](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/reference/endpoints.md): every HTTP endpoint with the scopes it requires. This is the authoritative source for authorization, because the OpenAPI documents model authentication only.
+- [Control plane OpenAPI](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/openapi/control/control.openapi.yaml) and [Broker OpenAPI](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/openapi/broker/broker.openapi.yaml): the two machine-readable API descriptions, for calling an instance over raw HTTP instead of through the CLI.
+- [Agent skill](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/skills/jentic/SKILL.md): the instructions installed into an agent runtime by `jentic skill`, describing the identity, discover, request access, execute loop.
+- [Context and configuration](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/context-and-config.md): how a deployment is configured, and what an agent's execution context carries.
+- [Overlays](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/overlays.md): correcting or adapting an imported API description without editing the original.
+
+## APIs to run against
+
+- [Jentic API Directory](https://github.com/jentic/jentic-public-apis): open-source directory of machine-readable API descriptions, released under CC0. Thousands of standardized OpenAPI documents plus Arazzo workflows, importable straight into a Jentic One instance.
+- [Directory on the web](https://jentic.com/apis): the same APIs as browsable pages, with an AI-readiness score for each.
+
+## Project
+
+- [CONTRIBUTING.md](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/CONTRIBUTING.md): development workflow, commit conventions and the checks a change has to pass.
+- [Issues](https://github.com/jentic/jentic-one/issues) and [Discussions](https://github.com/jentic/jentic-one/discussions): bug reports and feature requests, and questions about running it.
+- [SUPPORT.md](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/SUPPORT.md): what community support covers for a self-hosted deployment.
+- [Releases](https://github.com/jentic/jentic-one/releases) and [CHANGELOG.md](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/CHANGELOG.md): what shipped in each version.
+- [LICENSE](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/LICENSE): Apache-2.0.
+
+## Optional
+
+- A running instance serves its own `/llms.txt` and `/.well-known/llms.txt`, generated with that deployment's base URL and the onboarding sequence for an agent already pointed at it. Once you have an instance, prefer that document over this one for anything an agent does at runtime. This file covers evaluating and installing.
+- [Cloud platform compared with self-hosted](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/cloud-vs-self-hosted.md): the two products are easy to conflate and share no state. Read this before copying integration instructions from one into the other.
+- [Extending Jentic One](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/development/extending-jentic-one.md): adding a surface or a capability to the codebase itself.
+- [VERSIONING.md](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/VERSIONING.md): what the version number promises while the project is in public beta.
+- [Jentic documentation](https://docs.jentic.com/): the documentation site. A deployment also serves generated references at `/docs` (interactive Swagger) and `/redoc`.


### PR DESCRIPTION
Draft for review. Two additive changes, no existing content altered.

Serves the flow this project already encourages and #994 documents: *"point your coding agent at the repo and ask it to install and register itself."*

### AGENTS.md

`AGENTS.md` is the file a coding agent reads when pointed at a repository. Its current 38 lines are entirely about **changing** this codebase — layering, ESLint, git conventions — so an agent asked to **install and use** Jentic One finds instructions for modifying it instead.

This adds a `## Using Jentic One (not changing it)` section above the existing guidance. The existing guidance is untouched (38 → 85 lines, all additions).

Design choices worth a maintainer's view:

- **Signed release binary listed first.** Per #994, a sandboxed agent refuses `curl | sh` as an injection pattern, and all three controls that blocked that reporter were behaving correctly. A verifiable artifact is the only install path some agents have.
- **Names the two facts that strand people:** `jentic register` blocks on operator approval (`cli/README.md:284`), and the bootstrap login is `admin@local` / `1234` (`cli/README.md:183`).
- **Tells the agent to stop rather than route around a control.** If its own sandbox or egress rules block a step, it should report that and stop. An agent that circumvents a security control to finish an install is a worse outcome than a failed install.

Every claim is drawn from existing docs and cited above.

### llms.txt

Follows the [llmstxt.org](https://llmstxt.org) convention: a short document an agent or assistant reads to evaluate and install. It **defers to** the richer document a running instance already serves at `/llms.txt` and `/.well-known/llms.txt` (#809) and covers only evaluation and installation, so the two do not compete.

It also states that private and internal APIs are a first-class path, and that both PostgreSQL and SQLite are supported production backends.

### Please confirm

- `admin@local` / `1234` is still the bootstrap credential, and that naming it in `AGENTS.md` is acceptable rather than leaving it in the CLI reference only.
- Nothing in the `Using` section conflicts with how you would want an agent to behave against a real deployment.