### PR TITLE
fix(install.sh): fresh-install fixes — bash 3.2 auth arrays + 0700 ~/.jentic

### DIFF
--- a/tests/tools/install_test.sh
+++ b/tests/tools/install_test.sh
@@ -454,6 +454,22 @@ else
   pass "empty-auth: no unbound-variable crash"
 fi
 
+# --- ensure_private_home: ~/.jentic is created/tightened to 0700 -------------
+# jenticctl install ASSERTS ~/.jentic is 0700 before creating the 0777 logs dir
+# (SEC-6). The installer's own mkdir -p calls run under the user's umask, so
+# ensure_private_home must (a) create the home 0700 on a fresh machine and
+# (b) tighten a pre-existing 0755 one — otherwise the chained `jenticctl
+# install` fails on every fresh curl|sh run.
+home_tmp="$(mktemp -d "${TMPDIR:-/tmp}/jentic-home-test.XXXXXX")"
+JENTIC_HOME="$home_tmp/fresh/.jentic" ensure_private_home
+mode="$(ls -ld "$home_tmp/fresh/.jentic" | awk '{print $1}' | cut -c2-10)"
+assert_eq "ensure_private_home: fresh home created owner-only" "rwx------" "$mode"
+mkdir -p "$home_tmp/loose/.jentic" && chmod 755 "$home_tmp/loose/.jentic"
+JENTIC_HOME="$home_tmp/loose/.jentic" ensure_private_home
+mode="$(ls -ld "$home_tmp/loose/.jentic" | awk '{print $1}' | cut -c2-10)"
+assert_eq "ensure_private_home: pre-existing 0755 home tightened to 0700" "rwx------" "$mode"
+rm -rf "$home_tmp"
+
 # ---------------------------------------------------------------------------
 # Contract tier: run the installer through each shell and prove it re-execs and
 # reaches main() without a bash syntax error. We build a minimal PATH that has

--- a/tests/tools/install_test.sh
+++ b/tests/tools/install_test.sh
@@ -431,6 +431,29 @@ out="$(JENTIC_REPO=jentic/jentic-one JENTIC_REF=v0.31.0 \
 assert_eq "release_asset_url: composes the GitHub releases download URL" \
   "https://github.com/jentic/jentic-one/releases/download/v0.31.0/checksums.txt" "$out"
 
+# --- download mode: empty auth array survives `set -u` on bash 3.2 -----------
+# With GITHUB_TOKEN unset the local auth=() arrays in release_assets_exist and
+# curl_asset expand EMPTY; macOS stock bash 3.2 treats a bare "${auth[@]}" as an
+# unbound variable under `set -u`, which crashed every explicit-JENTIC_REF
+# install ("auth[@]: unbound variable"). The ${auth[@]+…} guard must hold: with
+# curl stubbed to succeed, both helpers must run to completion with no token.
+set +e
+noauth_out="$(bash -c "set -euo pipefail; . '$INSTALL_SH'
+  curl() { return 0; }
+  GITHUB_TOKEN=\"\" JENTIC_REPO=jentic/jentic-one JENTIC_REF=v0.31.0 OS=darwin ARCH=arm64
+  release_assets_exist || exit 1
+  curl_asset https://github.com/x/y/releases/download/v0.31.0/a.tar.gz /dev/null || exit 1
+  echo survived" 2>&1)"
+noauth_rc=$?
+set -e
+assert_eq "empty-auth: helpers run under set -u with no token" "0" "$noauth_rc"
+assert_contains "empty-auth: both helpers completed" "$noauth_out" "survived"
+if printf '%s' "$noauth_out" | grep -q "unbound variable"; then
+  fail "empty-auth: 'unbound variable' crash regressed: $noauth_out"
+else
+  pass "empty-auth: no unbound-variable crash"
+fi
+
 # ---------------------------------------------------------------------------
 # Contract tier: run the installer through each shell and prove it re-execs and
 # reaches main() without a bash syntax error. We build a minimal PATH that has

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1128,10 +1128,28 @@ provision_via_download() {
   download_binaries
 }
 
+# --- jentic home ------------------------------------------------------------
+# ensure_private_home creates the jentic home (~/.jentic) owner-only, or
+# TIGHTENS an existing looser one to 0700. `jenticctl install` bind-mounts a
+# world-writable (0777) logs dir under it for the container's uid and ASSERTS
+# the parent is 0700 (SEC-6) before creating it. The bare `mkdir -p` calls in
+# this script (bin/, toolchain/, the manifest) would otherwise create ~/.jentic
+# with the umask default (0755) first — making the chained `jenticctl install`
+# fail on every fresh machine. Best-effort: a chmod failure only warns, and the
+# Go side still fails closed on the invariant.
+ensure_private_home() {
+  local home_dir="${JENTIC_HOME:-$HOME/.jentic}"
+  mkdir -p "$home_dir" 2>/dev/null || true
+  if [ -d "$home_dir" ] && ! chmod 700 "$home_dir" 2>/dev/null; then
+    warn "could not chmod 700 ${home_dir} — 'jenticctl install' may refuse to create its logs dir there"
+  fi
+}
+
 # --- main -------------------------------------------------------------------
 main() {
   logo
   check_prereqs
+  ensure_private_home
   STATE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/jentic-install-state.XXXXXX")"
   STEP_LOG="$STATE_DIR/step.log"
   detect_platform

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -606,7 +606,9 @@ curl_asset() {
         auth=(-H "Authorization: Bearer ${GITHUB_TOKEN}") ;;
     esac
   fi
-  curl -fSL "${auth[@]}" -o "$dest" -- "$url"
+  # ${auth[@]+…} guard: macOS stock bash 3.2 treats an EMPTY array expansion as
+  # an unbound variable under `set -u` (same idiom as the git_auth call sites).
+  curl -fSL ${auth[@]+"${auth[@]}"} -o "$dest" -- "$url"
 }
 
 # sha256_file <path> prints the lowercase hex sha256 of a file, using whichever
@@ -668,7 +670,8 @@ release_assets_exist() {
   if [ -n "$GITHUB_TOKEN" ]; then
     auth=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
   fi
-  curl -fsSL "${auth[@]}" -I -o /dev/null -- "$url" 2>/dev/null
+  # Same empty-array-under-`set -u` guard as curl_asset (macOS bash 3.2).
+  curl -fsSL ${auth[@]+"${auth[@]}"} -I -o /dev/null -- "$url" 2>/dev/null
 }
 
 # download_binaries fetches + verifies the selected release archives and unpacks


### PR DESCRIPTION
## Summary

Two bugs that break the fresh-machine `curl ... | sh` flow on `cli-v2-release`, found while dogfooding a clean reinstall on macOS.

### 1. `auth[@]: unbound variable` (install dies at step 2)

The prebuilt-download path uses bare `"${auth[@]}"` in `release_assets_exist` and `curl_asset`. With `GITHUB_TOKEN` unset the array is empty, and **stock macOS bash 3.2 treats an empty array expansion as unbound under `set -u`** — any install with an explicit `JENTIC_REF` and no token crashes before doing anything. The git-auth call sites already use the bash-3.2-safe `${auth[@]+"${auth[@]}"}` idiom; these two curl sites missed it. Fixed both + regression test (stubs `curl`, runs both helpers token-less; verified it fails against the unfixed script).

### 2. `jenticctl install` refuses its logs dir on a fresh machine

`jenticctl install` bind-mounts a 0777 logs dir (container uid 999 must write) and correctly asserts its parent `~/.jentic` is 0700 (SEC-6). But the shell installer runs first and creates `~/.jentic` via plain `mkdir -p` under the user's umask (0755) — so the chained `jenticctl install` fails with:

```
refusing to create world-writable logs dir ~/.jentic/logs: parent ~/.jentic is group/other-accessible (-rwxr-xr-x, want 0700)
```

New `ensure_private_home` runs before anything touches the home: creates `~/.jentic` 0700, or tightens an existing looser one. Best-effort (warns on chmod failure); the Go guard still fails closed. Tests cover both the fresh-create and tighten paths.

## Test plan
- [x] `/bin/bash tests/tools/install_test.sh` — all 75 checks pass on macOS bash 3.2.57
- [x] Empty-auth regression test reproduces the crash against the unfixed script
- [x] `ensure_private_home`: fresh home created `rwx------`; pre-existing 0755 home tightened
- [ ] End-to-end: `curl ... | JENTIC_REF=cli-v2-release sh` on a clean macOS box through `jenticctl install --build-local`

Reminder: squash + merge.