### PR TITLE
ci(dependabot): use the build commit prefix for dependency bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,12 +15,15 @@ updates:
   # The repo is a uv project (CI uses astral-sh/setup-uv + `make sync`), so the
   # updater must target the uv lockfile, not pip. The original "pip" ecosystem
   # pointed at a manifest this project does not use.
+  # Dependency bumps use the `build` type (not `chore`): release-please hides
+  # chore commits from the changelog, while build lands under "Build System",
+  # so lib updates stay visible in release notes.
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore"
+      prefix: "build"
       include: "scope"
     open-pull-requests-limit: 5
     # uv does not support the group-level `dependency-type` selector (only
@@ -41,7 +44,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore"
+      prefix: "build"
       include: "scope"
     open-pull-requests-limit: 5
     groups:
@@ -53,7 +56,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore"
+      prefix: "build"
       include: "scope"
     open-pull-requests-limit: 5
     # Coupled toolchains must upgrade together or `npm ci` fails with ERESOLVE


### PR DESCRIPTION
## Summary

Dependabot dependency bumps never appear in the auto-generated changelog: they are committed as `chore(deps)`, and `release-please-config.json` hides the `chore` type (`"hidden": true`). The framer-motion bump (#1056) is missing from the 0.31.1 release notes (#1046) for exactly this reason. Switching the Dependabot commit prefix to `build` — an already-allowed commit type that release-please renders under "Build System" — makes lib updates visible in release notes going forward.

## Changes

- `.github/dependabot.yml`: `commit-message.prefix` changed `chore` → `build` for the npm (`/ui`), uv, and docker ecosystems, with a comment explaining why
- Deliberately out of scope: GitHub Actions bumps stay `ci` (hidden by design); the already-merged #1056 stays hidden in #1046 since release-please won't regenerate notes for a hidden type

## Risk & rollback

- Low risk: config-only change affecting future Dependabot commit messages; `build` is already in the commitizen `schema_pattern`, so the commit-msg hook and PR titles remain valid. Revert the squash commit to roll back.
- Note: `build` (like `chore`) does not trigger a version bump on its own — dep bumps become visible in the next `feat`/`fix`-driven release.

## Test plan

- No automated tests; manual verification: confirmed `build` is an allowed type in `pyproject.toml` `[tool.commitizen.customize]` and that `release-please-config.json` has `{ "type": "build", "section": "Build System", "hidden": false }`. Next weekly Dependabot PR will confirm the new prefix end-to-end.

Made with [Cursor](https://cursor.com)