### PR TITLE
fix(registry): catalog import derives vendor-doubled api_name; warn on unmatched credential scope

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1638,7 +1638,7 @@
         "filename": "tests/web/control/test_credentials.py",
         "hashed_secret": "5a22d03a3a0988b8bd98d9a1fe374b6f8793a6b7",
         "is_verified": false,
-        "line_number": 109
+        "line_number": 111
       }
     ],
     "ui/public/mockServiceWorker.js": [
@@ -1788,5 +1788,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-17T15:21:23Z"
+  "generated_at": "2026-08-18T14:13:36Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -341,7 +341,7 @@
         "filename": "openapi/control/control.openapi.yaml",
         "hashed_secret": "5ccd78467ff52d61471c0cf0f32543d0d5d14367",
         "is_verified": false,
-        "line_number": 17148
+        "line_number": 17156
       }
     ],
     "release-please-config.json": [
@@ -858,6 +858,22 @@
         "type": "Hex High Entropy String",
         "filename": "src/jentic_one/migrations/registry/versions/d4e5f6a7b8c9_add_revision_pagination_index.py",
         "hashed_secret": "5f54b82127fdf5d4704c3fa47ea6efb79f16f243",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "src/jentic_one/migrations/registry/versions/d6e7f8a9b0c1_add_deprecated_reason_to_overlays.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/jentic_one/migrations/registry/versions/d6e7f8a9b0c1_add_deprecated_reason_to_overlays.py",
+        "hashed_secret": "5131f4849513642dfcd9d9a20123223584850684",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/jentic_one/migrations/registry/versions/d6e7f8a9b0c1_add_deprecated_reason_to_overlays.py",
+        "hashed_secret": "ceeb46597b474a1b71d009d35dbe2782f54ebe5c",
         "is_verified": false,
         "line_number": 15
       }
@@ -1772,5 +1788,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T09:06:21Z"
+  "generated_at": "2026-08-17T15:21:23Z"
 }

--- a/openapi/control/control.openapi.yaml
+++ b/openapi/control/control.openapi.yaml
@@ -1710,6 +1710,14 @@ components:
           additionalProperties: true
           title: Secret
           type: object
+        warnings:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          description: Advisory warnings from create — e.g. the credential's API scope matches no imported API identity, so execution through it would fail until a matching API is imported. The credential is created regardless; null when there is nothing to flag.
+          title: Warnings
       required:
       - credential
       - secret

--- a/src/jentic_one/control/repos/__init__.py
+++ b/src/jentic_one/control/repos/__init__.py
@@ -9,6 +9,7 @@ from jentic_one.control.repos.credential_repo import CredentialRepository
 from jentic_one.control.repos.customer_api_key_repo import CustomerAPIKeyRepository
 from jentic_one.control.repos.oauth_client_credential_repo import OAuthClientCredentialRepository
 from jentic_one.control.repos.oauth_token_repo import OAuthTokenRepository
+from jentic_one.control.repos.registry_api_lookup_repo import RegistryApiLookupRepository
 from jentic_one.control.repos.sigv4_credential_repo import Sigv4CredentialRepository
 from jentic_one.control.repos.token_value_credential_repo import TokenValueCredentialRepository
 from jentic_one.control.repos.toolkit_binding_repo import ToolkitBindingRepository
@@ -24,6 +25,7 @@ __all__ = [
     "CustomerAPIKeyRepository",
     "OAuthClientCredentialRepository",
     "OAuthTokenRepository",
+    "RegistryApiLookupRepository",
     "Sigv4CredentialRepository",
     "TokenValueCredentialRepository",
     "ToolkitBindingRepository",

--- a/src/jentic_one/control/repos/registry_api_lookup_repo.py
+++ b/src/jentic_one/control/repos/registry_api_lookup_repo.py
@@ -1,0 +1,78 @@
+"""Cross-DB read: does a credential's API scope cover any registry API identity?
+
+Credential resolution keys on the *workspace* API identity, but credential
+creation accepts an unvalidated reference — a scope that matches no imported
+API only surfaces at execute time as an opaque 403 ``no_toolkit_binding``
+(#1020). This repository answers the coverage question at create time so the
+service can attach an advisory warning.
+
+Control may not import registry ORM (arch boundary: no cross-imports between
+broker/control/admin/registry), so — mirroring the broker's
+``toolkit_binding_resolver`` — this runs raw SQL over the registry DB through
+the shared ``DatabaseSession``. Only plain comparisons are emitted, so the
+statements are dialect-portable across Postgres and SQLite.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import TextClause, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from jentic_one.shared.models.api_identity import CredentialScope
+
+
+def _scope_query(*, name_scoped: bool, version_scoped: bool) -> TextClause:
+    """Coverage probe with a NULL (wildcard) scope axis dropped from the WHERE.
+
+    The inverse of ``credential_coverage_where``: there the *credential* rows
+    carry the NULL wildcards and the probe identity is concrete; here the
+    scope's non-NULL axes constrain the concrete ``apis`` rows.
+    """
+    clauses = ["vendor = :vendor"]
+    if name_scoped:
+        clauses.append("name = :name")
+    if version_scoped:
+        clauses.append("version = :version")
+    return text("SELECT 1 FROM apis WHERE " + " AND ".join(clauses) + " LIMIT 1")
+
+
+_IDENTITIES_FOR_VENDOR = text(
+    "SELECT DISTINCT name, version FROM apis WHERE vendor = :vendor "
+    "ORDER BY name, version LIMIT :limit"
+)
+
+
+class RegistryApiLookupRepository:
+    """Read-only raw-SQL lookups against the registry ``apis`` table."""
+
+    @staticmethod
+    async def scope_covers_any(session: AsyncSession, scope: CredentialScope) -> bool:
+        """True when at least one registry API identity is covered by ``scope``.
+
+        ``scope`` is assumed canonical (``canonical_credential_scope``) — the
+        registry stores slugified vendor/name, so the comparison is exact.
+        """
+        params: dict[str, str] = {"vendor": scope.vendor}
+        if scope.name is not None:
+            params["name"] = scope.name
+        if scope.version is not None:
+            params["version"] = scope.version
+        stmt = _scope_query(
+            name_scoped=scope.name is not None, version_scoped=scope.version is not None
+        )
+        row = (await session.execute(stmt, params)).first()
+        return row is not None
+
+    @staticmethod
+    async def identities_for_vendor(
+        session: AsyncSession, vendor: str, *, limit: int = 5
+    ) -> list[tuple[str, str]]:
+        """Distinct ``(name, version)`` identities registered under ``vendor``.
+
+        Used for the nearest-identity hint when a scope covers nothing: same
+        vendor, different name/version is exactly the #1020 dead-end shape.
+        """
+        rows = (
+            await session.execute(_IDENTITIES_FOR_VENDOR, {"vendor": vendor, "limit": limit})
+        ).all()
+        return [(row.name, row.version) for row in rows]

--- a/src/jentic_one/control/services/credentials/schemas/credentials.py
+++ b/src/jentic_one/control/services/credentials/schemas/credentials.py
@@ -208,6 +208,10 @@ class CredentialFullView(BaseModel):
     created_at: datetime
     server_variables: dict[str, str] | None = None
     secret: BearerTokenFull | ApiKeyFull | BasicAuthFull | OAuth2Full | NoAuthFull | Sigv4Full
+    # Advisory only — e.g. the API scope covers no imported registry API
+    # identity (#1020). The credential is created regardless; None when there
+    # is nothing to flag (or the check could not run).
+    warnings: list[str] | None = None
 
 
 class CredentialRedactedView(BaseModel):

--- a/src/jentic_one/control/services/credentials/service.py
+++ b/src/jentic_one/control/services/credentials/service.py
@@ -17,6 +17,7 @@ from jentic_one.control.repos import (
     TokenValueCredentialRepository,
 )
 from jentic_one.control.repos.prerequisite_repo import PrerequisiteRepository
+from jentic_one.control.repos.registry_api_lookup_repo import RegistryApiLookupRepository
 from jentic_one.control.scoping.filters import build_access_filters
 from jentic_one.control.services.credentials.errors import (
     CredentialNotFoundError,
@@ -126,6 +127,10 @@ class CredentialService:
         # identity at execute time (#775), and stores github.com as github-com
         # rather than a dead-on-arrival identity (#746).
         api_scope = self._canonical_api_scope(payload.api)
+        # Advisory pre-check (#1020): a scope that covers no imported API is
+        # legal (the API may be imported later) but every execute through it
+        # would 403 — surface the mismatch now instead of at execute time.
+        warnings = await self._unmatched_scope_warnings(api_scope)
 
         stored_type = to_stored(payload.type, grant_type=payload.grant_type)
         encryption = self._ctx.encryption
@@ -288,6 +293,7 @@ class CredentialService:
                 created_at=credential.created_at,
                 server_variables=credential.server_variables,
                 secret=secret,
+                warnings=warnings or None,
             )
 
         await record_audit_best_effort(
@@ -316,6 +322,16 @@ class CredentialService:
                     actor_id=identity.sub,
                     actor_type=identity.actor_type.value,
                 )
+                for warning in warnings:
+                    await emit_event_best_effort(
+                        session,
+                        type=EventType.CREDENTIAL_UNMATCHED_API,
+                        severity=EventSeverity.WARNING,
+                        summary=f"Credential {view.credential_id}: {warning}",
+                        created_by=identity.sub,
+                        actor_id=identity.sub,
+                        actor_type=identity.actor_type.value,
+                    )
         except Exception:
             logger.warning(
                 "telemetry_emit_failed", event_type=EventType.CREDENTIAL_STORED, exc_info=True
@@ -726,3 +742,43 @@ class CredentialService:
                     f"api.{axis} '{value}' is not an identity — it looks like a spec path"
                 )
         return canonical_credential_scope(vendor=api.vendor, name=api.name, version=api.version)
+
+    async def _unmatched_scope_warnings(self, scope: CredentialScope) -> list[str]:
+        """Advisory check: does the canonical scope cover any imported API? (#1020)
+
+        Creating a credential before importing its API is a legitimate order of
+        operations (and standalone control deployments have no registry DB at
+        all), so this never blocks or fails the create — best-effort only. When
+        the scope covers nothing, the warning names the vendor's imported
+        identities so a near-miss (e.g. a #1020 vendor-doubled workspace name)
+        is visible at create time rather than as an execute-time 403.
+        """
+        if not self._ctx.is_db_allowed("registry"):
+            return []
+        try:
+            async with self._ctx.registry_db.session() as session:
+                if await RegistryApiLookupRepository.scope_covers_any(session, scope):
+                    return []
+                siblings = await RegistryApiLookupRepository.identities_for_vendor(
+                    session, scope.vendor
+                )
+        except Exception:
+            logger.warning(
+                "credential_api_match_check_failed", api_vendor=scope.vendor, exc_info=True
+            )
+            return []
+        reference = "/".join(axis for axis in (scope.vendor, scope.name, scope.version) if axis)
+        message = (
+            f"API scope '{reference}' matches no imported API — execution through this "
+            "credential will fail until a matching API is imported"
+        )
+        if siblings:
+            listed = ", ".join(f"{scope.vendor}/{name} ({version})" for name, version in siblings)
+            message += f"; imported APIs for this vendor: {listed}"
+        logger.warning(
+            "credential_api_unmatched",
+            api_vendor=scope.vendor,
+            api_name=scope.name,
+            api_version=scope.version,
+        )
+        return [message]

--- a/src/jentic_one/control/services/credentials/service.py
+++ b/src/jentic_one/control/services/credentials/service.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, NamedTuple
 
 import structlog
 
@@ -61,6 +62,19 @@ from jentic_one.shared.scopes import ORG_ADMIN
 from jentic_one.shared.url_validation import validate_upstream_url
 
 logger = structlog.get_logger()
+
+# Upper bound on the advisory registry probe at credential create (#1020). The
+# probe is purely best-effort, so a hung registry DB (network blackhole, dying
+# node) must not drag POST /credentials to the driver's connect timeout (~60s);
+# on expiry the TimeoutError lands in the probe's own except-and-skip fallback.
+_REGISTRY_PROBE_TIMEOUT_S = 2.0
+
+
+class _UnmatchedScopeWarning(NamedTuple):
+    """One advisory warning: the human message plus the scope it names."""
+
+    reference: str
+    message: str
 
 
 class CredentialService:
@@ -293,7 +307,7 @@ class CredentialService:
                 created_at=credential.created_at,
                 server_variables=credential.server_variables,
                 secret=secret,
-                warnings=warnings or None,
+                warnings=[w.message for w in warnings] or None,
             )
 
         await record_audit_best_effort(
@@ -327,14 +341,30 @@ class CredentialService:
                         session,
                         type=EventType.CREDENTIAL_UNMATCHED_API,
                         severity=EventSeverity.WARNING,
-                        summary=f"Credential {view.credential_id}: {warning}",
+                        # Keep the summary short and bounded (the events column
+                        # caps at 512 chars and every UI surface truncates to
+                        # one line); the actionable remedy + sibling-identity
+                        # hint travel in `detail`, which the events page renders
+                        # in full. The reference is caller-shaped (version is
+                        # free-text), so clamp it defensively.
+                        summary=(
+                            f"Credential {view.credential_id}: API scope "
+                            f"'{warning.reference[:200]}' matches no imported API"
+                        ),
+                        detail=warning.message,
+                        data={"credential_id": view.credential_id},
                         created_by=identity.sub,
                         actor_id=identity.sub,
                         actor_type=identity.actor_type.value,
                     )
         except Exception:
+            # Per-emit failures are swallowed inside emit_event_best_effort; what
+            # lands here is the shared admin transaction itself failing, which
+            # can't be attributed to a single event type.
             logger.warning(
-                "telemetry_emit_failed", event_type=EventType.CREDENTIAL_STORED, exc_info=True
+                "credential_event_emit_failed",
+                credential_id=view.credential_id,
+                exc_info=True,
             )
         return view
 
@@ -743,42 +773,49 @@ class CredentialService:
                 )
         return canonical_credential_scope(vendor=api.vendor, name=api.name, version=api.version)
 
-    async def _unmatched_scope_warnings(self, scope: CredentialScope) -> list[str]:
+    async def _unmatched_scope_warnings(
+        self, scope: CredentialScope
+    ) -> list[_UnmatchedScopeWarning]:
         """Advisory check: does the canonical scope cover any imported API? (#1020)
 
         Creating a credential before importing its API is a legitimate order of
-        operations (and standalone control deployments have no registry DB at
-        all), so this never blocks or fails the create — best-effort only. When
-        the scope covers nothing, the warning names the vendor's imported
+        operations (and a standalone control process is not granted the registry
+        DB), so this never blocks or fails the create — best-effort only, with a
+        hard time bound so a hung registry DB can't stall the create either.
+        When the scope covers nothing, the warning names the vendor's imported
         identities so a near-miss (e.g. a #1020 vendor-doubled workspace name)
         is visible at create time rather than as an execute-time 403.
         """
-        if not self._ctx.is_db_allowed("registry"):
+        if not self._ctx.has_db("registry"):
             return []
         try:
-            async with self._ctx.registry_db.session() as session:
-                if await RegistryApiLookupRepository.scope_covers_any(session, scope):
-                    return []
-                siblings = await RegistryApiLookupRepository.identities_for_vendor(
-                    session, scope.vendor
-                )
+            async with asyncio.timeout(_REGISTRY_PROBE_TIMEOUT_S):
+                async with self._ctx.registry_db.session() as session:
+                    if await RegistryApiLookupRepository.scope_covers_any(session, scope):
+                        return []
+                    siblings = await RegistryApiLookupRepository.identities_for_vendor(
+                        session, scope.vendor
+                    )
         except Exception:
             logger.warning(
                 "credential_api_match_check_failed", api_vendor=scope.vendor, exc_info=True
             )
             return []
         reference = "/".join(axis for axis in (scope.vendor, scope.name, scope.version) if axis)
+        # The scope is immutable after create, so "import the API" is only half
+        # the remedy — a mis-scoped credential must be re-created.
         message = (
-            f"API scope '{reference}' matches no imported API — execution through this "
-            "credential will fail until a matching API is imported"
+            f"API scope '{reference}' matches no imported API — executions using this "
+            "credential will fail. Import a matching API, or delete this credential "
+            "and re-create it scoped to an imported identity"
         )
         if siblings:
             listed = ", ".join(f"{scope.vendor}/{name} ({version})" for name, version in siblings)
             message += f"; imported APIs for this vendor: {listed}"
         logger.warning(
-            "credential_api_unmatched",
+            "credential_unmatched_api",
             api_vendor=scope.vendor,
             api_name=scope.name,
             api_version=scope.version,
         )
-        return [message]
+        return [_UnmatchedScopeWarning(reference=reference, message=message)]

--- a/src/jentic_one/control/web/routers/credentials.py
+++ b/src/jentic_one/control/web/routers/credentials.py
@@ -159,6 +159,7 @@ async def create_credential(
     return CredentialCreateResponse(
         credential=redacted,
         secret=result.secret.model_dump(),
+        warnings=result.warnings,
     )
 
 

--- a/src/jentic_one/control/web/schemas/credentials.py
+++ b/src/jentic_one/control/web/schemas/credentials.py
@@ -398,6 +398,15 @@ class CredentialCreateResponse(BaseModel):
 
     credential: CredentialRedactedResponse
     secret: dict[str, Any]
+    warnings: list[str] | None = Field(
+        default=None,
+        description=(
+            "Advisory warnings from create — e.g. the credential's API scope "
+            "matches no imported API identity, so execution through it would "
+            "fail until a matching API is imported. The credential is created "
+            "regardless; null when there is nothing to flag."
+        ),
+    )
 
 
 class CredentialListResponse(BaseModel):

--- a/src/jentic_one/registry/ingest/exc.py
+++ b/src/jentic_one/registry/ingest/exc.py
@@ -21,6 +21,26 @@ class IngestJobError(BaseIngestError):
     """Raised when an ingest job fails."""
 
 
+class CatalogIdentityConflictError(IngestStageError):
+    """Raised when a catalog import collides with a different catalog entry's identity.
+
+    Two distinct catalog entries can collapse to the same registry identity
+    (vendor extraction reduces hosts to eTLD+1); stacking the second entry's
+    spec onto the first's Api row as a new revision would silently corrupt
+    provenance, so the import is refused instead (#1020).
+    """
+
+    def __init__(
+        self, *, vendor: str, name: str, version: str, stored_id: str, incoming_id: str
+    ) -> None:
+        super().__init__(
+            f"catalog identity conflict: '{vendor}/{name}' ({version}) is already "
+            f"imported from catalog entry '{stored_id}', which collides with "
+            f"'{incoming_id}' on the same registry identity; the existing import is "
+            f"unchanged — delete API '{vendor}/{name}' first if you meant to replace it"
+        )
+
+
 class DuplicateRevisionError(IngestStageError):
     """Raised when a revision with identical content already exists for the API."""
 

--- a/src/jentic_one/registry/ingest/stages/extract_api.py
+++ b/src/jentic_one/registry/ingest/stages/extract_api.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import uuid
 from typing import ClassVar
 
-from jentic_one.registry.ingest.exc import DuplicateRevisionError, IngestStageError
+from jentic_one.registry.ingest.exc import (
+    CatalogIdentityConflictError,
+    DuplicateRevisionError,
+)
 from jentic_one.registry.ingest.pipeline.ctx import PipelineContext
 from jentic_one.registry.ingest.stages.base import BasePipelineStage
 from jentic_one.registry.repos import ApiRepository, ApiRevisionRepository, OverlayRepository
@@ -30,19 +33,22 @@ class ResolveApiStage(BasePipelineStage):
             # foreign spec onto the existing Api as a new revision — refuse
             # instead. A NULL stored id (manual import of the same identity)
             # stays a backfill, and a matching id is an ordinary re-import.
+            # The read locks the row (see get_by_identifier) so two concurrent
+            # colliding imports can't both pass the guard and race the backfill.
             existing = await ApiRepository.get_by_identifier(
-                ctx.session, identifier.vendor, identifier.name, identifier.version
+                ctx.session, identifier.vendor, identifier.name, identifier.version, for_update=True
             )
             if (
                 existing is not None
                 and existing.catalog_api_id
                 and existing.catalog_api_id != incoming_catalog_api_id
             ):
-                raise IngestStageError(
-                    f"catalog identity conflict: '{identifier.vendor}/{identifier.name}' "
-                    f"({identifier.version}) is already imported from catalog entry "
-                    f"'{existing.catalog_api_id}', which collides with "
-                    f"'{incoming_catalog_api_id}' on the same registry identity"
+                raise CatalogIdentityConflictError(
+                    vendor=identifier.vendor,
+                    name=identifier.name,
+                    version=identifier.version,
+                    stored_id=existing.catalog_api_id,
+                    incoming_id=incoming_catalog_api_id,
                 )
         api = await ApiRepository.upsert(
             ctx.session,

--- a/src/jentic_one/registry/ingest/stages/extract_api.py
+++ b/src/jentic_one/registry/ingest/stages/extract_api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from typing import ClassVar
 
-from jentic_one.registry.ingest.exc import DuplicateRevisionError
+from jentic_one.registry.ingest.exc import DuplicateRevisionError, IngestStageError
 from jentic_one.registry.ingest.pipeline.ctx import PipelineContext
 from jentic_one.registry.ingest.stages.base import BasePipelineStage
 from jentic_one.registry.repos import ApiRepository, ApiRevisionRepository, OverlayRepository
@@ -20,13 +20,37 @@ class ResolveApiStage(BasePipelineStage):
     _produces: ClassVar[dict[str, type]] = {"api_id": uuid.UUID}
 
     async def _run(self, ctx: PipelineContext) -> None:
+        identifier = ctx.specification.api_identifier
+        incoming_catalog_api_id = ctx.specification.catalog_api_id
+        if incoming_catalog_api_id:
+            # Two distinct catalog entries can collapse to the same registry
+            # identity (`extract_vendor` reduces hosts to eTLD+1, so e.g.
+            # `stripe.com/checkout` and `api.stripe.com/checkout` both resolve
+            # to `stripe-com/checkout`). Silently upserting would stack a
+            # foreign spec onto the existing Api as a new revision — refuse
+            # instead. A NULL stored id (manual import of the same identity)
+            # stays a backfill, and a matching id is an ordinary re-import.
+            existing = await ApiRepository.get_by_identifier(
+                ctx.session, identifier.vendor, identifier.name, identifier.version
+            )
+            if (
+                existing is not None
+                and existing.catalog_api_id
+                and existing.catalog_api_id != incoming_catalog_api_id
+            ):
+                raise IngestStageError(
+                    f"catalog identity conflict: '{identifier.vendor}/{identifier.name}' "
+                    f"({identifier.version}) is already imported from catalog entry "
+                    f"'{existing.catalog_api_id}', which collides with "
+                    f"'{incoming_catalog_api_id}' on the same registry identity"
+                )
         api = await ApiRepository.upsert(
             ctx.session,
-            vendor=ctx.specification.api_identifier.vendor,
-            name=ctx.specification.api_identifier.name,
-            version=ctx.specification.api_identifier.version,
+            vendor=identifier.vendor,
+            name=identifier.name,
+            version=identifier.version,
             created_by=ctx.created_by,
-            catalog_api_id=ctx.specification.catalog_api_id,
+            catalog_api_id=incoming_catalog_api_id,
         )
         ctx.produce("api_id", api.id, uuid.UUID)
 

--- a/src/jentic_one/registry/repos/api_repo.py
+++ b/src/jentic_one/registry/repos/api_repo.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 from sqlalchemy import and_, delete, func, or_, select, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, noload
 
 from jentic_one.registry.core.schema.api_revisions import ApiRevision
 from jentic_one.registry.core.schema.apis import Api
@@ -27,11 +27,20 @@ class ApiRepository:
 
     @staticmethod
     async def get_by_identifier(
-        session: AsyncSession, vendor: str, name: str, version: str
+        session: AsyncSession, vendor: str, name: str, version: str, *, for_update: bool = False
     ) -> Api | None:
-        result = await session.execute(
-            select(Api).where(Api.vendor == vendor, Api.name == name, Api.version == version)
-        )
+        stmt = select(Api).where(Api.vendor == vendor, Api.name == name, Api.version == version)
+        if for_update:
+            # Row lock for check-then-act callers (the catalog-identity collision
+            # guard): under Postgres READ COMMITTED a concurrent import would
+            # otherwise read the same pre-update row and both pass the guard.
+            # Lock only the apis row (`of=Api`) and skip the joined-eager
+            # current_revision — Postgres refuses FOR UPDATE on the nullable
+            # side of an outer join. SQLite ignores FOR UPDATE (writers are
+            # already serialized by BEGIN IMMEDIATE); the no-row case is
+            # backstopped by uq_apis_vendor_name_version.
+            stmt = stmt.options(noload(Api.current_revision)).with_for_update(of=Api)
+        result = await session.execute(stmt)
         return result.scalar_one_or_none()
 
     @staticmethod

--- a/src/jentic_one/registry/services/catalog/service.py
+++ b/src/jentic_one/registry/services/catalog/service.py
@@ -781,6 +781,16 @@ class CatalogService:
         re-import dedup) deterministic from the catalog id rather than dependent on
         the upstream spec's info.
 
+        The ``api_name`` override is the catalog id's **sub segment** (``domain/sub``
+        → ``sub``): the vendor half of the id is already carried separately, so
+        slugifying the full id would fuse it into the name and produce a
+        vendor-doubled identity like ``posthog-com/posthog-com-posthog-api`` that no
+        other surface (catalog path, repo layout, broker upstream registration)
+        agrees with — and that credential bindings then silently miss (#1020). A
+        bare-domain id has no sub segment, so the full id stays the name there
+        (e.g. ``coincap.io`` → name ``coincap-io``, the established identity for
+        domain-only entries).
+
         ``submitted_by`` attributes the resulting revision to the principal who
         triggered the (re-)import — same policy as ``POST /apis``.
         """
@@ -796,11 +806,12 @@ class CatalogService:
         if entry.vendor:
             source["vendor"] = entry.vendor
         if entry.api_id:
-            source["api_name"] = entry.api_id
-            # Also carried verbatim: `api_name` above only seeds the slugified
-            # vendor/name identity (the separable `domain/sub` structure is
-            # destroyed by slugification), while this copy is persisted as-is
-            # on the Api row for friendly-title derivation.
+            _, _, sub = entry.api_id.partition("/")
+            source["api_name"] = sub or entry.api_id
+            # The full id is also carried verbatim: `api_name` above only seeds
+            # the slugified vendor/name identity (the separable `domain/sub`
+            # structure is destroyed by slugification), while this copy is
+            # persisted as-is on the Api row for friendly-title derivation.
             source["catalog_api_id"] = entry.api_id
         return source
 

--- a/src/jentic_one/registry/services/import_service.py
+++ b/src/jentic_one/registry/services/import_service.py
@@ -50,6 +50,15 @@ _source_adapter: TypeAdapter[IngestSource] = TypeAdapter(IngestSource)
 #     can't catch this (it's keyed on api_id alone, independent of spec_digest).
 _DIGEST_CONSTRAINT = "uq_api_revisions_api_id_spec_digest"
 _ONE_ACTIVE_CONSTRAINT = "ix_api_revisions_one_active"
+# uq_apis_vendor_name_version: two concurrent imports both saw no Api row for the
+# same identity and both inserted; the loser lands here. Retrying re-runs the
+# catalog-identity collision guard against the winner's committed row, which then
+# either accepts (same/no catalog entry) or refuses with the readable conflict.
+_API_IDENTITY_CONSTRAINT = "uq_apis_vendor_name_version"
+_IDENTITY_RACE_MESSAGE = (
+    "A concurrent import created this API identity first; retry the import — "
+    "a colliding catalog entry will then be refused as a catalog identity conflict"
+)
 
 
 def _readable_source_error(exc: Exception) -> str:
@@ -60,10 +69,11 @@ def _readable_source_error(exc: Exception) -> str:
     race for the one-active slot) to a clear message and keep other failures as
     their (domain) exception text.
     """
-    if isinstance(exc, DatabaseIntegrityError) and (
-        _DIGEST_CONSTRAINT in exc.detail or _ONE_ACTIVE_CONSTRAINT in exc.detail
-    ):
-        return DuplicateRevisionError().message
+    if isinstance(exc, DatabaseIntegrityError):
+        if _DIGEST_CONSTRAINT in exc.detail or _ONE_ACTIVE_CONSTRAINT in exc.detail:
+            return DuplicateRevisionError().message
+        if _API_IDENTITY_CONSTRAINT in exc.detail:
+            return _IDENTITY_RACE_MESSAGE
     return str(exc)
 
 

--- a/src/jentic_one/shared/models/events.py
+++ b/src/jentic_one/shared/models/events.py
@@ -23,6 +23,13 @@ class EventType:
     CREDENTIAL_EXPIRING_SOON = "credential.expiring_soon"
     CREDENTIAL_EXPIRED = "credential.expired"
     CREDENTIAL_ACCESSED = "credential.accessed"
+    # A credential was created whose API scope covers no imported registry API
+    # identity — the create succeeds (importing the API later is a legitimate
+    # order of operations), but every execute through it would 403 with
+    # ``no_toolkit_binding`` until the identity matches (#1020). Advisory,
+    # warning severity; the summary carries a nearest-identity hint when the
+    # vendor has other imported APIs.
+    CREDENTIAL_UNMATCHED_API = "credential.unmatched_api"
     ACCESS_REQUEST_FILED = "access_request.filed"
     ACCESS_REQUEST_APPROVED = "access_request.approved"
     ACCESS_REQUEST_DENIED = "access_request.denied"
@@ -100,6 +107,7 @@ class EventType:
             CREDENTIAL_EXPIRING_SOON,
             CREDENTIAL_EXPIRED,
             CREDENTIAL_ACCESSED,
+            CREDENTIAL_UNMATCHED_API,
             ACCESS_REQUEST_FILED,
             ACCESS_REQUEST_APPROVED,
             ACCESS_REQUEST_DENIED,

--- a/tests/integration/control/test_credential_unmatched_api_warning.py
+++ b/tests/integration/control/test_credential_unmatched_api_warning.py
@@ -125,12 +125,32 @@ async def test_unmatched_scope_warns_with_nearest_identity_hint(
     [warning] = result.warnings
     assert "posthog-com/posthog-api" in warning
     assert "matches no imported API" in warning
+    # Both remedies: import the API, or re-create the (immutable-scope) credential.
+    assert "re-create" in warning
     assert "posthog-com/posthog-com-posthog-api (1.0)" in warning
 
     events = await _unmatched_events(integration_context)
     assert len(events) == 1
     assert events[0].severity == "warning"
+    # Short, bounded summary; the remedy + sibling hint travel in detail.
     assert result.credential_id in events[0].summary
+    assert "posthog-com/posthog-api" in events[0].summary
+    assert "imported APIs for this vendor" not in events[0].summary
+    assert events[0].detail == warning
+    assert (events[0].data or {}).get("credential_id") == result.credential_id
+
+
+async def test_version_only_wildcard_scope_covering_an_api_carries_no_warning(
+    integration_context: Context, svc: CredentialService, clean_tables: None
+) -> None:
+    """A name-wildcard, version-pinned scope (vendor/*/1.0) that covers an
+    imported API stays warning-free — the fourth wildcard combination."""
+    await _seed_api(integration_context, vendor="posthog-com", name="posthog-api", version="1.0")
+    result = await svc.create(
+        _payload(APIReference(vendor="posthog-com", name="", version="1.0")),
+        identity=_ADMIN_IDENTITY,
+    )
+    assert result.warnings is None
 
 
 async def test_unmatched_vendor_warns_without_hint(

--- a/tests/integration/control/test_credential_unmatched_api_warning.py
+++ b/tests/integration/control/test_credential_unmatched_api_warning.py
@@ -1,0 +1,161 @@
+"""Integration tests for the create-time unmatched-API advisory (#1020).
+
+A credential whose canonical scope covers no imported registry API identity is
+still created (importing the API later is a legitimate order of operations),
+but the create response must carry an advisory warning — with a
+nearest-identity hint when the vendor has other imported APIs (the #1020
+vendor-doubled dead-end shape) — and a warning-severity
+``credential.unmatched_api`` event must land in the admin events feed.
+
+Cross-DB by construction: registry ``apis`` rows are seeded through the
+registry repo/session, the credential is created through the control service,
+and events are asserted in the admin DB.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy import delete, select
+
+from jentic_one.admin.core.schema.events import Event
+from jentic_one.control.core.schema.credentials import Credential
+from jentic_one.control.core.schema.token_value_credentials import TokenValueCredential
+from jentic_one.control.services.credentials.schemas.credentials import CredentialCreate
+from jentic_one.control.services.credentials.schemas.provision import APIReference
+from jentic_one.control.services.credentials.service import CredentialService
+from jentic_one.registry.core.schema.apis import Api
+from jentic_one.registry.repos.api_repo import ApiRepository
+from jentic_one.shared.auth.identity import Identity
+from jentic_one.shared.context import Context
+from jentic_one.shared.models.credentials import CredentialType
+from jentic_one.shared.models.events import EventType
+
+_ADMIN_IDENTITY = Identity(sub="admin_user", email="admin@test.com", permissions=["org:admin"])
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+async def clean_tables(integration_context: Context) -> AsyncGenerator[None, None]:
+    async def _wipe() -> None:
+        async with integration_context.control_db.session() as session:
+            await session.execute(delete(TokenValueCredential))
+            await session.execute(delete(Credential))
+            await session.commit()
+        async with integration_context.registry_db.session() as session:
+            await session.execute(delete(Api))
+            await session.commit()
+        async with integration_context.admin_db.session() as session:
+            await session.execute(delete(Event))
+            await session.commit()
+
+    await _wipe()
+    yield
+    await _wipe()
+
+
+@pytest.fixture()
+def svc(integration_context: Context) -> CredentialService:
+    return CredentialService(integration_context)
+
+
+async def _seed_api(ctx: Context, *, vendor: str, name: str, version: str) -> None:
+    async with ctx.registry_db.session() as session:
+        await ApiRepository.upsert(
+            session, vendor=vendor, name=name, version=version, created_by="usr_test"
+        )
+        await session.commit()
+
+
+def _payload(api: APIReference) -> CredentialCreate:
+    return CredentialCreate(
+        type=CredentialType.BEARER_TOKEN,
+        name="test credential",
+        api=api,
+        token="sk-test-token-value",  # pragma: allowlist secret
+    )
+
+
+async def _unmatched_events(ctx: Context) -> list[Event]:
+    async with ctx.admin_db.session() as session:
+        result = await session.execute(
+            select(Event).where(Event.type == EventType.CREDENTIAL_UNMATCHED_API)
+        )
+        return list(result.scalars().all())
+
+
+async def test_matching_scope_carries_no_warning(
+    integration_context: Context, svc: CredentialService, clean_tables: None
+) -> None:
+    await _seed_api(integration_context, vendor="posthog-com", name="posthog-api", version="1.0")
+    result = await svc.create(
+        _payload(APIReference(vendor="posthog-com", name="posthog-api", version="1.0")),
+        identity=_ADMIN_IDENTITY,
+    )
+    assert result.warnings is None
+    assert await _unmatched_events(integration_context) == []
+
+
+async def test_wildcard_scope_covering_an_api_carries_no_warning(
+    integration_context: Context, svc: CredentialService, clean_tables: None
+) -> None:
+    await _seed_api(integration_context, vendor="posthog-com", name="posthog-api", version="1.0")
+    result = await svc.create(
+        _payload(APIReference(vendor="posthog-com", name="", version="")),
+        identity=_ADMIN_IDENTITY,
+    )
+    assert result.warnings is None
+
+
+async def test_unmatched_scope_warns_with_nearest_identity_hint(
+    integration_context: Context, svc: CredentialService, clean_tables: None
+) -> None:
+    """The #1020 shape: the user binds the clean name while the workspace holds
+    a different (e.g. vendor-doubled) identity — the hint names what exists."""
+    await _seed_api(
+        integration_context, vendor="posthog-com", name="posthog-com-posthog-api", version="1.0"
+    )
+    result = await svc.create(
+        _payload(APIReference(vendor="posthog-com", name="posthog-api", version="")),
+        identity=_ADMIN_IDENTITY,
+    )
+    assert result.warnings is not None
+    [warning] = result.warnings
+    assert "posthog-com/posthog-api" in warning
+    assert "matches no imported API" in warning
+    assert "posthog-com/posthog-com-posthog-api (1.0)" in warning
+
+    events = await _unmatched_events(integration_context)
+    assert len(events) == 1
+    assert events[0].severity == "warning"
+    assert result.credential_id in events[0].summary
+
+
+async def test_unmatched_vendor_warns_without_hint(
+    integration_context: Context, svc: CredentialService, clean_tables: None
+) -> None:
+    result = await svc.create(
+        _payload(APIReference(vendor="nowhere-example", name="", version="")),
+        identity=_ADMIN_IDENTITY,
+    )
+    assert result.warnings is not None
+    [warning] = result.warnings
+    assert "nowhere-example" in warning
+    assert "imported APIs for this vendor" not in warning
+    # The create itself must have succeeded regardless of the warning.
+    assert result.credential_id
+
+
+async def test_version_scoped_mismatch_warns(
+    integration_context: Context, svc: CredentialService, clean_tables: None
+) -> None:
+    await _seed_api(integration_context, vendor="posthog-com", name="posthog-api", version="1.0")
+    result = await svc.create(
+        _payload(APIReference(vendor="posthog-com", name="posthog-api", version="2.0")),
+        identity=_ADMIN_IDENTITY,
+    )
+    assert result.warnings is not None
+    [warning] = result.warnings
+    assert "posthog-com/posthog-api/2.0" in warning

--- a/tests/integration/registry/services/test_import_handler.py
+++ b/tests/integration/registry/services/test_import_handler.py
@@ -19,6 +19,8 @@ from jentic_one.registry.core.schema.security_schemes import SecurityScheme, Sec
 from jentic_one.registry.core.schema.servers import Server, ServerVariable
 from jentic_one.registry.core.schema.spec_files import SpecFile
 from jentic_one.registry.ingest.exc import IngestJobError
+from jentic_one.registry.repos.api_repo import ApiRepository
+from jentic_one.registry.services.catalog.service import CatalogEntryView, CatalogService
 from jentic_one.registry.services.errors import OverlayStateConflictError
 from jentic_one.registry.services.import_service import ImportHandler
 from jentic_one.registry.services.overlay_service import OverlayService
@@ -2066,3 +2068,121 @@ async def test_url_source_via_mock(
     async with registry_db.session() as session:
         rows = (await session.execute(select(ApiRevision))).unique().scalars().all()
         assert len(rows) == 1
+
+
+def _mock_spec_client(spec_text: str) -> AsyncMock:
+    """An httpx.AsyncClient double serving ``spec_text`` for any GET."""
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.text = spec_text
+    mock_response.content = spec_text.encode()
+    mock_response.headers = {"content-length": str(len(spec_text.encode()))}
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return mock_client
+
+
+async def test_catalog_import_lands_clean_identity_from_sub_segment(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    _clean_registry: None,
+) -> None:
+    """#1020 end-to-end: a ``domain/sub`` catalog entry lands the clean identity.
+
+    Threads the *real* production seam — ``CatalogService._to_import_source``
+    builds the job source (sub-segment ``api_name`` + verbatim
+    ``catalog_api_id``) and ``ImportHandler`` ingests it — and asserts the
+    registry row is ``posthog-com/posthog-api``, not the vendor-doubled
+    ``posthog-com/posthog-com-posthog-api`` the pre-fix full-id slug produced.
+    """
+    entry = CatalogEntryView(
+        api_id="posthog.com/posthog-api",
+        vendor="posthog.com",
+        path=None,
+        spec_url="https://catalog.example.com/posthog/openapi.json",
+        github_url=None,
+        registered=False,
+    )
+    source = CatalogService(integration_context)._to_import_source(
+        entry, Identity(sub="usr_test", email="t@test.com", permissions=["org:admin"])
+    )
+
+    with patch(
+        "jentic_one.registry.ingest.fetch.httpx.AsyncClient",
+        return_value=_mock_spec_client(MINIMAL_OPENAPI),
+    ):
+        result = await ImportHandler(integration_context).execute(
+            job_id=str(uuid.uuid4()),
+            session=None,
+            payload={"sources": [source]},
+            created_by="usr_test",
+        )
+
+    [revision] = result.body["revisions"]
+    assert revision["api"]["vendor"] == "posthog-com"
+    assert revision["api"]["name"] == "posthog-api"
+
+    async with registry_db.session() as session:
+        rows = (await session.execute(select(Api))).scalars().all()
+        assert len(rows) == 1
+        assert (rows[0].vendor, rows[0].name) == ("posthog-com", "posthog-api")
+        assert rows[0].catalog_api_id == "posthog.com/posthog-api"
+
+
+async def test_catalog_identity_conflict_surfaces_as_readable_job_failure(
+    integration_context: Context,
+    registry_db: DatabaseSession,
+    _clean_registry: None,
+) -> None:
+    """The #1020 collision guard reaches the operator through the job error.
+
+    Two catalog ids collapsing to the same registry identity must fail the
+    second import job with the guard's readable conflict message, leaving no
+    new revision behind and the stored provenance untouched.
+    """
+    async with registry_db.session() as session:
+        await ApiRepository.upsert(
+            session,
+            vendor="posthog-com",
+            name="posthog-api",
+            version="1.0.0",
+            created_by="usr_test",
+            catalog_api_id="posthog.com/posthog-api",
+        )
+        await session.commit()
+
+    with (
+        patch(
+            "jentic_one.registry.ingest.fetch.httpx.AsyncClient",
+            return_value=_mock_spec_client(MINIMAL_OPENAPI),
+        ),
+        pytest.raises(IngestJobError, match="catalog identity conflict"),
+    ):
+        await ImportHandler(integration_context).execute(
+            job_id=str(uuid.uuid4()),
+            session=None,
+            payload={
+                "sources": [
+                    {
+                        "type": "url",
+                        "url": "https://catalog.example.com/other/openapi.json",
+                        "origin": "catalog",
+                        # The manifest's extract_vendor reduces both hosts to the
+                        # eTLD+1, so this entry carries the same vendor as the
+                        # seeded one — same identity, different catalog id.
+                        "vendor": "posthog.com",
+                        "api_name": "posthog-api",
+                        "catalog_api_id": "app.posthog.com/posthog-api",
+                    }
+                ]
+            },
+            created_by="usr_test",
+        )
+
+    async with registry_db.session() as session:
+        revisions = (await session.execute(select(ApiRevision))).unique().scalars().all()
+        assert revisions == []
+        api = (await session.execute(select(Api))).scalar_one()
+        assert api.catalog_api_id == "posthog.com/posthog-api"

--- a/tests/unit/control/credentials/test_unmatched_scope_probe.py
+++ b/tests/unit/control/credentials/test_unmatched_scope_probe.py
@@ -1,0 +1,53 @@
+"""Branch coverage for the credential-create advisory registry probe (#1020).
+
+The probe must be inert in every deployment shape it can meet: skipped when
+the process is not granted the registry DB (standalone control), skipped when
+the DB is allowed but was never connected (hand-rolled contexts, partial
+startups — the gate is ``has_db``, not mere allowance), and swallowed when the
+registry read itself fails. The failure case uses a *real* connected SQLite
+with no ``apis`` table (no DB mocking — ``tests/arch/test_no_db_mocking.py``).
+"""
+
+from __future__ import annotations
+
+from jentic_one.control.services.credentials.service import CredentialService
+from jentic_one.shared.config import AppConfig, DatabaseConfig, DatabasesConfig
+from jentic_one.shared.context import Context
+from jentic_one.shared.models.api_identity import canonical_credential_scope
+
+
+def _config() -> AppConfig:
+    return AppConfig(
+        databases=DatabasesConfig(
+            registry=DatabaseConfig(backend="sqlite", path=":memory:"),
+            admin=DatabaseConfig(backend="sqlite", path=":memory:"),
+            control=DatabaseConfig(backend="sqlite", path=":memory:"),
+        )
+    )
+
+
+_SCOPE = canonical_credential_scope(vendor="posthog-com", name="posthog-api", version="")
+
+
+async def test_probe_skipped_when_registry_db_not_allowed() -> None:
+    """Standalone control (registry not in allowed_dbs) skips without touching it."""
+    ctx = Context(_config(), allowed_dbs={"control", "admin"})
+    assert await CredentialService(ctx)._unmatched_scope_warnings(_SCOPE) == []
+
+
+async def test_probe_skipped_when_registry_db_never_connected() -> None:
+    """Allowed-but-unconnected (startup never ran) skips instead of raising on
+    every create — the gate is ``has_db``, which stays False until connect."""
+    ctx = Context(_config())
+    assert await CredentialService(ctx)._unmatched_scope_warnings(_SCOPE) == []
+
+
+async def test_probe_swallows_registry_read_errors() -> None:
+    """A connected registry DB whose read fails (no ``apis`` table here)
+    degrades to no warnings — the advisory must never fail the create."""
+    ctx = Context(_config())
+    await ctx.registry_db.connect()
+    try:
+        assert await CredentialService(ctx)._unmatched_scope_warnings(_SCOPE) == []
+    finally:
+        await ctx.registry_db.close()

--- a/tests/unit/registry/conftest.py
+++ b/tests/unit/registry/conftest.py
@@ -1,0 +1,73 @@
+"""Shared fixtures for unit registry tests that need a real SQLite ``apis`` table.
+
+Promoted from ``repos/test_api_repo_upsert.py`` / ``ingest/test_extract_api_catalog_conflict.py``
+(fixture-reuse rule: fixtures useful to more than one file live in the closest
+shared conftest). Real in-memory SQLite, no DB mocking
+(``tests/arch/test_no_db_mocking.py``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import cast
+
+import pytest
+from sqlalchemy import Table
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.schema import CreateTable
+from sqlalchemy.sql.functions import Function
+
+import jentic_one.registry.core.schema  # noqa: F401  (register all registry tables)
+from jentic_one.registry.core.schema.api_revisions import ApiRevision
+from jentic_one.registry.core.schema.apis import Api
+
+
+def _create_registry_tables(sync_conn: Connection) -> None:
+    """Create the tables these tests touch on SQLite, dropping Postgres-only
+    server defaults.
+
+    ``api_revisions`` too (not just ``apis``) because ``apis`` carries an FK to
+    it and SQLite refuses DML on a table whose referenced table is missing. The
+    tests supply explicit values, so the defaults are dropped for the DDL and
+    restored (leaving the shared models untouched). Only the Postgres-only
+    *function* defaults (gen_random_uuid etc.) fail on SQLite; plain literal
+    defaults (e.g. revision's "1") must stay.
+    """
+    tables = (cast(Table, Api.__table__), cast(Table, ApiRevision.__table__))
+    saved = {
+        col: col.server_default
+        for table in tables
+        for col in table.columns
+        if col.server_default is not None
+        and isinstance(getattr(col.server_default, "arg", None), Function)
+    }
+    for col in saved:
+        col.server_default = None
+    try:
+        for table in tables:
+            sync_conn.execute(CreateTable(table, if_not_exists=True))
+    finally:
+        for col, default in saved.items():
+            col.server_default = default
+
+
+@pytest.fixture()
+async def apis_sqlite_session() -> AsyncGenerator[AsyncSession, None]:
+    """A real in-memory SQLite registry session with the apis table created."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(_create_registry_tables)
+    factory = async_sessionmaker(bind=engine, expire_on_commit=False)
+    async with factory() as sess:
+        yield sess
+    await engine.dispose()

--- a/tests/unit/registry/ingest/test_extract_api_catalog_conflict.py
+++ b/tests/unit/registry/ingest/test_extract_api_catalog_conflict.py
@@ -1,0 +1,166 @@
+"""``ResolveApiStage`` catalog-identity collision guard (#1020).
+
+After #1020 the catalog import derives the registry ``api_name`` from the
+catalog id's *sub* segment, so two distinct catalog entries can collapse to the
+same registry identity (``extract_vendor`` reduces hosts to eTLD+1: e.g.
+``stripe.com/checkout`` and ``api.stripe.com/checkout`` both resolve to
+``stripe-com/checkout``). These tests pin the guard's behaviour:
+
+- a *different* stored ``catalog_api_id`` on the resolved identity refuses the
+  import (no silent stacking of a foreign spec as a new revision),
+- a matching id (ordinary re-import) and a NULL stored id (backfill of a
+  manual import) proceed,
+- a manual import (no incoming id) never triggers the guard.
+
+Run against a real in-memory SQLite registry DB (no DB mocking —
+``tests/arch/test_no_db_mocking.py``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from typing import cast
+
+import pytest
+from sqlalchemy import Table
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.schema import CreateTable
+from sqlalchemy.sql.functions import Function
+
+import jentic_one.registry.core.schema  # noqa: F401  (register all registry tables)
+from jentic_one.registry.core.schema.api_revisions import ApiRevision
+from jentic_one.registry.core.schema.apis import Api
+from jentic_one.registry.ingest.exc import IngestStageError
+from jentic_one.registry.ingest.models import ApiIdentifier, IngestSpecification, SpecType
+from jentic_one.registry.ingest.pipeline.ctx import PipelineContext
+from jentic_one.registry.ingest.stages.extract_api import ResolveApiStage
+from jentic_one.registry.repos.api_repo import ApiRepository
+
+
+def _create_registry_tables(sync_conn: Connection) -> None:
+    """Create the tables these tests touch on SQLite, dropping Postgres-only
+    server defaults (see ``test_api_repo_upsert`` for the rationale)."""
+    tables = (cast(Table, Api.__table__), cast(Table, ApiRevision.__table__))
+    saved = {
+        col: col.server_default
+        for table in tables
+        for col in table.columns
+        if col.server_default is not None
+        and isinstance(getattr(col.server_default, "arg", None), Function)
+    }
+    for col in saved:
+        col.server_default = None
+    try:
+        for table in tables:
+            sync_conn.execute(CreateTable(table, if_not_exists=True))
+    finally:
+        for col, default in saved.items():
+            col.server_default = default
+
+
+@pytest.fixture()
+async def session() -> AsyncGenerator[AsyncSession, None]:
+    """A real in-memory SQLite registry session with the apis table created."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(_create_registry_tables)
+    factory = async_sessionmaker(bind=engine, expire_on_commit=False)
+    async with factory() as sess:
+        yield sess
+    await engine.dispose()
+
+
+_IDENTIFIER = ApiIdentifier(vendor="stripe-com", name="checkout", version="1.0.0")
+
+
+def _ctx(session: AsyncSession, *, catalog_api_id: str | None) -> PipelineContext:
+    spec = IngestSpecification(
+        spec_type=SpecType.OPENAPI,
+        api_identifier=_IDENTIFIER,
+        content={"openapi": "3.1.0"},
+        catalog_api_id=catalog_api_id,
+    )
+    return PipelineContext(session=session, specification=spec, created_by="usr_test")
+
+
+async def _seed(session: AsyncSession, *, catalog_api_id: str | None) -> None:
+    await ApiRepository.upsert(
+        session,
+        vendor=_IDENTIFIER.vendor,
+        name=_IDENTIFIER.name,
+        version=_IDENTIFIER.version,
+        created_by="usr_test",
+        catalog_api_id=catalog_api_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_conflicting_catalog_id_refuses_import(session: AsyncSession) -> None:
+    await _seed(session, catalog_api_id="stripe.com/checkout")
+    ctx = _ctx(session, catalog_api_id="api.stripe.com/checkout")
+    with pytest.raises(IngestStageError, match="catalog identity conflict"):
+        await ResolveApiStage().run(ctx)
+    # The stored provenance must be untouched by the refused import.
+    existing = await ApiRepository.get_by_identifier(
+        session, _IDENTIFIER.vendor, _IDENTIFIER.name, _IDENTIFIER.version
+    )
+    assert existing is not None
+    assert existing.catalog_api_id == "stripe.com/checkout"
+
+
+@pytest.mark.asyncio
+async def test_same_catalog_id_reimports(session: AsyncSession) -> None:
+    await _seed(session, catalog_api_id="stripe.com/checkout")
+    ctx = _ctx(session, catalog_api_id="stripe.com/checkout")
+    await ResolveApiStage().run(ctx)
+    assert isinstance(ctx.require("api_id", uuid.UUID), uuid.UUID)
+
+
+@pytest.mark.asyncio
+async def test_null_stored_id_backfills(session: AsyncSession) -> None:
+    """A manual import of the same identity picks up the catalog id on the next
+    catalog import (#910 backfill) — not a conflict."""
+    await _seed(session, catalog_api_id=None)
+    ctx = _ctx(session, catalog_api_id="stripe.com/checkout")
+    await ResolveApiStage().run(ctx)
+    existing = await ApiRepository.get_by_identifier(
+        session, _IDENTIFIER.vendor, _IDENTIFIER.name, _IDENTIFIER.version
+    )
+    assert existing is not None
+    assert existing.catalog_api_id == "stripe.com/checkout"
+
+
+@pytest.mark.asyncio
+async def test_manual_import_skips_guard(session: AsyncSession) -> None:
+    """No incoming catalog id (manual/inline import) never conflicts, even when
+    the identity was previously catalog-imported."""
+    await _seed(session, catalog_api_id="stripe.com/checkout")
+    ctx = _ctx(session, catalog_api_id=None)
+    await ResolveApiStage().run(ctx)
+    existing = await ApiRepository.get_by_identifier(
+        session, _IDENTIFIER.vendor, _IDENTIFIER.name, _IDENTIFIER.version
+    )
+    assert existing is not None
+    assert existing.catalog_api_id == "stripe.com/checkout"
+
+
+@pytest.mark.asyncio
+async def test_fresh_identity_creates(session: AsyncSession) -> None:
+    ctx = _ctx(session, catalog_api_id="stripe.com/checkout")
+    await ResolveApiStage().run(ctx)
+    existing = await ApiRepository.get_by_identifier(
+        session, _IDENTIFIER.vendor, _IDENTIFIER.name, _IDENTIFIER.version
+    )
+    assert existing is not None
+    assert existing.catalog_api_id == "stripe.com/checkout"

--- a/tests/unit/registry/ingest/test_extract_api_catalog_conflict.py
+++ b/tests/unit/registry/ingest/test_extract_api_catalog_conflict.py
@@ -13,73 +13,22 @@ same registry identity (``extract_vendor`` reduces hosts to eTLD+1: e.g.
 - a manual import (no incoming id) never triggers the guard.
 
 Run against a real in-memory SQLite registry DB (no DB mocking —
-``tests/arch/test_no_db_mocking.py``).
+``tests/arch/test_no_db_mocking.py``); the session fixture lives in the shared
+``tests/unit/registry/conftest.py``.
 """
 
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncGenerator
-from typing import cast
 
 import pytest
-from sqlalchemy import Table
-from sqlalchemy.engine import Connection
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
-from sqlalchemy.pool import StaticPool
-from sqlalchemy.schema import CreateTable
-from sqlalchemy.sql.functions import Function
+from sqlalchemy.ext.asyncio import AsyncSession
 
-import jentic_one.registry.core.schema  # noqa: F401  (register all registry tables)
-from jentic_one.registry.core.schema.api_revisions import ApiRevision
-from jentic_one.registry.core.schema.apis import Api
-from jentic_one.registry.ingest.exc import IngestStageError
+from jentic_one.registry.ingest.exc import CatalogIdentityConflictError
 from jentic_one.registry.ingest.models import ApiIdentifier, IngestSpecification, SpecType
 from jentic_one.registry.ingest.pipeline.ctx import PipelineContext
 from jentic_one.registry.ingest.stages.extract_api import ResolveApiStage
 from jentic_one.registry.repos.api_repo import ApiRepository
-
-
-def _create_registry_tables(sync_conn: Connection) -> None:
-    """Create the tables these tests touch on SQLite, dropping Postgres-only
-    server defaults (see ``test_api_repo_upsert`` for the rationale)."""
-    tables = (cast(Table, Api.__table__), cast(Table, ApiRevision.__table__))
-    saved = {
-        col: col.server_default
-        for table in tables
-        for col in table.columns
-        if col.server_default is not None
-        and isinstance(getattr(col.server_default, "arg", None), Function)
-    }
-    for col in saved:
-        col.server_default = None
-    try:
-        for table in tables:
-            sync_conn.execute(CreateTable(table, if_not_exists=True))
-    finally:
-        for col, default in saved.items():
-            col.server_default = default
-
-
-@pytest.fixture()
-async def session() -> AsyncGenerator[AsyncSession, None]:
-    """A real in-memory SQLite registry session with the apis table created."""
-    engine = create_async_engine(
-        "sqlite+aiosqlite://",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    async with engine.begin() as conn:
-        await conn.run_sync(_create_registry_tables)
-    factory = async_sessionmaker(bind=engine, expire_on_commit=False)
-    async with factory() as sess:
-        yield sess
-    await engine.dispose()
-
 
 _IDENTIFIER = ApiIdentifier(vendor="stripe-com", name="checkout", version="1.0.0")
 
@@ -106,11 +55,18 @@ async def _seed(session: AsyncSession, *, catalog_api_id: str | None) -> None:
 
 
 @pytest.mark.asyncio
-async def test_conflicting_catalog_id_refuses_import(session: AsyncSession) -> None:
+async def test_conflicting_catalog_id_refuses_import(apis_sqlite_session: AsyncSession) -> None:
+    session = apis_sqlite_session
     await _seed(session, catalog_api_id="stripe.com/checkout")
     ctx = _ctx(session, catalog_api_id="api.stripe.com/checkout")
-    with pytest.raises(IngestStageError, match="catalog identity conflict"):
+    # The typed subclass (an IngestStageError) lets the import job / dead-letter
+    # path distinguish the guard's refusal; the message names both catalog ids
+    # and the next step.
+    with pytest.raises(CatalogIdentityConflictError, match="catalog identity conflict") as exc:
         await ResolveApiStage().run(ctx)
+    assert "stripe.com/checkout" in str(exc.value)
+    assert "api.stripe.com/checkout" in str(exc.value)
+    assert "delete API" in str(exc.value)
     # The stored provenance must be untouched by the refused import.
     existing = await ApiRepository.get_by_identifier(
         session, _IDENTIFIER.vendor, _IDENTIFIER.name, _IDENTIFIER.version
@@ -120,7 +76,8 @@ async def test_conflicting_catalog_id_refuses_import(session: AsyncSession) -> N
 
 
 @pytest.mark.asyncio
-async def test_same_catalog_id_reimports(session: AsyncSession) -> None:
+async def test_same_catalog_id_reimports(apis_sqlite_session: AsyncSession) -> None:
+    session = apis_sqlite_session
     await _seed(session, catalog_api_id="stripe.com/checkout")
     ctx = _ctx(session, catalog_api_id="stripe.com/checkout")
     await ResolveApiStage().run(ctx)
@@ -128,9 +85,10 @@ async def test_same_catalog_id_reimports(session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
-async def test_null_stored_id_backfills(session: AsyncSession) -> None:
+async def test_null_stored_id_backfills(apis_sqlite_session: AsyncSession) -> None:
     """A manual import of the same identity picks up the catalog id on the next
     catalog import (#910 backfill) — not a conflict."""
+    session = apis_sqlite_session
     await _seed(session, catalog_api_id=None)
     ctx = _ctx(session, catalog_api_id="stripe.com/checkout")
     await ResolveApiStage().run(ctx)
@@ -142,9 +100,10 @@ async def test_null_stored_id_backfills(session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
-async def test_manual_import_skips_guard(session: AsyncSession) -> None:
+async def test_manual_import_skips_guard(apis_sqlite_session: AsyncSession) -> None:
     """No incoming catalog id (manual/inline import) never conflicts, even when
     the identity was previously catalog-imported."""
+    session = apis_sqlite_session
     await _seed(session, catalog_api_id="stripe.com/checkout")
     ctx = _ctx(session, catalog_api_id=None)
     await ResolveApiStage().run(ctx)
@@ -156,7 +115,8 @@ async def test_manual_import_skips_guard(session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
-async def test_fresh_identity_creates(session: AsyncSession) -> None:
+async def test_fresh_identity_creates(apis_sqlite_session: AsyncSession) -> None:
+    session = apis_sqlite_session
     ctx = _ctx(session, catalog_api_id="stripe.com/checkout")
     await ResolveApiStage().run(ctx)
     existing = await ApiRepository.get_by_identifier(

--- a/tests/unit/registry/repos/test_api_repo_upsert.py
+++ b/tests/unit/registry/repos/test_api_repo_upsert.py
@@ -9,84 +9,24 @@ identity — these tests pin the update rules that keep it trustworthy:
   recorded (e.g. overlay materialization re-ingests inline without the slug).
 
 Run against a real in-memory SQLite registry DB (no DB mocking —
-``tests/arch/test_no_db_mocking.py``).
+``tests/arch/test_no_db_mocking.py``); the session fixture lives in the shared
+``tests/unit/registry/conftest.py``.
 """
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
-from typing import cast
-
 import pytest
-from sqlalchemy import Table
-from sqlalchemy.engine import Connection
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
-from sqlalchemy.pool import StaticPool
-from sqlalchemy.schema import CreateTable
-from sqlalchemy.sql.functions import Function
+from sqlalchemy.ext.asyncio import AsyncSession
 
-import jentic_one.registry.core.schema  # noqa: F401  (register all registry tables)
-from jentic_one.registry.core.schema.api_revisions import ApiRevision
-from jentic_one.registry.core.schema.apis import Api
 from jentic_one.registry.repos.api_repo import ApiRepository
-
-
-def _create_registry_tables(sync_conn: Connection) -> None:
-    """Create the tables these tests touch on SQLite, dropping Postgres-only
-    server defaults.
-
-    ``api_revisions`` too (not just ``apis``) because ``apis`` carries an FK to
-    it and SQLite refuses DML on a table whose referenced table is missing. The
-    tests supply explicit values, so the defaults are dropped for the DDL and
-    restored (leaving the shared models untouched).
-    """
-    tables = (cast(Table, Api.__table__), cast(Table, ApiRevision.__table__))
-    # Only the Postgres-only *function* defaults (gen_random_uuid etc.) fail on
-    # SQLite; plain literal defaults (e.g. revision's "1") must stay.
-    saved = {
-        col: col.server_default
-        for table in tables
-        for col in table.columns
-        if col.server_default is not None
-        and isinstance(getattr(col.server_default, "arg", None), Function)
-    }
-    for col in saved:
-        col.server_default = None
-    try:
-        for table in tables:
-            sync_conn.execute(CreateTable(table, if_not_exists=True))
-    finally:
-        for col, default in saved.items():
-            col.server_default = default
-
-
-@pytest.fixture()
-async def session() -> AsyncGenerator[AsyncSession, None]:
-    """A real in-memory SQLite registry session with the apis table created."""
-    engine = create_async_engine(
-        "sqlite+aiosqlite://",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    async with engine.begin() as conn:
-        await conn.run_sync(_create_registry_tables)
-    factory = async_sessionmaker(bind=engine, expire_on_commit=False)
-    async with factory() as sess:
-        yield sess
-    await engine.dispose()
-
 
 _TRIPLE = {"vendor": "nytimes.com", "name": "nytimes-com-article-search", "version": "1.0.0"}
 
 
 @pytest.mark.asyncio
-async def test_catalog_import_records_slug_on_create(session: AsyncSession) -> None:
+async def test_catalog_import_records_slug_on_create(apis_sqlite_session: AsyncSession) -> None:
     api = await ApiRepository.upsert(
-        session,
+        apis_sqlite_session,
         **_TRIPLE,
         created_by="usr_test",
         catalog_api_id="nytimes.com/article_search",
@@ -95,20 +35,20 @@ async def test_catalog_import_records_slug_on_create(session: AsyncSession) -> N
 
 
 @pytest.mark.asyncio
-async def test_manual_import_leaves_slug_null(session: AsyncSession) -> None:
-    api = await ApiRepository.upsert(session, **_TRIPLE, created_by="usr_test")
+async def test_manual_import_leaves_slug_null(apis_sqlite_session: AsyncSession) -> None:
+    api = await ApiRepository.upsert(apis_sqlite_session, **_TRIPLE, created_by="usr_test")
     assert api.catalog_api_id is None
 
 
 @pytest.mark.asyncio
-async def test_catalog_reimport_backfills_existing_row(session: AsyncSession) -> None:
+async def test_catalog_reimport_backfills_existing_row(apis_sqlite_session: AsyncSession) -> None:
     """A pre-#910 row (or manual first import) picks up the slug on its next
     catalog import of the same triple."""
-    first = await ApiRepository.upsert(session, **_TRIPLE, created_by="usr_test")
+    first = await ApiRepository.upsert(apis_sqlite_session, **_TRIPLE, created_by="usr_test")
     assert first.catalog_api_id is None
 
     again = await ApiRepository.upsert(
-        session,
+        apis_sqlite_session,
         **_TRIPLE,
         created_by="usr_test",
         catalog_api_id="nytimes.com/article_search",
@@ -118,14 +58,16 @@ async def test_catalog_reimport_backfills_existing_row(session: AsyncSession) ->
 
 
 @pytest.mark.asyncio
-async def test_slugless_reimport_never_clears_recorded_slug(session: AsyncSession) -> None:
+async def test_slugless_reimport_never_clears_recorded_slug(
+    apis_sqlite_session: AsyncSession,
+) -> None:
     """Overlay materialization and manual re-imports pass ``None`` — that must
     not erase the identity a catalog import already recorded."""
     await ApiRepository.upsert(
-        session,
+        apis_sqlite_session,
         **_TRIPLE,
         created_by="usr_test",
         catalog_api_id="nytimes.com/article_search",
     )
-    again = await ApiRepository.upsert(session, **_TRIPLE, created_by="usr_test")
+    again = await ApiRepository.upsert(apis_sqlite_session, **_TRIPLE, created_by="usr_test")
     assert again.catalog_api_id == "nytimes.com/article_search"

--- a/tests/web/control/test_credentials.py
+++ b/tests/web/control/test_credentials.py
@@ -15,8 +15,10 @@ from datetime import datetime
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import text
+from sqlalchemy import delete, text
 
+from jentic_one.registry.core.schema.apis import Api
+from jentic_one.registry.repos.api_repo import ApiRepository
 from jentic_one.shared.context import Context
 
 pytestmark = pytest.mark.integration
@@ -268,3 +270,60 @@ def test_catalog_api_id_defaults_to_null(cred_writer_client: TestClient) -> None
     cred_id = _create_api_key(cred_writer_client)
     got = cred_writer_client.get(f"/credentials/{cred_id}").json()
     assert got["catalog_api_id"] is None
+
+
+# --- Create-time unmatched-API advisory on the wire (#1020) ---
+
+
+def test_create_unmatched_scope_returns_warnings(cred_writer_client: TestClient) -> None:
+    """A scope covering no imported API still creates (201) but the response
+    carries the advisory `warnings` list."""
+    resp = cred_writer_client.post(
+        "/credentials",
+        json={
+            "type": "bearer_token",
+            "name": "web-cred-1020-unmatched",
+            "api": {"vendor": "webtest-unmatched.example", "name": "nothing-here", "version": ""},
+            "provider": "static",
+            "token": "sk-web-warn-token",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    warnings = resp.json()["warnings"]
+    assert isinstance(warnings, list) and warnings
+    assert "matches no imported API" in warnings[0]
+    assert "webtest-unmatched-example/nothing-here" in warnings[0]
+
+
+async def test_create_matching_scope_returns_null_warnings(
+    cred_writer_client: TestClient, web_context: Context
+) -> None:
+    """When the (canonicalized) scope covers an imported registry API the
+    response `warnings` field is null."""
+    async with web_context.registry_db.session() as session:
+        api = await ApiRepository.upsert(
+            session,
+            vendor="webtest-match-example",
+            name="onecall",
+            version="3.0",
+            created_by="usr_test",
+        )
+        api_id = api.id
+        await session.commit()
+    try:
+        resp = cred_writer_client.post(
+            "/credentials",
+            json={
+                "type": "bearer_token",
+                "name": "web-cred-1020-matched",
+                "api": {"vendor": "webtest-match.example", "name": "onecall", "version": "3.0"},
+                "provider": "static",
+                "token": "sk-web-match-token",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["warnings"] is None
+    finally:
+        async with web_context.registry_db.session() as session:
+            await session.execute(delete(Api).where(Api.id == api_id))
+            await session.commit()

--- a/tests/web/registry/test_catalog.py
+++ b/tests/web/registry/test_catalog.py
@@ -546,25 +546,28 @@ def test_to_import_source_threads_catalog_vendor_and_api_name(web_context: Conte
     }
 
 
-def test_to_import_source_threads_api_name_with_slash(web_context: Context) -> None:
-    """A slash-containing api_id (e.g. slack.com/api) threads the full value as api_name."""
+def test_to_import_source_derives_api_name_from_sub_segment(web_context: Context) -> None:
+    """A `domain/sub` api_id seeds only the sub segment as api_name (#1020): slugifying
+    the full id would fuse the vendor into the name and produce a vendor-doubled
+    identity (`posthog-com/posthog-com-posthog-api`) that credential bindings then
+    silently miss."""
     view = CatalogEntryView(
-        api_id="slack.com/api",
-        vendor="slack.com",
-        path="apis/openapi/slack.com/api",
-        spec_url="https://example.test/slack/openapi.json",
+        api_id="posthog.com/posthog-api",
+        vendor="posthog.com",
+        path="apis/openapi/posthog.com/posthog-api",
+        spec_url="https://example.test/posthog/openapi.json",
         github_url=None,
         registered=False,
     )
     result = CatalogService(web_context)._to_import_source(
         view, Identity(sub="usr_importer", email="u@test.local", permissions=[])
     )
-    assert result["api_name"] == "slack.com/api"
-    assert result["vendor"] == "slack.com"
+    assert result["api_name"] == "posthog-api"
+    assert result["vendor"] == "posthog.com"
     assert result["origin"] == "catalog"
-    # The separable slug is also carried verbatim — `api_name` above gets
+    # The separable slug is still carried verbatim — `api_name` above gets
     # slugified during identity resolution, this copy is persisted as-is.
-    assert result["catalog_api_id"] == "slack.com/api"
+    assert result["catalog_api_id"] == "posthog.com/posthog-api"
 
 
 def test_to_import_source_omits_absent_vendor(web_context: Context) -> None:

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -2720,6 +2720,21 @@
             "additionalProperties": true,
             "title": "Secret",
             "type": "object"
+          },
+          "warnings": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Advisory warnings from create — e.g. the credential's API scope matches no imported API identity, so execution through it would fail until a matching API is imported. The credential is created regardless; null when there is nothing to flag.",
+            "title": "Warnings"
           }
         },
         "required": [

--- a/ui/src/shared/api/generated/models/CredentialCreateResponse.ts
+++ b/ui/src/shared/api/generated/models/CredentialCreateResponse.ts
@@ -9,5 +9,9 @@ import type { CredentialRedactedResponse } from './CredentialRedactedResponse';
 export type CredentialCreateResponse = {
     credential: CredentialRedactedResponse;
     secret: Record<string, any>;
+    /**
+     * Advisory warnings from create — e.g. the credential's API scope matches no imported API identity, so execution through it would fail until a matching API is imported. The credential is created regardless; null when there is nothing to flag.
+     */
+    warnings?: (Array<string> | null);
 };
 


### PR DESCRIPTION
## Summary

A plain `jentic catalog import <domain/sub>` seeded the ingest `api_name` with the **full** catalog id, which slugification collapsed into a vendor-doubled workspace identity (`posthog-com/posthog-com-posthog-api`) that no other surface agrees with — and since credential creation accepts an unvalidated API reference, a credential bound to the expected clean name silently never matched and every execute 403'd with `no_toolkit_binding`. This fixes the identity derivation at import time and surfaces the credential-scope mismatch at create time instead of at execute time.

Plan: `jentic-one-plans/issues/issue-1020-catalog-import-vendor-doubled-api-name.md`.

## Changes

- **registry**: `_to_import_source` seeds `api_name` from the catalog id's *sub* segment (`posthog.com/posthog-api` → `posthog-api`), so the workspace identity matches the catalog path, repo layout, and broker upstream registration. Bare-domain entries (`coincap.io`) keep their established identity.
- **registry**: collision guard in `ResolveApiStage` — two distinct catalog entries that collapse to the same registry identity (`stripe.com/x` vs `api.stripe.com/x`, possible now that names are clean) refuse the import with a readable `catalog identity conflict` error instead of silently stacking a foreign spec as a new revision. Same-id re-imports and NULL backfills (#910 semantics) are unchanged.
- **control**: `CredentialService.create` now checks (best-effort) whether the canonical scope covers any imported registry API, via a new raw-SQL `RegistryApiLookupRepository` following the broker's cross-tier pattern (no cross-imports). On a miss it **warns, never rejects**: `warnings` field on the create response, a new warning-severity `credential.unmatched_api` event, and a structured log — with a nearest-identity hint naming the vendor's imported APIs. Skipped on standalone control deployments (no registry DB) and on registry read errors.
- OpenAPI spec regenerated (`make openapi`).
- **Out of scope** (per the plan, follow-up PR): migrating *existing* doubled identities in installed deployments — needs a coordinated registry+control re-slug migration; the import fix stops the bleeding for all new imports first.

## Risk & rollback

- New response field (`warnings`, nullable) on `POST /credentials` — additive, no client breakage.
- New event type `credential.unmatched_api` — UI event rail falls back to the generic credential icon for unknown `credential.*` types.
- Identity change applies only to *new* catalog imports of `domain/sub` entries; existing workspace rows are untouched (re-importing one after upgrade creates the clean identity alongside the old doubled row — resolved properly by the follow-up migration).
- Revert the squash commit to roll back.

## Test plan

- `make lint` (ruff + mypy) clean; `tests/arch` 274 passed
- `make test-fast`, `make test-integration` (Postgres), `make test-integration-sqlite` — all green
- New tests: `tests/unit/registry/ingest/test_extract_api_catalog_conflict.py` (collision guard, real SQLite DB), `tests/integration/control/test_credential_unmatched_api_warning.py` (cross-DB: registry seed → control create → admin event), updated `tests/web/registry/test_catalog.py` to pin the sub-segment derivation
- Pre-existing/environmental failures unrelated to this change (identical on untouched `main` checkout): `test_spec_is_valid[broker]` (needs network for a remote `$ref`), `make score` (private npm package 404)

## Review follow-ups (8-lens deep review)

Hardening applied in this PR after review:

- **Time-bounded advisory probe**: the registry lookup at credential create is wrapped in `asyncio.timeout(2s)` and gated on `has_db("registry")` — a hung or never-connected registry DB can neither stall `POST /credentials` nor log-spam; timeouts land in the existing best-effort fallback.
- **Collision guard hardening**: the refusal is now a typed `CatalogIdentityConflictError` naming both catalog ids and the next step; the guard read takes `FOR UPDATE` (closes the READ COMMITTED backfill race where two colliding imports could both pass); `uq_apis_vendor_name_version` maps to a readable job error for the insert race.
- **Event hygiene**: `credential.unmatched_api` now carries a short bounded summary (fits the 512-char column and one-line UI rows), the remedy + sibling-identity hint in `detail`, and `credential_id` in `data`; warning text names both remedies (import the API, or delete + re-create the immutable-scope credential); emit-failure log no longer misattributes an event type.
- **Test gaps closed**: end-to-end catalog import through the real `_to_import_source` → `ImportHandler` seam asserting the clean identity lands; conflict surfacing as a readable job failure; `POST /credentials` web tests for the `warnings` field (present + null); version-only wildcard, standalone-control skip, and registry-error probe branches; shared SQLite `apis` fixture promoted to `tests/unit/registry/conftest.py`.

Ticketed follow-ups: #1076 (UI surfaces `warnings`), #1077 (unmatched-api event race with the import job), #1078 (A4b transition edge over doubled rows), #1079 (Phase 3 migration of existing doubled identities).


Closes #1020

Made with [Cursor](https://cursor.com)
