### PR TITLE
test(arch): validate OpenAPI specs offline via vendored problem-details schemas

### DIFF
--- a/tests/arch/test_openapi_conformance.py
+++ b/tests/arch/test_openapi_conformance.py
@@ -7,10 +7,16 @@ file, so a route or model change that isn't accompanied by ``make openapi``
 fails CI. The broker spec is hand-curated and validity-checked; its docs-SPA
 artifact (``ui/public/broker-openapi.json``, see ``tools/broker_reference``) is
 drift-checked against it here too.
+
+Validation is fully **offline**: the broker spec's external problem-details
+``$ref``s resolve from vendored copies under
+``tests/arch/vendored/problem-details/`` (never the network), with checksum and
+ref-pin guards keeping the vendored set in sync with the spec's pinned commit.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from typing import Any
@@ -48,12 +54,32 @@ PROBLEM_DETAILS_PIN = "c741877182d2deea2bb38859e3df4caa76265d98"
 _PIN_BASE = (
     f"https://raw.githubusercontent.com/jentic/api-problem-details/{PROBLEM_DETAILS_PIN}/schemas/"
 )
-# problem-details.yaml declares an $id on the upstream main branch; its
-# relative "./error-item.yaml" ref resolves against that $id, so both bases
-# must map onto the vendored copies.
+# problem-details.yaml declares an $id on the upstream main branch. Today the
+# referencing library resolves its relative "./error-item.yaml" ref against
+# the retrieval URI (the pinned URL), so this base is never requested — it is
+# a forward-compatibility fallback in case a future library version resolves
+# against the $id instead. Mapping the mutable main-branch URL onto the pinned
+# vendored copy is the only deterministic offline choice.
 _ID_BASE = "https://raw.githubusercontent.com/jentic/api-problem-details/refs/heads/main/schemas/"
 _VENDORED_SCHEMA_DIR = Path(__file__).resolve().parent / "vendored" / "problem-details"
-_VENDORED_SCHEMA_BASES = (_PIN_BASE, _ID_BASE)
+# filename -> sha256 of the vendored copy, asserted by
+# test_vendored_schemas_match_pinned_checksums so a hand-edit — or a pin bump
+# that skips the re-download step — cannot silently validate against content
+# that differs from what the pinned URL serves. Update on re-vendoring:
+#   shasum -a 256 tests/arch/vendored/problem-details/*.yaml
+_VENDORED_SCHEMA_SHA256 = {
+    "problem-details.yaml": "9ffa96dbbac83e73ba727d09ad8881a665840a3a4fe44477bc6c376a9c5de716",
+    "error-item.yaml": "edc4041b7a226f83136cd9dbe82b17ee0e5160608c5313a25c84e854045c3a9e",
+}
+# Exact-URI resolution map: no prefix/basename matching, so a ref to a
+# different upstream file with a colliding basename (or a non-normalized path
+# under the pinned base) cannot silently resolve to the wrong vendored copy.
+_VENDORED_SCHEMA_URIS = {
+    f"{base}{filename}": _VENDORED_SCHEMA_DIR / filename
+    for filename in _VENDORED_SCHEMA_SHA256
+    for base in (_PIN_BASE, _ID_BASE)
+}
+_PINNED_SCHEMA_URIS = frozenset(f"{_PIN_BASE}{filename}" for filename in _VENDORED_SCHEMA_SHA256)
 
 
 def _vendored_schema_resolver(uri: str) -> Any:
@@ -63,14 +89,13 @@ def _vendored_schema_resolver(uri: str) -> Any:
     to a spec requires vendoring it, otherwise CI would silently depend on a
     third-party host being up.
     """
-    base = next((b for b in _VENDORED_SCHEMA_BASES if uri.startswith(b)), None)
-    filename = Path(urlparse(uri).path).name
-    vendored = _VENDORED_SCHEMA_DIR / filename if base else None
-    if vendored is None or not vendored.is_file():
+    vendored = _VENDORED_SCHEMA_URIS.get(uri)
+    if vendored is None:
         raise LookupError(
             f"external $ref {uri!r} has no vendored copy. Spec validation must "
             "not touch the network — vendor the schema under "
-            f"{_VENDORED_SCHEMA_DIR} (see tests/arch/vendored/README.md)."
+            f"{_VENDORED_SCHEMA_DIR} and register it in _VENDORED_SCHEMA_SHA256 "
+            "(see tests/arch/vendored/README.md)."
         )
     return yaml.safe_load(vendored.read_text(encoding="utf-8"))
 
@@ -89,11 +114,11 @@ def _validate_offline(spec: dict[str, Any]) -> None:
 
 
 def _external_refs(node: Any) -> set[str]:
-    """Collect every absolute http(s) ``$ref`` target in a spec document."""
+    """Collect every absolute ``$ref`` target (any URI scheme) in a spec document."""
     refs: set[str] = set()
     if isinstance(node, dict):
         for key, value in node.items():
-            if key == "$ref" and isinstance(value, str) and value.startswith("http"):
+            if key == "$ref" and isinstance(value, str) and urlparse(value).scheme:
                 refs.add(value)
             else:
                 refs.update(_external_refs(value))
@@ -112,32 +137,46 @@ def test_spec_is_valid(name: str, spec_path: Path) -> None:
 
 
 @pytest.mark.arch
+def test_vendored_schemas_match_pinned_checksums() -> None:
+    """The vendored schema bytes must be exactly what was fetched at the pin.
+
+    Without this, a hand-edited vendored file — or a pin bump in the spec and
+    ``PROBLEM_DETAILS_PIN`` that skips the re-download step — would pass the
+    ref guard while ``test_spec_is_valid`` silently validates against content
+    that differs from what the pinned URL serves.
+    """
+    for filename, expected in sorted(_VENDORED_SCHEMA_SHA256.items()):
+        vendored = _VENDORED_SCHEMA_DIR / filename
+        assert vendored.is_file(), f"missing vendored schema: {vendored}"
+        actual = hashlib.sha256(vendored.read_bytes()).hexdigest()
+        assert actual == expected, (
+            f"{vendored} — sha256 {actual} does not match the recorded checksum "
+            f"{expected}. If you re-vendored at a new pin, update "
+            "_VENDORED_SCHEMA_SHA256; if not, restore the file from the pinned "
+            "URL (see tests/arch/vendored/README.md)."
+        )
+
+
+@pytest.mark.arch
 @pytest.mark.parametrize("name,spec_path", SPECS, ids=[s[0] for s in SPECS])
 def test_spec_external_refs_are_pinned_and_vendored(name: str, spec_path: Path) -> None:
-    """Every external ``$ref`` must point at the pinned, vendored schema set.
+    """Every external ``$ref`` must be exactly a pinned, vendored schema URI.
 
-    This is the drift guard for the vendored copies: bumping the
-    ``api-problem-details`` pin in a spec without re-vendoring (or vice versa)
-    fails here with instructions, instead of silently validating against stale
-    content or reaching for the network.
+    This is the ref-level drift guard: bumping the ``api-problem-details`` pin
+    in a spec without updating ``PROBLEM_DETAILS_PIN`` (or vice versa), or
+    adding any new external ref without vendoring it, fails here with
+    instructions instead of reaching for the network. Content-level drift is
+    covered by ``test_vendored_schemas_match_pinned_checksums``.
     """
     spec = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
-    problems: list[str] = []
-    for ref in sorted(_external_refs(spec)):
-        if not ref.startswith(_PIN_BASE):
-            problems.append(
-                f"{ref} — not under the pinned base {_PIN_BASE!r}. External refs "
-                "must pin an immutable commit; update PROBLEM_DETAILS_PIN in "
-                "this test and re-vendor (tests/arch/vendored/README.md)."
-            )
-            continue
-        vendored = _VENDORED_SCHEMA_DIR / Path(urlparse(ref).path).name
-        if not vendored.is_file():
-            problems.append(
-                f"{ref} — no vendored copy at {vendored}. Vendor it so spec "
-                "validation stays offline (tests/arch/vendored/README.md)."
-            )
-    assert not problems, f"{name} spec external $refs out of sync:\n" + "\n".join(problems)
+    unexpected = _external_refs(spec) - _PINNED_SCHEMA_URIS
+    assert not unexpected, (
+        f"{name} spec has external $refs that are not exactly a pinned, vendored "
+        "schema URI:\n"
+        + "\n".join(sorted(unexpected))
+        + "\nExternal refs must pin an immutable commit and have a vendored copy: "
+        "update PROBLEM_DETAILS_PIN and re-vendor per tests/arch/vendored/README.md."
+    )
 
 
 @pytest.mark.arch

--- a/tests/arch/test_openapi_conformance.py
+++ b/tests/arch/test_openapi_conformance.py
@@ -14,10 +14,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import pytest
 import yaml
-from openapi_spec_validator import validate
+from jsonschema_path import SchemaPath
+from openapi_spec_validator.shortcuts import get_validator_cls
 from tools.broker_reference import (
     BROKER_SPEC_JSON,
     dump_spec_json,
@@ -36,13 +38,106 @@ SPECS = [
     ("control", OPENAPI_DIR / "control" / "control.openapi.yaml"),
 ]
 
+# The broker spec $refs its RFC 9457 problem-details schemas from
+# jentic/api-problem-details, pinned to an immutable commit. Validation must
+# resolve those refs from the vendored copies below — never the network — so a
+# GitHub outage cannot fail CI (as happened on 2026-08-17, when
+# raw.githubusercontent.com was returning errors on main pushes).
+# See tests/arch/vendored/README.md for the re-vendoring procedure.
+PROBLEM_DETAILS_PIN = "c741877182d2deea2bb38859e3df4caa76265d98"
+_PIN_BASE = (
+    f"https://raw.githubusercontent.com/jentic/api-problem-details/{PROBLEM_DETAILS_PIN}/schemas/"
+)
+# problem-details.yaml declares an $id on the upstream main branch; its
+# relative "./error-item.yaml" ref resolves against that $id, so both bases
+# must map onto the vendored copies.
+_ID_BASE = "https://raw.githubusercontent.com/jentic/api-problem-details/refs/heads/main/schemas/"
+_VENDORED_SCHEMA_DIR = Path(__file__).resolve().parent / "vendored" / "problem-details"
+_VENDORED_SCHEMA_BASES = (_PIN_BASE, _ID_BASE)
+
+
+def _vendored_schema_resolver(uri: str) -> Any:
+    """Serve pinned external ``$ref``s from the vendored copies, offline.
+
+    Any URI outside the vendored set fails loudly: adding a new external ref
+    to a spec requires vendoring it, otherwise CI would silently depend on a
+    third-party host being up.
+    """
+    base = next((b for b in _VENDORED_SCHEMA_BASES if uri.startswith(b)), None)
+    filename = Path(urlparse(uri).path).name
+    vendored = _VENDORED_SCHEMA_DIR / filename if base else None
+    if vendored is None or not vendored.is_file():
+        raise LookupError(
+            f"external $ref {uri!r} has no vendored copy. Spec validation must "
+            "not touch the network — vendor the schema under "
+            f"{_VENDORED_SCHEMA_DIR} (see tests/arch/vendored/README.md)."
+        )
+    return yaml.safe_load(vendored.read_text(encoding="utf-8"))
+
+
+_OFFLINE_HANDLERS = {
+    "http": _vendored_schema_resolver,
+    "https": _vendored_schema_resolver,
+}
+
+
+def _validate_offline(spec: dict[str, Any]) -> None:
+    """``openapi_spec_validator.validate`` with network resolution disabled."""
+    validator_cls = get_validator_cls(spec)
+    schema_path = SchemaPath.from_dict(spec, handlers=_OFFLINE_HANDLERS)
+    validator_cls(schema_path).validate()
+
+
+def _external_refs(node: Any) -> set[str]:
+    """Collect every absolute http(s) ``$ref`` target in a spec document."""
+    refs: set[str] = set()
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "$ref" and isinstance(value, str) and value.startswith("http"):
+                refs.add(value)
+            else:
+                refs.update(_external_refs(value))
+    elif isinstance(node, list):
+        for item in node:
+            refs.update(_external_refs(item))
+    return refs
+
 
 @pytest.mark.arch
 @pytest.mark.parametrize("name,spec_path", SPECS, ids=[s[0] for s in SPECS])
 def test_spec_is_valid(name: str, spec_path: Path) -> None:
     assert spec_path.exists(), f"OpenAPI spec not found: {spec_path}"
     spec = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
-    validate(spec)
+    _validate_offline(spec)
+
+
+@pytest.mark.arch
+@pytest.mark.parametrize("name,spec_path", SPECS, ids=[s[0] for s in SPECS])
+def test_spec_external_refs_are_pinned_and_vendored(name: str, spec_path: Path) -> None:
+    """Every external ``$ref`` must point at the pinned, vendored schema set.
+
+    This is the drift guard for the vendored copies: bumping the
+    ``api-problem-details`` pin in a spec without re-vendoring (or vice versa)
+    fails here with instructions, instead of silently validating against stale
+    content or reaching for the network.
+    """
+    spec = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+    problems: list[str] = []
+    for ref in sorted(_external_refs(spec)):
+        if not ref.startswith(_PIN_BASE):
+            problems.append(
+                f"{ref} — not under the pinned base {_PIN_BASE!r}. External refs "
+                "must pin an immutable commit; update PROBLEM_DETAILS_PIN in "
+                "this test and re-vendor (tests/arch/vendored/README.md)."
+            )
+            continue
+        vendored = _VENDORED_SCHEMA_DIR / Path(urlparse(ref).path).name
+        if not vendored.is_file():
+            problems.append(
+                f"{ref} — no vendored copy at {vendored}. Vendor it so spec "
+                "validation stays offline (tests/arch/vendored/README.md)."
+            )
+    assert not problems, f"{name} spec external $refs out of sync:\n" + "\n".join(problems)
 
 
 @pytest.mark.arch

--- a/tests/arch/vendored/README.md
+++ b/tests/arch/vendored/README.md
@@ -11,7 +11,10 @@ facts, plus vendored third-party schemas the arch tests need to run offline:
   [`jentic/api-problem-details`](https://github.com/jentic/api-problem-details),
   at the commit pinned by the broker spec's external `$ref`s. Used by
   `tests/arch/test_openapi_conformance.py` to validate the OpenAPI specs
-  **without touching the network** — a GitHub outage must not fail CI.
+  **without touching the network** — a GitHub outage must not fail CI. Two
+  guards keep the copies honest: a ref-pin guard (every external `$ref` must be
+  exactly a pinned, vendored URI) and a sha256 checksum guard (the vendored
+  bytes must be what was fetched at the pin).
 
 ## Why it's vendored
 
@@ -66,6 +69,13 @@ The broker spec's external `$ref`s pin an immutable commit of
    curl -sSf "$base/error-item.yaml"      -o tests/arch/vendored/problem-details/error-item.yaml
    ```
 
-3. Run `uv run pytest tests/arch/test_openapi_conformance.py`. The
-   `test_spec_external_refs_are_pinned_and_vendored` guard fails if the spec
-   refs and the vendored set are out of sync.
+3. Update the recorded checksums in `_VENDORED_SCHEMA_SHA256`
+   (`tests/arch/test_openapi_conformance.py`):
+
+   ```sh
+   shasum -a 256 tests/arch/vendored/problem-details/*.yaml
+   ```
+
+4. Run `uv run pytest tests/arch/test_openapi_conformance.py`. The guards fail
+   if the spec refs, `PROBLEM_DETAILS_PIN`, the vendored files, or the recorded
+   checksums are out of sync with each other.

--- a/tests/arch/vendored/README.md
+++ b/tests/arch/vendored/README.md
@@ -1,11 +1,17 @@
 # Vendored rules facts
 
 This directory holds a **committed subset** of the machine-readable enforcement
-facts. Today that is a single file:
+facts, plus vendored third-party schemas the arch tests need to run offline:
 
 - `orm.facts.yaml` — the ORM conventions (`valid_bases`, required columns,
   tablename rules, KSUID-exempt tables) that `tests/arch/test_orm_conventions.py`
   reads instead of hard-coding.
+- `problem-details/` — the RFC 9457 problem-details schemas
+  (`problem-details.yaml`, `error-item.yaml`) from
+  [`jentic/api-problem-details`](https://github.com/jentic/api-problem-details),
+  at the commit pinned by the broker spec's external `$ref`s. Used by
+  `tests/arch/test_openapi_conformance.py` to validate the OpenAPI specs
+  **without touching the network** — a GitHub outage must not fail CI.
 
 ## Why it's vendored
 
@@ -43,3 +49,23 @@ meaningful in this repo. Concretely:
 4. Re-run the guards. `test_vendored_orm_facts_is_oss_safe` must still pass — if
    it fails, the upstream file carries content that is not OSS-safe and must not
    be vendored as-is.
+
+## Re-vendoring the problem-details schemas (when the spec pin changes)
+
+The broker spec's external `$ref`s pin an immutable commit of
+`jentic/api-problem-details`. If you bump that pin in
+`openapi/broker/broker.openapi.yaml`:
+
+1. Update `PROBLEM_DETAILS_PIN` in `tests/arch/test_openapi_conformance.py` to
+   the new commit SHA.
+2. Re-download the schemas at that SHA into `problem-details/`:
+
+   ```sh
+   base="https://raw.githubusercontent.com/jentic/api-problem-details/<sha>/schemas"
+   curl -sSf "$base/problem-details.yaml" -o tests/arch/vendored/problem-details/problem-details.yaml
+   curl -sSf "$base/error-item.yaml"      -o tests/arch/vendored/problem-details/error-item.yaml
+   ```
+
+3. Run `uv run pytest tests/arch/test_openapi_conformance.py`. The
+   `test_spec_external_refs_are_pinned_and_vendored` guard fails if the spec
+   refs and the vendored set are out of sync.

--- a/tests/arch/vendored/problem-details/error-item.yaml
+++ b/tests/arch/vendored/problem-details/error-item.yaml
@@ -1,0 +1,40 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "https://raw.githubusercontent.com/jentic/api-problem-details/refs/heads/main/schemas/error-item.yaml"
+description: A granular error detail entry within the errors[] array of a ProblemDetails response.
+type: object
+required:
+  - detail
+properties:
+  detail:
+    type: string
+    description: >-
+      A human-readable explanation of this specific error. Be precise —
+      name the field, parameter, or header involved.
+    maxLength: 4096
+    example: Field 'name' must not be blank.
+  pointer:
+    type: string
+    description: >-
+      A JSON Pointer (RFC 6901) to the specific request body property
+      that is the source of this error.
+    maxLength: 1024
+    example: '#/name'
+  parameter:
+    type: string
+    description: >-
+      The name of the query or path parameter that is the source of this error.
+    maxLength: 1024
+    example: limit
+  header:
+    type: string
+    description: >-
+      The name of the request header that is the source of this error.
+    maxLength: 1024
+    example: Authorization
+  code:
+    type: string
+    description: >-
+      An optional provider-specific code identifying this error in internal
+      taxonomy or documentation.
+    maxLength: 50
+    example: JENTIC-V-001

--- a/tests/arch/vendored/problem-details/problem-details.yaml
+++ b/tests/arch/vendored/problem-details/problem-details.yaml
@@ -1,0 +1,61 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "https://raw.githubusercontent.com/jentic/api-problem-details/refs/heads/main/schemas/problem-details.yaml"
+description: Jentic Problem Details error schema (RFC 9457)
+type: object
+required:
+  - detail
+properties:
+  type:
+    type: string
+    format: uri
+    description: >-
+      A URI reference identifying the problem type. When set to "about:blank",
+      the title SHOULD be the standard HTTP status phrase. Use an IANA-registered
+      type URI where one applies.
+    default: about:blank
+    maxLength: 1024
+    example: about:blank
+  status:
+    type: integer
+    format: int32
+    description: The HTTP status code for this occurrence of the problem.
+    minimum: 100
+    maximum: 599
+    example: 400
+  title:
+    type: string
+    description: >-
+      A short, human-readable summary of the problem type. Should not change
+      between occurrences except for localisation purposes.
+    maxLength: 1024
+    example: Bad Request
+  detail:
+    type: string
+    description: >-
+      A human-readable explanation specific to this occurrence of the problem.
+      MUST be present. Provide actionable information where possible.
+    maxLength: 4096
+    example: The request body is missing required field 'name'.
+  instance:
+    type: string
+    format: uri-reference
+    description: >-
+      A URI reference identifying the specific occurrence of the problem.
+      Typically the request path.
+    maxLength: 1024
+    example: /v2/capability-sets
+  code:
+    type: string
+    description: >-
+      An optional provider-specific code for internal error taxonomy and
+      observability correlation.
+    maxLength: 50
+    example: JENTIC-4001
+  errors:
+    type: array
+    description: >-
+      An array of granular error details. Use when multiple validation errors
+      or field-level problems need to be surfaced in a single response.
+    maxItems: 1000
+    items:
+      $ref: "./error-item.yaml"


### PR DESCRIPTION
## Summary

Both pushes to `main` on Aug 17 (~15:00–15:40 UTC) failed CI because `test_spec_is_valid[broker]` resolves the broker spec's external problem-details `$ref`s over the network at test time, and `raw.githubusercontent.com` was returning 503/429 during a GitHub outage (the same outage also broke action downloads and release-please; those recovered on re-run). This makes spec validation fully offline so a third-party outage can never fail `main` again.

## Changes

- `tests/arch/vendored/problem-details/` — vendored copies of `problem-details.yaml` and `error-item.yaml` from `jentic/api-problem-details` at the commit the broker spec pins (`c741877…`), byte-identical to upstream, following the existing vendoring pattern in `tests/arch/vendored/`
- `tests/arch/test_openapi_conformance.py` — `test_spec_is_valid` now validates with resolver handlers that serve refs from the vendored copies via an **exact-URI map** (no prefix/basename matching) and fail loudly on anything non-vendored (no silent network dependency)
- New guard `test_spec_external_refs_are_pinned_and_vendored` — every external `$ref` (any URI scheme) must be exactly a pinned, vendored URI; bumping the spec's pin without updating `PROBLEM_DETAILS_PIN` (or vice versa) fails with re-vendoring instructions
- New guard `test_vendored_schemas_match_pinned_checksums` — sha256 ties the vendored bytes to the pin, so a hand-edited vendored file or a pin bump that skips the re-download step cannot silently validate against stale content
- `tests/arch/vendored/README.md` — documents the vendored schemas, both guards, and the re-vendoring procedure (including the checksum step)
- Out of scope: the flaky action downloads (`setup-go`, `setup-uv`) — that was GitHub infrastructure failing to serve the actions themselves; nothing to fix repo-side

## Risk & rollback

- Low risk: test-only change; the pinned URL is an immutable commit SHA, so the vendored content cannot drift from what the URL serves. Revert the squash commit to roll back.

## Test plan

- `make test-arch` — 146 passed
- `make lint` — ruff + mypy clean
- Verified the handlers are actually used: temporarily removing `tests/arch/vendored/problem-details/` makes `test_spec_is_valid[broker]` fail with the offline `LookupError` (no network fallback)
- Negative probes: a colliding-basename or non-normalized URI under the pinned base is rejected; a tampered vendored file fails the checksum guard; the ref scan catches uppercase and non-http schemes
- Reviewed by three subagents (bug hunt, resolver-semantics deep dive, conventions/rules compliance); all findings addressed in the second commit