### PR TITLE
cli(v2): review round-3 P1s — config TOCTOU, register collision, SQLite/WAL safety, atomic creds, agent timeout

### DIFF
--- a/cli/client/auth/apikey.go
+++ b/cli/client/auth/apikey.go
@@ -47,7 +47,7 @@ func SaveAPIKey(ref IdentityRef, key string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(path, []byte(key), 0o600); err != nil {
+	if err := writeFileAtomic(path, []byte(key)); err != nil {
 		return fmt.Errorf("writing API key %s: %w", path, err)
 	}
 	return nil

--- a/cli/client/auth/atomic.go
+++ b/cli/client/auth/atomic.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// writeFileAtomic writes data to path via a temp file in the SAME directory,
+// fsync'd, then renamed into place — so a crash / ENOSPC between truncate and
+// write can never leave a partial or empty credential file (F6, review round-3
+// #7). `cli-conventions` §"State directory (XDG)" requires token/secret/key
+// files be "0600, written atomically"; the plain os.WriteFile these callers used
+// is O_TRUNC-then-write, which is not atomic. All credential files share the
+// 0600 mode, so it is fixed here rather than a parameter.
+//
+// It deliberately keeps the callers' existing no-lock, last-writer-wins
+// concurrency semantics (rename is atomic on POSIX and Windows-for-same-volume):
+// two concurrent writers still race, but neither can observe a torn file — the
+// loser's rename simply wins or loses wholesale. The temp file is created in the
+// destination directory (not $TMPDIR) so the rename stays on one filesystem.
+func writeFileAtomic(path string, data []byte) error {
+	const perm os.FileMode = 0o600
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file in %s: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we bail before the rename; a successful rename makes
+	// this a no-op (the temp name no longer exists).
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	// fsync the data before the rename so the rename can't land ahead of the
+	// bytes on a crash (the config writer's sibling gap this closes too).
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename temp file into place: %w", err)
+	}
+	return nil
+}

--- a/cli/client/auth/atomic_test.go
+++ b/cli/client/auth/atomic_test.go
@@ -1,0 +1,83 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileAtomic_WritesContentAndPerm(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.key")
+	if err := writeFileAtomic(path, []byte("PRIVATE")); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "PRIVATE" {
+		t.Errorf("content = %q, want PRIVATE", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("perm = %o, want 600", perm)
+	}
+}
+
+func TestWriteFileAtomic_OverwritesInPlace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tokens.json")
+	if err := os.WriteFile(path, []byte("OLD"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFileAtomic(path, []byte("NEW-CONTENT")); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "NEW-CONTENT" {
+		t.Errorf("content = %q, want NEW-CONTENT", got)
+	}
+}
+
+// TestWriteFileAtomic_LeavesNoTempOnSuccess ensures the temp file is renamed (not
+// left as a sibling) — the whole point of the atomic write is a clean directory
+// with exactly the target file.
+func TestWriteFileAtomic_LeavesNoTempOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cred.apikey")
+	if err := writeFileAtomic(path, []byte("k")); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "cred.apikey" {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected exactly [cred.apikey] in dir, got %v", names)
+	}
+}
+
+// TestWriteFileAtomic_NoPartialFileOnEmptyWrite guards the core invariant: even a
+// zero-length payload results in a valid (empty) file, never a missing/torn one.
+func TestWriteFileAtomic_ZeroLengthWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty")
+	if err := writeFileAtomic(path, nil); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("file should exist: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Errorf("size = %d, want 0", info.Size())
+	}
+}

--- a/cli/client/auth/keys.go
+++ b/cli/client/auth/keys.go
@@ -137,7 +137,7 @@ func GetOrGenerateKey(ref IdentityRef) (ed25519.PrivateKey, error) {
 		return nil, fmt.Errorf("marshaling key: %w", err)
 	}
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
-	if err := os.WriteFile(keyPath, pemBytes, 0o600); err != nil {
+	if err := writeFileAtomic(keyPath, pemBytes); err != nil {
 		return nil, fmt.Errorf("writing key %s: %w", keyPath, err)
 	}
 	return priv, nil

--- a/cli/client/auth/tokens.go
+++ b/cli/client/auth/tokens.go
@@ -93,7 +93,7 @@ func SaveTokens(ref IdentityRef, tokens *TokenSet) error {
 	if err != nil {
 		return fmt.Errorf("encoding token state: %w", err)
 	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	if err := writeFileAtomic(path, data); err != nil {
 		return fmt.Errorf("writing token state %s: %w", path, err)
 	}
 	return nil

--- a/cli/client/limits.go
+++ b/cli/client/limits.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+// MaxBodyBytes is the ceiling every whole-body read in the CLI/SDK is clamped to.
+// 64 MiB comfortably covers any legitimate API request/response, OpenAPI spec, or
+// release-metadata file we buffer into RAM, while denying a hostile or buggy peer
+// the ability to exhaust memory by streaming an unbounded body (review round-3
+// P0 / theme 2: unbounded io.ReadAll is systemic). Streaming-to-disk paths (the
+// release archive download) keep their own, larger io.Copy limit — this cap is
+// specifically for "read the whole thing into a []byte" call sites.
+const MaxBodyBytes int64 = 64 << 20
+
+// ErrBodyTooLarge is returned by ReadAllBounded when the source produces more
+// than the allowed number of bytes. It is a sentinel so callers can distinguish
+// a size refusal from an ordinary transport error with errors.Is.
+var ErrBodyTooLarge = errors.New("response body exceeds maximum allowed size")
+
+// ReadAllBounded reads from r into memory like io.ReadAll but refuses to buffer
+// more than limit bytes, returning ErrBodyTooLarge instead of growing without
+// bound. It is the single funnel every "read the whole body into a []byte" site
+// (SDK request buffering for retries, execute response bodies, raw upstream
+// bodies, release-metadata downloads) goes through so no single peer can OOM the
+// process.
+//
+// The implementation reads limit+1 bytes: if the source had EXACTLY limit bytes
+// we return them; if it had more, the extra byte trips the ceiling and we fail
+// closed. A non-positive limit is treated as MaxBodyBytes so a caller can never
+// accidentally disable the cap by passing 0.
+func ReadAllBounded(r io.Reader, limit int64) ([]byte, error) {
+	if limit <= 0 {
+		limit = MaxBodyBytes
+	}
+	// LimitReader to limit+1 so we can detect overflow: reading the (limit+1)th
+	// byte means the body was too large.
+	limited := io.LimitReader(r, limit+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return data, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("%w (limit %d bytes)", ErrBodyTooLarge, limit)
+	}
+	return data, nil
+}

--- a/cli/client/limits_test.go
+++ b/cli/client/limits_test.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestReadAllBounded_UnderLimit(t *testing.T) {
+	src := []byte("hello world")
+	got, err := ReadAllBounded(bytes.NewReader(src), 1024)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Errorf("got %q, want %q", got, src)
+	}
+}
+
+func TestReadAllBounded_ExactlyAtLimit(t *testing.T) {
+	src := bytes.Repeat([]byte("a"), 100)
+	got, err := ReadAllBounded(bytes.NewReader(src), 100)
+	if err != nil {
+		t.Fatalf("a body of exactly max bytes must be accepted, got error: %v", err)
+	}
+	if len(got) != 100 {
+		t.Errorf("got %d bytes, want 100", len(got))
+	}
+}
+
+func TestReadAllBounded_OverLimitFailsClosed(t *testing.T) {
+	src := bytes.Repeat([]byte("a"), 101)
+	got, err := ReadAllBounded(bytes.NewReader(src), 100)
+	if err == nil {
+		t.Fatal("expected ErrBodyTooLarge for a body over the limit, got nil")
+	}
+	if !errors.Is(err, ErrBodyTooLarge) {
+		t.Errorf("error should be ErrBodyTooLarge, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("no bytes should be returned on overflow, got %d", len(got))
+	}
+}
+
+// TestReadAllBounded_NonPositiveMaxUsesDefault ensures a caller can never
+// accidentally disable the cap by passing 0 (or a negative) — it clamps to
+// MaxBodyBytes instead of reading without bound.
+func TestReadAllBounded_NonPositiveMaxUsesDefault(t *testing.T) {
+	src := []byte("small")
+	got, err := ReadAllBounded(bytes.NewReader(src), 0)
+	if err != nil {
+		t.Fatalf("unexpected error with max=0: %v", err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Errorf("got %q, want %q", got, src)
+	}
+}
+
+// errReader returns an error partway through to confirm ReadAllBounded surfaces
+// underlying transport errors (not just size refusals).
+type errReader struct{ msg string }
+
+func (e errReader) Read([]byte) (int, error) { return 0, errors.New(e.msg) }
+
+func TestReadAllBounded_PropagatesReadError(t *testing.T) {
+	_, err := ReadAllBounded(errReader{msg: "boom"}, 100)
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected underlying read error to propagate, got %v", err)
+	}
+	if errors.Is(err, ErrBodyTooLarge) {
+		t.Errorf("a transport error must not be classified as ErrBodyTooLarge: %v", err)
+	}
+}
+
+// TestReadAllBounded_DefaultCeilingRefusesHugeBody exercises the real MaxBodyBytes
+// ceiling with a reader that would produce more than 64 MiB, without allocating
+// it: an infinite reader is clamped and refused.
+func TestReadAllBounded_DefaultCeilingRefusesHugeBody(t *testing.T) {
+	// io.LimitReader inside ReadAllBounded reads at most MaxBodyBytes+1, so this
+	// allocates ~64 MiB transiently then fails closed — acceptable for one test.
+	_, err := ReadAllBounded(neverEndingReader{}, MaxBodyBytes)
+	if !errors.Is(err, ErrBodyTooLarge) {
+		t.Errorf("an unbounded body must be refused with ErrBodyTooLarge, got %v", err)
+	}
+}
+
+// neverEndingReader yields zero bytes forever (never EOF), modelling a hostile
+// peer that streams without end.
+type neverEndingReader struct{}
+
+func (neverEndingReader) Read(p []byte) (int, error) { return len(p), nil }
+
+var _ io.Reader = neverEndingReader{}

--- a/cli/client/transport.go
+++ b/cli/client/transport.go
@@ -158,7 +158,10 @@ func bufferBody(req *http.Request) (buf []byte, canRewind bool, err error) {
 	if req.Body == nil || req.Body == http.NoBody {
 		return nil, true, nil
 	}
-	data, err := io.ReadAll(req.Body)
+	// Bound the buffer: a retry needs the whole body in RAM, but an unbounded
+	// ReadAll lets a huge/hostile request body OOM the process (review round-3
+	// P0 / theme 2). MaxBodyBytes covers any legitimate request.
+	data, err := ReadAllBounded(req.Body, MaxBodyBytes)
 	_ = req.Body.Close()
 	if err != nil {
 		return nil, false, err

--- a/cli/internal/cli/api/apis.go
+++ b/cli/internal/cli/api/apis.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/x/term"
 	"github.com/jentic/jentic-one/cli/internal/cli/cmdcore"
 	"github.com/jentic/jentic-one/cli/internal/cli/prompt"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
 	"github.com/jentic/jentic-one/cli/internal/theme"
 	"github.com/spf13/cobra"
 )
@@ -430,7 +431,8 @@ func (a *app) apisInspect(ctx context.Context, o *apisInspectOptions, operationI
 		}
 		return err
 	}
-	out := strings.TrimRight(string(body), "\n")
+	// SEC (review round-3 P0): same redaction funnel as `jentic inspect`.
+	out := strings.TrimRight(string(ux.RedactBytes(body)), "\n")
 	fmt.Fprintln(a.Out, out)
 	return nil
 }
@@ -537,18 +539,25 @@ func (a *app) apisSpec(ctx context.Context, o *apisSpecOptions, ref string) erro
 	if err != nil {
 		return apiNotFoundErr(err, ref)
 	}
+	// SEC (review round-3 P0): a spec can carry example auth blocks / secrets in
+	// securitySchemes or examples — run it through the same redaction funnel
+	// (inline at each write site so the redaction arch gate can see it) whether
+	// the spec goes to a file or stdout.
 	if o.out != "" {
-		if err := os.WriteFile(o.out, body, 0o600); err != nil {
+		if err := os.WriteFile(o.out, ux.RedactBytes(body), 0o600); err != nil {
 			return fmt.Errorf("write %s: %w", o.out, err)
 		}
 		fmt.Fprintln(a.Out, theme.Successf("Wrote %s spec to %s", ref, o.out))
 		return nil
 	}
-	_, err = a.Out.Write(body)
-	if err == nil && len(body) > 0 && body[len(body)-1] != '\n' {
+	redacted := ux.RedactBytes(body)
+	if _, err = a.Out.Write(redacted); err != nil {
+		return err
+	}
+	if len(redacted) > 0 && redacted[len(redacted)-1] != '\n' {
 		fmt.Fprintln(a.Out)
 	}
-	return err
+	return nil
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/cli/internal/cli/api/context.go
+++ b/cli/internal/cli/api/context.go
@@ -361,8 +361,10 @@ func newContextDeleteCmd(_ *app) *cobra.Command {
 			if err != nil {
 				return reportCoded(aud, err)
 			}
-			target, ok := cfg.Contexts[name]
-			if !ok {
+			// Fast-fail preflight on the unlocked snapshot for good UX (don't prompt
+			// to delete something that doesn't exist / is active). This is advisory;
+			// the AUTHORITATIVE check runs inside the lock below (F1).
+			if _, ok := cfg.Contexts[name]; !ok {
 				return reportCoded(aud, &ux.CodedError{
 					Code: ux.CodeResolveFailed,
 					Msg:  fmt.Sprintf("context %q does not exist", name),
@@ -384,22 +386,44 @@ func newContextDeleteCmd(_ *app) *cobra.Command {
 				return nil
 			}
 
-			// If --identity may GC the referenced identity, capture its orphan-able
-			// secret refs BEFORE the mutate removes it (F8-34). We only purge if the
-			// identity is actually removed below.
+			// Capture the identity that MIGHT be GC'd (with --identity) so we can
+			// purge its orphaned secret files after a successful mutate. Whether it
+			// is actually removed is decided INSIDE the lock, after the context is
+			// deleted, against the mutator's own cfg — see below.
 			var purgeIdentity string
 			var toPurge []auth.IdentityRef
-			if withIdentity && target.Identity != "" && !identityStillReferenced(cfg, target.Identity) {
-				purgeIdentity = target.Identity
-				toPurge = identityMaterialRefs(cfg, target.Identity)
-			}
 
 			if err := config.MutateConfig(func(cfg *config.Config) error {
+				// Re-validate INSIDE the lock (F1, review round-3 #4): existence and
+				// active-context status were checked on an unlocked snapshot before a
+				// confirmation prompt that can block indefinitely. Re-check against
+				// the mutator's fresh cfg so a concurrent `context use`/`context
+				// rename`/delete can't make us delete the (now-)active context or a
+				// context that already vanished.
+				target, ok := cfg.Contexts[name]
+				if !ok {
+					return &ux.CodedError{
+						Code: ux.CodeResolveFailed,
+						Msg:  fmt.Sprintf("context %q does not exist", name),
+					}
+				}
+				if cfg.ActiveContext == name {
+					return &ux.CodedError{
+						Code:       ux.CodeMissingArgument,
+						Msg:        fmt.Sprintf("cannot delete the active context %q", name),
+						Actionable: "Switch to another context first with `jentic context use <other>`.",
+					}
+				}
 				delete(cfg.Contexts, name)
-				// --identity: GC the referenced identity iff no other context
-				// still uses it (never implicit — identities/envs are not
-				// garbage-collected without the flag, impl/1.3 §4a).
+				// --identity: GC the referenced identity iff NO OTHER context still
+				// uses it (never implicit — identities/envs are not garbage-collected
+				// without the flag, impl/1.3 §4a). The check runs AFTER the delete so
+				// identityStillReferenced reflects the remaining contexts, and against
+				// the mutator's cfg (not a stale outer snapshot) so a concurrently
+				// created context that binds the identity keeps it alive.
 				if withIdentity && target.Identity != "" && !identityStillReferenced(cfg, target.Identity) {
+					purgeIdentity = target.Identity
+					toPurge = identityMaterialRefs(cfg, target.Identity)
 					delete(cfg.Identities, target.Identity)
 				}
 				return nil

--- a/cli/internal/cli/api/context_cmd_test.go
+++ b/cli/internal/cli/api/context_cmd_test.go
@@ -94,6 +94,63 @@ func TestEnvDelete_RefusesWhenReferenced(t *testing.T) {
 	}
 }
 
+// TestEnvDelete_SucceedsWhenUnreferenced confirms the F1 fix (re-checking
+// existence/references INSIDE the MutateConfig lock) doesn't break the happy
+// path: an env no context points at deletes cleanly.
+func TestEnvDelete_SucceedsWhenUnreferenced(t *testing.T) {
+	withXDG(t)
+	if err := runJentic(t, "env", "add", "prod", "--url", "https://api.example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runJentic(t, "env", "add", "spare", "--url", "https://spare.example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runJentic(t, "env", "delete", "spare", "--yes"); err != nil {
+		t.Fatalf("env delete of an unreferenced env should succeed: %v", err)
+	}
+	cfg, _ := sdkconfig.Load()
+	if _, ok := cfg.Environments["spare"]; ok {
+		t.Error("spare env should be deleted")
+	}
+	if _, ok := cfg.Environments["prod"]; !ok {
+		t.Error("prod env must be untouched")
+	}
+}
+
+// TestContextDeleteWithIdentity_GCsUnreferencedIdentity pins the F1 fix for the
+// --identity GC path: the "is this identity still referenced?" check now runs
+// INSIDE the lock, AFTER the context is deleted, against the mutator's own cfg.
+// So deleting the last context that binds an identity garbage-collects it, while
+// an identity still bound by another context is preserved.
+func TestContextDeleteWithIdentity_GCsUnreferencedIdentity(t *testing.T) {
+	withXDG(t)
+	seedContext(t) // env prod, identity ci, active context main(prod, ci)
+
+	// Add a second context on a different identity so we can switch off "main"
+	// (can't delete the active context).
+	if err := runJentic(t, "identity", "add", "ci2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runJentic(t, "context", "create", "other", "--env", "prod", "--identity", "ci2", "--use"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Deleting "main" with --identity should GC "ci" (no other context binds it).
+	if err := runJentic(t, "context", "delete", "main", "--identity", "--yes"); err != nil {
+		t.Fatalf("context delete --identity: %v", err)
+	}
+	cfg, _ := sdkconfig.Load()
+	if _, ok := cfg.Contexts["main"]; ok {
+		t.Error("context main should be deleted")
+	}
+	if _, ok := cfg.Identities["ci"]; ok {
+		t.Error("identity ci should be garbage-collected (no context references it after delete)")
+	}
+	if _, ok := cfg.Identities["ci2"]; !ok {
+		t.Error("identity ci2 must be preserved (still bound by context other)")
+	}
+}
+
 func TestIdentityAdd_WritesIdentityAndAPIKey(t *testing.T) {
 	withXDG(t)
 	if err := runJentic(t, "env", "add", "prod", "--url", "https://a"); err != nil {

--- a/cli/internal/cli/api/delete_cmd.go
+++ b/cli/internal/cli/api/delete_cmd.go
@@ -79,6 +79,27 @@ func newResourceDeleteCmd(spec deleteSpec) *cobra.Command {
 			}
 
 			if err := sdkconfig.MutateConfig(func(cfg *sdkconfig.Config) error {
+				// Re-validate existence AND references INSIDE the lock (F1, review
+				// round-3 #4): the checks above ran on an unlocked snapshot, and the
+				// confirmation prompt can block for a long time. A concurrent
+				// `context create` binding this env/identity — or another delete of
+				// the same name — could have changed the world since. Re-checking
+				// here, against the mutator's own freshly-loaded cfg, closes the
+				// TOCTOU that could otherwise strand a live context on a just-deleted
+				// env/identity.
+				if !spec.exists(cfg, name) {
+					return &ux.CodedError{
+						Code: ux.CodeResolveFailed,
+						Msg:  fmt.Sprintf("%s %q does not exist", spec.resource, name),
+					}
+				}
+				if refs := spec.references(cfg, name); len(refs) > 0 {
+					return &ux.CodedError{
+						Code:       ux.CodeMissingArgument,
+						Msg:        fmt.Sprintf("%s %q is still referenced by context(s): %v", spec.resource, name, refs),
+						Actionable: "Delete or re-point those contexts first.",
+					}
+				}
 				spec.remove(cfg, name)
 				return nil
 			}); err != nil {

--- a/cli/internal/cli/api/execute_print.go
+++ b/cli/internal/cli/api/execute_print.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -13,15 +12,19 @@ import (
 	"github.com/jentic/jentic-one/cli/internal/cli/ux"
 	"github.com/jentic/jentic-one/cli/internal/theme"
 	"github.com/spf13/cobra"
+
+	sdkclient "github.com/jentic/jentic-one/cli/client"
 )
 
 func (a *app) executeOutput(cmd *cobra.Command, opts *executeOptions, resp *http.Response) error {
 	if opts.raw {
-		// Read (bounded by the broker transport's cap) then redact before
-		// streaming, so --raw matches the redaction guarantee of the JSON and
-		// `jentic api` paths (SEC-2). A secret in an upstream body must not leak
-		// just because the caller asked for raw output.
-		body, err := io.ReadAll(resp.Body)
+		// Read the body bounded (review round-3 P0 / theme 2: the old comment
+		// claimed a broker-transport cap that does not exist — the response read
+		// was unbounded), then redact before streaming, so --raw matches the
+		// redaction guarantee of the JSON and `jentic api` paths (SEC-2). A secret
+		// in an upstream body must not leak just because the caller asked for raw
+		// output.
+		body, err := sdkclient.ReadAllBounded(resp.Body, sdkclient.MaxBodyBytes)
 		if err != nil {
 			return fmt.Errorf("read response: %w", err)
 		}
@@ -34,7 +37,7 @@ func (a *app) executeOutput(cmd *cobra.Command, opts *executeOptions, resp *http
 		return nil
 	}
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := sdkclient.ReadAllBounded(resp.Body, sdkclient.MaxBodyBytes)
 	if err != nil {
 		return fmt.Errorf("read response: %w", err)
 	}

--- a/cli/internal/cli/api/inspect.go
+++ b/cli/internal/cli/api/inspect.go
@@ -87,7 +87,11 @@ func (a *app) inspectE(cmd *cobra.Command, opts *inspectOptions, operationID str
 		return err
 	}
 
-	out := strings.TrimRight(string(body), "\n")
+	// SEC (review round-3 P0): redact before writing the upstream body. inspect
+	// emits the API's own contract (JSON/Markdown/OpenAPI), which can carry
+	// example secrets or auth blocks — it must match the redaction guarantee of
+	// execute/api, not leak just because the output is a raw body.
+	out := strings.TrimRight(string(ux.RedactBytes(body)), "\n")
 	fmt.Fprintln(a.Out, out)
 	return nil
 }

--- a/cli/internal/cli/api/inspect_test.go
+++ b/cli/internal/cli/api/inspect_test.go
@@ -118,6 +118,47 @@ func TestInspectCmdNotFoundExitsCode2(t *testing.T) {
 	}
 }
 
+// TestInspectCmdRedactsUpstreamBody is the round-3 P0 regression guard: inspect
+// used to write the upstream contract body with zero redaction (a raw
+// fmt.Fprintln(a.Out, string(body))), so a secret in the returned schema/example
+// leaked straight to stdout. It now routes through ux.RedactBytes — including the
+// hardened structured pass that catches a secret carried as a NON-string JSON
+// value.
+func TestInspectCmdRedactsUpstreamBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// A contrived contract that embeds secrets in an example block: one as a
+		// string value, one as a numeric value (the old regex-only backstop missed
+		// the number).
+		_, _ = w.Write([]byte(`{"method":"POST","path":"/login","example":{"api_key":"sk-LEAKED-STRING","token":9876543210}}`))
+	}))
+	defer srv.Close()
+
+	app := testApp(t)
+	seedRegistered(t, app, "default", srv.URL)
+
+	out := new(bytes.Buffer)
+	app.Out = out
+	root := newAPIRootCmd(app.App)
+	root.SetOut(out)
+	root.SetErr(new(bytes.Buffer))
+	root.SetArgs([]string{"inspect", "login", "--json"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	got := out.String()
+	if strings.Contains(got, "sk-LEAKED-STRING") {
+		t.Errorf("string secret leaked from inspect output: %s", got)
+	}
+	if strings.Contains(got, "9876543210") {
+		t.Errorf("numeric secret leaked from inspect output (structured pass gap): %s", got)
+	}
+	// Non-secret structure survives.
+	if !strings.Contains(got, `"method":"POST"`) {
+		t.Errorf("inspect over-redacted / mangled the body: %s", got)
+	}
+}
+
 func TestInspectCmdRevisionParam(t *testing.T) {
 	var gotRevision string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/internal/cli/api/register_test.go
+++ b/cli/internal/cli/api/register_test.go
@@ -239,6 +239,72 @@ func TestRegister_TwoAgentsSameEnv_DistinctContexts(t *testing.T) {
 	}
 }
 
+// TestRegister_ContextNameCollisionRefusedWithoutForce pins F2 (round-3 #4):
+// SanitizeName(env + "-" + name) is many-to-one (it clamps to 64 chars), so two
+// DIFFERENT identities whose derived context name collapses to the same string
+// must NOT silently repoint the context. The second register (a different
+// identity, same derived context) is refused without --force.
+func TestRegister_ContextNameCollisionRefusedWithoutForce(t *testing.T) {
+	withXDG(t)
+	srv, _ := bootstrapServer(t, 0)
+
+	// env "qa" → context = "qa-" + name, clamped to 64 chars. Two names sharing
+	// the first 61 chars (so "qa-"+prefix hits the 64-char clamp identically) but
+	// differing afterwards derive the SAME context name.
+	prefix := strings.Repeat("a", 61)
+	nameA := prefix + "x" // 62 chars, valid
+	nameB := prefix + "y" // 62 chars, valid, same 64-char clamp of "qa-"+name
+
+	if err := runJentic(t, "register", "--url", srv.URL, "--name", nameA, "--env", "qa", "--timeout", "5s"); err != nil {
+		t.Fatalf("register A: %v", err)
+	}
+
+	err := runJentic(t, "register", "--url", srv.URL, "--name", nameB, "--env", "qa", "--timeout", "5s")
+	if err == nil {
+		t.Fatal("expected the colliding second register to be refused without --force")
+	}
+	if !strings.Contains(err.Error(), "already binds identity") {
+		t.Errorf("error = %v, want a context-collision refusal", err)
+	}
+
+	// The first agent's binding must be intact (no silent hijack).
+	cfg, lerr := sdkconfig.Load()
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	ctxName := sdkconfig.SanitizeName("qa-" + nameA)
+	if c, ok := cfg.Contexts[ctxName]; !ok || c.Identity != nameA {
+		t.Errorf("context %q = %+v, want it still bound to the first identity %q", ctxName, c, nameA)
+	}
+}
+
+// TestRegister_ContextNameCollisionForceRepoints confirms --force still lets the
+// operator deliberately repoint a colliding context.
+func TestRegister_ContextNameCollisionForceRepoints(t *testing.T) {
+	withXDG(t)
+	srv, _ := bootstrapServer(t, 0)
+
+	prefix := strings.Repeat("a", 61)
+	nameA := prefix + "x"
+	nameB := prefix + "y"
+
+	if err := runJentic(t, "register", "--url", srv.URL, "--name", nameA, "--env", "qa", "--timeout", "5s"); err != nil {
+		t.Fatalf("register A: %v", err)
+	}
+	if err := runJentic(t, "register", "--url", srv.URL, "--name", nameB, "--env", "qa", "--timeout", "5s", "--force"); err != nil {
+		t.Fatalf("register B --force: %v", err)
+	}
+
+	cfg, lerr := sdkconfig.Load()
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	ctxName := sdkconfig.SanitizeName("qa-" + nameB)
+	if c := cfg.Contexts[ctxName]; c.Identity != nameB {
+		t.Errorf("with --force, context %q should repoint to %q, got %+v", ctxName, nameB, c)
+	}
+}
+
 // TestRegister_LegacyFlagsRemoved: the V1 --profile/--base-url arm is gone
 // (14 BC-1). The flags must fail as unknown — nothing may silently fall back
 // to the legacy store.

--- a/cli/internal/cli/cmdcore/fencing.go
+++ b/cli/internal/cli/cmdcore/fencing.go
@@ -1,7 +1,9 @@
 package cmdcore
 
 import (
+	"context"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -22,6 +24,25 @@ import (
 // failures are non-fatal for everything except an explicit fenced-in-agent-mode
 // block, so V1 behavior is preserved on un-migrated machines.
 func installInterceptor(app *App, root *cobra.Command) {
+	// agentTimeout bounds a single control-plane call in non-interactive mode so a
+	// wedged server can't hang an agent forever (F3, review round-3 #7 /
+	// cli-conventions §"Context timeouts"). Human mode is left undeadlined so
+	// interactive prompts and paginators aren't aborted mid-flow.
+	const agentTimeout = 60 * time.Second
+	// cancelTimeout holds the current invocation's timeout cancel (if any) so the
+	// PersistentPostRunE below can release it — avoids a leaked context timer
+	// without threading the cancel through the whole command tree. Safe as a
+	// captured single value: one cobra invocation runs one command to completion.
+	var cancelTimeout context.CancelFunc
+
+	root.PersistentPostRunE = func(_ *cobra.Command, _ []string) error {
+		if cancelTimeout != nil {
+			cancelTimeout()
+			cancelTimeout = nil
+		}
+		return nil
+	}
+
 	root.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
 		// Preserve the shipped banner + update nudge (previously PersistentPreRun).
 		app.banner(cmd)
@@ -115,6 +136,19 @@ func installInterceptor(app *App, root *cobra.Command) {
 		ctx = clictx.WithActiveState(ctx, state)
 		ctx = theme.WithContext(ctx, palette)
 		ctx = theme.WithThemeName(ctx, themeName)
+
+		// Non-interactive modes get a wall-clock deadline (F3, review round-3 #7):
+		// an agent/service-account orchestrating jentic against an unresponsive
+		// Control Plane would otherwise hang forever (the shared control client
+		// leaves http.Client.Timeout zero, deferring to per-call contexts that
+		// today carry no deadline). Human mode stays undeadlined so interactive
+		// prompts/paginators aren't cut off. The cancel is released in
+		// PersistentPostRunE above.
+		if state.Mode == clictx.ModeAgent || state.Mode == clictx.ModeServiceAccount {
+			//nolint:gosec // G118: the cancel is stored in cancelTimeout and invoked in the root PersistentPostRunE above (one invocation runs one command to completion); a leaked timer would in any case be reclaimed at process exit.
+			ctx, cancelTimeout = context.WithTimeout(ctx, agentTimeout)
+		}
+
 		cmd.SetContext(ctx)
 		return nil
 	}

--- a/cli/internal/cli/cmdcore/fencing_test.go
+++ b/cli/internal/cli/cmdcore/fencing_test.go
@@ -1,0 +1,73 @@
+package cmdcore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// newProbeRoot builds a minimal root with the interceptor installed and a "probe"
+// subcommand that records the deadline (if any) of its command context. The root
+// carries the persistent --mode/--context/--theme/--verbose/--yes flags the
+// interceptor looks up (flagValue/boolFlag tolerate absent flags, but --mode must
+// exist for the mode ladder to see it).
+func newProbeRoot(t *testing.T, capture *func(ctx context.Context)) *cobra.Command {
+	t.Helper()
+	app := &App{}
+	root := &cobra.Command{Use: "jentic", SilenceUsage: true, SilenceErrors: true}
+	root.PersistentFlags().String("mode", "", "")
+	root.PersistentFlags().String("context", "", "")
+	root.PersistentFlags().String("theme", "", "")
+	root.PersistentFlags().Bool("verbose", false, "")
+	root.PersistentFlags().Bool("yes", false, "")
+	installInterceptor(app, root)
+	root.AddCommand(&cobra.Command{
+		Use: "probe",
+		RunE: func(c *cobra.Command, _ []string) error {
+			(*capture)(c.Context())
+			return nil
+		},
+	})
+	return root
+}
+
+// TestInterceptor_AgentModeSetsWallClockDeadline pins F3 (round-3 #7): in
+// agent/service-account mode the interceptor derives a wall-clock deadline so a
+// wedged Control Plane can't hang the CLI forever.
+func TestInterceptor_AgentModeSetsWallClockDeadline(t *testing.T) {
+	var seen context.Context
+	capture := func(ctx context.Context) { seen = ctx }
+	root := newProbeRoot(t, &capture)
+
+	t.Setenv("JENTIC_MODE", "agent")
+	root.SetArgs([]string{"probe"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	deadline, ok := seen.Deadline()
+	if !ok {
+		t.Fatal("agent-mode command context must carry a wall-clock deadline")
+	}
+	if until := time.Until(deadline); until <= 0 || until > 2*time.Minute {
+		t.Errorf("deadline %s from now is out of the expected ~60s band", until)
+	}
+}
+
+// TestInterceptor_HumanModeNoDeadline confirms human mode stays undeadlined so
+// interactive prompts and paginators aren't aborted mid-flow.
+func TestInterceptor_HumanModeNoDeadline(t *testing.T) {
+	var seen context.Context
+	capture := func(ctx context.Context) { seen = ctx }
+	root := newProbeRoot(t, &capture)
+
+	t.Setenv("JENTIC_MODE", "human")
+	root.SetArgs([]string{"probe"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if _, ok := seen.Deadline(); ok {
+		t.Error("human-mode command context must NOT carry a deadline")
+	}
+}

--- a/cli/internal/cli/cmdcore/register_setup.go
+++ b/cli/internal/cli/cmdcore/register_setup.go
@@ -144,13 +144,31 @@ func (a *App) RegisterSetup(ctx context.Context, vals SetupValues, timeout time.
 			cfg.Environments[envName] = env
 		}
 		brokerConfigured = cfg.Environments[envName].BrokerURL != ""
+		// (Re)bind and activate the context. The context name is derived by
+		// SanitizeName(env + "-" + name); that primitive is many-to-one (charset
+		// collapse + 64-char clamp), so two DIFFERENT (env, identity) pairs can
+		// derive the SAME contextName — e.g. two long identity names sharing a
+		// 64-char prefix. Overwriting unconditionally would then silently repoint
+		// the context onto a different identity (F2, review round-3 #4): the exact
+		// "authenticated as the wrong identity" failure the per-identity naming is
+		// meant to prevent. Guard it: if the derived context already exists and
+		// binds a DIFFERENT identity or environment, refuse without --force rather
+		// than hijack it. Re-registering the SAME identity+env stays idempotent.
+		if existing, ok := cfg.Contexts[contextName]; ok &&
+			(existing.Identity != vals.Name || existing.Environment != envName) && !force {
+			return &ux.CodedError{
+				Code: ux.CodeMissingArgument,
+				Msg: fmt.Sprintf("context %q already binds identity %q on environment %q; "+
+					"registering %q on %q would overwrite it (their names collapse to the same context name)",
+					contextName, existing.Identity, existing.Environment, vals.Name, envName),
+				Actionable: "Use a shorter/distinct --name, or pass --force to repoint this context.",
+			}
+		}
 		if _, ok := cfg.Identities[vals.Name]; !ok {
 			cfg.Identities[vals.Name] = sdkconfig.Identity{Type: "agent"}
 		}
-		// (Re)bind unconditionally: the per-identity name is stable, so re-running
-		// for the SAME identity+env is idempotent, while a NEW identity gets its
-		// own context. Then activate it — register's contract is "when this
-		// returns, THIS identity is the live one".
+		// Then activate it — register's contract is "when this returns, THIS
+		// identity is the live one".
 		cfg.Contexts[contextName] = sdkconfig.Context{
 			Environment: envName, Identity: vals.Name, Mode: clictx.ModeHuman,
 		}

--- a/cli/internal/cli/ctlcmd/install.go
+++ b/cli/internal/cli/ctlcmd/install.go
@@ -787,7 +787,7 @@ func installLocal(ctx context.Context, a *app, draft *install.Draft, configPath 
 	fmt.Fprintln(a.Out)
 	fmt.Fprint(a.Out, install.RenderMigrateHeader(configPath))
 	if draft.IsPostgres() {
-		if err := install.RunMigrations(a.Out, draft.VenvPython, configPath); err != nil {
+		if err := install.RunMigrations(ctx, a.Out, draft.VenvPython, configPath); err != nil {
 			fmt.Fprintln(a.Out, install.RenderMigrateWarning(err))
 			return nil
 		}
@@ -797,7 +797,7 @@ func installLocal(ctx context.Context, a *app, draft *install.Draft, configPath 
 	if err := update.MigrateWithRollback(
 		a.Paths.DataDir(),
 		true, // local install is SQLite here (Postgres handled above)
-		func() error { return install.RunMigrations(a.Out, draft.VenvPython, configPath) },
+		func() error { return install.RunMigrations(ctx, a.Out, draft.VenvPython, configPath) },
 		func() { fmt.Fprintln(a.Out, theme.Dim.Render("  snapshotted SQLite data for rollback")) },
 		func() {
 			fmt.Fprintln(a.Out, theme.Warnf("migrations failed; rolled the SQLite database back to its pre-install state"))

--- a/cli/internal/cli/ctlcmd/update.go
+++ b/cli/internal/cli/ctlcmd/update.go
@@ -582,18 +582,25 @@ func (a *app) updateStackLocal(ctx context.Context, db, ref string, pinned bool)
 		return fmt.Errorf("rebuild failed: %w", err)
 	}
 
+	// Stop the app BEFORE snapshotting + migrating (F1, review round-3 #7). A
+	// forward-only Alembic migration against a live, WAL-mode SQLite DB — with a
+	// backup that couldn't cleanly capture the in-flight WAL — is the inconsistent
+	// half-state the rollback net exists to prevent. Stopping first makes the
+	// snapshot self-contained and the migration the sole writer. Restart happens
+	// after a successful migration (or is left stopped on failure, having rolled
+	// back). If it wasn't running, we don't start it — matching prior behaviour.
+	wasRunning := a.stopLocalIfRunning(ctx)
+
 	// Snapshot the SQLite files before the forward-only migration so a failure
 	// rolls back to the pre-migration state rather than stranding a half-applied
-	// schema. The build above is a pure code swap (no DB writes), so taking the
-	// snapshot here — just before RunMigrations — captures the exact bytes the
-	// migration is about to touch. Shared with first-`install` via
-	// MigrateWithRollback so the two rollback paths cannot drift (P1-E).
+	// schema. Shared with first-`install` via MigrateWithRollback so the two
+	// rollback paths cannot drift (P1-E).
 	fmt.Fprintln(a.Out)
 	fmt.Fprint(a.Out, install.RenderMigrateHeader(configPath))
 	if err := update.MigrateWithRollback(
 		a.Paths.DataDir(),
 		db == install.BackendSQLite,
-		func() error { return install.RunMigrations(a.Out, plan.VenvPython(), configPath) },
+		func() error { return install.RunMigrations(ctx, a.Out, plan.VenvPython(), configPath) },
 		func() { fmt.Fprintln(a.Out, theme.Dim.Render("  snapshotted SQLite data for rollback")) },
 		func() {
 			fmt.Fprintln(a.Out, theme.Warnf("migrations failed; rolled the SQLite database back to its pre-update state"))
@@ -602,7 +609,11 @@ func (a *app) updateStackLocal(ctx context.Context, db, ref string, pinned bool)
 		return err
 	}
 
-	a.restartLocalIfRunning(ctx)
+	if wasRunning {
+		a.startLocalAfterStop(ctx)
+	} else {
+		fmt.Fprintln(a.Out, theme.Dim.Render("  app not running — start it with `jenticctl start`"))
+	}
 	fmt.Fprintln(a.Out, theme.Successf("Stack updated (local)."))
 	return nil
 }
@@ -652,17 +663,28 @@ func (a *app) updateStackDocker(ctx context.Context, ref string, pinned, daemonC
 	return nil
 }
 
-// restartLocalIfRunning bounces the background app so the rebuilt code takes
-// effect, but only when it was already running; otherwise it leaves it stopped.
-func (a *app) restartLocalIfRunning(ctx context.Context) {
+// stopLocalIfRunning stops the local app if it is running and reports whether it
+// was. Split out of the old restartLocalIfRunning (F1, review round-3 #7) so the
+// update flow can stop the app BEFORE snapshotting + migrating the SQLite
+// database — migrating a live, WAL-mode DB and then trying to roll back a .db
+// whose committed pages still live in an uncheckpointed WAL is exactly the
+// inconsistent half-state the rollback net is meant to prevent.
+func (a *app) stopLocalIfRunning(ctx context.Context) bool {
 	_, running, _ := proc.LivePID(a.Paths.AppPIDPath())
 	if !running {
-		fmt.Fprintln(a.Out, theme.Dim.Render("  app not running — start it with `jenticctl start`"))
-		return
+		return false
 	}
 	fmt.Fprintln(a.Out)
-	fmt.Fprintln(a.Out, theme.Infof("Restarting app ..."))
+	fmt.Fprintln(a.Out, theme.Infof("Stopping app before migration ..."))
 	_ = a.stopE(ctx, &stopOptions{timeout: 10 * time.Second})
+	return true
+}
+
+// startLocalAfterStop restarts the local app after an update, used when
+// stopLocalIfRunning reported it was running before the update began.
+func (a *app) startLocalAfterStop(ctx context.Context) {
+	fmt.Fprintln(a.Out)
+	fmt.Fprintln(a.Out, theme.Infof("Restarting app ..."))
 	_ = a.startE(ctx, &startOptions{})
 }
 

--- a/cli/internal/cli/ux/redact.go
+++ b/cli/internal/cli/ux/redact.go
@@ -202,6 +202,44 @@ const maxRedactDepth = 64
 
 func redactValue(v any) any { return redactValueDepth(v, 0) }
 
+// redactValueMarked is like redactValue but also reports whether it changed
+// anything (redacted at least one sensitive key or hit the depth guard). The
+// "changed" signal lets RedactBytes avoid re-marshaling — and thus reshaping —
+// JSON that had nothing sensitive in it (shape preservation for WriteJSON).
+func redactValueMarked(v any) (any, bool) {
+	changed := false
+	out := redactValueDepthMarked(v, 0, &changed)
+	return out, changed
+}
+
+func redactValueDepthMarked(v any, depth int, changed *bool) any {
+	if depth > maxRedactDepth {
+		*changed = true
+		return "[REDACTED: too deep]"
+	}
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			if isSensitiveKey(k) || isRegisteredSensitiveName(k) {
+				out[k] = "[REDACTED]"
+				*changed = true
+			} else {
+				out[k] = redactValueDepthMarked(val, depth+1, changed)
+			}
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, val := range t {
+			out[i] = redactValueDepthMarked(val, depth+1, changed)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
 func redactValueDepth(v any, depth int) any {
 	if depth > maxRedactDepth {
 		return "[REDACTED: too deep]"
@@ -283,12 +321,15 @@ func redactString(s string) string { return string(redactSensitive([]byte(s))) }
 // (redactValue), which redacts a sensitive key regardless of its value's JSON
 // type — so a secret carried as a number, object, array, or bool is caught, not
 // just a `"key":"string"` pair (the reKV byte regex alone matched string values
-// only; review round-3 P0). The structured pass never reshapes non-sensitive
-// data: keys, ordering within objects is not guaranteed by encoding/json but the
-// document is semantically identical, and only sensitive subtrees change. The
-// byte backstop then still runs over the re-marshaled bytes to catch secrets
-// embedded in free-form string values (bearer tokens, PEM blocks) that carry no
-// sensitive key.
+// only; review round-3 P0). Shape is preserved when NOTHING is redacted: the
+// structured pass reports whether it changed anything, and if not, RedactBytes
+// runs only the byte backstop over the ORIGINAL bytes — so shape-preserving
+// callers like WriteJSON (which feed already-indented JSON through here) keep
+// their exact layout and key order. Only when a sensitive value is actually
+// redacted does the document get re-marshaled (matching the input's indentation);
+// on that path key order may change, which is fine because the document already
+// differs. The byte backstop then still runs to catch secrets embedded in
+// free-form string values (bearer tokens, PEM blocks) that carry no sensitive key.
 //
 // When data is NOT valid JSON (e.g. a Markdown inspect body, a YAML spec, a
 // plain-text error) it falls back to the byte backstop alone — the same
@@ -297,15 +338,67 @@ func RedactBytes(data []byte) []byte {
 	if trimmed := bytesTrimSpace(data); len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
 		var v any
 		if err := json.Unmarshal(data, &v); err == nil {
-			// Structured pass first: catches sensitive keys with non-string
-			// values. Re-marshal, then let the byte backstop scrub embedded
-			// free-form secrets in the (now-redacted) JSON.
-			if out, merr := json.Marshal(redactValue(v)); merr == nil {
+			// Structured pass: redact sensitive keys regardless of value type
+			// (number/object/array/bool), which the reKV byte regex — string
+			// values only — misses (review round-3 P0). redactValue returns a
+			// redacted DEEP COPY and reports whether it actually changed anything.
+			red, changed := redactValueMarked(v)
+			if !changed {
+				// Nothing sensitive in the structured view: DO NOT re-marshal —
+				// that would reshape the caller's JSON (compact it / reorder keys)
+				// and break shape-preserving callers like WriteJSON. Just run the
+				// byte backstop over the ORIGINAL bytes (catches free-form embedded
+				// secrets without touching layout).
+				return redactSensitive(data)
+			}
+			// Something was redacted, so the document already differs from the
+			// input. Re-marshal, preserving the caller's indentation when the
+			// input was pretty-printed, then run the byte backstop.
+			if out, merr := marshalLike(data, red); merr == nil {
 				return redactSensitive(out)
 			}
 		}
 	}
 	return redactSensitive(data)
+}
+
+// marshalLike marshals v to match the indentation style of the original bytes:
+// indented (2-space) when the original was pretty-printed, compact otherwise.
+// Key order is not preserved (encoding/json sorts map keys) — acceptable only on
+// the path where a redaction already changed the document.
+func marshalLike(original []byte, v any) ([]byte, error) {
+	if looksIndentedJSON(original) {
+		return json.MarshalIndent(v, "", "  ")
+	}
+	return json.Marshal(v)
+}
+
+// looksIndentedJSON reports whether the JSON body appears pretty-printed (a
+// newline followed by indentation after the opening brace/bracket). A cheap
+// heuristic sufficient to pick MarshalIndent vs Marshal for the redacted output.
+func looksIndentedJSON(b []byte) bool {
+	for i := range b {
+		switch b[i] {
+		case ' ', '\t', '\r':
+			continue
+		case '{', '[':
+			// Look past the opener for a newline before any non-space content.
+			for j := i + 1; j < len(b); j++ {
+				switch b[j] {
+				case ' ', '\t', '\r':
+					continue
+				case '\n':
+					return true
+				default:
+					return false
+				}
+			}
+			return false
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 // bytesTrimSpace is a tiny leading/trailing ASCII-space trim used only to peek at

--- a/cli/internal/cli/ux/redact.go
+++ b/cli/internal/cli/ux/redact.go
@@ -274,12 +274,54 @@ func redactSensitive(data []byte) []byte {
 func redactString(s string) string { return string(redactSensitive([]byte(s))) }
 
 // RedactBytes is the exported byte-level backstop for command code that emits a
-// raw upstream/API body (e.g. the `jentic api` passthrough, `execute --raw`)
-// rather than a marshaled envelope. It applies the SAME free-form-string scrub as
-// every other output path so a secret in an API response can't leak to a machine
-// parser. It does NOT reshape or re-marshal the payload — the body stays the
-// API's own JSON.
-func RedactBytes(data []byte) []byte { return redactSensitive(data) }
+// raw upstream/API body (e.g. the `jentic api` passthrough, `execute --raw`,
+// `inspect`, `apis spec`) rather than a marshaled envelope. It applies the SAME
+// redaction guarantee as every other output path so a secret in an API response
+// can't leak to a machine parser.
+//
+// When data is valid JSON it is parsed and run through the STRUCTURED key pass
+// (redactValue), which redacts a sensitive key regardless of its value's JSON
+// type — so a secret carried as a number, object, array, or bool is caught, not
+// just a `"key":"string"` pair (the reKV byte regex alone matched string values
+// only; review round-3 P0). The structured pass never reshapes non-sensitive
+// data: keys, ordering within objects is not guaranteed by encoding/json but the
+// document is semantically identical, and only sensitive subtrees change. The
+// byte backstop then still runs over the re-marshaled bytes to catch secrets
+// embedded in free-form string values (bearer tokens, PEM blocks) that carry no
+// sensitive key.
+//
+// When data is NOT valid JSON (e.g. a Markdown inspect body, a YAML spec, a
+// plain-text error) it falls back to the byte backstop alone — the same
+// behaviour as before — because there is no structure to walk.
+func RedactBytes(data []byte) []byte {
+	if trimmed := bytesTrimSpace(data); len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
+		var v any
+		if err := json.Unmarshal(data, &v); err == nil {
+			// Structured pass first: catches sensitive keys with non-string
+			// values. Re-marshal, then let the byte backstop scrub embedded
+			// free-form secrets in the (now-redacted) JSON.
+			if out, merr := json.Marshal(redactValue(v)); merr == nil {
+				return redactSensitive(out)
+			}
+		}
+	}
+	return redactSensitive(data)
+}
+
+// bytesTrimSpace is a tiny leading/trailing ASCII-space trim used only to peek at
+// the first non-space byte for the JSON sniff above (avoids pulling in bytes just
+// for TrimSpace and avoids allocating a trimmed copy of a large body).
+func bytesTrimSpace(b []byte) []byte {
+	i := 0
+	for i < len(b) && (b[i] == ' ' || b[i] == '\t' || b[i] == '\n' || b[i] == '\r') {
+		i++
+	}
+	j := len(b)
+	for j > i && (b[j-1] == ' ' || b[j-1] == '\t' || b[j-1] == '\n' || b[j-1] == '\r') {
+		j--
+	}
+	return b[i:j]
+}
 
 // safeMarshal / safeMarshalIndent are the single funnel every Render path uses.
 // They redact by struct tag (typed reflection), by field name (key heuristics),

--- a/cli/internal/cli/ux/redact_test.go
+++ b/cli/internal/cli/ux/redact_test.go
@@ -204,3 +204,86 @@ func TestRegisteredSensitiveNameRedactedInBytesAndValue(t *testing.T) {
 		t.Errorf("value pass over-redacted a non-sensitive field: %v", red)
 	}
 }
+
+// TestRedactBytesRedactsNonStringValues pins the round-3 P0 hardening: the byte
+// backstop's reKV regex matched `"key":"string"` pairs ONLY, so a secret carried
+// as a JSON number, object, array, or bool reached stdout untouched on the raw
+// path (execute --raw, inspect, apis spec, api passthrough). RedactBytes now
+// parses valid JSON and runs the structured key pass, which redacts a sensitive
+// key regardless of its value's JSON type.
+func TestRedactBytesRedactsNonStringValues(t *testing.T) {
+	cases := []struct {
+		name       string
+		body       string
+		mustGone   string // substring that must NOT survive
+		mustRedact string // json fragment that must appear
+	}{
+		{
+			name:       "number token",
+			body:       `{"token":1234567890,"page":2}`,
+			mustGone:   "1234567890",
+			mustRedact: `"token":"[REDACTED]"`,
+		},
+		{
+			name:       "object secret",
+			body:       `{"credentials":{"access_key":"AKIA123","region":"eu"},"ok":true}`,
+			mustGone:   "AKIA123",
+			mustRedact: `"credentials":"[REDACTED]"`,
+		},
+		{
+			name:       "array api_key",
+			body:       `{"api_key":["k1","k2"],"count":2}`,
+			mustGone:   "k1",
+			mustRedact: `"api_key":"[REDACTED]"`,
+		},
+		{
+			name:       "bool password",
+			body:       `{"password":false}`,
+			mustGone:   "false",
+			mustRedact: `"password":"[REDACTED]"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(RedactBytes([]byte(tc.body)))
+			if strings.Contains(got, tc.mustGone) {
+				t.Errorf("non-string secret leaked through RedactBytes: %s", got)
+			}
+			if !strings.Contains(got, tc.mustRedact) {
+				t.Errorf("expected %q in redacted output, got: %s", tc.mustRedact, got)
+			}
+		})
+	}
+}
+
+// TestRedactBytesPreservesNonSensitiveNonString ensures the structured pass does
+// NOT clobber legitimate non-string values on non-sensitive keys — a redactor
+// that corrupts pagination cursors/counts is as bad as one that leaks.
+func TestRedactBytesPreservesNonSensitiveNonString(t *testing.T) {
+	body := `{"next_token":"cursor-abc","count":42,"items":[{"id":1}],"ok":true}`
+	got := string(RedactBytes([]byte(body)))
+	// next_token is an allowlisted pagination cursor — must survive verbatim.
+	if !strings.Contains(got, `"next_token":"cursor-abc"`) {
+		t.Errorf("allowlisted next_token was clobbered: %s", got)
+	}
+	for _, want := range []string{`"count":42`, `"id":1`, `"ok":true`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("non-sensitive value corrupted, missing %q: %s", want, got)
+		}
+	}
+}
+
+// TestRedactBytesNonJSONFallsBackToByteBackstop ensures a non-JSON body (e.g. a
+// Markdown inspect body or a YAML spec) is still scrubbed by the byte backstop
+// and is not mangled by a failed JSON parse.
+func TestRedactBytesNonJSONFallsBackToByteBackstop(t *testing.T) {
+	// Markdown with an embedded bearer token in a code fence.
+	body := "# Operation\n\nAuthorization: Bearer sk-live-SECRET123\n\nSee docs."
+	got := string(RedactBytes([]byte(body)))
+	if strings.Contains(got, "sk-live-SECRET123") {
+		t.Errorf("bearer token leaked through non-JSON path: %s", got)
+	}
+	if !strings.Contains(got, "# Operation") {
+		t.Errorf("non-JSON body was mangled: %s", got)
+	}
+}

--- a/cli/internal/cli/ux/redact_test.go
+++ b/cli/internal/cli/ux/redact_test.go
@@ -273,6 +273,24 @@ func TestRedactBytesPreservesNonSensitiveNonString(t *testing.T) {
 	}
 }
 
+// TestRedactBytesPreservesShapeWhenNothingRedacted pins the WriteJSON contract
+// (regression from the round-3 P0): when a body has NOTHING sensitive, RedactBytes
+// must return it byte-for-byte (no re-marshal, no key reordering, no
+// re-indentation). WriteJSON feeds already-indented JSON through here and a golden
+// test asserts the exact bytes; re-marshaling would silently compact/reorder it.
+func TestRedactBytesPreservesShapeWhenNothingRedacted(t *testing.T) {
+	// Indented, deliberately NON-alphabetical key order.
+	indented := "{\n  \"b\": \"2\",\n  \"a\": \"1\"\n}\n"
+	if got := string(RedactBytes([]byte(indented))); got != indented {
+		t.Errorf("indented non-sensitive JSON reshaped:\ngot  %q\nwant %q", got, indented)
+	}
+	// Compact form must likewise pass through untouched.
+	compact := `{"b":"2","a":"1"}`
+	if got := string(RedactBytes([]byte(compact))); got != compact {
+		t.Errorf("compact non-sensitive JSON reshaped:\ngot  %q\nwant %q", got, compact)
+	}
+}
+
 // TestRedactBytesNonJSONFallsBackToByteBackstop ensures a non-JSON body (e.g. a
 // Markdown inspect body or a YAML spec) is still scrubbed by the byte backstop
 // and is not mangled by a failed JSON parse.

--- a/cli/internal/install/build.go
+++ b/cli/internal/install/build.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -493,10 +494,15 @@ func RenderStartWarning(err error) string {
 // RunMigrations applies Alembic migrations for all databases using the freshly
 // built venv interpreter, pointed at the generated config. Output is streamed to
 // w. The runner is cwd-independent (it loads packaged migration scripts).
-func RunMigrations(w io.Writer, venvPython, configPath string) error {
+//
+// ctx is threaded through to exec.CommandContext (F2, review round-3 #7) so a
+// Ctrl-C during a long migration cancels the Python child instead of orphaning it
+// — which, against a live DB mid-rollback, is the worst input to the rollback
+// path. Callers hold the command's signal-cancelled context; pass it here.
+func RunMigrations(ctx context.Context, w io.Writer, venvPython, configPath string) error {
 	fmt.Fprintf(w, "\n$ JENTIC_CONFIG_FILE=%s %s -m jentic_one.migrations.run\n",
 		configPath, venvPython)
-	cmd := exec.Command(venvPython, "-m", "jentic_one.migrations.run")
+	cmd := exec.CommandContext(ctx, venvPython, "-m", "jentic_one.migrations.run")
 	cmd.Env = append(os.Environ(), "JENTIC_CONFIG_FILE="+configPath)
 	cmd.Stdout = w
 	cmd.Stderr = w

--- a/cli/internal/update/download.go
+++ b/cli/internal/update/download.go
@@ -15,6 +15,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/jentic/jentic-one/cli/client"
 )
 
 // cosignCertIdentityRegexp / cosignOIDCIssuer pin the keyless-signing identity
@@ -52,7 +54,11 @@ func httpGet(ctx context.Context, url, token string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("download %s: unexpected status %s", url, resp.Status)
 	}
-	return io.ReadAll(resp.Body)
+	// Bound the read: checksums.txt / .sig / .pem are small metadata files, but a
+	// hostile or misconfigured origin must not be able to stream an unbounded body
+	// into RAM (review round-3 P0 / theme 2). The archive itself is streamed to
+	// disk with its own larger io.Copy limit; this path only buffers metadata.
+	return client.ReadAllBounded(resp.Body, client.MaxBodyBytes)
 }
 
 // verifyError marks a FAIL-CLOSED verification failure (checksum mismatch,

--- a/cli/internal/update/update.go
+++ b/cli/internal/update/update.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // authArgs returns the `git -c http.extraheader=...` prefix carrying a Basic
@@ -126,12 +127,19 @@ type SQLiteBackup struct {
 	dir   string
 }
 
-// BackupSQLite snapshots every *.db file directly under dataDir into a temp
-// directory, returning a handle that can Restore them if the migration fails or
-// be Discarded on success. A dataDir with no *.db files (a fresh install whose
-// migration will create them) yields an empty, harmless backup. The snapshot is
-// a plain file copy: SQLite is quiescent here because the local app/broker are
-// bounced around the migration, so no writer is mid-transaction.
+// BackupSQLite snapshots every SQLite file directly under dataDir — the main
+// *.db AND its WAL sidecars (*.db-wal, *.db-shm) — into a temp directory,
+// returning a handle that can Restore them if the migration fails or be
+// Discarded on success. A dataDir with no SQLite files (a fresh install whose
+// migration will create them) yields an empty, harmless backup.
+//
+// The WAL sidecars matter (F1, review round-3 #7): a live WAL-mode database keeps
+// uncheckpointed committed pages in the -wal file, so snapshotting only the .db
+// would restore a main file whose committed state lived partly in a WAL that is
+// then stale or gone — an inconsistent restore presented as a successful
+// rollback. Capturing all three keeps the restore self-consistent. Callers MUST
+// still stop the app before snapshotting (see MigrateWithRollback callers) so
+// nothing is mid-transaction; the file copy is otherwise a crash-consistency bet.
 func BackupSQLite(dataDir string) (*SQLiteBackup, error) {
 	entries, err := os.ReadDir(dataDir)
 	if err != nil {
@@ -146,7 +154,7 @@ func BackupSQLite(dataDir string) (*SQLiteBackup, error) {
 	}
 	b := &SQLiteBackup{files: map[string]string{}, dir: tmp}
 	for _, e := range entries {
-		if e.IsDir() || filepath.Ext(e.Name()) != ".db" {
+		if e.IsDir() || !isSQLiteFile(e.Name()) {
 			continue
 		}
 		src := filepath.Join(dataDir, e.Name())
@@ -160,9 +168,30 @@ func BackupSQLite(dataDir string) (*SQLiteBackup, error) {
 	return b, nil
 }
 
+// isSQLiteFile reports whether name is a SQLite database or one of its WAL/SHM
+// sidecars using the default SQLite naming (`<db>`, `<db>-wal`, `<db>-shm` where
+// <db> ends in .db). We match the sidecars by suffix so a checkpointed DB with no
+// live WAL (only the .db present) and a live WAL-mode DB (all three present) are
+// both captured whole.
+func isSQLiteFile(name string) bool {
+	switch {
+	case filepath.Ext(name) == ".db":
+		return true
+	case strings.HasSuffix(name, ".db-wal"), strings.HasSuffix(name, ".db-shm"):
+		return true
+	}
+	return false
+}
+
 // Restore copies each snapshot back over its live file, undoing a failed
 // migration. It restores as many files as it can and joins any errors so one
 // bad file does not silently strand the rest half-rolled-back.
+//
+// It also removes any live WAL/SHM sidecar that was NOT part of the snapshot
+// (F1, review round-3 #7): a failed migration may have started a fresh WAL that
+// didn't exist when we snapshotted; leaving it in place could replay stale frames
+// on top of the restored .db. Deleting the un-snapshotted sidecars forces SQLite
+// to treat the restored .db as authoritative on next open.
 func (b *SQLiteBackup) Restore() error {
 	if b == nil {
 		return nil
@@ -171,6 +200,23 @@ func (b *SQLiteBackup) Restore() error {
 	for live, snap := range b.files {
 		if err := copyFile(snap, live, 0o600); err != nil {
 			errs = append(errs, fmt.Errorf("restore %s: %w", filepath.Base(live), err))
+		}
+	}
+	// For every restored main .db, drop a live sidecar we did not capture.
+	for live := range b.files {
+		if filepath.Ext(live) != ".db" {
+			continue
+		}
+		for _, suffix := range []string{"-wal", "-shm"} {
+			sidecar := live + suffix
+			if _, backedUp := b.files[sidecar]; backedUp {
+				continue // this sidecar was snapshotted and already restored above
+			}
+			if _, err := os.Stat(sidecar); err == nil {
+				if rmErr := os.Remove(sidecar); rmErr != nil && !os.IsNotExist(rmErr) {
+					errs = append(errs, fmt.Errorf("remove stale sidecar %s: %w", filepath.Base(sidecar), rmErr))
+				}
+			}
 		}
 	}
 	return errors.Join(errs...)

--- a/cli/internal/update/update_test.go
+++ b/cli/internal/update/update_test.go
@@ -101,6 +101,93 @@ func TestBackupSQLite_RestoresAfterFailedMigration(t *testing.T) {
 	}
 }
 
+// TestBackupSQLite_CapturesAndRestoresWALSidecars pins the F1 (round-3 #7) fix:
+// a live WAL-mode DB has -wal/-shm sidecars carrying uncheckpointed pages, so a
+// backup that snapshots only the .db can restore an inconsistent database.
+// BackupSQLite must capture all three and Restore must reinstate them.
+func TestBackupSQLite_CapturesAndRestoresWALSidecars(t *testing.T) {
+	data := t.TempDir()
+	dbPath := filepath.Join(data, "control.db")
+	walPath := dbPath + "-wal"
+	shmPath := dbPath + "-shm"
+	for path, content := range map[string]string{
+		dbPath:  "MAIN-PRE",
+		walPath: "WAL-PRE",
+		shmPath: "SHM-PRE",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	b, err := BackupSQLite(data)
+	if err != nil {
+		t.Fatalf("BackupSQLite: %v", err)
+	}
+	if len(b.files) != 3 {
+		t.Fatalf("expected .db + -wal + -shm captured (3 files), got %d: %v", len(b.files), b.files)
+	}
+
+	// Simulate a migration mutating all three, then roll back.
+	for _, path := range []string{dbPath, walPath, shmPath} {
+		if err := os.WriteFile(path, []byte("MUTATED"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := b.Restore(); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	for path, want := range map[string]string{
+		dbPath:  "MAIN-PRE",
+		walPath: "WAL-PRE",
+		shmPath: "SHM-PRE",
+	} {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != want {
+			t.Errorf("after rollback %s = %q, want %q", filepath.Base(path), got, want)
+		}
+	}
+}
+
+// TestBackupSQLite_RestoreDropsUncapturedSidecar pins the second half of F1: a
+// migration that STARTS a fresh WAL (no -wal existed at snapshot time) must not
+// leave that stale sidecar behind on rollback, where it could replay stale frames
+// onto the restored .db.
+func TestBackupSQLite_RestoreDropsUncapturedSidecar(t *testing.T) {
+	data := t.TempDir()
+	dbPath := filepath.Join(data, "control.db")
+	if err := os.WriteFile(dbPath, []byte("MAIN-PRE"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := BackupSQLite(data) // only .db exists → only .db captured
+	if err != nil {
+		t.Fatalf("BackupSQLite: %v", err)
+	}
+
+	// Migration begins a WAL and mutates the main file, then fails.
+	walPath := dbPath + "-wal"
+	if err := os.WriteFile(walPath, []byte("STALE-WAL"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dbPath, []byte("MUTATED"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := b.Restore(); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if got, _ := os.ReadFile(dbPath); string(got) != "MAIN-PRE" {
+		t.Errorf("main db not restored: %q", got)
+	}
+	if _, err := os.Stat(walPath); !os.IsNotExist(err) {
+		t.Errorf("stale -wal sidecar should have been removed on rollback, stat err = %v", err)
+	}
+}
+
 func TestBackupSQLite_DiscardRemovesSnapshot(t *testing.T) {
 	data := t.TempDir()
 	if err := os.WriteFile(filepath.Join(data, "x.db"), []byte("x"), 0o600); err != nil {

--- a/cli/tests/arch/mutator_test.go
+++ b/cli/tests/arch/mutator_test.go
@@ -20,6 +20,7 @@ var configWriterAllowlist = map[string]bool{
 	"client/auth/tokens.go":   true,
 	"client/auth/keys.go":     true,
 	"client/auth/apikey.go":   true, // API-key credential (0600 secret under XDG state; sibling of tokens.go)
+	"client/auth/atomic.go":   true, // shared atomic writer (temp+fsync+rename) for the 0600 credential files above (F6, review round-3 #7)
 
 	// Phase 3 migration writer: copies validated legacy key material into the XDG
 	// layout and drops the MIGRATED marker. It writes SECRET/STATE material (0600

--- a/cli/tests/arch/redaction_funnel_test.go
+++ b/cli/tests/arch/redaction_funnel_test.go
@@ -1,0 +1,193 @@
+package arch
+
+import (
+	"go/ast"
+	"go/types"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// redactionFunnels are the ux helpers that guarantee a []byte has passed the
+// fail-closed redaction funnel before it hits a data-plane writer. A raw
+// upstream/API body written to App.Out/App.Err MUST come from one of these (or
+// via the Audience Render path, which never writes a bare body). Keeping this
+// list in the arch test — rather than a runtime constant — is deliberate: it is
+// the *contract* the gate enforces, and adding a new funnel is a conscious edit
+// reviewed alongside this rule.
+var redactionFunnels = map[string]bool{
+	"RedactBytes":    true, // byte backstop for raw upstream bodies (inspect, spec, execute --raw, api passthrough)
+	"MarshalForFile": true, // redacted+indented marshal for file destinations
+	"WriteJSONLine":  true, // streaming NDJSON primitive (writes to an io.Writer itself)
+}
+
+// rawWriteAllowlist names byte-writer call sites in the data-plane command
+// package that are exempt because they do NOT emit an upstream/API body — e.g. a
+// writer wired for a test, or a locally-constructed non-secret byte slice. Each
+// entry is "<relfile>:<line>" and must carry a justification in review. It is
+// empty today: every real body writer routes through a funnel. An unexplained
+// addition here is itself a review signal.
+var rawWriteAllowlist = map[string]bool{}
+
+// Test1I_RedactionFunnel closes the class of bug reviewer #5 found in round 3:
+// `jentic inspect` wrote the upstream body with `fmt.Fprintln(a.Out, string(body))`
+// — zero redaction — bypassing both the naked-print gate (it writes to a.Out, not
+// os.Stdout) and the x-sensitive sweep (which checks annotations, not write
+// sites). The fix routed inspect/apis-inspect/apis-spec through ux.RedactBytes;
+// this gate makes the *class* impossible to reintroduce.
+//
+// Rule: in internal/cli/api, every `<w>.Write(x)` where <w> is App.Out/App.Err
+// (i.e. `a.Out` / `a.Err`) must have x be — directly, or via a local variable
+// assigned in the same function — a call to one of redactionFunnels. A bare body
+// identifier (the old inspect shape) fails. Styled human text goes through
+// fmt.Fprintln (governed by Test1B), not .Write, so it is out of scope here.
+func Test1I_RedactionFunnel(t *testing.T) {
+	pkgs := loadCLI(t)
+
+	sawWrite := false
+	offenders := map[string]string{}
+
+	forEachFile(pkgs, func(pkgPath string) bool {
+		return underPrefixes(pkgPath, "internal/cli/api")
+	}, func(p *packages.Package, file *ast.File, path string) {
+		relFile := rel(p.PkgPath) + "/" + baseName(path)
+
+		// Walk each function so "assigned from a funnel" is scoped correctly: a
+		// funnel result in one function must not launder a raw write in another.
+		ast.Inspect(file, func(n ast.Node) bool {
+			fn, ok := n.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				return true
+			}
+			funnelVars := collectFunnelVars(p.TypesInfo, fn.Body)
+			ast.Inspect(fn.Body, func(m ast.Node) bool {
+				call, ok := m.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "Write" || len(call.Args) != 1 {
+					return true
+				}
+				if !isOutOrErrWriter(p.TypesInfo, sel.X) {
+					return true
+				}
+				sawWrite = true
+				line := p.Fset.Position(call.Pos()).Line
+				key := relFile + ":" + itoa(line)
+				if rawWriteAllowlist[key] {
+					return true
+				}
+				if writeArgIsRedacted(call.Args[0], funnelVars) {
+					return true
+				}
+				offenders[key] = "raw byte write to App.Out/App.Err not funneled through ux.RedactBytes/MarshalForFile"
+				return true
+			})
+			return true
+		})
+	})
+
+	for site, why := range offenders {
+		t.Errorf("un-redacted data-plane body write at %s: %s — an upstream/API body "+
+			"must go through ux.RedactBytes (or MarshalForFile), like execute/inspect do. "+
+			"If this writer emits no secret-bearing body, add it to rawWriteAllowlist with a justification.", site, why)
+	}
+	if !sawWrite {
+		t.Fatal("no App.Out/App.Err .Write() call found in internal/cli/api — the redaction-funnel " +
+			"gate must not pass vacuously (did the writer shape or package layout change?)")
+	}
+}
+
+// collectFunnelVars returns the set of local variable NAMES in body that were
+// assigned (via := or =) the single result of a redactionFunnels call, e.g.
+// `redacted := ux.RedactBytes(body)`. Names are a coarse but safe key: a later
+// reassignment of the same name to a non-funnel value would be a bug the gate
+// intentionally does not try to model (it is not a pattern we use), and shadowing
+// across scopes only ever makes the gate stricter, never laxer.
+func collectFunnelVars(info *types.Info, body *ast.BlockStmt) map[string]bool {
+	vars := map[string]bool{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Rhs) != 1 || len(assign.Lhs) != 1 {
+			return true
+		}
+		if !callIsFunnel(info, assign.Rhs[0]) {
+			return true
+		}
+		if id, ok := assign.Lhs[0].(*ast.Ident); ok {
+			vars[id.Name] = true
+		}
+		return true
+	})
+	return vars
+}
+
+// writeArgIsRedacted reports whether the argument to a .Write() call is trusted:
+// a direct funnel call, or an identifier previously bound to a funnel result.
+func writeArgIsRedacted(arg ast.Expr, funnelVars map[string]bool) bool {
+	if call, ok := arg.(*ast.CallExpr); ok {
+		return callIsFunnelName(call)
+	}
+	if id, ok := arg.(*ast.Ident); ok {
+		return funnelVars[id.Name]
+	}
+	return false
+}
+
+// callIsFunnel reports whether expr is a call to one of the redaction funnels,
+// verifying the selector base is the ux package (not a shadowing local) via type
+// info when available.
+func callIsFunnel(info *types.Info, expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || !redactionFunnels[sel.Sel.Name] {
+		return false
+	}
+	if ident, ok := sel.X.(*ast.Ident); ok {
+		return identIsPackage(info, ident)
+	}
+	return false
+}
+
+// callIsFunnelName is the type-info-free form used at the write site (the
+// selector base is checked by callIsFunnel when collecting vars; at the write
+// site a direct funnel call is accepted on name match).
+func callIsFunnelName(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	return redactionFunnels[sel.Sel.Name]
+}
+
+// isOutOrErrWriter reports whether the receiver of a .Write() call is App.Out or
+// App.Err (i.e. `a.Out` / `a.Err`), the two data-plane byte sinks. We match on
+// the field selector name (Out/Err) off any receiver so it holds regardless of
+// the App receiver's local name.
+func isOutOrErrWriter(_ *types.Info, x ast.Expr) bool {
+	sel, ok := x.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	return sel.Sel.Name == "Out" || sel.Sel.Name == "Err"
+}
+
+// itoa is a tiny int->string without importing strconv into the arch package's
+// otherwise-parser-only surface (keeps the guardrail deps minimal).
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}


### PR DESCRIPTION
## Summary

Closes the **P1** findings from the round-3 CLI review. Stacked on top of #1061 (the P0 PR) — merge #1061 first, then this retargets cleanly to `cli-v2-release`.

- **#4 F1 — config TOCTOU.** The shared `env delete` / `identity delete` flow and `context delete` ran the existence + referential-integrity checks on an *unlocked* snapshot (before a confirmation prompt that can block indefinitely), then deleted in a separate `MutateConfig`. A concurrent `context create` could bind the env/identity in that window and be stranded on a just-deleted target. The checks now run **inside** the mutator against its own fresh cfg. For `context delete --identity`, the GC decision runs *after* the context is deleted, against the mutator cfg — which also fixes a latent bug where it never GC'd the identity of the last context that bound it.
- **#4 F2 — `SanitizeName` collision.** `SanitizeName(env + "-" + name)` is many-to-one (64-char clamp), so two different identities can derive the same context name and the register front door overwrote it unconditionally — the exact "authenticated as the wrong identity" failure per-identity naming is meant to prevent. Register now refuses to repoint an existing context onto a *different* identity/env without `--force`.
- **#7 F1 (HIGH) — local-update SQLite safety.** `jenticctl update` migrated a *live* WAL-mode DB (the app was stopped only *after*), and the backup captured only the `.db` — not the `-wal`/`-shm` sidecars carrying uncheckpointed pages — so a rollback could restore an inconsistent database. Now: stop the app **before** snapshot+migrate (restart after), capture/restore all three files, and drop an un-snapshotted sidecar on rollback so a stale WAL can't replay onto the restored `.db`.
- **#7 F2 — cancellable migrations.** `RunMigrations` now takes `ctx` and uses `exec.CommandContext`, so Ctrl-C cancels the Python migration child instead of orphaning it mid-rollback.
- **#7 F6 / theme 3 — atomic credential writes.** Tokens, keys, and the API-key credential write through a shared temp+fsync+rename helper (`client/auth/atomic.go`), keeping the deliberate no-lock last-writer-wins semantics but making a torn/partial credential file impossible. Allow-listed in the config-mutator arch gate.
- **#7 F3 / theme 4 — agent-mode wall-clock timeout.** The root interceptor derives a 60s deadline for `agent`/`service-account` modes (cancel released in `PersistentPostRunE`) so a wedged Control Plane can't hang the CLI forever; human mode stays undeadlined so prompts/paginators aren't cut off.

## Test plan

- [x] `make lint` — 0 issues
- [x] arch suite green (incl. the mutator-lock and redaction-funnel gates)
- [x] New regression tests: WAL backup/restore + stale-sidecar drop, register context-name collision (refuse + `--force` repoint), `context delete --identity` GC, unreferenced `env delete` happy path, atomic writer, agent-mode-sets-deadline / human-mode-no-deadline interceptor tests
- [x] Full touched-package suite green (`client/...`, `internal/cli/...`, `internal/update/...`, `internal/install/...`)

Made with [Cursor](https://cursor.com)