### PR TITLE
fix(security): patch util-linux CVE-2026-53615 in the app image base

### DIFF
--- a/deploy/docker/python-base.Dockerfile
+++ b/deploy/docker/python-base.Dockerfile
@@ -32,6 +32,18 @@ RUN uv build --wheel --out-dir /build/dist
 
 FROM ${PYTHON_IMAGE} AS runtime
 
+# Apply Debian security updates for the util-linux family on top of the pinned
+# base. The base image lags the Debian archive's security point-releases, so
+# even the latest `python:3.12-slim` still ships util-linux 2.41-5 which Trivy
+# flags HIGH (CVE-2026-53615, libblkid integer overflow; fixed in
+# 2.41.5-0+deb13u1). Upgrading just this family clears the image CVE gate
+# without a non-reproducible full `apt upgrade`. Revisit when the pinned base
+# already carries the fixed util-linux (then this becomes a no-op and can drop).
+RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
+        bsdutils libblkid1 libmount1 libsmartcols1 libuuid1 mount util-linux \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN groupadd -r jentic && useradd --no-log-init -r -g jentic jentic
 
 EXPOSE 8000


### PR DESCRIPTION
## Summary

Standalone security fix, isolated so it can merge into `main` on its own (no dependency on the CLI V2 release stack).

The published `jentic-one-app` image fails the **Security scan** CVE gate with **9 HIGH** findings — all the `util-linux` family (`bsdutils`, `libblkid1`, `libmount1`, `libsmartcols1`, `libuuid1`, `mount`, `util-linux`), a single **[CVE-2026-53615](https://avd.aquasec.com/nvd/cve-2026-53615)** (integer overflow in `libblkid`). They come from the pinned `python:3.12-slim` base, which ships `util-linux 2.41-5`.

**Bumping the base digest does not fix it** — even the latest `3.12-slim` (built 2026-08-13) predates the Debian point-release. The fixed `2.41.5-0+deb13u1` is available as the apt candidate in the trixie archive, so this upgrades **just** the util-linux family in the `python-base.Dockerfile` runtime stage (a targeted, reproducible fix — no blanket `apt upgrade`). The shared base means all five service images inherit the fix.

## Test plan
- [x] `docker buildx build --call=check` clean.
- [x] `make build-base` + `docker build -f deploy/docker/app.Dockerfile` on `main` → **`debian 13.6, 0 vulnerabilities`** under `trivy image --severity CRITICAL,HIGH --ignore-unfixed --exit-code 1` (was 9 HIGH).
- [x] CI **Security scan** green on this PR.

Drop the `RUN apt-get upgrade` once the pinned base image itself carries the fixed util-linux.

Made with [Cursor](https://cursor.com)