### PR TITLE
cli(v2): review round-3 P0s — redaction completeness + bounded body reads

### DIFF
--- a/cli/client/limits.go
+++ b/cli/client/limits.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+// MaxBodyBytes is the ceiling every whole-body read in the CLI/SDK is clamped to.
+// 64 MiB comfortably covers any legitimate API request/response, OpenAPI spec, or
+// release-metadata file we buffer into RAM, while denying a hostile or buggy peer
+// the ability to exhaust memory by streaming an unbounded body (review round-3
+// P0 / theme 2: unbounded io.ReadAll is systemic). Streaming-to-disk paths (the
+// release archive download) keep their own, larger io.Copy limit — this cap is
+// specifically for "read the whole thing into a []byte" call sites.
+const MaxBodyBytes int64 = 64 << 20
+
+// ErrBodyTooLarge is returned by ReadAllBounded when the source produces more
+// than the allowed number of bytes. It is a sentinel so callers can distinguish
+// a size refusal from an ordinary transport error with errors.Is.
+var ErrBodyTooLarge = errors.New("response body exceeds maximum allowed size")
+
+// ReadAllBounded reads from r into memory like io.ReadAll but refuses to buffer
+// more than limit bytes, returning ErrBodyTooLarge instead of growing without
+// bound. It is the single funnel every "read the whole body into a []byte" site
+// (SDK request buffering for retries, execute response bodies, raw upstream
+// bodies, release-metadata downloads) goes through so no single peer can OOM the
+// process.
+//
+// The implementation reads limit+1 bytes: if the source had EXACTLY limit bytes
+// we return them; if it had more, the extra byte trips the ceiling and we fail
+// closed. A non-positive limit is treated as MaxBodyBytes so a caller can never
+// accidentally disable the cap by passing 0.
+func ReadAllBounded(r io.Reader, limit int64) ([]byte, error) {
+	if limit <= 0 {
+		limit = MaxBodyBytes
+	}
+	// LimitReader to limit+1 so we can detect overflow: reading the (limit+1)th
+	// byte means the body was too large.
+	limited := io.LimitReader(r, limit+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return data, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("%w (limit %d bytes)", ErrBodyTooLarge, limit)
+	}
+	return data, nil
+}

--- a/cli/client/limits_test.go
+++ b/cli/client/limits_test.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestReadAllBounded_UnderLimit(t *testing.T) {
+	src := []byte("hello world")
+	got, err := ReadAllBounded(bytes.NewReader(src), 1024)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Errorf("got %q, want %q", got, src)
+	}
+}
+
+func TestReadAllBounded_ExactlyAtLimit(t *testing.T) {
+	src := bytes.Repeat([]byte("a"), 100)
+	got, err := ReadAllBounded(bytes.NewReader(src), 100)
+	if err != nil {
+		t.Fatalf("a body of exactly max bytes must be accepted, got error: %v", err)
+	}
+	if len(got) != 100 {
+		t.Errorf("got %d bytes, want 100", len(got))
+	}
+}
+
+func TestReadAllBounded_OverLimitFailsClosed(t *testing.T) {
+	src := bytes.Repeat([]byte("a"), 101)
+	got, err := ReadAllBounded(bytes.NewReader(src), 100)
+	if err == nil {
+		t.Fatal("expected ErrBodyTooLarge for a body over the limit, got nil")
+	}
+	if !errors.Is(err, ErrBodyTooLarge) {
+		t.Errorf("error should be ErrBodyTooLarge, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("no bytes should be returned on overflow, got %d", len(got))
+	}
+}
+
+// TestReadAllBounded_NonPositiveMaxUsesDefault ensures a caller can never
+// accidentally disable the cap by passing 0 (or a negative) — it clamps to
+// MaxBodyBytes instead of reading without bound.
+func TestReadAllBounded_NonPositiveMaxUsesDefault(t *testing.T) {
+	src := []byte("small")
+	got, err := ReadAllBounded(bytes.NewReader(src), 0)
+	if err != nil {
+		t.Fatalf("unexpected error with max=0: %v", err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Errorf("got %q, want %q", got, src)
+	}
+}
+
+// errReader returns an error partway through to confirm ReadAllBounded surfaces
+// underlying transport errors (not just size refusals).
+type errReader struct{ msg string }
+
+func (e errReader) Read([]byte) (int, error) { return 0, errors.New(e.msg) }
+
+func TestReadAllBounded_PropagatesReadError(t *testing.T) {
+	_, err := ReadAllBounded(errReader{msg: "boom"}, 100)
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected underlying read error to propagate, got %v", err)
+	}
+	if errors.Is(err, ErrBodyTooLarge) {
+		t.Errorf("a transport error must not be classified as ErrBodyTooLarge: %v", err)
+	}
+}
+
+// TestReadAllBounded_DefaultCeilingRefusesHugeBody exercises the real MaxBodyBytes
+// ceiling with a reader that would produce more than 64 MiB, without allocating
+// it: an infinite reader is clamped and refused.
+func TestReadAllBounded_DefaultCeilingRefusesHugeBody(t *testing.T) {
+	// io.LimitReader inside ReadAllBounded reads at most MaxBodyBytes+1, so this
+	// allocates ~64 MiB transiently then fails closed — acceptable for one test.
+	_, err := ReadAllBounded(neverEndingReader{}, MaxBodyBytes)
+	if !errors.Is(err, ErrBodyTooLarge) {
+		t.Errorf("an unbounded body must be refused with ErrBodyTooLarge, got %v", err)
+	}
+}
+
+// neverEndingReader yields zero bytes forever (never EOF), modelling a hostile
+// peer that streams without end.
+type neverEndingReader struct{}
+
+func (neverEndingReader) Read(p []byte) (int, error) { return len(p), nil }
+
+var _ io.Reader = neverEndingReader{}

--- a/cli/client/transport.go
+++ b/cli/client/transport.go
@@ -158,7 +158,10 @@ func bufferBody(req *http.Request) (buf []byte, canRewind bool, err error) {
 	if req.Body == nil || req.Body == http.NoBody {
 		return nil, true, nil
 	}
-	data, err := io.ReadAll(req.Body)
+	// Bound the buffer: a retry needs the whole body in RAM, but an unbounded
+	// ReadAll lets a huge/hostile request body OOM the process (review round-3
+	// P0 / theme 2). MaxBodyBytes covers any legitimate request.
+	data, err := ReadAllBounded(req.Body, MaxBodyBytes)
 	_ = req.Body.Close()
 	if err != nil {
 		return nil, false, err

--- a/cli/internal/cli/api/apis.go
+++ b/cli/internal/cli/api/apis.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/x/term"
 	"github.com/jentic/jentic-one/cli/internal/cli/cmdcore"
 	"github.com/jentic/jentic-one/cli/internal/cli/prompt"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
 	"github.com/jentic/jentic-one/cli/internal/theme"
 	"github.com/spf13/cobra"
 )
@@ -430,7 +431,8 @@ func (a *app) apisInspect(ctx context.Context, o *apisInspectOptions, operationI
 		}
 		return err
 	}
-	out := strings.TrimRight(string(body), "\n")
+	// SEC (review round-3 P0): same redaction funnel as `jentic inspect`.
+	out := strings.TrimRight(string(ux.RedactBytes(body)), "\n")
 	fmt.Fprintln(a.Out, out)
 	return nil
 }
@@ -537,18 +539,25 @@ func (a *app) apisSpec(ctx context.Context, o *apisSpecOptions, ref string) erro
 	if err != nil {
 		return apiNotFoundErr(err, ref)
 	}
+	// SEC (review round-3 P0): a spec can carry example auth blocks / secrets in
+	// securitySchemes or examples — run it through the same redaction funnel
+	// (inline at each write site so the redaction arch gate can see it) whether
+	// the spec goes to a file or stdout.
 	if o.out != "" {
-		if err := os.WriteFile(o.out, body, 0o600); err != nil {
+		if err := os.WriteFile(o.out, ux.RedactBytes(body), 0o600); err != nil {
 			return fmt.Errorf("write %s: %w", o.out, err)
 		}
 		fmt.Fprintln(a.Out, theme.Successf("Wrote %s spec to %s", ref, o.out))
 		return nil
 	}
-	_, err = a.Out.Write(body)
-	if err == nil && len(body) > 0 && body[len(body)-1] != '\n' {
+	redacted := ux.RedactBytes(body)
+	if _, err = a.Out.Write(redacted); err != nil {
+		return err
+	}
+	if len(redacted) > 0 && redacted[len(redacted)-1] != '\n' {
 		fmt.Fprintln(a.Out)
 	}
-	return err
+	return nil
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/cli/internal/cli/api/execute_print.go
+++ b/cli/internal/cli/api/execute_print.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -13,15 +12,19 @@ import (
 	"github.com/jentic/jentic-one/cli/internal/cli/ux"
 	"github.com/jentic/jentic-one/cli/internal/theme"
 	"github.com/spf13/cobra"
+
+	sdkclient "github.com/jentic/jentic-one/cli/client"
 )
 
 func (a *app) executeOutput(cmd *cobra.Command, opts *executeOptions, resp *http.Response) error {
 	if opts.raw {
-		// Read (bounded by the broker transport's cap) then redact before
-		// streaming, so --raw matches the redaction guarantee of the JSON and
-		// `jentic api` paths (SEC-2). A secret in an upstream body must not leak
-		// just because the caller asked for raw output.
-		body, err := io.ReadAll(resp.Body)
+		// Read the body bounded (review round-3 P0 / theme 2: the old comment
+		// claimed a broker-transport cap that does not exist — the response read
+		// was unbounded), then redact before streaming, so --raw matches the
+		// redaction guarantee of the JSON and `jentic api` paths (SEC-2). A secret
+		// in an upstream body must not leak just because the caller asked for raw
+		// output.
+		body, err := sdkclient.ReadAllBounded(resp.Body, sdkclient.MaxBodyBytes)
 		if err != nil {
 			return fmt.Errorf("read response: %w", err)
 		}
@@ -34,7 +37,7 @@ func (a *app) executeOutput(cmd *cobra.Command, opts *executeOptions, resp *http
 		return nil
 	}
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := sdkclient.ReadAllBounded(resp.Body, sdkclient.MaxBodyBytes)
 	if err != nil {
 		return fmt.Errorf("read response: %w", err)
 	}

--- a/cli/internal/cli/api/inspect.go
+++ b/cli/internal/cli/api/inspect.go
@@ -87,7 +87,11 @@ func (a *app) inspectE(cmd *cobra.Command, opts *inspectOptions, operationID str
 		return err
 	}
 
-	out := strings.TrimRight(string(body), "\n")
+	// SEC (review round-3 P0): redact before writing the upstream body. inspect
+	// emits the API's own contract (JSON/Markdown/OpenAPI), which can carry
+	// example secrets or auth blocks — it must match the redaction guarantee of
+	// execute/api, not leak just because the output is a raw body.
+	out := strings.TrimRight(string(ux.RedactBytes(body)), "\n")
 	fmt.Fprintln(a.Out, out)
 	return nil
 }

--- a/cli/internal/cli/api/inspect_test.go
+++ b/cli/internal/cli/api/inspect_test.go
@@ -118,6 +118,47 @@ func TestInspectCmdNotFoundExitsCode2(t *testing.T) {
 	}
 }
 
+// TestInspectCmdRedactsUpstreamBody is the round-3 P0 regression guard: inspect
+// used to write the upstream contract body with zero redaction (a raw
+// fmt.Fprintln(a.Out, string(body))), so a secret in the returned schema/example
+// leaked straight to stdout. It now routes through ux.RedactBytes — including the
+// hardened structured pass that catches a secret carried as a NON-string JSON
+// value.
+func TestInspectCmdRedactsUpstreamBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// A contrived contract that embeds secrets in an example block: one as a
+		// string value, one as a numeric value (the old regex-only backstop missed
+		// the number).
+		_, _ = w.Write([]byte(`{"method":"POST","path":"/login","example":{"api_key":"sk-LEAKED-STRING","token":9876543210}}`))
+	}))
+	defer srv.Close()
+
+	app := testApp(t)
+	seedRegistered(t, app, "default", srv.URL)
+
+	out := new(bytes.Buffer)
+	app.Out = out
+	root := newAPIRootCmd(app.App)
+	root.SetOut(out)
+	root.SetErr(new(bytes.Buffer))
+	root.SetArgs([]string{"inspect", "login", "--json"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	got := out.String()
+	if strings.Contains(got, "sk-LEAKED-STRING") {
+		t.Errorf("string secret leaked from inspect output: %s", got)
+	}
+	if strings.Contains(got, "9876543210") {
+		t.Errorf("numeric secret leaked from inspect output (structured pass gap): %s", got)
+	}
+	// Non-secret structure survives.
+	if !strings.Contains(got, `"method":"POST"`) {
+		t.Errorf("inspect over-redacted / mangled the body: %s", got)
+	}
+}
+
 func TestInspectCmdRevisionParam(t *testing.T) {
 	var gotRevision string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/internal/cli/ux/redact.go
+++ b/cli/internal/cli/ux/redact.go
@@ -202,6 +202,44 @@ const maxRedactDepth = 64
 
 func redactValue(v any) any { return redactValueDepth(v, 0) }
 
+// redactValueMarked is like redactValue but also reports whether it changed
+// anything (redacted at least one sensitive key or hit the depth guard). The
+// "changed" signal lets RedactBytes avoid re-marshaling — and thus reshaping —
+// JSON that had nothing sensitive in it (shape preservation for WriteJSON).
+func redactValueMarked(v any) (any, bool) {
+	changed := false
+	out := redactValueDepthMarked(v, 0, &changed)
+	return out, changed
+}
+
+func redactValueDepthMarked(v any, depth int, changed *bool) any {
+	if depth > maxRedactDepth {
+		*changed = true
+		return "[REDACTED: too deep]"
+	}
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			if isSensitiveKey(k) || isRegisteredSensitiveName(k) {
+				out[k] = "[REDACTED]"
+				*changed = true
+			} else {
+				out[k] = redactValueDepthMarked(val, depth+1, changed)
+			}
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, val := range t {
+			out[i] = redactValueDepthMarked(val, depth+1, changed)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
 func redactValueDepth(v any, depth int) any {
 	if depth > maxRedactDepth {
 		return "[REDACTED: too deep]"
@@ -283,12 +321,15 @@ func redactString(s string) string { return string(redactSensitive([]byte(s))) }
 // (redactValue), which redacts a sensitive key regardless of its value's JSON
 // type — so a secret carried as a number, object, array, or bool is caught, not
 // just a `"key":"string"` pair (the reKV byte regex alone matched string values
-// only; review round-3 P0). The structured pass never reshapes non-sensitive
-// data: keys, ordering within objects is not guaranteed by encoding/json but the
-// document is semantically identical, and only sensitive subtrees change. The
-// byte backstop then still runs over the re-marshaled bytes to catch secrets
-// embedded in free-form string values (bearer tokens, PEM blocks) that carry no
-// sensitive key.
+// only; review round-3 P0). Shape is preserved when NOTHING is redacted: the
+// structured pass reports whether it changed anything, and if not, RedactBytes
+// runs only the byte backstop over the ORIGINAL bytes — so shape-preserving
+// callers like WriteJSON (which feed already-indented JSON through here) keep
+// their exact layout and key order. Only when a sensitive value is actually
+// redacted does the document get re-marshaled (matching the input's indentation);
+// on that path key order may change, which is fine because the document already
+// differs. The byte backstop then still runs to catch secrets embedded in
+// free-form string values (bearer tokens, PEM blocks) that carry no sensitive key.
 //
 // When data is NOT valid JSON (e.g. a Markdown inspect body, a YAML spec, a
 // plain-text error) it falls back to the byte backstop alone — the same
@@ -297,15 +338,67 @@ func RedactBytes(data []byte) []byte {
 	if trimmed := bytesTrimSpace(data); len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
 		var v any
 		if err := json.Unmarshal(data, &v); err == nil {
-			// Structured pass first: catches sensitive keys with non-string
-			// values. Re-marshal, then let the byte backstop scrub embedded
-			// free-form secrets in the (now-redacted) JSON.
-			if out, merr := json.Marshal(redactValue(v)); merr == nil {
+			// Structured pass: redact sensitive keys regardless of value type
+			// (number/object/array/bool), which the reKV byte regex — string
+			// values only — misses (review round-3 P0). redactValue returns a
+			// redacted DEEP COPY and reports whether it actually changed anything.
+			red, changed := redactValueMarked(v)
+			if !changed {
+				// Nothing sensitive in the structured view: DO NOT re-marshal —
+				// that would reshape the caller's JSON (compact it / reorder keys)
+				// and break shape-preserving callers like WriteJSON. Just run the
+				// byte backstop over the ORIGINAL bytes (catches free-form embedded
+				// secrets without touching layout).
+				return redactSensitive(data)
+			}
+			// Something was redacted, so the document already differs from the
+			// input. Re-marshal, preserving the caller's indentation when the
+			// input was pretty-printed, then run the byte backstop.
+			if out, merr := marshalLike(data, red); merr == nil {
 				return redactSensitive(out)
 			}
 		}
 	}
 	return redactSensitive(data)
+}
+
+// marshalLike marshals v to match the indentation style of the original bytes:
+// indented (2-space) when the original was pretty-printed, compact otherwise.
+// Key order is not preserved (encoding/json sorts map keys) — acceptable only on
+// the path where a redaction already changed the document.
+func marshalLike(original []byte, v any) ([]byte, error) {
+	if looksIndentedJSON(original) {
+		return json.MarshalIndent(v, "", "  ")
+	}
+	return json.Marshal(v)
+}
+
+// looksIndentedJSON reports whether the JSON body appears pretty-printed (a
+// newline followed by indentation after the opening brace/bracket). A cheap
+// heuristic sufficient to pick MarshalIndent vs Marshal for the redacted output.
+func looksIndentedJSON(b []byte) bool {
+	for i := range b {
+		switch b[i] {
+		case ' ', '\t', '\r':
+			continue
+		case '{', '[':
+			// Look past the opener for a newline before any non-space content.
+			for j := i + 1; j < len(b); j++ {
+				switch b[j] {
+				case ' ', '\t', '\r':
+					continue
+				case '\n':
+					return true
+				default:
+					return false
+				}
+			}
+			return false
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 // bytesTrimSpace is a tiny leading/trailing ASCII-space trim used only to peek at

--- a/cli/internal/cli/ux/redact.go
+++ b/cli/internal/cli/ux/redact.go
@@ -274,12 +274,54 @@ func redactSensitive(data []byte) []byte {
 func redactString(s string) string { return string(redactSensitive([]byte(s))) }
 
 // RedactBytes is the exported byte-level backstop for command code that emits a
-// raw upstream/API body (e.g. the `jentic api` passthrough, `execute --raw`)
-// rather than a marshaled envelope. It applies the SAME free-form-string scrub as
-// every other output path so a secret in an API response can't leak to a machine
-// parser. It does NOT reshape or re-marshal the payload — the body stays the
-// API's own JSON.
-func RedactBytes(data []byte) []byte { return redactSensitive(data) }
+// raw upstream/API body (e.g. the `jentic api` passthrough, `execute --raw`,
+// `inspect`, `apis spec`) rather than a marshaled envelope. It applies the SAME
+// redaction guarantee as every other output path so a secret in an API response
+// can't leak to a machine parser.
+//
+// When data is valid JSON it is parsed and run through the STRUCTURED key pass
+// (redactValue), which redacts a sensitive key regardless of its value's JSON
+// type — so a secret carried as a number, object, array, or bool is caught, not
+// just a `"key":"string"` pair (the reKV byte regex alone matched string values
+// only; review round-3 P0). The structured pass never reshapes non-sensitive
+// data: keys, ordering within objects is not guaranteed by encoding/json but the
+// document is semantically identical, and only sensitive subtrees change. The
+// byte backstop then still runs over the re-marshaled bytes to catch secrets
+// embedded in free-form string values (bearer tokens, PEM blocks) that carry no
+// sensitive key.
+//
+// When data is NOT valid JSON (e.g. a Markdown inspect body, a YAML spec, a
+// plain-text error) it falls back to the byte backstop alone — the same
+// behaviour as before — because there is no structure to walk.
+func RedactBytes(data []byte) []byte {
+	if trimmed := bytesTrimSpace(data); len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
+		var v any
+		if err := json.Unmarshal(data, &v); err == nil {
+			// Structured pass first: catches sensitive keys with non-string
+			// values. Re-marshal, then let the byte backstop scrub embedded
+			// free-form secrets in the (now-redacted) JSON.
+			if out, merr := json.Marshal(redactValue(v)); merr == nil {
+				return redactSensitive(out)
+			}
+		}
+	}
+	return redactSensitive(data)
+}
+
+// bytesTrimSpace is a tiny leading/trailing ASCII-space trim used only to peek at
+// the first non-space byte for the JSON sniff above (avoids pulling in bytes just
+// for TrimSpace and avoids allocating a trimmed copy of a large body).
+func bytesTrimSpace(b []byte) []byte {
+	i := 0
+	for i < len(b) && (b[i] == ' ' || b[i] == '\t' || b[i] == '\n' || b[i] == '\r') {
+		i++
+	}
+	j := len(b)
+	for j > i && (b[j-1] == ' ' || b[j-1] == '\t' || b[j-1] == '\n' || b[j-1] == '\r') {
+		j--
+	}
+	return b[i:j]
+}
 
 // safeMarshal / safeMarshalIndent are the single funnel every Render path uses.
 // They redact by struct tag (typed reflection), by field name (key heuristics),

--- a/cli/internal/cli/ux/redact_test.go
+++ b/cli/internal/cli/ux/redact_test.go
@@ -204,3 +204,86 @@ func TestRegisteredSensitiveNameRedactedInBytesAndValue(t *testing.T) {
 		t.Errorf("value pass over-redacted a non-sensitive field: %v", red)
 	}
 }
+
+// TestRedactBytesRedactsNonStringValues pins the round-3 P0 hardening: the byte
+// backstop's reKV regex matched `"key":"string"` pairs ONLY, so a secret carried
+// as a JSON number, object, array, or bool reached stdout untouched on the raw
+// path (execute --raw, inspect, apis spec, api passthrough). RedactBytes now
+// parses valid JSON and runs the structured key pass, which redacts a sensitive
+// key regardless of its value's JSON type.
+func TestRedactBytesRedactsNonStringValues(t *testing.T) {
+	cases := []struct {
+		name       string
+		body       string
+		mustGone   string // substring that must NOT survive
+		mustRedact string // json fragment that must appear
+	}{
+		{
+			name:       "number token",
+			body:       `{"token":1234567890,"page":2}`,
+			mustGone:   "1234567890",
+			mustRedact: `"token":"[REDACTED]"`,
+		},
+		{
+			name:       "object secret",
+			body:       `{"credentials":{"access_key":"AKIA123","region":"eu"},"ok":true}`,
+			mustGone:   "AKIA123",
+			mustRedact: `"credentials":"[REDACTED]"`,
+		},
+		{
+			name:       "array api_key",
+			body:       `{"api_key":["k1","k2"],"count":2}`,
+			mustGone:   "k1",
+			mustRedact: `"api_key":"[REDACTED]"`,
+		},
+		{
+			name:       "bool password",
+			body:       `{"password":false}`,
+			mustGone:   "false",
+			mustRedact: `"password":"[REDACTED]"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(RedactBytes([]byte(tc.body)))
+			if strings.Contains(got, tc.mustGone) {
+				t.Errorf("non-string secret leaked through RedactBytes: %s", got)
+			}
+			if !strings.Contains(got, tc.mustRedact) {
+				t.Errorf("expected %q in redacted output, got: %s", tc.mustRedact, got)
+			}
+		})
+	}
+}
+
+// TestRedactBytesPreservesNonSensitiveNonString ensures the structured pass does
+// NOT clobber legitimate non-string values on non-sensitive keys — a redactor
+// that corrupts pagination cursors/counts is as bad as one that leaks.
+func TestRedactBytesPreservesNonSensitiveNonString(t *testing.T) {
+	body := `{"next_token":"cursor-abc","count":42,"items":[{"id":1}],"ok":true}`
+	got := string(RedactBytes([]byte(body)))
+	// next_token is an allowlisted pagination cursor — must survive verbatim.
+	if !strings.Contains(got, `"next_token":"cursor-abc"`) {
+		t.Errorf("allowlisted next_token was clobbered: %s", got)
+	}
+	for _, want := range []string{`"count":42`, `"id":1`, `"ok":true`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("non-sensitive value corrupted, missing %q: %s", want, got)
+		}
+	}
+}
+
+// TestRedactBytesNonJSONFallsBackToByteBackstop ensures a non-JSON body (e.g. a
+// Markdown inspect body or a YAML spec) is still scrubbed by the byte backstop
+// and is not mangled by a failed JSON parse.
+func TestRedactBytesNonJSONFallsBackToByteBackstop(t *testing.T) {
+	// Markdown with an embedded bearer token in a code fence.
+	body := "# Operation\n\nAuthorization: Bearer sk-live-SECRET123\n\nSee docs."
+	got := string(RedactBytes([]byte(body)))
+	if strings.Contains(got, "sk-live-SECRET123") {
+		t.Errorf("bearer token leaked through non-JSON path: %s", got)
+	}
+	if !strings.Contains(got, "# Operation") {
+		t.Errorf("non-JSON body was mangled: %s", got)
+	}
+}

--- a/cli/internal/cli/ux/redact_test.go
+++ b/cli/internal/cli/ux/redact_test.go
@@ -273,6 +273,24 @@ func TestRedactBytesPreservesNonSensitiveNonString(t *testing.T) {
 	}
 }
 
+// TestRedactBytesPreservesShapeWhenNothingRedacted pins the WriteJSON contract
+// (regression from the round-3 P0): when a body has NOTHING sensitive, RedactBytes
+// must return it byte-for-byte (no re-marshal, no key reordering, no
+// re-indentation). WriteJSON feeds already-indented JSON through here and a golden
+// test asserts the exact bytes; re-marshaling would silently compact/reorder it.
+func TestRedactBytesPreservesShapeWhenNothingRedacted(t *testing.T) {
+	// Indented, deliberately NON-alphabetical key order.
+	indented := "{\n  \"b\": \"2\",\n  \"a\": \"1\"\n}\n"
+	if got := string(RedactBytes([]byte(indented))); got != indented {
+		t.Errorf("indented non-sensitive JSON reshaped:\ngot  %q\nwant %q", got, indented)
+	}
+	// Compact form must likewise pass through untouched.
+	compact := `{"b":"2","a":"1"}`
+	if got := string(RedactBytes([]byte(compact))); got != compact {
+		t.Errorf("compact non-sensitive JSON reshaped:\ngot  %q\nwant %q", got, compact)
+	}
+}
+
 // TestRedactBytesNonJSONFallsBackToByteBackstop ensures a non-JSON body (e.g. a
 // Markdown inspect body or a YAML spec) is still scrubbed by the byte backstop
 // and is not mangled by a failed JSON parse.

--- a/cli/internal/update/download.go
+++ b/cli/internal/update/download.go
@@ -15,6 +15,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/jentic/jentic-one/cli/client"
 )
 
 // cosignCertIdentityRegexp / cosignOIDCIssuer pin the keyless-signing identity
@@ -52,7 +54,11 @@ func httpGet(ctx context.Context, url, token string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("download %s: unexpected status %s", url, resp.Status)
 	}
-	return io.ReadAll(resp.Body)
+	// Bound the read: checksums.txt / .sig / .pem are small metadata files, but a
+	// hostile or misconfigured origin must not be able to stream an unbounded body
+	// into RAM (review round-3 P0 / theme 2). The archive itself is streamed to
+	// disk with its own larger io.Copy limit; this path only buffers metadata.
+	return client.ReadAllBounded(resp.Body, client.MaxBodyBytes)
 }
 
 // verifyError marks a FAIL-CLOSED verification failure (checksum mismatch,

--- a/cli/tests/arch/redaction_funnel_test.go
+++ b/cli/tests/arch/redaction_funnel_test.go
@@ -1,0 +1,193 @@
+package arch
+
+import (
+	"go/ast"
+	"go/types"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// redactionFunnels are the ux helpers that guarantee a []byte has passed the
+// fail-closed redaction funnel before it hits a data-plane writer. A raw
+// upstream/API body written to App.Out/App.Err MUST come from one of these (or
+// via the Audience Render path, which never writes a bare body). Keeping this
+// list in the arch test — rather than a runtime constant — is deliberate: it is
+// the *contract* the gate enforces, and adding a new funnel is a conscious edit
+// reviewed alongside this rule.
+var redactionFunnels = map[string]bool{
+	"RedactBytes":    true, // byte backstop for raw upstream bodies (inspect, spec, execute --raw, api passthrough)
+	"MarshalForFile": true, // redacted+indented marshal for file destinations
+	"WriteJSONLine":  true, // streaming NDJSON primitive (writes to an io.Writer itself)
+}
+
+// rawWriteAllowlist names byte-writer call sites in the data-plane command
+// package that are exempt because they do NOT emit an upstream/API body — e.g. a
+// writer wired for a test, or a locally-constructed non-secret byte slice. Each
+// entry is "<relfile>:<line>" and must carry a justification in review. It is
+// empty today: every real body writer routes through a funnel. An unexplained
+// addition here is itself a review signal.
+var rawWriteAllowlist = map[string]bool{}
+
+// Test1I_RedactionFunnel closes the class of bug reviewer #5 found in round 3:
+// `jentic inspect` wrote the upstream body with `fmt.Fprintln(a.Out, string(body))`
+// — zero redaction — bypassing both the naked-print gate (it writes to a.Out, not
+// os.Stdout) and the x-sensitive sweep (which checks annotations, not write
+// sites). The fix routed inspect/apis-inspect/apis-spec through ux.RedactBytes;
+// this gate makes the *class* impossible to reintroduce.
+//
+// Rule: in internal/cli/api, every `<w>.Write(x)` where <w> is App.Out/App.Err
+// (i.e. `a.Out` / `a.Err`) must have x be — directly, or via a local variable
+// assigned in the same function — a call to one of redactionFunnels. A bare body
+// identifier (the old inspect shape) fails. Styled human text goes through
+// fmt.Fprintln (governed by Test1B), not .Write, so it is out of scope here.
+func Test1I_RedactionFunnel(t *testing.T) {
+	pkgs := loadCLI(t)
+
+	sawWrite := false
+	offenders := map[string]string{}
+
+	forEachFile(pkgs, func(pkgPath string) bool {
+		return underPrefixes(pkgPath, "internal/cli/api")
+	}, func(p *packages.Package, file *ast.File, path string) {
+		relFile := rel(p.PkgPath) + "/" + baseName(path)
+
+		// Walk each function so "assigned from a funnel" is scoped correctly: a
+		// funnel result in one function must not launder a raw write in another.
+		ast.Inspect(file, func(n ast.Node) bool {
+			fn, ok := n.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				return true
+			}
+			funnelVars := collectFunnelVars(p.TypesInfo, fn.Body)
+			ast.Inspect(fn.Body, func(m ast.Node) bool {
+				call, ok := m.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "Write" || len(call.Args) != 1 {
+					return true
+				}
+				if !isOutOrErrWriter(p.TypesInfo, sel.X) {
+					return true
+				}
+				sawWrite = true
+				line := p.Fset.Position(call.Pos()).Line
+				key := relFile + ":" + itoa(line)
+				if rawWriteAllowlist[key] {
+					return true
+				}
+				if writeArgIsRedacted(call.Args[0], funnelVars) {
+					return true
+				}
+				offenders[key] = "raw byte write to App.Out/App.Err not funneled through ux.RedactBytes/MarshalForFile"
+				return true
+			})
+			return true
+		})
+	})
+
+	for site, why := range offenders {
+		t.Errorf("un-redacted data-plane body write at %s: %s — an upstream/API body "+
+			"must go through ux.RedactBytes (or MarshalForFile), like execute/inspect do. "+
+			"If this writer emits no secret-bearing body, add it to rawWriteAllowlist with a justification.", site, why)
+	}
+	if !sawWrite {
+		t.Fatal("no App.Out/App.Err .Write() call found in internal/cli/api — the redaction-funnel " +
+			"gate must not pass vacuously (did the writer shape or package layout change?)")
+	}
+}
+
+// collectFunnelVars returns the set of local variable NAMES in body that were
+// assigned (via := or =) the single result of a redactionFunnels call, e.g.
+// `redacted := ux.RedactBytes(body)`. Names are a coarse but safe key: a later
+// reassignment of the same name to a non-funnel value would be a bug the gate
+// intentionally does not try to model (it is not a pattern we use), and shadowing
+// across scopes only ever makes the gate stricter, never laxer.
+func collectFunnelVars(info *types.Info, body *ast.BlockStmt) map[string]bool {
+	vars := map[string]bool{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Rhs) != 1 || len(assign.Lhs) != 1 {
+			return true
+		}
+		if !callIsFunnel(info, assign.Rhs[0]) {
+			return true
+		}
+		if id, ok := assign.Lhs[0].(*ast.Ident); ok {
+			vars[id.Name] = true
+		}
+		return true
+	})
+	return vars
+}
+
+// writeArgIsRedacted reports whether the argument to a .Write() call is trusted:
+// a direct funnel call, or an identifier previously bound to a funnel result.
+func writeArgIsRedacted(arg ast.Expr, funnelVars map[string]bool) bool {
+	if call, ok := arg.(*ast.CallExpr); ok {
+		return callIsFunnelName(call)
+	}
+	if id, ok := arg.(*ast.Ident); ok {
+		return funnelVars[id.Name]
+	}
+	return false
+}
+
+// callIsFunnel reports whether expr is a call to one of the redaction funnels,
+// verifying the selector base is the ux package (not a shadowing local) via type
+// info when available.
+func callIsFunnel(info *types.Info, expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || !redactionFunnels[sel.Sel.Name] {
+		return false
+	}
+	if ident, ok := sel.X.(*ast.Ident); ok {
+		return identIsPackage(info, ident)
+	}
+	return false
+}
+
+// callIsFunnelName is the type-info-free form used at the write site (the
+// selector base is checked by callIsFunnel when collecting vars; at the write
+// site a direct funnel call is accepted on name match).
+func callIsFunnelName(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	return redactionFunnels[sel.Sel.Name]
+}
+
+// isOutOrErrWriter reports whether the receiver of a .Write() call is App.Out or
+// App.Err (i.e. `a.Out` / `a.Err`), the two data-plane byte sinks. We match on
+// the field selector name (Out/Err) off any receiver so it holds regardless of
+// the App receiver's local name.
+func isOutOrErrWriter(_ *types.Info, x ast.Expr) bool {
+	sel, ok := x.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	return sel.Sel.Name == "Out" || sel.Sel.Name == "Err"
+}
+
+// itoa is a tiny int->string without importing strconv into the arch package's
+// otherwise-parser-only surface (keeps the guardrail deps minimal).
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}


### PR DESCRIPTION
## Summary

Implements the two **P0** items from the [round-3 CLI review](https://github.com/jentic/jentic-one-plans/pull/22) (`cli-review3-index-2026-08-17.md`). Both are hardening fixes — everything is fail-closed today, but the guarantees were **incomplete**. Targets `cli-v2-release` (not `main`).

### P0a — redaction completeness (theme 1)
- **`jentic inspect` leaked the upstream body with zero redaction** (`inspect.go` wrote `fmt.Fprintln(a.Out, string(body))`). Now routed through `ux.RedactBytes` — as are `apis inspect` and `apis spec` (both the stdout path **and** the `-o <file>` write, which previously bypassed redaction entirely).
- **Hardened `ux.RedactBytes`** to walk JSON values: when the body is valid JSON it runs the structured key pass (`redactValue`), which redacts a sensitive key regardless of its value's JSON type. The `reKV` byte regex matched `"key":"string"` pairs **only**, so a secret carried as a JSON number/object/array/bool reached stdout on the raw path (`execute --raw`, `inspect`, `apis spec`, `api` passthrough). Non-JSON bodies (Markdown/YAML) still fall back to the byte backstop unchanged.
- **New arch gate `Test1I_RedactionFunnel`**: every `App.Out`/`App.Err` `.Write(x)` in `internal/cli/api` must funnel `x` through `ux.RedactBytes`/`MarshalForFile` (directly, or via a local assigned from one). This closes the **class**, not just the instance — the `x-sensitive` sweep (`Test1H`) checks annotations, not write sites, so it never caught this. Verified non-vacuous (fires on a bare `a.Out.Write(body)`).

### P0b — bounded body reads (theme 2)
- Added **`client.ReadAllBounded` / `MaxBodyBytes` (64 MiB) / `ErrBodyTooLarge`** — one fail-closed funnel for "read the whole body into a `[]byte`".
- Wired into the three unbounded `io.ReadAll` sites three independent reviewers flagged:
  - SDK retry request-body buffering (`client/transport.go`)
  - execute response bodies (`execute_print.go`) — the `--raw` comment **falsely claimed a broker-transport cap that never existed**; comment fixed
  - release-metadata downloads (`internal/update/download.go`)
  - (the archive-to-disk `io.Copy` already had its own larger 256 MiB limit)

## Test plan
- [x] `go build ./...`, `go vet` (touched pkgs) — clean
- [x] `make lint` (golangci-lint) — 0 issues
- [x] `go test ./tests/arch/...` — all gates green incl. new `Test1I` (proven non-vacuous)
- [x] `go test ./client/... ./internal/cli/api/... ./internal/cli/ux/... ./internal/update/...` — green
- [x] New units: non-string `RedactBytes` (number/object/array/bool) + preserves non-sensitive values + non-JSON fallback; `inspect` end-to-end redaction (incl. numeric secret); `ReadAllBounded` under/at/over limit, non-positive default, error propagation, unbounded-reader refusal
- [ ] CI green on this branch

## Not in scope
Remaining round-3 findings (P1 config race/collision, local-update SQLite safety, atomic credential writes, agent-mode timeouts; P2 broker-guard edges, phantom `NewBroker`, test coverage) — tracked in the review index for follow-up.

Made with [Cursor](https://cursor.com)