### PR TITLE
cli(v2): review round-3 P2s — broker guard edges, confinement depth, SDK doc drift, register coverage

### DIFF
--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -34,8 +34,13 @@ type Config struct {
 	// ControlBaseURL is the management/control-plane URL (registry, auth,
 	// executions). Required.
 	ControlBaseURL string
-	// BrokerBaseURL is the execution/broker-plane URL. Optional; NewBroker errors
-	// if it is empty.
+	// BrokerBaseURL is the execution/broker-plane URL. Optional and, today,
+	// informational only: the SDK exposes the broker as a transport
+	// (BrokerTransport) rather than a typed constructor, and `jentic execute`
+	// composes the broker catch-all URL itself ({scheme}://{host}/{upstreamURL})
+	// from its own flags/env — it does NOT read this field. It is carried on
+	// Config so a future typed broker seam (or a consumer that wants the resolved
+	// URL) has it without re-resolving; leaving it empty is harmless.
 	BrokerBaseURL string
 
 	IdentityName    string

--- a/cli/client/config/loader.go
+++ b/cli/client/config/loader.go
@@ -55,7 +55,7 @@ func LoadState(cmdContextOverride string) (*ResolvedState, error) {
 
 	if envBaseURL != "" && envToken != "" {
 		state.BaseURL = envBaseURL
-		state.BrokerURL = os.Getenv("JENTIC_BROKER_URL") // required before any broker call (NewBroker errors without it)
+		state.BrokerURL = os.Getenv("JENTIC_BROKER_URL") // consumed by `jentic execute`; empty is allowed (the remote-broker guard fires only for a remote base_url)
 		state.InjectedBearerToken = envToken
 		state.PersistedMode = "agent"     // file-less defaults to agent
 		state.PersistedTheme = "no-color" // file-less defaults to no-color

--- a/cli/client/config/schema.go
+++ b/cli/client/config/schema.go
@@ -40,7 +40,9 @@ type Context struct {
 type Env struct {
 	BaseURL string `yaml:"base_url"` // Control Plane (registry, auth, executions)
 	// BrokerURL is the Data Plane endpoint used by execute/history (Phase 5).
-	// Optional here; NewBroker errors when a broker call is attempted without it.
+	// Optional here; when unset for a REMOTE control plane, `jentic execute`
+	// fail-closes with a recovery directive rather than silently dialing the
+	// local default (see the remote-broker guard in api/execute.go).
 	BrokerURL string `yaml:"broker_url,omitempty"`
 	// CACertPath optionally points at a custom CA bundle for verifying TLS to
 	// self-hosted deployments behind a private CA. It never mutates the OS trust

--- a/cli/internal/cli/api/execute.go
+++ b/cli/internal/cli/api/execute.go
@@ -136,28 +136,41 @@ func (a *app) executeE(cmd *cobra.Command, opts *executeOptions, target string) 
 	// install would still execute against the built-in local default.
 	flags := cmd.Flags()
 	if st := clictx.ActiveContext(cmd.Context()); st != nil && st.BrokerURL != "" {
-		if u, perr := url.Parse(st.BrokerURL); perr == nil && u.Host != "" && u.Scheme != "" {
-			// SEC-21: in a machine mode (agent/service-account) the broker host is
-			// pinned to the environment's configured broker_url. An agent must not
-			// be able to redirect its bearer + injected upstream context at an
-			// arbitrary host via --broker-host/--broker-scheme. A human operator
-			// keeps the override (they own the machine and may be testing). The
-			// scheme may still be overridden (http↔https on the same host is the
-			// common local papercut, guarded separately by RequireSecureURL).
-			if st.IsMachine() && flags.Changed("broker-host") && opts.brokerHost != u.Host {
-				return &ux.CodedError{
-					Code: ux.CodeResolveFailed,
-					Msg: fmt.Sprintf("--broker-host %q is not allowed in %s mode: the broker is pinned to the "+
-						"environment's broker_url host (%s)", opts.brokerHost, st.Mode, u.Host),
-					Actionable: "Drop --broker-host (it uses the environment's broker_url), or change the environment's broker_url with `jentic env add <env> --broker-url <URL> --force`.",
-				}
+		u, perr := url.Parse(st.BrokerURL)
+		if perr != nil || u.Host == "" || u.Scheme == "" {
+			// M2 (review round-3 #3): a broker_url that is SET but malformed
+			// (parse error, or missing host/scheme) must not silently fall through
+			// to the loopback default — that dials 127.0.0.1 and surfaces a
+			// confusing connection-refused instead of naming the real problem.
+			// Fail closed with a coded error pointing at the bad value.
+			return &ux.CodedError{
+				Code: ux.CodeResolveFailed,
+				Msg: fmt.Sprintf("environment %q has a malformed broker_url (%q): it must be an absolute URL with a scheme and host",
+					st.EnvironmentName, st.BrokerURL),
+				Actionable: fmt.Sprintf("Fix it with `jentic env add %s --broker-url https://<broker-host>:<port> --force`, or export JENTIC_BROKER_URL with a valid URL.",
+					st.EnvironmentName),
 			}
-			if !flags.Changed("broker-scheme") {
-				opts.brokerScheme = u.Scheme
+		}
+		// SEC-21: in a machine mode (agent/service-account) the broker host is
+		// pinned to the environment's configured broker_url. An agent must not
+		// be able to redirect its bearer + injected upstream context at an
+		// arbitrary host via --broker-host/--broker-scheme. A human operator
+		// keeps the override (they own the machine and may be testing). The
+		// scheme may still be overridden (http↔https on the same host is the
+		// common local papercut, guarded separately by RequireSecureURL).
+		if st.IsMachine() && flags.Changed("broker-host") && opts.brokerHost != u.Host {
+			return &ux.CodedError{
+				Code: ux.CodeResolveFailed,
+				Msg: fmt.Sprintf("--broker-host %q is not allowed in %s mode: the broker is pinned to the "+
+					"environment's broker_url host (%s)", opts.brokerHost, st.Mode, u.Host),
+				Actionable: "Drop --broker-host (it uses the environment's broker_url), or change the environment's broker_url with `jentic env add <env> --broker-url <URL> --force`.",
 			}
-			if !flags.Changed("broker-host") {
-				opts.brokerHost = u.Host
-			}
+		}
+		if !flags.Changed("broker-scheme") {
+			opts.brokerScheme = u.Scheme
+		}
+		if !flags.Changed("broker-host") {
+			opts.brokerHost = u.Host
 		}
 	}
 
@@ -171,8 +184,18 @@ func (a *app) executeE(cmd *cobra.Command, opts *executeOptions, target string) 
 	// recovery directive instead. Keyed off loopback-ness (reusing the auth
 	// layer's classifier via isLoopbackHostname), so a genuinely-local workflow
 	// (loopback base_url, seeded loopback broker) never trips it.
+	//
+	// M1 (review round-3 #3): only fire when the loopback broker is the built-in
+	// DEFAULT, not an EXPLICIT operator choice. An operator running
+	// `jentic execute --broker-host 127.0.0.1:8100` against a remote control
+	// plane (an SSH tunnel / port-forward to the remote broker) deliberately
+	// chose a loopback broker — refusing that with "set broker_url" is wrong
+	// advice. `flags.Changed` distinguishes the explicit override from the
+	// surviving default. (In machine mode the SEC-21 pin above already blocks a
+	// disagreeing --broker-host, so honoring it here can't help an agent escape.)
 	if st := clictx.ActiveContext(cmd.Context()); st != nil {
-		if brokerIsLoopbackDefault(opts.brokerHost) && baseURLIsRemote(st.BaseURL) {
+		explicitBroker := flags.Changed("broker-scheme") || flags.Changed("broker-host")
+		if !explicitBroker && brokerIsLoopbackDefault(opts.brokerHost) && baseURLIsRemote(st.BaseURL) {
 			return &ux.CodedError{
 				Code: ux.CodeResolveFailed,
 				Msg: fmt.Sprintf("environment %q has a remote control plane (%s) but no broker is configured; "+

--- a/cli/internal/cli/api/execute_test.go
+++ b/cli/internal/cli/api/execute_test.go
@@ -1135,3 +1135,74 @@ func TestExecuteLocalWorkflowGuardSilent(t *testing.T) {
 		t.Errorf("local workflow must not trip the remote-broker guard: %v", err)
 	}
 }
+
+// TestExecuteRemoteBrokerGuardHonoursExplicitLoopback pins M1 (review round-3
+// #3): an operator who EXPLICITLY points --broker-host at a loopback address (an
+// SSH tunnel / port-forward to a remote broker) against a remote control plane
+// must NOT be refused by the fail-closed guard — that is a deliberate, valid
+// setup. Only the surviving built-in DEFAULT loopback should trip the guard.
+func TestExecuteRemoteBrokerGuardHonoursExplicitLoopback(t *testing.T) {
+	remoteCtx := clictx.WithActiveState(context.Background(), &clictx.ActiveState{
+		ResolvedState: &sdkconfig.ResolvedState{
+			IdentityName:        "me",
+			EnvironmentName:     "qa1",
+			BaseURL:             "https://jentic.example.com",
+			BrokerURL:           "", // no configured broker; operator tunnels instead
+			InjectedBearerToken: "tok_abc",
+		},
+		Mode: clictx.ModeHuman,
+	})
+	app := testApp(t)
+	cmd := newExecuteCmd(app)
+	// Explicit loopback broker via the flag (marks flags.Changed("broker-host")).
+	if err := cmd.Flags().Set("broker-host", "127.0.0.1:8100"); err != nil {
+		t.Fatal(err)
+	}
+	cmd.SetContext(remoteCtx)
+
+	err := app.executeE(cmd, &executeOptions{
+		brokerHost:   "127.0.0.1:8100",
+		brokerScheme: config.DefaultBrokerScheme,
+	}, "someOp")
+	// It will fail later (no server), but must NOT be the guard's RESOLVE_FAILED.
+	var coded *ux.CodedError
+	if errors.As(err, &coded) && coded.Code == ux.CodeResolveFailed &&
+		strings.Contains(coded.Msg, "no broker is configured") {
+		t.Errorf("explicit loopback broker must be honoured, not refused by the guard: %v", err)
+	}
+}
+
+// TestExecuteMalformedBrokerURLErrors pins M2 (review round-3 #3): a broker_url
+// that is SET but malformed (no scheme/host) must fail closed with a coded
+// RESOLVE_FAILED naming the bad value, not silently fall through to dialing the
+// loopback default.
+func TestExecuteMalformedBrokerURLErrors(t *testing.T) {
+	badCtx := clictx.WithActiveState(context.Background(), &clictx.ActiveState{
+		ResolvedState: &sdkconfig.ResolvedState{
+			IdentityName:        "me",
+			EnvironmentName:     "qa1",
+			BaseURL:             "http://127.0.0.1:8000",
+			BrokerURL:           "not a url ::::", // parses to no scheme/host
+			InjectedBearerToken: "tok_abc",
+		},
+		Mode: clictx.ModeHuman,
+	})
+	app := testApp(t)
+	cmd := newExecuteCmd(app)
+	cmd.SetContext(badCtx)
+
+	err := app.executeE(cmd, &executeOptions{
+		brokerHost:   config.DefaultBrokerHost,
+		brokerScheme: config.DefaultBrokerScheme,
+	}, "someOp")
+	var coded *ux.CodedError
+	if !errors.As(err, &coded) {
+		t.Fatalf("malformed broker_url returned %T (%v), want *ux.CodedError", err, err)
+	}
+	if coded.Code != ux.CodeResolveFailed {
+		t.Errorf("code = %q, want RESOLVE_FAILED", coded.Code)
+	}
+	if !strings.Contains(coded.Msg, "malformed broker_url") {
+		t.Errorf("error should name the malformed broker_url: %q", coded.Msg)
+	}
+}

--- a/cli/internal/cli/api/register_test.go
+++ b/cli/internal/cli/api/register_test.go
@@ -2,13 +2,16 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/jentic/jentic-one/cli/client/auth"
 	sdkconfig "github.com/jentic/jentic-one/cli/client/config"
@@ -331,6 +334,152 @@ func TestRegister_LegacyFlagsRemoved(t *testing.T) {
 	}
 	if len(cfg.Environments) != 0 || len(cfg.Identities) != 0 || cfg.ActiveContext != "" {
 		t.Errorf("failed register leaked into the XDG store: %+v", cfg)
+	}
+}
+
+// runRegisterCtx runs `jentic register …` through the full api tree with a
+// caller-supplied context (so a test can cancel it mid-poll). It mirrors
+// runJenticCapture but uses root.ExecuteContext, returning app.Out plus the
+// error. The poll cadence is already shrunk to milliseconds by testApp.
+func runRegisterCtx(ctx context.Context, t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	app := testApp(t)
+	out := new(bytes.Buffer)
+	app.Out = out
+	root := newAPIRootCmd(app.App)
+	root.SetOut(new(bytes.Buffer))
+	root.SetErr(new(bytes.Buffer))
+	root.SetArgs(args)
+	err := root.ExecuteContext(ctx)
+	return out.String(), err
+}
+
+// TestRegister_ContextCancelExitsPromptly pins the cancellation branch of the
+// approval poll loop (review round-3 #8 F1: `case <-ctx.Done(): return
+// ctx.Err()` at register_flow.go was uncovered). A never-approving pending
+// server keeps the loop spinning; cancelling the command context must make
+// register return ctx.Err() quickly instead of waiting out the full --timeout.
+func TestRegister_ContextCancelExitsPromptly(t *testing.T) {
+	withXDG(t)
+
+	var polls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/register":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"client_id":"agnt_boot","status":"pending"}`))
+		case "/oauth/token":
+			polls.Add(1) // always pending → the loop never exits on its own
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"type":"invalid_grant","status":400,"detail":"agent pending approval","instance":"/oauth/token"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel shortly after the loop has certainly started polling (cadence is
+	// ~2ms in tests), well before the generous --timeout below would fire.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := runRegisterCtx(ctx, t, "register", "--url", srv.URL, "--name", "crawler", "--env", "qa", "--timeout", "30s")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancel must surface context.Canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("register did not return promptly after context cancel (the ctx.Done branch is not honoured)")
+	}
+}
+
+// TestRegister_AssertionInvalidNoClaimIsFatal pins the non-claim
+// assertion-invalid branch (review round-3 #8 F1 case (d)): with NO claim
+// token outstanding, an "Assertion is invalid" token-exchange failure is a hard
+// NOT_AUTHENTICATED (usually an audience mismatch) — the CLI must abort with the
+// coded error immediately, never treat it as pending and hang.
+func TestRegister_AssertionInvalidNoClaimIsFatal(t *testing.T) {
+	withXDG(t)
+
+	var polls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/register":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			// No claim_token → claimPending=false → assertion-invalid is fatal.
+			_, _ = w.Write([]byte(`{"client_id":"agnt_boot","status":"pending"}`))
+		case "/oauth/token":
+			polls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"type":"invalid_grant","status":400,"detail":"Assertion is invalid","instance":"/oauth/token"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	// A generous --timeout: if the classifier wrongly treated this as pending it
+	// would poll until this fires; the test's own deadline would then trip first.
+	_, err := runJenticCapture(t, "register", "--url", srv.URL, "--name", "crawler", "--env", "qa", "--timeout", "30s")
+	if err == nil {
+		t.Fatal("a non-claim assertion-invalid must be fatal, not pending")
+	}
+	var coded *ux.CodedError
+	if !errors.As(err, &coded) {
+		t.Fatalf("error is not coded: %v", err)
+	}
+	if coded.Code != ux.CodeNotAuthenticated {
+		t.Errorf("code = %q, want NOT_AUTHENTICATED (audience-mismatch abort, no hang)", coded.Code)
+	}
+	// The very first exchange decides it; the loop must not have spun.
+	if got := polls.Load(); got != 1 {
+		t.Errorf("token exchange hit %d times, want exactly 1 (must abort before polling)", got)
+	}
+}
+
+// TestRegister_PendingTimeoutCarriesApproveURL pins the non-claim timeout branch
+// (review round-3 #8 F1): a pending agent that is never approved times out as
+// TIMEOUT_PENDING (exit 3) and the envelope details MUST carry approve_url +
+// agent_id so an agent that timed out can still route a human to approve
+// (AGT-4/AGT-21).
+func TestRegister_PendingTimeoutCarriesApproveURL(t *testing.T) {
+	withXDG(t)
+	srv, _ := bootstrapServer(t, 1_000_000) // effectively always pending
+
+	_, err := runJenticCapture(t, "register", "--url", srv.URL, "--name", "crawler", "--env", "qa", "--timeout", "20ms")
+	if err == nil {
+		t.Fatal("expected a pending timeout, got success")
+	}
+	var coded *ux.CodedError
+	if !errors.As(err, &coded) {
+		t.Fatalf("error is not coded: %v", err)
+	}
+	if coded.Code != ux.CodeTimeoutPending {
+		t.Fatalf("code = %q, want TIMEOUT_PENDING", coded.Code)
+	}
+	if coded.Details["agent_id"] != "agnt_boot" {
+		t.Errorf("details.agent_id = %v, want agnt_boot", coded.Details["agent_id"])
+	}
+	approve, _ := coded.Details["approve_url"].(string)
+	if approve == "" || !strings.Contains(approve, "agnt_boot") {
+		t.Errorf("details.approve_url = %q, want a console URL naming the agent so a timed-out agent can route a human", approve)
+	}
+	// A non-claim timeout must NOT advertise a claim_url (nothing to claim).
+	if _, ok := coded.Details["claim_url"]; ok {
+		t.Errorf("non-claim timeout should not carry claim_url, details = %v", coded.Details)
 	}
 }
 

--- a/cli/internal/cli/localagentcmd/run.go
+++ b/cli/internal/cli/localagentcmd/run.go
@@ -488,6 +488,24 @@ func (a *Cmd) launchAgent(ctx context.Context, acct config.AgentAccount, agentUs
 		agentHome = localagent.DefaultHomeDir(agentUser)
 	}
 
+	// M1 (review round-3 #6): re-validate the operator-editable inputs
+	// IMMEDIATELY before the privileged launch, mirroring grantDir /
+	// exportContextToAgent. These reach the SBPL profile / bwrap argv; the sinks
+	// are independently defended (control-char strip, per-token shell-quoting),
+	// but the `local-agent-isolation` rule requires "validated at the source AND
+	// re-checked immediately before every privileged command" — grantedDirs were
+	// only trusted from recorded config, and agentHome is unvalidated when
+	// exportContextToAgent early-returned (no active context / file-less mode).
+	// Fail closed on the first bad entry rather than relying on sink-only defence.
+	if err := localagent.ValidateHomeDir(agentHome); err != nil {
+		return confinementUnavailableErr(fmt.Sprintf("recorded agent home is invalid: %v", err))
+	}
+	for _, gd := range grantedDirs {
+		if err := localagent.ValidateGrantPath(gd); err != nil {
+			return confinementUnavailableErr(fmt.Sprintf("recorded granted directory %q is invalid: %v", gd, err))
+		}
+	}
+
 	where := dir
 	if where == "" {
 		where = "the agent's home"

--- a/cli/internal/localagent/confine.go
+++ b/cli/internal/localagent/confine.go
@@ -608,19 +608,62 @@ func bwrapArgs(agentHome string, grantedDirs, cmdArgv []string) []string {
 // namespaces. A var so tests can point the probe at a controlled path.
 var usernsClonePath = "/proc/sys/kernel/unprivileged_userns_clone"
 
+// apparmorUserNSRestrictPath is the Ubuntu 23.10+/24.04 AppArmor knob that gates
+// unprivileged user namespaces INDEPENDENTLY of the legacy clone knob. When it is
+// "1" the kernel refuses unprivileged userns for programs without a matching
+// AppArmor profile — bubblewrap is denied at runtime even though
+// unprivileged_userns_clone may be absent or "1". A var for test injection.
+var apparmorUserNSRestrictPath = "/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
+
+// maxUserNamespacesPath is the hard cap on user namespaces for the calling
+// user/namespace. "0" means unprivileged userns is disabled outright regardless
+// of the other knobs. A var for test injection.
+var maxUserNamespacesPath = "/proc/sys/user/max_user_namespaces"
+
 // unprivilegedUserNSEnabled reports whether the kernel permits unprivileged user
 // namespaces, which bubblewrap needs to build its mount namespace without root.
-// The sysctl is Debian/Ubuntu-specific; when the knob is genuinely ABSENT
-// (mainline kernels, RHEL) unprivileged userns is generally on, so a
-// not-exist error is treated as enabled. Any OTHER read error — the knob exists
-// but is unreadable (a masked /proc, an LSM/AppArmor denial, a hardened
-// container) — is treated as DISABLED: the whole confinement contract is
-// error-closed, so an inconclusive probe must fail closed rather than let
-// ConfinementAvailable claim a boundary it can't confirm.
+//
+// Three knobs are consulted, all fail-closed (M2, review round-3 #6):
+//
+//  1. kernel.unprivileged_userns_clone (Debian/Ubuntu legacy). ABSENT → treated
+//     as enabled (mainline/RHEL kernels don't have it and generally allow
+//     userns); "0" → disabled; unreadable → fail closed.
+//  2. kernel.apparmor_restrict_unprivileged_userns (Ubuntu 23.10+/24.04). "1" →
+//     disabled (AppArmor will deny bwrap without a profile); absent/"0" → no
+//     opinion. This is the knob the legacy check is blind to.
+//  3. user.max_user_namespaces. "0" → disabled outright; anything else / absent
+//     → no opinion.
+//
+// The result is the AND of "not explicitly disabled by any knob": a single knob
+// saying "off" disables it, so an Ubuntu 24.04 box with the AppArmor restriction
+// set is correctly reported unavailable (curated prereq message) instead of
+// reaching a raw bwrap failure.
 func unprivilegedUserNSEnabled() bool {
-	data, err := os.ReadFile(usernsClonePath)
-	if err != nil {
-		return errors.Is(err, os.ErrNotExist) // absent → enabled; unreadable → fail closed
+	// (1) Legacy clone knob: absent → enabled, "0" → disabled, unreadable → closed.
+	if data, err := os.ReadFile(usernsClonePath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return false // knob exists but unreadable → fail closed
+		}
+		// absent → fall through; the other knobs decide
+	} else if strings.TrimSpace(string(data)) == "0" {
+		return false
 	}
-	return strings.TrimSpace(string(data)) != "0"
+
+	// (2) AppArmor userns restriction (Ubuntu 23.10+): "1" disables unprivileged
+	// userns for unprofiled programs. Absent/unreadable → no opinion (older
+	// kernels), so don't fail closed on a knob that simply doesn't exist here.
+	if data, err := os.ReadFile(apparmorUserNSRestrictPath); err == nil {
+		if strings.TrimSpace(string(data)) == "1" {
+			return false
+		}
+	}
+
+	// (3) Hard cap: "0" disables userns entirely. Absent/unreadable → no opinion.
+	if data, err := os.ReadFile(maxUserNamespacesPath); err == nil {
+		if strings.TrimSpace(string(data)) == "0" {
+			return false
+		}
+	}
+
+	return true
 }

--- a/cli/internal/localagent/confine_test.go
+++ b/cli/internal/localagent/confine_test.go
@@ -596,8 +596,18 @@ func TestConfinementAvailableAgreesWithMissingPrereqs(t *testing.T) {
 // of the confinement model) and reads the sysctl value when it is present.
 func TestUnprivilegedUserNSProbe(t *testing.T) {
 	orig := usernsClonePath
-	t.Cleanup(func() { usernsClonePath = orig })
+	origAA := apparmorUserNSRestrictPath
+	origMax := maxUserNamespacesPath
+	t.Cleanup(func() {
+		usernsClonePath = orig
+		apparmorUserNSRestrictPath = origAA
+		maxUserNamespacesPath = origMax
+	})
 	dir := t.TempDir()
+	// Point the two Ubuntu-24.04 knobs at absent paths so this test isolates the
+	// legacy clone knob (M2 knobs get their own test below); absent = no opinion.
+	apparmorUserNSRestrictPath = filepath.Join(dir, "no-apparmor")
+	maxUserNamespacesPath = filepath.Join(dir, "no-max")
 
 	// Knob absent → enabled (not gated on this kernel).
 	usernsClonePath = filepath.Join(dir, "does-not-exist")
@@ -630,6 +640,65 @@ func TestUnprivilegedUserNSProbe(t *testing.T) {
 	}
 	if unprivilegedUserNSEnabled() {
 		t.Error("an unreadable knob must fail closed (treated as disabled)")
+	}
+}
+
+// TestUnprivilegedUserNSProbeAppArmorAndMax pins M2 (review round-3 #6): the
+// probe must also honour the Ubuntu 23.10+/24.04 AppArmor restriction and the
+// max_user_namespaces cap, which the legacy unprivileged_userns_clone knob is
+// blind to. A box where the clone knob is absent/enabled but AppArmor restricts
+// (or the cap is 0) must report unavailable so the operator gets the curated
+// prereq message instead of a raw bwrap denial.
+func TestUnprivilegedUserNSProbeAppArmorAndMax(t *testing.T) {
+	orig := usernsClonePath
+	origAA := apparmorUserNSRestrictPath
+	origMax := maxUserNamespacesPath
+	t.Cleanup(func() {
+		usernsClonePath = orig
+		apparmorUserNSRestrictPath = origAA
+		maxUserNamespacesPath = origMax
+	})
+	dir := t.TempDir()
+
+	// Baseline: clone absent, AppArmor absent, max absent → enabled.
+	usernsClonePath = filepath.Join(dir, "clone-absent")
+	apparmorUserNSRestrictPath = filepath.Join(dir, "aa-absent")
+	maxUserNamespacesPath = filepath.Join(dir, "max-absent")
+	if !unprivilegedUserNSEnabled() {
+		t.Fatal("clone/AppArmor/max all absent should be enabled")
+	}
+
+	// AppArmor restriction = 1 disables it, even with the legacy knob absent —
+	// this is the exact Ubuntu 24.04 case the legacy probe missed.
+	apparmorUserNSRestrictPath = filepath.Join(dir, "aa")
+	if err := os.WriteFile(apparmorUserNSRestrictPath, []byte("1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if unprivilegedUserNSEnabled() {
+		t.Error("apparmor_restrict_unprivileged_userns=1 must disable (Ubuntu 24.04)")
+	}
+	// AppArmor restriction = 0 → no opinion (back to enabled).
+	if err := os.WriteFile(apparmorUserNSRestrictPath, []byte("0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !unprivilegedUserNSEnabled() {
+		t.Error("apparmor_restrict_unprivileged_userns=0 must not disable")
+	}
+
+	// max_user_namespaces = 0 disables outright.
+	maxUserNamespacesPath = filepath.Join(dir, "max")
+	if err := os.WriteFile(maxUserNamespacesPath, []byte("0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if unprivilegedUserNSEnabled() {
+		t.Error("max_user_namespaces=0 must disable")
+	}
+	// A positive cap → no opinion.
+	if err := os.WriteFile(maxUserNamespacesPath, []byte("15000\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !unprivilegedUserNSEnabled() {
+		t.Error("a positive max_user_namespaces must not disable")
 	}
 }
 


### PR DESCRIPTION
Round-3 **P2** items from [`cli-review3-index-2026-08-17.md`] sequencing steps 6–7. Follows the merged round-3 P0 (#1061) and P1 (#1062); targets `cli-v2-release`.

## Summary

- **Broker guard edges (#3 M1/M2, `execute.go`)**
  - **M1:** honour an *explicit* loopback `--broker-host`/`--broker-scheme` (SSH-tunnel / port-forward to a remote broker) instead of falsely refusing it — the fail-closed guard now fires only for the surviving built-in default (`flags.Changed` distinguishes them).
  - **M2:** a `broker_url` that is *set but malformed* (no scheme/host) now fails closed with a coded `RESOLVE_FAILED` naming the bad value, instead of silently falling through to the loopback default.
- **Confinement defence-in-depth (#6 M1/M2)**
  - **M1:** re-validate granted dirs + agent home immediately before the confined launch (`ValidateGrantPath`/`ValidateHomeDir`), restoring the "re-check before every privileged command" invariant instead of relying on sink-only defence.
  - **M2:** the Linux userns probe now also consults the Ubuntu 23.10+/24.04 AppArmor restriction (`apparmor_restrict_unprivileged_userns`) and `max_user_namespaces`, so a box that will refuse `bwrap` reports "unavailable" with the curated prereq message instead of a raw bwrap failure.
- **SDK phantom `NewBroker` (#1, doc-only):** the dead typed broker client was already removed by ARCH-20; `generated/broker` remains in use for its `SensitiveFields` redaction tables. Fixed the 3 misleading `NewBroker` doc comments (`client.go`/`schema.go`/`loader.go`) to describe the actual transport-only design.
- **Test coverage (#8 F1):** added tests for the previously-untested register/claim orchestration branches — context-cancel mid-poll, non-claim assertion-invalid abort (`NOT_AUTHENTICATED`, no hang), and the pending-timeout envelope carrying `approve_url`; plus regression tests for the broker M1/M2 and confinement M2 fixes.
- **Per-command `--json` (#5):** resolved by a rule amendment in `jentic-one-rules` (`agent-commands.md`) — kept as a human-convenience override that is additive to the mode ladder. Committed separately in the rules repo; no product-code change here.

Everything remains fail-closed; this is hardening, not a live-bug fix.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/cli/api/ ./internal/localagent/ ./internal/cli/cmdcore/ ./client/... ./tests/arch/...` — all green
- [x] `golangci-lint run` on changed packages — 0 issues
- [x] New tests pass: register cancel/assertion-invalid/timeout-approve_url; broker explicit-loopback/malformed-url; userns AppArmor/max probe

Made with [Cursor](https://cursor.com)