### PR TITLE
fix(docs): repair the agent onboarding front door and add a drift guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,17 +29,18 @@ allow. See `docs/security/hardening.md` before using real credentials.
 
 1. `jentic bootstrap --base-url <control-plane URL>` creates the agent identity, waits for an
    operator to approve it, and installs the agent skill. (`jentic register --base-url …` is the
-   registration-only path; without `--base-url` both default to `http://localhost:8000`.)
+   registration-only path; without `--base-url` both fall back to the configured base URL or
+   `http://127.0.0.1:8000`, and prompt for it on an interactive terminal.)
    Report the wait to the user: on a single-operator install they are the operator, and they
    approve the agent in the UI at `/app`.
 2. If no admin account exists yet, point the user to `/setup` (browser) or `jenticctl setup`
    (terminal). This is a one-time step.
-3. Import an API from https://github.com/jentic/jentic-public-apis, or register a private
-   OpenAPI description of the user's own service.
+3. Import an API from https://github.com/jentic/jentic-public-apis (e.g. `httpbin.org`, used in
+   step 6), or register a private OpenAPI description of the user's own service.
 4. Store a credential for that API, once. It is encrypted at rest and is never returned.
-5. Request access: `jentic access request` files a reviewable request; granting is always a
-   human action. The operator binds the agent to a toolkit — access is default-deny, and a
-   rule-less binding still blocks everything.
+5. Request access: `jentic access request --toolkit <vendor/name>` files a reviewable request;
+   granting is always a human action. The operator binds the agent to a toolkit — access is
+   default-deny, and a rule-less binding still blocks everything.
 6. `jentic execute GET:https://httpbin.org/get --json` runs a call through the Broker with the
    credential injected. Give `execute` the operation's full upstream URL (as returned by
    `jentic search`/`jentic inspect`) or its operation_id — the Broker is a forward proxy, not a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ rest of this file is for changing the codebase.
    `curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/main/tools/install.sh | sh`
    This downloads a Go toolchain if none is present, clones this repository, builds `jenticctl`
    and `jentic`, then runs `jenticctl install`. Set `JENTIC_NO_INSTALL=1` to stop after the
-   binaries are installed.
+   binaries are installed — do that on the agent machine, which needs only the binaries, not a
+   second deployment.
 
 **Run Jentic One on a different machine from the agent.** An agent running as the same OS user
 can read the credential database and encryption key from disk, whatever the API-level controls
@@ -26,16 +27,23 @@ allow. See `docs/security/hardening.md` before using real credentials.
 
 **Register and reach a first call:**
 
-1. `jentic register` creates the agent identity. It then blocks, waiting for an operator to
-   approve the agent. Report this to the user: on a single-operator install they are the
-   operator, and they approve it in the UI at `/app`.
+1. `jentic bootstrap --base-url <control-plane URL>` creates the agent identity, waits for an
+   operator to approve it, and installs the agent skill. (`jentic register --base-url …` is the
+   registration-only path; without `--base-url` both default to `http://localhost:8000`.)
+   Report the wait to the user: on a single-operator install they are the operator, and they
+   approve the agent in the UI at `/app`.
 2. If no admin account exists yet, point the user to `/setup` (browser) or `jenticctl setup`
    (terminal). This is a one-time step.
 3. Import an API from https://github.com/jentic/jentic-public-apis, or register a private
    OpenAPI description of the user's own service.
 4. Store a credential for that API, once. It is encrypted at rest and is never returned.
-5. Bind the agent to a toolkit. A rule-less binding blocks everything; the default is deny.
-6. `jentic execute GET:/get --json` runs a call through the Broker with the credential injected.
+5. Request access: `jentic access request` files a reviewable request; granting is always a
+   human action. The operator binds the agent to a toolkit — access is default-deny, and a
+   rule-less binding still blocks everything.
+6. `jentic execute GET:https://httpbin.org/get --json` runs a call through the Broker with the
+   credential injected. Give `execute` the operation's full upstream URL (as returned by
+   `jentic search`/`jentic inspect`) or its operation_id — the Broker is a forward proxy, not a
+   path router.
 
 **Constraints to respect:**
 

--- a/README.md
+++ b/README.md
@@ -121,10 +121,12 @@ Six steps from a running instance to a response from a real API.
    agent. On a single-operator install, approve it in the UI and the command completes.
 5. **Grant access** by binding the agent to a toolkit. A rule-less binding blocks everything;
    the default is deny.
-6. **Make the call:** `jentic execute GET:/get --json`.
+6. **Make the call:** `jentic execute GET:https://httpbin.org/get --json` — the operation's
+   full URL, as returned by `jentic search`/`jentic inspect`.
 
 Full walkthrough: [docs/quickstart.md](docs/quickstart.md). To have a coding agent install and
-register itself, see [AGENTS.md](AGENTS.md).
+register itself, see [AGENTS.md](AGENTS.md); [llms.txt](llms.txt) is the machine-readable index
+of these docs for assistants evaluating the project.
 
 ## How it works
 
@@ -175,10 +177,10 @@ for APIs that already have one.
 ## CLI reference
 
 ```bash
-jenticctl install                 # interactive wizard: config + install (local venv or Docker)
-jentic register                   # mint an agent identity, then wait for operator approval
-jentic catalog search stripe      # find an API in the directory
-jentic execute GET:/get --json    # run a call through the Broker with the credential injected
+jenticctl install                                    # interactive wizard: config + install (local venv or Docker)
+jentic register                                      # mint an agent identity, then wait for operator approval
+jentic catalog search stripe                         # find an API in the directory
+jentic execute GET:https://httpbin.org/get --json    # run a call through the Broker with the credential injected
 ```
 
 Full reference: [`cli/README.md`](cli/README.md).

--- a/README.md
+++ b/README.md
@@ -113,11 +113,12 @@ Six steps from a running instance to a response from a real API.
 
 1. **Create your admin account** at `/setup` (the wizard opens this automatically, or run
    `jenticctl setup` to do it from the terminal).
-2. **Import an API** from the [Jentic API Directory](https://github.com/jentic/jentic-public-apis),
-   or upload your own specification.
+2. **Import an API** from the [Jentic API Directory](https://github.com/jentic/jentic-public-apis)
+   (e.g. `httpbin.org`, used in step 6), or upload your own specification.
 3. **Store a credential** for that API. It is encrypted at rest and is never returned to a
    caller.
-4. **Register the agent:** `jentic register`. Registration waits for an operator to approve the
+4. **Register the agent:** `jentic register` (add `--base-url <URL>` when the agent runs on a
+   different machine). Registration waits for an operator to approve the
    agent. On a single-operator install, approve it in the UI and the command completes.
 5. **Grant access** by binding the agent to a toolkit. A rule-less binding blocks everything;
    the default is deny.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ public [Jentic API Directory](https://github.com/jentic/jentic-public-apis) with
 the catalog browser:
 
 ```bash
-jentic catalog search stripe   # find an API in the public directory
+jentic catalog search httpbin   # find an API in the public directory (used in step 6)
 ```
 
 `jentic catalog` opens an interactive browser to search the public directory and
@@ -76,8 +76,8 @@ first-match. An agent reaches only the operations it has been approved for, and
 asking for more is a reviewable request rather than a silent widening:
 
 ```bash
-jentic access request <operation>   # file a request the operator can review
-jentic access status                # check whether it has been granted
+jentic access request --toolkit httpbin.org/httpbin   # file a request the operator can review
+jentic access status <request-id>                     # check whether it has been granted
 ```
 
 ## 6. Make the call

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -87,8 +87,12 @@ Find an operation, inspect it, and run it through the Broker:
 ```bash
 jentic search get             # find an imported operation
 jentic inspect <operation>    # see its method, params and schemas
-jentic execute GET:/get --json
+jentic execute GET:https://httpbin.org/get --json
 ```
+
+The `execute` target is the operation's full upstream URL (the same form `search`
+and `inspect` report) or its operation_id — the Broker is a forward proxy, not a
+path router.
 
 The Broker checks the agent's permissions, attaches the stored credential after
 the permission check, forwards the request, and writes an audit record. The

--- a/llms.txt
+++ b/llms.txt
@@ -14,17 +14,17 @@ What it does not do. Jentic One bounds what a mistaken or compromised agent can 
 
 A self-hosted deployment exposes no MCP endpoint. Agents integrate through the `jentic` CLI and the skill it generates, or over plain HTTP against the deployment's own API. Both paths are documented below.
 
-## Install
-
 Jentic One runs on one machine and the agent runs on another. Install on both with the same bootstrap:
 
 ```
 curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/tools/install.sh | sh
 ```
 
-On the host machine that is the whole command. The installer builds the two CLI binaries, `jenticctl` and `jentic`, then hands off into `jenticctl install`, which stands the deployment up through an interactive wizard. On the agent machine, run `jentic register` afterwards to create the agent identity against that deployment.
+On the host machine that is the whole command. The installer builds the two CLI binaries, `jenticctl` and `jentic`, then hands off into `jenticctl install`, which stands the deployment up through an interactive wizard. On the agent machine, set `JENTIC_NO_INSTALL=1` (it needs only the binaries, not a second deployment), then run `jentic bootstrap --base-url <deployment URL>` to create the agent identity against that deployment and install the agent skill (`jentic register` is the registration-only path; both default to `http://localhost:8000` when `--base-url` is omitted).
 
 Keep the agent off the machine that runs Jentic One. An agent running as the same OS user can read the credential database and the encryption key directly off disk whatever the API-level controls say, so keep them on separate machines. The hardening guide below sets out the tiers; read it before pointing an instance at a real credential.
+
+## Install
 
 - [tools/install.sh](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/tools/install.sh): the installer. Detects OS and architecture, provides a Go toolchain if you have none, builds only the `cli/` subtree, and installs to `~/.jentic/bin`.
 - [Installer reference](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/tools/install-README.md): every environment variable, including `JENTIC_REF` to build a specific release and `JENTIC_NO_INSTALL=1` to stop after the binaries.
@@ -44,7 +44,7 @@ Keep the agent off the machine that runs Jentic One. An agent running as the sam
 - [README](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/README.md): the architecture diagram and component table. An App control plane (Registry, Control, Admin) and a stateless Broker data plane over PostgreSQL or SQLite; both are supported production backends.
 - [Endpoint and authorization reference](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/reference/endpoints.md): every HTTP endpoint with the scopes it requires. This is the authoritative source for authorization, because the OpenAPI documents model authentication only.
 - [Control plane OpenAPI](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/openapi/control/control.openapi.yaml) and [Broker OpenAPI](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/openapi/broker/broker.openapi.yaml): the two machine-readable API descriptions, for calling an instance over raw HTTP instead of through the CLI.
-- [Agent skill](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/skills/jentic/SKILL.md): the instructions installed into an agent runtime by `jentic skill`, describing the identity, discover, request access, execute loop.
+- [Agent skill](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/skills/jentic/SKILL.md): the instructions installed into an agent runtime by `jentic skill init` (or `jentic bootstrap`), describing the identity, discover, request access, execute loop.
 - [Context and configuration](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/context-and-config.md): how a deployment is configured, and what an agent's execution context carries.
 - [Overlays](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/overlays.md): correcting or adapting an imported API description without editing the original.
 

--- a/llms.txt
+++ b/llms.txt
@@ -20,9 +20,11 @@ Jentic One runs on one machine and the agent runs on another. Install on both wi
 curl -fsSL https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/tools/install.sh | sh
 ```
 
-On the host machine that is the whole command. The installer builds the two CLI binaries, `jenticctl` and `jentic`, then hands off into `jenticctl install`, which stands the deployment up through an interactive wizard. On the agent machine, set `JENTIC_NO_INSTALL=1` (it needs only the binaries, not a second deployment), then run `jentic bootstrap --base-url <deployment URL>` to create the agent identity against that deployment and install the agent skill (`jentic register` is the registration-only path; both default to `http://localhost:8000` when `--base-url` is omitted).
+On the host machine that is the whole command. The installer builds the two CLI binaries, `jenticctl` and `jentic`, then hands off into `jenticctl install`, which stands the deployment up through an interactive wizard. On the agent machine, set `JENTIC_NO_INSTALL=1` (it needs only the binaries, not a second deployment), then run `jentic bootstrap --base-url <deployment URL>` to create the agent identity against that deployment and install the agent skill (`jentic register` is the registration-only path; when `--base-url` is omitted both fall back to the configured base URL or `http://127.0.0.1:8000`).
 
 Keep the agent off the machine that runs Jentic One. An agent running as the same OS user can read the credential database and the encryption key directly off disk whatever the API-level controls say, so keep them on separate machines. The hardening guide below sets out the tiers; read it before pointing an instance at a real credential.
+
+A running instance serves its own `/llms.txt` and `/.well-known/llms.txt`, generated with that deployment's base URL and the onboarding sequence for an agent already pointed at it. Once you have an instance, prefer that document over this one for anything an agent does at runtime. This file covers evaluating and installing.
 
 ## Install
 
@@ -63,7 +65,6 @@ Keep the agent off the machine that runs Jentic One. An agent running as the sam
 
 ## Optional
 
-- A running instance serves its own `/llms.txt` and `/.well-known/llms.txt`, generated with that deployment's base URL and the onboarding sequence for an agent already pointed at it. Once you have an instance, prefer that document over this one for anything an agent does at runtime. This file covers evaluating and installing.
 - [Cloud platform compared with self-hosted](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/cloud-vs-self-hosted.md): the two products are easy to conflate and share no state. Read this before copying integration instructions from one into the other.
 - [Extending Jentic One](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/docs/development/extending-jentic-one.md): adding a surface or a capability to the codebase itself.
 - [VERSIONING.md](https://raw.githubusercontent.com/jentic/jentic-one/refs/heads/main/VERSIONING.md): what the version number promises while the project is in public beta.

--- a/tests/arch/test_agent_docs_refs.py
+++ b/tests/arch/test_agent_docs_refs.py
@@ -1,0 +1,129 @@
+"""Drift guards for the static agent-facing docs (``llms.txt``, ``AGENTS.md``).
+
+These two repo-root documents tell a coding agent how to evaluate, install and
+use Jentic One. Unlike the runtime-served llms.txt (rendered by
+``shared/web/agent_discovery.py`` and pinned by its own unit tests) and the
+agent skill (byte-drift-guarded by ``test_skill_drift.py``), nothing pinned the
+static docs to the code they describe — which is how a quickstart example
+rotted into an instruction that cannot work (the broker is a forward proxy;
+``GET:/get`` resolves upstream host ``get``).
+
+These tests guard *referential* facts only — never prose, wording, or step
+orderings — using committed artifacts that are themselves drift-guarded
+against code as ground truth:
+
+- ``ui/public/cli-reference.json`` is pinned to the cobra command tree by the
+  Go test ``TestCommittedCLIReferenceUpToDate`` (``make cli-reference``), so a
+  ``jentic``/``jenticctl`` command mentioned in the docs can be validated
+  against it without building Go here.
+- Links into this repository (raw.githubusercontent.com or relative) must
+  point at committed paths.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+AGENT_DOCS = [REPO_ROOT / "llms.txt", REPO_ROOT / "AGENTS.md"]
+
+CLI_REFERENCE = REPO_ROOT / "ui" / "public" / "cli-reference.json"
+
+#: Links into this repo's files on GitHub: both the ``refs/heads/<branch>`` and
+#: bare ``<branch>`` raw-URL forms are in use across the docs.
+_RAW_LINK_RE = re.compile(
+    r"https://raw\.githubusercontent\.com/jentic/jentic-one/(?:refs/heads/)?[\w.-]+/([\w./-]+)"
+)
+
+#: Relative markdown link targets, e.g. ``[text](docs/quickstart.md)``.
+_MD_LINK_RE = re.compile(r"\]\((?!https?://|#|mailto:)([\w./-]+?)(?:#[\w-]*)?\)")
+
+#: Backticked repo paths mentioned in prose, e.g. ```docs/security/hardening.md``.
+#: Requires a ``/`` and a file extension so plain filenames and flags don't match.
+_PATH_MENTION_RE = re.compile(r"`([\w-]+(?:/[\w.-]+)+\.(?:md|ya?ml|json|sh|txt))`")
+
+#: CLI command mentions, e.g. ```jentic access request`` or ```jenticctl install``.
+#: Only lowercase word tokens count as command segments; args, flags and
+#: placeholders (``<...>``, ``--flag``, ``GET:...``) end the match.
+_CLI_MENTION_RE = re.compile(r"`((?:jentic|jenticctl)(?: [a-z][a-z-]+)*)")
+
+
+def _command_paths() -> frozenset[str]:
+    """Every command path in the committed CLI reference, e.g. ``jentic access``."""
+    reference = json.loads(CLI_REFERENCE.read_text(encoding="utf-8"))
+
+    def walk(node: dict[str, Any], prefix: str) -> set[str]:
+        full = f"{prefix} {node['name']}".strip()
+        found = {full}
+        for child in node.get("commands") or []:
+            found |= walk(child, full)
+        return found
+
+    paths: set[str] = set()
+    for binary in reference["binaries"]:
+        paths |= walk(binary, "")
+    return frozenset(paths)
+
+
+def _doc_lines() -> list[tuple[Path, int, str]]:
+    lines: list[tuple[Path, int, str]] = []
+    for doc in AGENT_DOCS:
+        for lineno, line in enumerate(doc.read_text(encoding="utf-8").splitlines(), 1):
+            lines.append((doc, lineno, line))
+    return lines
+
+
+@pytest.mark.arch
+def test_agent_docs_repo_links_resolve() -> None:
+    """Every link or path reference into this repo must name a committed file.
+
+    Covers raw.githubusercontent.com links, relative markdown links, and
+    backticked path mentions in llms.txt and AGENTS.md, so a rename or removal
+    fails here instead of shipping a dead reference to every agent that reads
+    the repo front door.
+    """
+    violations: list[str] = []
+    for doc, lineno, line in _doc_lines():
+        referenced = (
+            _RAW_LINK_RE.findall(line) + _MD_LINK_RE.findall(line) + _PATH_MENTION_RE.findall(line)
+        )
+        for rel in referenced:
+            target = REPO_ROOT / rel
+            if not target.exists():
+                violations.append(
+                    f"{doc.relative_to(REPO_ROOT)}:{lineno} — references {rel!r}, which does "
+                    "not exist in the repo (fix the link or restore the file)"
+                )
+    assert not violations, "Agent docs reference missing repo paths:\n" + "\n".join(violations)
+
+
+@pytest.mark.arch
+def test_agent_docs_cli_commands_exist() -> None:
+    """Every ``jentic``/``jenticctl`` command mentioned must exist in the CLI.
+
+    Validated against ``ui/public/cli-reference.json`` (itself drift-guarded
+    against the cobra tree), checking the binary plus first subcommand — deeper
+    segments are arguments or subcommands the one-level reference does not
+    carry. A renamed or removed command fails here instead of silently leaving
+    the front-door docs instructing agents to run something that errors.
+    """
+    known = _command_paths()
+    violations: list[str] = []
+    for doc, lineno, line in _doc_lines():
+        for mention in _CLI_MENTION_RE.findall(line):
+            tokens = mention.split()
+            prefix = " ".join(tokens[:2])
+            if prefix not in known:
+                violations.append(
+                    f"{doc.relative_to(REPO_ROOT)}:{lineno} — mentions `{mention}`, but "
+                    f"{prefix!r} is not in ui/public/cli-reference.json (command renamed or "
+                    "removed? update the doc, or run `make cli-reference` if the reference "
+                    "is stale)"
+                )
+    assert not violations, "Agent docs mention unknown CLI commands:\n" + "\n".join(violations)

--- a/tests/arch/test_agent_docs_refs.py
+++ b/tests/arch/test_agent_docs_refs.py
@@ -35,23 +35,29 @@ AGENT_DOCS = [REPO_ROOT / "llms.txt", REPO_ROOT / "AGENTS.md"]
 
 CLI_REFERENCE = REPO_ROOT / "ui" / "public" / "cli-reference.json"
 
-#: Links into this repo's files on GitHub: both the ``refs/heads/<branch>`` and
-#: bare ``<branch>`` raw-URL forms are in use across the docs.
+#: Links into this repo's files on GitHub: the ``refs/heads/<branch>``,
+#: ``refs/tags/<tag>`` and bare ``<ref>`` raw-URL forms are all in use. The
+#: capture must not end in ``.`` so sentence punctuation is not swallowed.
 _RAW_LINK_RE = re.compile(
-    r"https://raw\.githubusercontent\.com/jentic/jentic-one/(?:refs/heads/)?[\w.-]+/([\w./-]+)"
+    r"https://raw\.githubusercontent\.com/jentic/jentic-one/"
+    r"(?:refs/(?:heads|tags)/)?[\w.-]+/([\w./-]*[\w-])"
 )
 
 #: Relative markdown link targets, e.g. ``[text](docs/quickstart.md)``.
-_MD_LINK_RE = re.compile(r"\]\((?!https?://|#|mailto:)([\w./-]+?)(?:#[\w-]*)?\)")
+#: Root-absolute targets (``](/app)``) are excluded: joining them onto
+#: ``REPO_ROOT`` would silently discard the root and check the host filesystem.
+_MD_LINK_RE = re.compile(r"\]\((?!https?://|#|mailto:|/)([\w./-]+?)(?:#[^)]*)?\)")
 
 #: Backticked repo paths mentioned in prose, e.g. ```docs/security/hardening.md``.
 #: Requires a ``/`` and a file extension so plain filenames and flags don't match.
-_PATH_MENTION_RE = re.compile(r"`([\w-]+(?:/[\w.-]+)+\.(?:md|ya?ml|json|sh|txt))`")
+_PATH_MENTION_RE = re.compile(r"`([\w-]+(?:/[\w.-]+)+\.(?:md|ya?ml|json|sh|txt|js|py|toml))`")
 
 #: CLI command mentions, e.g. ```jentic access request`` or ```jenticctl install``.
-#: Only lowercase word tokens count as command segments; args, flags and
-#: placeholders (``<...>``, ``--flag``, ``GET:...``) end the match.
-_CLI_MENTION_RE = re.compile(r"`((?:jentic|jenticctl)(?: [a-z][a-z-]+)*)")
+#: Longest alternative first — ``jentic|jenticctl`` would match the ``jentic``
+#: prefix of ``jenticctl`` and never backtrack, exempting every jenticctl
+#: mention. Only lowercase word tokens count as command segments; args, flags
+#: and placeholders (``<...>``, ``--flag``, ``GET:...``) end the match.
+_CLI_MENTION_RE = re.compile(r"`((?:jenticctl|jentic)\b(?: [a-z][a-z-]+)*)")
 
 
 def _command_paths() -> frozenset[str]:

--- a/tools/install-README.md
+++ b/tools/install-README.md
@@ -140,6 +140,9 @@ jentic --help
 ## Notes
 
 - This builds from source, so it needs network access to GitHub and the Go
-  module proxy. There is no prebuilt-binary download path yet.
+  module proxy. Prebuilt signed binaries are published with each
+  [GitHub release](https://github.com/jentic/jentic-one/releases) (verify
+  against `checksums.txt`, signature `checksums.txt.sig`, certificate
+  `checksums.txt.pem`); this script is the build-from-source alternative.
 - The script honors Go's `GOTOOLCHAIN=auto`, so even if the resolved Go is a bit
   older than the one named in `cli/go.mod`, the build can self-upgrade.

--- a/ui/src/modules/docs/components/sections/QuickstartSection.tsx
+++ b/ui/src/modules/docs/components/sections/QuickstartSection.tsx
@@ -57,12 +57,13 @@ jentic catalog import <api_id>`,
 		title: 'Execute through the Broker',
 		body: (
 			<>
-				Send a real request through the Broker by <code>METHOD:/path</code> or
+				Send a real request through the Broker by <code>METHOD:URL</code> (the
+				operation&apos;s full upstream URL, as returned by search and inspect) or
 				<code> operation_id</code>. The Broker injects your bound credential, forwards the
 				call, and records an execution.
 			</>
 		),
-		code: `jentic execute GET:/get --query foo=bar --json`,
+		code: `jentic execute GET:https://httpbin.org/get --query foo=bar --json`,
 		prompt: true,
 	},
 ];


### PR DESCRIPTION
## Summary

A gap review of the agent-facing docs (repo `llms.txt` + `AGENTS.md` from #1052, checked against the served llms.txt, the agent skill, and the CLI/broker code) found the quickstart's brokered-call example cannot work and several onboarding steps that strand a coding agent. This fixes everything mechanical and adds the drift guard those static docs were missing.

## Changes

- **Broken example (five copies)**: `jentic execute GET:/get --json` sends `/get` to the broker verbatim; the broker's forward proxy rewrites it to upstream host `get`, which fails DNS (`cli/internal/cmd/execute.go` form 3, `broker/core/proxy_headers.py`). Replaced with the operation's full upstream URL in `AGENTS.md`, `README.md` (×2), `docs/quickstart.md`, and the docs SPA's `QuickstartSection.tsx`.
- **AGENTS.md onboarding pass**: lead with `jentic bootstrap --base-url …` (registers, waits for approval, installs the skill — the path the served docs treat as canonical), document the `localhost:8000` default, tell agent-machine installs to set `JENTIC_NO_INSTALL=1`, and rewrite step 5 around `jentic access request` — it previously told the *agent* to bind a toolkit, which is an operator-only action (`POST /agents/{id}/toolkits`, scope `agents:write`).
- **llms.txt**: move the install command out of the `## Install` H2 section into the prose zone (strict llmstxt.org parsers keep only link items inside H2 sections, so the install command itself was being dropped); `jentic skill` → `jentic skill init`.
- **tools/install-README.md**: drop the stale "no prebuilt-binary download path yet" — signed binaries with `checksums.txt(.sig/.pem)` ship with each release.
- **README**: point to `llms.txt` next to the AGENTS.md pointer.
- **New `tests/arch/test_agent_docs_refs.py`**: guards referential facts in `llms.txt`/`AGENTS.md` — repo links/path mentions must name committed files, and `jentic`/`jenticctl` command mentions must exist in `ui/public/cli-reference.json` (itself pinned to the cobra tree by the Go drift test). Prose, wording, and step orderings are deliberately unguarded.
- **Out of scope (product decisions, flagged from the review)**: whether "SQLite is a supported production backend" needs a search-disabled caveat in `llms.txt`, the differing product one-liners across documents, and website/release-artifact discoverability of these docs.

## Risk & rollback

- Low risk: docs, one docs-SPA string, and a new test. Revert the squash commit to roll back.

## Test plan

- `make test-arch` — 148 passed (including the two new guards)
- `make lint` — ruff + mypy clean
- Negative probes: injecting a dead link and an unknown `jentic frobnicate` command into AGENTS.md makes the new guards fail with actionable messages
- UI: ESLint + `tsc --noEmit` clean; no test references `QuickstartSection` (CI's UI job builds it)

Made with [Cursor](https://cursor.com)