### PR TITLE
docs(readme): fix first-run admin flow guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,8 @@ allow. See `docs/security/hardening.md` before using real credentials.
 1. `jentic register` creates the agent identity. It then blocks, waiting for an operator to
    approve the agent. Report this to the user: on a single-operator install they are the
    operator, and they approve it in the UI at `/app`.
-2. The bootstrap operator login is `admin@local` / `1234`. Tell the user to change it.
+2. If no admin account exists yet, point the user to `/setup` (browser) or `jenticctl setup`
+   (terminal). This is a one-time step.
 3. Import an API from https://github.com/jentic/jentic-public-apis, or register a private
    OpenAPI description of the user's own service.
 4. Store a credential for that API, once. It is encrypted at rest and is never returned.

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ make dev       # idempotent local bring-up: fixtures + migrations + UI, then run
 
 Six steps from a running instance to a response from a real API.
 
-1. **Sign in** to the operator UI at `/app` with the bootstrap login `admin@local` / `1234`,
-   then change the password.
+1. **Create your admin account** at `/setup` (the wizard opens this automatically, or run
+   `jenticctl setup` to do it from the terminal).
 2. **Import an API** from the [Jentic API Directory](https://github.com/jentic/jentic-public-apis),
    or upload your own specification.
 3. **Store a credential** for that API. It is encrypted at rest and is never returned to a

--- a/cli/README.md
+++ b/cli/README.md
@@ -179,8 +179,8 @@ migrate, or start) and print the next-step commands.
 Secrets (the credential-encryption key, admin JWT secret, invite pepper, connect
 state secret) are **freshly generated** on each run and written into the config
 with `0600` perms — never prompted for. After writing the file the wizard prints
-the next-step commands for your chosen path and the bootstrap-admin reminder
-(`admin@local` / `1234`, rotate to a 12+ char password on first login).
+the next-step commands for your chosen path, including the command to create
+the first admin account.
 
 > **Local development only.** Both the generated `jentic-one.yaml` and the
 > `docker-compose.yaml` embed credentials (including the Postgres password) in

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,18 +16,14 @@ the Broker are running and reachable (the local default is
 > [security hardening guide](security/hardening.md) before pointing an instance
 > at a real credential.
 
-## 1. Sign in and change the bootstrap password
+## 1. Create your admin account
 
-Open the operator UI at `/app` and sign in with the bootstrap login:
+Open `/setup` in the operator UI and create the first administrator. This is a
+one-time step: once the account exists, this page redirects to login. The account
+you create here is the operator: it configures the instance, imports APIs, stores
+credentials, and approves agents.
 
-```
-email:    admin@local
-password: 1234
-```
-
-Change the password immediately — rotate to a 12+ character password on first
-login. This account is the operator: it configures the instance, imports APIs,
-stores credentials, and approves agents.
+To do this from the terminal instead, run `jenticctl setup`.
 
 ## 2. Import an API
 


### PR DESCRIPTION
## Summary

The README, quickstart guide, CLI reference, and AGENTS.md incorrectly described the first-run flow as signing in with a pre-seeded `admin@local` / `1234` account. This reflects an earlier onboarding implementation that has since been replaced — the platform now ships with an empty users table and requires the operator to create the first admin at `/setup` (or via `jenticctl setup`).

## Changes

- `README.md` — step 1 of "First brokered call" rewritten to describe account creation at `/setup`
- `docs/quickstart.md` — section 1 rewritten accordingly
- `AGENTS.md` — bootstrap login instruction replaced with a direction to point the user to `/setup` or `jenticctl setup`
- `cli/README.md` — install wizard description corrected to remove the stale bootstrap credentials

## Risk & rollback

Low risk: documentation-only change.

## Test plan

No automated tests; verified against the implementation:

- `src/jentic_one/__main__.py` — `_create_admin` and the `create-admin` CLI command implement the actual first-run flow
- `cli/internal/cmd/setup.go` — `jenticctl setup` prompts for credentials and calls `create-admin`; its docstring explicitly states "there is no default password to rotate"
- `cli/internal/cmd/wizard.go` — wizard opens `/setup` in the browser and polls `setup_required`; no credentials are printed
- `cli/internal/install/commands.go` — comments confirm "there is no seeded account"
- `src/jentic_one/shared/web/openapi_meta.py` and `openapi/control/control.openapi.yaml` — both explicitly document that no `admin@local` account is seeded

## Checklist

- [ ] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [ ] `make check` passes (lint, type check, secrets audit, arch tests)
- [ ] Tests added/updated for the change
- [x] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included