### PR TITLE
fix(localagent): make repeat launches work — export chmod EPERM and probe/launch env mismatch

### DIFF
--- a/cli/internal/cli/localagentcmd/context_export.go
+++ b/cli/internal/cli/localagentcmd/context_export.go
@@ -72,9 +72,15 @@ func (a *Cmd) exportContextToAgent(ctx context.Context, acct config.AgentAccount
 		// MkdirAll's mode is masked by umask and leaves pre-existing dirs
 		// untouched; pin 0700 so the secrets dirs can't sit wider. A directory
 		// needs its owner-execute bit to be traversable, so 0700 (not 0600) is
-		// the correct floor here.
-		if err := os.Chmod(d, 0o700); err != nil { //nolint:gosec // G302: dir needs owner-exec; 0700 is the intended secrets-dir floor
-			return err
+		// the correct floor here. The pin must tolerate a dir a PREVIOUS export
+		// already chowned to the agent uid: chmod is owner-gated on POSIX, so
+		// the operator's re-run gets EPERM there even though the mode is the
+		// 0700 we pinned at creation — pinDirMode0700 skips an already-tight
+		// dir instead of failing every launch after the first. A dir that is
+		// genuinely wider AND un-chmod-able can't be fixed from here; warn
+		// rather than abort (its contents are written 0600 regardless).
+		if err := pinDirMode0700(d); err != nil {
+			fmt.Fprintln(a.Out, theme.Warnf("could not pin %s to 0700: %v", d, err))
 		}
 	}
 
@@ -195,17 +201,44 @@ func copyCredFile(src, dst string) error {
 	return writeFile0600(dst, data)
 }
 
+// pinDirMode0700 pins directory d to exactly 0700, skipping the chmod when the
+// mode already matches. The skip is what keeps repeat launches working: the
+// export chowns the agent's XDG tree to the agent uid at the end of each run,
+// and chmod is owner-gated on POSIX, so once the hand-off has happened the
+// operator can no longer chmod these dirs (the inherited ACL grants read/write,
+// never chmod) — but they are already at the pinned 0700, so there is nothing
+// to do. A chmod is attempted (and its error surfaced) only when the mode is
+// genuinely wider than the floor.
+func pinDirMode0700(d string) error {
+	info, err := os.Lstat(d)
+	if err != nil {
+		return err
+	}
+	if info.Mode().Perm() == 0o700 {
+		return nil
+	}
+	return os.Chmod(d, 0o700) //nolint:gosec // G302: dir needs owner-exec; 0700 is the intended secrets-dir floor
+}
+
 // writeFile0600 writes data to path with exactly 0600 perms (chmod pins the
 // mode even when the file pre-exists or umask is loose) and fsyncs so the
-// bytes are durable before the launch hands the tree over.
+// bytes are durable before the launch hands the tree over. Like
+// pinDirMode0700, the pin skips an already-0600 file: a previous export
+// chowned it to the agent uid, so the operator can still write it through the
+// inherited ACL but can no longer chmod it — and doesn't need to.
 func writeFile0600(path string, data []byte) error {
 	out, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec // path is a constructed agent-home XDG path, not user input.
 	if err != nil {
 		return err
 	}
-	if err := out.Chmod(0o600); err != nil {
+	if info, err := out.Stat(); err != nil {
 		_ = out.Close()
 		return err
+	} else if info.Mode().Perm() != 0o600 {
+		if err := out.Chmod(0o600); err != nil {
+			_ = out.Close()
+			return err
+		}
 	}
 	if _, err := out.Write(data); err != nil {
 		_ = out.Close()

--- a/cli/internal/cli/localagentcmd/context_export_test.go
+++ b/cli/internal/cli/localagentcmd/context_export_test.go
@@ -1,0 +1,93 @@
+package localagentcmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPinDirMode0700 guards the repeat-launch behaviour of the context export:
+// the export chowns the agent's XDG dirs to the agent uid after the first
+// launch, and POSIX gates chmod on ownership, so the pin MUST skip a dir whose
+// mode is already 0700 (the operator can no longer chmod it and doesn't need
+// to) while still tightening a dir that is genuinely wider.
+func TestPinDirMode0700(t *testing.T) {
+	// Already at the floor → no-op, no error. (We can't drop ownership in a
+	// unit test, but the skip path is exactly what makes the agent-owned case
+	// work: chmod is never attempted.)
+	tight := filepath.Join(t.TempDir(), "tight")
+	if err := os.Mkdir(tight, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := pinDirMode0700(tight); err != nil {
+		t.Fatalf("pinDirMode0700(already 0700) = %v, want nil", err)
+	}
+
+	// Wider than the floor → tightened to exactly 0700.
+	wide := filepath.Join(t.TempDir(), "wide")
+	if err := os.Mkdir(wide, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := pinDirMode0700(wide); err != nil {
+		t.Fatalf("pinDirMode0700(0755) = %v", err)
+	}
+	info, err := os.Lstat(wide)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Errorf("mode after pin = %o, want 0700", got)
+	}
+
+	// A missing dir is a real error (the caller just created it).
+	if err := pinDirMode0700(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Error("pinDirMode0700(missing) = nil, want error")
+	}
+}
+
+// TestWriteFile0600 covers fresh creation, overwrite of a pre-existing 0600
+// file (the repeat-launch path: the file may be agent-owned, so chmod must be
+// skipped when the mode already matches), and tightening a wider file.
+func TestWriteFile0600(t *testing.T) {
+	dir := t.TempDir()
+
+	// Fresh file lands 0600 with the payload.
+	fresh := filepath.Join(dir, "fresh.yaml")
+	if err := writeFile0600(fresh, []byte("a: 1\n")); err != nil {
+		t.Fatalf("writeFile0600(fresh) = %v", err)
+	}
+	assertMode(t, fresh, 0o600)
+	if data, _ := os.ReadFile(fresh); string(data) != "a: 1\n" {
+		t.Errorf("payload = %q", data)
+	}
+
+	// Overwriting an already-0600 file succeeds and replaces the content.
+	if err := writeFile0600(fresh, []byte("b: 2\n")); err != nil {
+		t.Fatalf("writeFile0600(existing 0600) = %v", err)
+	}
+	assertMode(t, fresh, 0o600)
+	if data, _ := os.ReadFile(fresh); string(data) != "b: 2\n" {
+		t.Errorf("payload after overwrite = %q", data)
+	}
+
+	// A pre-existing wider file is tightened to 0600 on write.
+	wide := filepath.Join(dir, "wide.yaml")
+	if err := os.WriteFile(wide, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFile0600(wide, []byte("new")); err != nil {
+		t.Fatalf("writeFile0600(existing 0644) = %v", err)
+	}
+	assertMode(t, wide, 0o600)
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Errorf("%s mode = %o, want %o", path, got, want)
+	}
+}

--- a/cli/internal/cli/localagentcmd/context_export_test.go
+++ b/cli/internal/cli/localagentcmd/context_export_test.go
@@ -1,3 +1,9 @@
+// The context export pins POSIX permission bits (0700 dirs / 0600 files),
+// which Windows does not model — Lstat reports 0777/0666 there regardless of
+// Chmod — and the isolated-agent launch this file supports is Unix-only.
+//
+//go:build !windows
+
 package localagentcmd
 
 import (

--- a/cli/internal/localagent/localagent.go
+++ b/cli/internal/localagent/localagent.go
@@ -782,16 +782,32 @@ func agentBashArgs(agentUser, snippet string) []string {
 // typically inside the operator's now-700 home, which the agent user cannot
 // read — inheriting it makes bash spew `getcwd: Permission denied` before the
 // snippet even runs. "/" is traversable by everyone.
+//
+// The environment is the curated launchEnv allowlist, NOT the operator's full
+// environment — the same env the confined launch hands to sudo. This is what
+// keeps the binary PROBE truthful: sudo's env_reset preserves the caller's
+// PATH unless sudoers sets secure_path (macOS's default sudoers sets none), so
+// an inherited environment leaks the OPERATOR's PATH into the agent's shell —
+// `command -v <binary>` then resolves the operator's copy under the operator's
+// (agent-unreachable) home, the provisioning flow is skipped as "already
+// installed", and the launch (which does use the curated env) dies with
+// `exec: <binary>: not found`. Probing with the launch's own environment makes
+// the probe answer the question the launch will actually ask. It also stops
+// operator-exported secrets from riding into agent-side commands.
 func agentCmd(agentUser, snippet string) *exec.Cmd {
 	cmd := exec.Command("sudo", agentBashArgs(agentUser, snippet)...) //nolint:gosec // agentUser is a config account name; snippet is shell-quoted / a fixed literal.
 	cmd.Dir = "/"
+	cmd.Env = launchEnv()
 	return cmd
 }
 
-// agentCmdContext is agentCmd with a cancellation context (for the launch).
+// agentCmdContext is agentCmd with a cancellation context. It carries the same
+// curated launchEnv environment — see agentCmd for why the probe/launch envs
+// must match.
 func agentCmdContext(ctx context.Context, agentUser, snippet string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "sudo", agentBashArgs(agentUser, snippet)...) //nolint:gosec // agentUser is a config account name; snippet is shell-quoted.
 	cmd.Dir = "/"
+	cmd.Env = launchEnv()
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

Two regressions in the isolated-agent launch path (both introduced with the v2 XDG/confinement work; found dogfooding `jentic run hermes` on macOS). Together they made **every launch after the first fail**, in sequence:

**1. Repeat launches died with `chmod <agent home>/.config/jentic: operation not permitted`.**
`exportContextToAgent` runs on every launch and ends by chowning the agent's `.config`/`.local` trees to the agent uid — but POSIX gates chmod on *ownership* (the operator's inherited ACL grants read/write, never chmod). So the export locked itself out: launch 2's unconditional `os.Chmod(dir, 0700)` hit EPERM and aborted, even though the dir was already at the pinned 0700 from launch 1. `writeFile0600` had the same latent bug (`Chmod(0600)` on the agent-owned file it re-opens through the ACL).

- `pinDirMode0700` / `writeFile0600` now skip the chmod when the mode already matches the pin (the agent-owned repeat-launch case — nothing to do), and only attempt it when the mode is genuinely wider
- a dir that is wider *and* un-chmod-able warns instead of aborting the launch (its contents are written 0600 regardless)

**2. With #1 fixed, the launch then died with `exec: hermes: not found` (127) — the provisioning flow never fired.**
The binary probe runs `sudo -u <agent> bash -lc 'command -v <binary>'` with the operator's environment inherited, and macOS's default sudoers sets no `secure_path`, so `env_reset` keeps the *caller's* PATH. The probe therefore resolved the **operator's** copy (`/Users/renton/.local/bin/hermes` — inside the operator's home, unreachable by the agent), reported "on PATH", skipped provisioning… and the confined launch, which correctly uses the curated allowlist env, couldn't exec it.

- `agentCmd` / `agentCmdContext` now hand sudo the same curated `launchEnv()` the confined launch uses, so probe, provisioning, and launch all see the same world
- verified both directions on a real agent account: curated probe still finds an agent-owned `~/.local/bin/hermes`, and correctly reports the operator-only copy as missing (triggering the install offer)
- side benefit: operator-exported env vars no longer ride into agent-side probe/grant/install commands

## Test plan

- [x] `make lint` — 0 issues
- [x] `go test ./internal/...` — all pass (new `context_export_test.go`: pin-skip, tighten, fresh/overwrite 0600 writes)
- [x] Manual: patched binary on a machine with an agent-owned `.config/jentic` — export no longer EPERMs on the second launch
- [x] Manual: curated-env probe against an agent with its own hermes install resolves the agent's copy; against an operator-only hermes reports missing
- [ ] End-to-end: fresh `jentic setup` + `jentic run hermes` → install-route offer → confined session starts

Made with [Cursor](https://cursor.com)