### PR TITLE
fix(localagent): fail closed when agent account creation silently fails

### DIFF
--- a/cli/internal/cli/localagentcmd/agentuser.go
+++ b/cli/internal/cli/localagentcmd/agentuser.go
@@ -146,6 +146,17 @@ func (a *Cmd) setupAgentUser(ctx context.Context, operators []string, interactiv
 		return agentSetup{}, err
 	}
 
+	// The home field was prefilled from the DEFAULT account name; if the operator
+	// renamed the account but left the home at that stale default, follow the name
+	// rather than silently keeping a directory derived from a name they rejected —
+	// which, when the default-named account already exists, is that OTHER account's
+	// live home (see HomeClaimedBy for the guard behind this convenience).
+	if home, changed := followRenamedHome(fields.name, defaultName, fields.homeDir); changed {
+		fields.homeDir = home
+		fmt.Fprintln(a.Out, theme.Dim.Render(
+			"Agent home follows the account name: "+fields.homeDir))
+	}
+
 	if err := a.createAgentAccount(ctx, operator, fields); err != nil {
 		return agentSetup{}, err
 	}
@@ -268,6 +279,16 @@ func (a *Cmd) createAgentAccount(ctx context.Context, operator string, fields ag
 		}
 		fmt.Fprintln(a.Out, theme.Dim.Render(fmt.Sprintf("Account %q already exists — reusing it.", fields.name)))
 	} else {
+		// A NEW account must not be pointed at a home some OTHER existing account
+		// already claims (typically another agent account's live home, left in the
+		// form's prefill after the operator renamed the account): the reclaim/grant
+		// steps below would chown that account's home wholesale to this one.
+		// VerifyManagedHome only guards the reuse branch, so check here too.
+		if claimant := localagent.HomeClaimedBy(ctx, fields.name, fields.homeDir); claimant != "" {
+			return fmt.Errorf("home directory %s already belongs to existing account %q — "+
+				"pick this account's own home (e.g. %s), or reuse that account by naming it %q",
+				fields.homeDir, claimant, localagent.DefaultHomeDir(fields.name), claimant)
+		}
 		fmt.Fprintln(a.Out, theme.Infof("Creating agent account %q (home %s) ...", fields.name, fields.homeDir))
 		for _, step := range localagent.CreateAccountCmds(operator, fields.name, fields.homeDir) {
 			c := step.Cmd
@@ -288,6 +309,18 @@ func (a *Cmd) createAgentAccount(ctx context.Context, operator string, fields ag
 				}
 				return fmt.Errorf("%s: %w", step.What, err)
 			}
+		}
+		// Fail closed on a create the OS refused: sysadminctl can reject the add
+		// (e.g. a Directory Services record conflict) while still EXITING 0, so the
+		// step loop above sails through with no account behind it. Without this
+		// check every later step degrades into best-effort "unknown user" noise,
+		// the account is recorded as created, and `jentic run` sends the operator
+		// back to bootstrap in a loop. Trust the account database, not exit codes.
+		if !localagent.UserExists(ctx, fields.name) {
+			return fmt.Errorf("agent account %q was not created — the account tool reported success "+
+				"but the account does not exist (see its messages above; a conflicting Directory "+
+				"Services record is the usual cause). Resolve the conflict or pick a different "+
+				"account name and re-run", fields.name)
 		}
 	}
 
@@ -440,6 +473,21 @@ func operatorNames(adapters []skillgen.Adapter) []string {
 		names = append(names, string(ad.Operator()))
 	}
 	return names
+}
+
+// followRenamedHome re-derives the agent home when the operator renamed the
+// account in the setup form but left the home at the DEFAULT name's prefill:
+// the two fields are edited independently, so the stale prefill would silently
+// point the new account at a directory derived from a name the operator
+// rejected — which, when the default-named account already exists, is that
+// other account's live home. Returns the home to use and whether it changed;
+// a deliberately customised home (anything but the exact stale prefill) is
+// always kept.
+func followRenamedHome(name, defaultName, homeDir string) (string, bool) {
+	if name != defaultName && homeDir == localagent.DefaultHomeDir(defaultName) {
+		return localagent.DefaultHomeDir(name), true
+	}
+	return homeDir, false
 }
 
 // firstKnownAgent returns the first selected operator that maps to a known local

--- a/cli/internal/cli/localagentcmd/agentuser_test.go
+++ b/cli/internal/cli/localagentcmd/agentuser_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/jentic/jentic-one/cli/internal/config"
+	"github.com/jentic/jentic-one/cli/internal/localagent"
 	"github.com/jentic/jentic-one/cli/internal/skillgen"
 )
 
@@ -34,6 +35,31 @@ func TestProviderToggleTitle(t *testing.T) {
 		if got := providerToggleTitle(name); got != "Copy your LLM provider config into the agent's home?" {
 			t.Errorf("providerToggleTitle(%q) = %q, want generic", name, got)
 		}
+	}
+}
+
+// TestFollowRenamedHome guards the form's home/name coupling: the home field is
+// prefilled from the DEFAULT account name, so an operator who renames the account
+// but leaves the home untouched must get the home re-derived from the new name —
+// otherwise the new account is silently pointed at a directory derived from a
+// name they rejected (the existing default-named account's live home, when one
+// exists). A deliberately customised home is always kept.
+func TestFollowRenamedHome(t *testing.T) {
+	defaultName := "alice-local-agent"
+	staleDefault := localagent.DefaultHomeDir(defaultName)
+
+	// Renamed account + untouched prefill → home follows the name.
+	if home, changed := followRenamedHome("alice-2", defaultName, staleDefault); !changed || home != localagent.DefaultHomeDir("alice-2") {
+		t.Errorf("followRenamedHome(renamed, stale prefill) = (%q, %v), want re-derived home", home, changed)
+	}
+	// Default name kept → prefill kept.
+	if home, changed := followRenamedHome(defaultName, defaultName, staleDefault); changed || home != staleDefault {
+		t.Errorf("followRenamedHome(default name) = (%q, %v), want unchanged", home, changed)
+	}
+	// Renamed account + deliberately customised home → the operator's choice wins.
+	custom := localagent.AgentHomeRoot() + "/team/alice-2"
+	if home, changed := followRenamedHome("alice-2", defaultName, custom); changed || home != custom {
+		t.Errorf("followRenamedHome(custom home) = (%q, %v), want operator's home kept", home, changed)
 	}
 }
 

--- a/cli/internal/localagent/localagent.go
+++ b/cli/internal/localagent/localagent.go
@@ -228,6 +228,10 @@ type AccountStep struct {
 // the directory; the operator ACL is an inherited `chmod +a` allow. Linux:
 // `useradd -m` creates the home in one step, then two `setfacl` calls lay down
 // the operator's access ACL and a matching default ACL for future contents.
+//
+// Note that sysadminctl can REFUSE the add yet still exit 0 (e.g. "User with
+// full name '…' already exists"), so callers must verify the account actually
+// exists afterwards (UserExists) rather than trusting the step's exit code.
 func CreateAccountCmds(operator, agentUser, homeDir string) []AccountStep {
 	if runtime.GOOS == "darwin" {
 		return []AccountStep{
@@ -235,7 +239,7 @@ func CreateAccountCmds(operator, agentUser, homeDir string) []AccountStep {
 				What: "create the agent account",
 				//nolint:gosec // operator/agentUser/homeDir are config-derived account names and a resolved path.
 				Cmd: exec.Command("sudo", "sysadminctl", "-addUser", agentUser,
-					"-fullName", operator+" Local Agent", "-home", homeDir, "-password", "-"),
+					"-fullName", AccountFullName(operator, agentUser), "-home", homeDir, "-password", "-"),
 			},
 			{
 				What: "create the agent's home directory",
@@ -265,6 +269,18 @@ func CreateAccountCmds(operator, agentUser, homeDir string) []AccountStep {
 			Cmd:  GrantOperatorHomeCmd(operator, homeDir),
 		},
 	}
+}
+
+// AccountFullName is the display (full) name recorded for the agent account on
+// macOS. It MUST be unique per account name, not merely per operator: macOS Open
+// Directory refuses a duplicate full name, so a constant "<operator> Local Agent"
+// made every SECOND agent account for the same operator (any custom name) collide
+// with the first's record — and sysadminctl reports that refusal on stderr while
+// still exiting 0, so the collision surfaced only as a cascade of "unknown user"
+// failures much later. Embedding the account name (which the OS already
+// guarantees unique) makes the full name collision-free by construction.
+func AccountFullName(operator, agentUser string) string {
+	return agentUser + " (jentic agent of " + operator + ")"
 }
 
 // GrantOperatorHomeCmd gives the operator RECURSIVE, inherited read/write on the
@@ -963,6 +979,65 @@ func VerifyManagedHome(agentUser, recordedHome string) error {
 			agentUser, actual, recordedHome)
 	}
 	return nil
+}
+
+// HomeClaimedBy returns the name of an existing OS account, OTHER than agentUser,
+// whose recorded home directory is exactly homeDir — or "" when no other account
+// claims it. It is the guard in front of CREATING an account: the account-setup
+// form prefixes the home from the DEFAULT name, so an operator who edits the name
+// but not the home (or hand-edits config) can point a brand-new account at an
+// EXISTING agent account's live home — and the create path (unlike reuse, which
+// goes through VerifyManagedHome) would then stamp operator ACLs over that home
+// and chown it wholesale to the new account. Refusing when another account claims
+// the home closes that.
+//
+// Enumeration shells to the platform account database (`dscl . -list /Users
+// NFSHomeDirectory` on macOS, `getent passwd` on Linux). It is best-effort in the
+// safe direction for a pure lookup: an enumeration failure returns "" (no claim
+// found) rather than blocking setup, because the post-create UserExists
+// verification still backstops a create that the OS refused.
+func HomeClaimedBy(ctx context.Context, agentUser, homeDir string) string {
+	target := filepath.Clean(homeDir)
+	for name, home := range accountHomes(ctx) {
+		if name != agentUser && filepath.Clean(home) == target {
+			return name
+		}
+	}
+	return ""
+}
+
+// accountHomes enumerates the OS account database as a name→home map, returning
+// nil on any failure (see HomeClaimedBy for why that is the safe direction).
+func accountHomes(ctx context.Context) map[string]string {
+	out := map[string]string{}
+	if runtime.GOOS == "darwin" {
+		data, err := exec.CommandContext(ctx, "dscl", ".", "-list", "/Users", "NFSHomeDirectory").Output()
+		if err != nil {
+			return nil
+		}
+		// Each line is "<name><spaces><home>"; the home may itself contain
+		// spaces, so split off the first field and take the trimmed remainder.
+		for _, line := range strings.Split(string(data), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+			name := fields[0]
+			out[name] = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), name))
+		}
+		return out
+	}
+	data, err := exec.CommandContext(ctx, "getent", "passwd").Output()
+	if err != nil {
+		return nil
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		parts := strings.Split(line, ":")
+		if len(parts) >= 6 && parts[0] != "" {
+			out[parts[0]] = parts[5]
+		}
+	}
+	return out
 }
 
 // CopyBinaryCmd copies the operator's binary at src into the agent user's

--- a/cli/internal/localagent/localagent_test.go
+++ b/cli/internal/localagent/localagent_test.go
@@ -867,6 +867,52 @@ func TestVerifyManagedHome(t *testing.T) {
 	}
 }
 
+// TestAccountFullName guards the collision-freedom of the macOS display name:
+// Open Directory refuses a duplicate full name (and sysadminctl reports that
+// refusal while exiting 0), so two DIFFERENT account names for the same operator
+// must never map to the same full name — the old constant "<operator> Local
+// Agent" did exactly that and broke every second agent account.
+func TestAccountFullName(t *testing.T) {
+	a := AccountFullName("alice", "alice-local-agent")
+	b := AccountFullName("alice", "alice-agent-2")
+	if a == b {
+		t.Fatalf("full names for different account names must differ, both %q", a)
+	}
+	if !strings.Contains(a, "alice-local-agent") {
+		t.Errorf("full name %q should embed the account name for uniqueness", a)
+	}
+	// The create step must actually use the per-account full name.
+	if runtime.GOOS == "darwin" {
+		joined := strings.Join(CreateAccountCmds("alice", "alice-agent-2", DefaultHomeDir("alice-agent-2"))[0].Cmd.Args, " ")
+		if !strings.Contains(joined, AccountFullName("alice", "alice-agent-2")) {
+			t.Errorf("sysadminctl step must carry the per-account full name: %s", joined)
+		}
+	}
+}
+
+// TestHomeClaimedBy exercises the create-path guard against pointing a NEW
+// account at a home some other existing account already claims, using the real
+// account database (the current user is guaranteed to exist and record a home).
+func TestHomeClaimedBy(t *testing.T) {
+	me, err := user.Current()
+	if err != nil || me.Username == "" || me.HomeDir == "" {
+		t.Skip("cannot resolve current user")
+	}
+	ctx := context.Background()
+	// Another account's recorded home is claimed.
+	if got := HomeClaimedBy(ctx, "nope-no-such-agent-xyz", me.HomeDir); got != me.Username {
+		t.Errorf("HomeClaimedBy(other, %q) = %q, want %q", me.HomeDir, got, me.Username)
+	}
+	// The account's OWN home is not a conflict (that is the reuse path).
+	if got := HomeClaimedBy(ctx, me.Username, me.HomeDir); got != "" {
+		t.Errorf("HomeClaimedBy(self, own home) = %q, want \"\"", got)
+	}
+	// A home nobody records is unclaimed.
+	if got := HomeClaimedBy(ctx, "nope-no-such-agent-xyz", "/nowhere/definitely-unclaimed-xyz"); got != "" {
+		t.Errorf("HomeClaimedBy(unclaimed) = %q, want \"\"", got)
+	}
+}
+
 func TestIsUnderHome(t *testing.T) {
 	home := "/Users/alice"
 	if !IsUnderHome(home, "/Users/alice/projects/api") {

--- a/docs/security/local-agent/local-agent-isolation.md
+++ b/docs/security/local-agent/local-agent-isolation.md
@@ -210,8 +210,12 @@ single-user machine that recipe is:
 ```bash
 # macOS
 AGENT="$(whoami)-local-agent"; AGENT_HOME_DIR="/Users/Shared/$AGENT"
-sudo sysadminctl -addUser "$AGENT" -fullName "$(whoami) Local Agent" -home "$AGENT_HOME_DIR" -password -
+# The full name embeds the account name: macOS refuses duplicate full names (and
+# sysadminctl exits 0 on that refusal), so a per-operator constant would break
+# every second agent account.
+sudo sysadminctl -addUser "$AGENT" -fullName "$AGENT (jentic agent of $(whoami))" -home "$AGENT_HOME_DIR" -password -
 sudo createhomedir -c -u "$AGENT"                                  # sysadminctl only *records* the home; this creates it
+id -u "$AGENT" >/dev/null                                          # verify the add actually took — do not trust sysadminctl's exit code
 sudo chmod +a "user:$(whoami) allow read,write,execute,file_inherit,directory_inherit" "$AGENT_HOME_DIR"
 # The operator's home is NOT force-locked to 700 — in-home confidentiality against
 # the agent is enforced per session by the confinement profile (see below).


### PR DESCRIPTION
## Summary

Creating a second agent account on macOS always failed silently and left the CLI in a dead-end loop (`jentic run` says the account doesn't exist → sends you to `jentic bootstrap` → bootstrap "succeeds" again). Root cause chain, reproduced on a machine with an existing `<operator>-local-agent` account:

1. `sysadminctl -addUser` was given a **constant per-operator full name** (`"<operator> Local Agent"`); macOS Open Directory refuses duplicate full names, so any second account name collided with the first's record.
2. `sysadminctl` reports that refusal on stderr but **exits 0**, and the create path trusted the exit code — so bootstrap sailed on: `createhomedir` no-op'd, ACL/chown/seed steps degraded into best-effort "unknown user" noise, a NOPASSWD sudoers rule was installed for a **nonexistent** user, and the phantom account was recorded as `account_created: true`.
3. Separately, the setup form prefills the home from the **default** name; renaming the account but leaving the home meant a brand-new account targeted the **existing** agent account's live home — the create path (unlike reuse, which goes through `VerifyManagedHome`) would stamp operator ACLs over it and chown it wholesale.

Changes:

- `AccountFullName`: macOS full name now embeds the account name (unique by construction), so second accounts can't collide
- `createAgentAccount` verifies `UserExists` after the create steps and fails closed **before** installing the sudoers rule or recording the account, surfacing a clear error instead of the "unknown user" cascade
- `HomeClaimedBy`: create path refuses a home that another existing account records as its home (`dscl` on macOS, `getent passwd` on Linux)
- `followRenamedHome`: renaming the account in the form re-derives the home from the new name when it was left at the stale default prefill (with a printed notice); a customised home is always kept
- docs: manual recipe in `local-agent-isolation.md` updated to the per-account full name + an `id -u` verification step

Out of scope (follow-up): the `agent_account` record still lives in the legacy `~/.jentic/config.yaml`, which `jentic migrate --purge-legacy` deletes wholesale.

## Test plan

- [x] `make lint` (golangci-lint) — 0 issues
- [x] `go test ./internal/...` — all packages pass (new: `TestAccountFullName`, `TestHomeClaimedBy`, `TestFollowRenamedHome`)
- [ ] On a macOS box with an existing `<operator>-local-agent`: `jentic bootstrap` with a new account name now creates the account (unique full name) instead of silently failing
- [ ] Bootstrap with a new name but the stale default home prefill re-derives the home and never touches the existing account's home

Made with [Cursor](https://cursor.com)