### PR TITLE
fix(install): build --build-local from the CLI's own ref, not the default branch

### DIFF
--- a/cli/internal/cli/ctlcmd/install.go
+++ b/cli/internal/cli/ctlcmd/install.go
@@ -53,6 +53,12 @@ type installOptions struct {
 	// checkout instead of pulling the published image (the default). It is
 	// auto-selected when a source checkout / $JENTIC_SRC / --ref is present.
 	buildLocal bool
+	// ref pins the git ref (branch, tag, or commit) the managed clone builds
+	// from under --build-local (which it implies). Without it the build targets
+	// the ref this CLI was installed from (per the install manifest), then the
+	// CLI version — never the remote's default branch, which can be a different
+	// generation than the CLI's compose/migration expectations.
+	ref string
 	// imageTag pins the app image the Docker path pulls: a bare tag, an
 	// @sha256: digest, or a full ghcr.io/…@sha256:… reference (overrides the
 	// CLI-version → tag mapping). Ignored under --build-local.
@@ -78,8 +84,8 @@ func newInstallCmd(app *app) *cobra.Command {
 			"Docker path: by default this PULLS the published, signed app image\n" +
 			"(ghcr.io/jentic/jentic-one-app, version-matched to the CLI) — no local build.\n" +
 			"Use --build-local to build from a checkout instead (auto-selected inside a\n" +
-			"jentic-one source tree or with $JENTIC_SRC), or --image-tag to pin a specific\n" +
-			"tag or @sha256: digest.\n\n" +
+			"jentic-one source tree or with $JENTIC_SRC), --ref to build a specific\n" +
+			"branch/tag/commit, or --image-tag to pin a specific tag or @sha256: digest.\n\n" +
 			"Advanced: --preset and the generated --<section>-<field> flags (e.g.\n" +
 			"--server-public-base-url, --logging-file-enabled) overlay schema-driven\n" +
 			"configuration onto the generated jentic-one.yaml, on top of the wizard.",
@@ -113,6 +119,9 @@ func newInstallCmd(app *app) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.buildLocal, "build-local", false,
 		"Docker path: build the app image from a local checkout instead of pulling the "+
 			"published image (auto-selected inside a jentic-one checkout, with $JENTIC_SRC, or --ref)")
+	cmd.Flags().StringVar(&opts.ref, "ref", "",
+		"git ref (branch/tag/commit) to build the stack from; implies --build-local "+
+			"(default: the ref this CLI was installed from, then the CLI version)")
 	cmd.Flags().StringVar(&opts.imageTag, "image-tag", "",
 		"Docker path: pull this app image tag or @sha256: digest (or a full ghcr.io/…@sha256 ref) "+
 			"instead of the version-matched tag; ignored with --build-local")
@@ -300,7 +309,7 @@ func (a *app) finishInstall(cmd *cobra.Command, opts *installOptions, draft *ins
 	// venv (from the local checkout if we're inside the repo, otherwise clone
 	// from GitHub first) and apply migrations.
 	if local {
-		if err := installLocal(cmd.Context(), a, draft, out, opts.freshVenv); err != nil {
+		if err := installLocal(cmd.Context(), a, draft, out, opts.freshVenv, opts.ref); err != nil {
 			banner.Stop()
 			return err
 		}
@@ -503,6 +512,35 @@ func (a *app) offerWizard(cmd *cobra.Command, opts *installOptions, started bool
 	}
 }
 
+// resolveStackBuildRef resolves which git ref a --build-local managed-clone
+// build should target. An explicit --ref wins (pinned). Otherwise fall back to
+// the ref this CLI was installed from (the install manifest, written by
+// tools/install.sh), then the CLI version — the same chain `update` uses. The
+// fallback is what keeps a from-source install coherent: without it the
+// managed clone hard-resets to the remote's default branch, which can be a
+// different generation than this CLI's compose/migration expectations (e.g. a
+// compose without the schema-bootstrap init script driving an app image whose
+// migrations still require it).
+func (a *app) resolveStackBuildRef(explicit string) (ref string, pinned bool) {
+	if explicit != "" {
+		return explicit, true
+	}
+	if m, _, err := config.LoadManifest(a.Paths); err == nil && m.Ref != "" {
+		return m.Ref, false
+	}
+	return defaultRef(version), false
+}
+
+// refIgnoredError explains why a pinned --ref cannot be honoured when the
+// build reads a local checkout: syncing the operator's working tree to a ref
+// would clobber their work, so refuse rather than build something other than
+// what was asked for. Mirrors `update --ref`'s refusal.
+func refIgnoredError(ref, sourceDir string) error {
+	return fmt.Errorf("--ref %s cannot be applied: the stack builds from the local checkout at %s, "+
+		"so the ref would be ignored. Check out %s there yourself and re-run without --ref, "+
+		"or unset %s to build from the managed clone", ref, sourceDir, ref, install.SrcEnv)
+}
+
 // recordManifest persists what was installed (deploy mode, db, and the CLI's
 // own ref/commit/version) so `jenticctl update` knows what to track and how to
 // refresh it. A failure here is non-fatal: the install succeeded regardless.
@@ -531,7 +569,12 @@ func (a *app) recordManifest(draft *install.Draft) {
 			m.BinaryPath = exe
 		}
 	}
-	if err := m.MergeStack(a.Paths, mode, db, draft.BrokerPort, version, commit, version); err != nil {
+	// Record the ref the stack was really built from (a managed-clone
+	// build-local install), so the next `install`/`update` keeps tracking it
+	// rather than snapping back to the CLI version. Pull-path and
+	// local-checkout installs keep recording the CLI version as before.
+	stackRef := firstNonEmpty(draft.StackRef, version)
+	if err := m.MergeStack(a.Paths, mode, db, draft.BrokerPort, stackRef, commit, version); err != nil {
 		fmt.Fprintln(a.Out, theme.Warnf("warning: could not record install manifest: %v", err))
 	}
 }
@@ -601,20 +644,28 @@ func (a *app) installDocker(ctx context.Context, draft *install.Draft, configPat
 		return install.DaemonError(check)
 	}
 
-	// Build locally when explicitly asked, or when a source checkout is in play
-	// (cwd repo-root walk / $JENTIC_SRC) — a contributor iterating on local
-	// changes should not silently run a published image. Otherwise pull the
-	// signed release image and thread it into compose.
+	// Build locally when explicitly asked (--build-local / --ref), or when a
+	// source checkout is in play (cwd repo-root walk / $JENTIC_SRC) — a
+	// contributor iterating on local changes should not silently run a
+	// published image. Otherwise pull the signed release image and thread it
+	// into compose.
 	_, haveSrc := install.RepoRoot()
-	buildLocal := opts.buildLocal || haveSrc
+	buildLocal := opts.buildLocal || haveSrc || opts.ref != ""
 
 	var appImage string
 	if buildLocal {
-		plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath())
+		ref, pinned := a.resolveStackBuildRef(opts.ref)
+		plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath()).AtRef(ref, pinned)
+		if plan.PinnedRefIgnored() {
+			return refIgnoredError(ref, plan.SourceDir)
+		}
 		fmt.Fprintln(a.Out)
 		fmt.Fprint(a.Out, plan.RenderDockerBuildHeader())
 		if err := plan.BuildImages(a.Out); err != nil {
 			return fmt.Errorf("image build failed: %w", err)
+		}
+		if plan.FromGit {
+			draft.StackRef = ref
 		}
 	} else {
 		appImage = install.ResolveAppImage(cmdcore.Version(), opts.imageTag)
@@ -740,7 +791,7 @@ func (a *app) startAppBackground(draft *install.Draft, configPath, logsDir strin
 	fmt.Fprintln(a.Out, theme.Successf("  Broker started (pid %d, port %s)", brokerPID, draft.BrokerPort))
 }
 
-func installLocal(ctx context.Context, a *app, draft *install.Draft, configPath string, freshVenv bool) error {
+func installLocal(ctx context.Context, a *app, draft *install.Draft, configPath string, freshVenv bool, explicitRef string) error {
 	venvDir := a.Paths.VenvPath()
 	srcDir := a.Paths.SrcPath()
 
@@ -766,7 +817,10 @@ func installLocal(ctx context.Context, a *app, draft *install.Draft, configPath 
 		return install.MissingError(missing)
 	}
 
-	plan := install.PlanLocalBuild(venvDir, srcDir)
+	plan := install.PlanLocalBuild(venvDir, srcDir).AtRef(a.resolveStackBuildRef(explicitRef))
+	if plan.PinnedRefIgnored() {
+		return refIgnoredError(plan.Ref, plan.SourceDir)
+	}
 	fmt.Fprintln(a.Out)
 	fmt.Fprint(a.Out, plan.RenderHeader())
 
@@ -778,6 +832,9 @@ func installLocal(ctx context.Context, a *app, draft *install.Draft, configPath 
 		return fmt.Errorf("build failed: %w", err)
 	}
 	draft.VenvPython = plan.VenvPython()
+	if plan.FromGit {
+		draft.StackRef = plan.Ref
+	}
 
 	// Apply migrations for real. On the SQLite path wrap them in the shared
 	// snapshot/rollback net so a failed first-install migration restores the

--- a/cli/internal/cli/ctlcmd/install_test.go
+++ b/cli/internal/cli/ctlcmd/install_test.go
@@ -8,8 +8,84 @@ import (
 	"testing"
 
 	"github.com/jentic/jentic-one/cli/internal/cli/cmdcore"
+	"github.com/jentic/jentic-one/cli/internal/config"
 	"github.com/jentic/jentic-one/cli/internal/install"
 )
+
+// TestResolveStackBuildRef pins the ref-resolution chain for --build-local
+// managed-clone builds: explicit --ref (pinned) > the ref this CLI was
+// installed from (manifest) > defaultRef(version). Falling through to the
+// remote's default branch is exactly the bug this exists to prevent — a stack
+// image from a different generation than the CLI's compose/migrations.
+func TestResolveStackBuildRef(t *testing.T) {
+	t.Run("explicit ref wins and is pinned", func(t *testing.T) {
+		a := testApp(t)
+		if err := (&config.Manifest{Ref: "cli-v2-release"}).Save(a.Paths); err != nil {
+			t.Fatal(err)
+		}
+		ref, pinned := a.resolveStackBuildRef("my-branch")
+		if ref != "my-branch" || !pinned {
+			t.Errorf("got (%q, %v), want (%q, true)", ref, pinned, "my-branch")
+		}
+	})
+
+	t.Run("falls back to the manifest ref, unpinned", func(t *testing.T) {
+		a := testApp(t)
+		if err := (&config.Manifest{Ref: "cli-v2-release"}).Save(a.Paths); err != nil {
+			t.Fatal(err)
+		}
+		ref, pinned := a.resolveStackBuildRef("")
+		if ref != "cli-v2-release" || pinned {
+			t.Errorf("got (%q, %v), want (%q, false)", ref, pinned, "cli-v2-release")
+		}
+	})
+
+	t.Run("no manifest falls back to the CLI version ref", func(t *testing.T) {
+		a := testApp(t)
+		ref, pinned := a.resolveStackBuildRef("")
+		if want := defaultRef(version); ref != want || pinned {
+			t.Errorf("got (%q, %v), want (%q, false)", ref, pinned, want)
+		}
+	})
+}
+
+// TestRecordManifestStackRef verifies that a build-local install records the
+// ref the stack was really built from (Draft.StackRef), while other paths keep
+// recording the CLI version. Without this, the first successful install would
+// clobber the installer-written branch ref and the next `install`/`update`
+// would snap back to a version that may not even exist as a git ref.
+func TestRecordManifestStackRef(t *testing.T) {
+	t.Run("managed-clone build records the built ref", func(t *testing.T) {
+		a := testApp(t)
+		draft := install.NewDraft()
+		draft.StackRef = "cli-v2-release"
+
+		a.recordManifest(draft)
+
+		m, _, err := config.LoadManifest(a.Paths)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if m.StackRef != "cli-v2-release" || m.Ref != "cli-v2-release" {
+			t.Errorf("StackRef=%q Ref=%q, want both %q", m.StackRef, m.Ref, "cli-v2-release")
+		}
+	})
+
+	t.Run("without a built ref the CLI version is recorded", func(t *testing.T) {
+		a := testApp(t)
+		draft := install.NewDraft()
+
+		a.recordManifest(draft)
+
+		m, _, err := config.LoadManifest(a.Paths)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := firstNonEmpty(version, ""); m.StackRef != want {
+			t.Errorf("StackRef=%q, want the CLI version %q", m.StackRef, want)
+		}
+	})
+}
 
 func TestStampTelemetryDecisionKeepsReusedInstanceID(t *testing.T) {
 	// The stability contract: an instance id carried over from a prior config

--- a/cli/internal/install/draft.go
+++ b/cli/internal/install/draft.go
@@ -140,6 +140,13 @@ type Draft struct {
 	// directly instead of `make install` + `uv run`.
 	VenvPython string
 
+	// StackRef is the git ref the stack was actually built from, when the build
+	// synced the managed clone to one (build-local from git). Empty for a pulled
+	// release image or a local-checkout build; the manifest then records the CLI
+	// version as before. Recording the real ref keeps `jenticctl update`'s
+	// tracking honest when the stack was built from a branch/tag/commit.
+	StackRef string
+
 	// MigrationsDone reports whether the wizard already applied migrations. When
 	// true the next steps skip the migrate command and only cover starting the app.
 	MigrationsDone bool

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -2987,7 +2987,7 @@
           "path": "jenticctl install",
           "use": "install",
           "short": "Interactive wizard to configure and onboard jentic-one",
-          "long": "install walks you through choosing a deployment path (from source or\nDocker, SQLite or Postgres) and configuration, generates a jentic-one.yaml,\nthen builds the stack (local venv or Docker image), applies migrations, and\nstarts the app. Use --skip-build to only generate the config, or --no-start\nto build without launching.\n\nDocker path: by default this PULLS the published, signed app image\n(ghcr.io/jentic/jentic-one-app, version-matched to the CLI) — no local build.\nUse --build-local to build from a checkout instead (auto-selected inside a\njentic-one source tree or with $JENTIC_SRC), or --image-tag to pin a specific\ntag or @sha256: digest.\n\nAdvanced: --preset and the generated --\u003csection\u003e-\u003cfield\u003e flags (e.g.\n--server-public-base-url, --logging-file-enabled) overlay schema-driven\nconfiguration onto the generated jentic-one.yaml, on top of the wizard.",
+          "long": "install walks you through choosing a deployment path (from source or\nDocker, SQLite or Postgres) and configuration, generates a jentic-one.yaml,\nthen builds the stack (local venv or Docker image), applies migrations, and\nstarts the app. Use --skip-build to only generate the config, or --no-start\nto build without launching.\n\nDocker path: by default this PULLS the published, signed app image\n(ghcr.io/jentic/jentic-one-app, version-matched to the CLI) — no local build.\nUse --build-local to build from a checkout instead (auto-selected inside a\njentic-one source tree or with $JENTIC_SRC), --ref to build a specific\nbranch/tag/commit, or --image-tag to pin a specific tag or @sha256: digest.\n\nAdvanced: --preset and the generated --\u003csection\u003e-\u003cfield\u003e flags (e.g.\n--server-public-base-url, --logging-file-enabled) overlay schema-driven\nconfiguration onto the generated jentic-one.yaml, on top of the wizard.",
           "group_title": "Setup \u0026 lifecycle",
           "flags": [
             {
@@ -3052,6 +3052,11 @@
               "name": "preset",
               "type": "string",
               "usage": "apply an embedded config preset over schema defaults (local-dev, production); empty means none"
+            },
+            {
+              "name": "ref",
+              "type": "string",
+              "usage": "git ref (branch/tag/commit) to build the stack from; implies --build-local (default: the ref this CLI was installed from, then the CLI version)"
             },
             {
               "name": "skip-build",


### PR DESCRIPTION
## Summary

`jenticctl install --build-local` planned the managed-clone build with **no ref**, so `fetchSource` hard-reset `~/.jentic/src` to the remote's **default branch** — even when the CLI itself was installed from another branch/tag (the installer's `JENTIC_REF` checkout gets clobbered too). The resulting app image can be a different generation than the CLI's compose/migration expectations: a `cli-v2-release` CLI generates the post-#992 compose (no `init-schemas.sql` bootstrap) while `main`'s migrations still rely on it, so a fresh install dies with `schema "registry" does not exist`.

- add `--ref <branch|tag|commit>` to `jenticctl install` (implies `--build-local`); a pinned ref is refused when a local checkout is in play, mirroring `update --ref` (the flag was already promised in the `--build-local` help text but never wired)
- default the managed-clone build ref to `manifest.Ref` (what `tools/install.sh` recorded for this CLI) then `defaultRef(version)` — the same chain `update` uses — so the stack matches the CLI instead of drifting to the default branch
- record the ref the stack was really built from (`Draft.StackRef`) into the manifest, so the first successful install no longer clobbers the installer-written branch ref with the CLI version

## Test plan

- [ ] `go test ./...` (new: `TestResolveStackBuildRef`, `TestRecordManifestStackRef`)
- [ ] `make lint` — 0 issues; `ui/public/cli-reference.json` regenerated
- [ ] Manual: source-install from `cli-v2-release` via `tools/install.sh`, then `jenticctl install --build-local` — builds the branch, migrations create schemas, stack starts

Reminder: squash + merge.

Made with [Cursor](https://cursor.com)