### PR TITLE
fix(auth): distinct pending detail after signature proof so the approval wait can poll

### DIFF
--- a/cli/client/auth/bearer_test.go
+++ b/cli/client/auth/bearer_test.go
@@ -197,6 +197,29 @@ func TestClassifyTokenError_AssertionInvalid(t *testing.T) {
 	}
 }
 
+// TestClassifyTokenError_ShippedPendingDetail pins the exact detail the shipped
+// backend emits for a signature-verified pending agent
+// ("Agent is not active yet (pending approval)" — auth/services/assertion_service.py).
+// It MUST classify as *PendingError: this is the signal that lets the
+// register/setup/wizard approval wait poll on self-hosted backends, which mint
+// no claim tokens. If a phrase added to isAssertionInvalidDetail ever matches
+// it, the approval flow dies on first contact again.
+func TestClassifyTokenError_ShippedPendingDetail(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body: io.NopCloser(strings.NewReader(
+			`{"type":"invalid_grant","status":400,"detail":"Agent is not active yet (pending approval)","instance":"/oauth/token"}`)),
+	}
+	err := classifyTokenError(resp)
+	var pending *PendingError
+	if !errors.As(err, &pending) {
+		t.Fatalf("shipped pending detail classified as %v, want *PendingError", err)
+	}
+	if ClassifyTokenExchange(err, ClaimContext{}) != OutcomePending {
+		t.Errorf("shipped pending detail must classify as OutcomePending without a claim outstanding")
+	}
+}
+
 // TestClassifyTokenExchange pins the shared claim-vs-audience disambiguation
 // (AR2-9): a pending error is always pending; an assertion-invalid error is a
 // hard failure UNLESS a claim is still outstanding, in which case the identical

--- a/cli/client/auth/oauth.go
+++ b/cli/client/auth/oauth.go
@@ -267,7 +267,10 @@ func classifyTokenError(resp *http.Response) error {
 		// back as 400 invalid_grant, but it is NOT a pending approval — polling
 		// will never clear it. Distinguish on the backend's detail text so the
 		// register wait loop stops with an actionable audience-mismatch hint
-		// instead of hanging (QA-9). Pending approvals carry no such phrasing.
+		// instead of hanging (QA-9). The shipped backend emits a distinct
+		// "Agent is not active yet (pending approval)" for a signature-verified
+		// pending agent (auth/services/assertion_service.py), which contains
+		// none of the assertion-failure phrases and so lands on PendingError.
 		if isAssertionInvalidDetail(detail) {
 			return &AssertionInvalidError{Detail: detail}
 		}

--- a/cli/internal/cli/cmdcore/register_flow.go
+++ b/cli/internal/cli/cmdcore/register_flow.go
@@ -238,13 +238,15 @@ func saveRegState(identity, envName, clientID, status string) error {
 // (AGT-4 semantics).
 //
 // claimPending is true when registration returned a claim token: the human must
-// still claim + approve in the console before the agent can mint. In that state
-// the backend rejects the token exchange with an ambiguous 400 invalid_grant
-// "Assertion is invalid" — the SAME string it uses for a real audience mismatch
-// (the approval-status gate is checked before signature/audience). So while a
-// claim is outstanding we treat that as PENDING (keep waiting / exit clean)
-// rather than the hard audience-mismatch failure, which would abort the flow the
-// moment it started.
+// still claim + approve in the console before the agent can mint. On backends
+// where the approval-status gate runs before signature verification, that state
+// comes back as an ambiguous 400 invalid_grant "Assertion is invalid" — the
+// SAME string as a real audience mismatch. So while a claim is outstanding we
+// treat that as PENDING (keep waiting / exit clean) rather than the hard
+// audience-mismatch failure, which would abort the flow the moment it started.
+// (The shipped backend now returns a distinct pending detail after verifying
+// the signature, which classifies as pending on its own; the claim-context
+// tolerance remains for claim-enabled backends that keep the ambiguous string.)
 func (a *App) waitForApproval(ctx context.Context, creds auth.Credentials, clientID string, timeout time.Duration, claimPending bool) error {
 	st := theme.StylesFromContext(ctx)
 	// Force a FRESH mint even if a (stale-scoped or old-client) token is

--- a/src/jentic_one/auth/services/assertion_service.py
+++ b/src/jentic_one/auth/services/assertion_service.py
@@ -18,6 +18,14 @@ from jentic_one.shared.models import ActorStatus, ActorType
 
 _INVALID = "Assertion is invalid"
 
+# Returned only after the assertion's signature has verified, so the caller has
+# proven possession of the registered private key. A distinct detail is what
+# lets the CLI's register/setup/wizard flows tell "wait for the operator to
+# approve" apart from a genuinely rejected assertion (audience/signature) —
+# with the ambiguous _INVALID for both, the approval wait aborted on first
+# contact on self-hosted backends, which mint no claim tokens by default.
+_PENDING = "Agent is not active yet (pending approval)"
+
 _DEFAULT_MAX_TTL = 300
 
 
@@ -89,7 +97,7 @@ class AssertionService:
         async with self._ctx.admin_db.transaction() as session:
             agent = await AgentRepository.get_by_id_for_update(session, issuer)
 
-            if agent is None or agent.status != ActorStatus.ACTIVE or not agent.jwks:
+            if agent is None or not agent.jwks:
                 raise InvalidGrantError(_INVALID)
 
             public_key = resolve_agent_key(agent.jwks, unverified_header.get("kid"))
@@ -108,6 +116,27 @@ class AssertionService:
                 raise InvalidGrantError(_INVALID) from None
 
             self._validate_timing(payload)
+
+            # Status gate AFTER signature verification, deliberately:
+            # 1. The distinct PENDING detail is only revealed to a caller who
+            #    holds the registered private key, so it leaks nothing an
+            #    unauthenticated prober could use (a bad signature still gets
+            #    the generic _INVALID regardless of status).
+            # 2. It is what makes the CLI's approval wait possible on backends
+            #    without a claim-token minter: register/setup/wizard poll the
+            #    token exchange until the operator approves, and need pending
+            #    to be distinguishable from a hard assertion failure.
+            # Other non-active statuses (rejected/disabled/archived) stay
+            # deliberately generic: they are terminal, not waitable, and get
+            # no dedicated probe signal.
+            #
+            # Checked BEFORE the jti replay cache so approval polling (a fresh
+            # jti per attempt) never populates the cache for exchanges that
+            # cannot succeed.
+            if agent.status == ActorStatus.PENDING:
+                raise InvalidGrantError(_PENDING)
+            if agent.status != ActorStatus.ACTIVE:
+                raise InvalidGrantError(_INVALID)
 
             jti = payload.get("jti")
             if not jti or not self._jti_cache.check_and_insert(jti):

--- a/tests/unit/auth/test_assertion_service.py
+++ b/tests/unit/auth/test_assertion_service.py
@@ -99,7 +99,15 @@ async def test_verify_and_exchange_happy_path(
 
 
 @patch("jentic_one.auth.services.assertion_service.AgentRepository")
-async def test_verify_rejects_pending_agent(mock_agent_repo: MagicMock) -> None:
+async def test_verify_pending_agent_gets_distinct_pending_detail(
+    mock_agent_repo: MagicMock,
+) -> None:
+    """A pending agent with a VALID signature gets the distinct pending detail.
+
+    This is what lets the CLI's register/setup/wizard approval wait poll instead
+    of aborting: self-hosted backends mint no claim tokens, so the pending
+    signal must be distinguishable from a hard assertion failure.
+    """
     ctx = _make_ctx()
     private_key, jwks = _generate_keypair()
     agent = _make_active_agent(jwks)
@@ -108,7 +116,46 @@ async def test_verify_rejects_pending_agent(mock_agent_repo: MagicMock) -> None:
 
     svc = AssertionService(ctx)
     assertion = _make_assertion(private_key)
-    with pytest.raises(InvalidGrantError, match="invalid"):
+    with pytest.raises(InvalidGrantError, match="pending approval"):
+        await svc.verify_and_exchange(assertion)
+
+
+@patch("jentic_one.auth.services.assertion_service.AgentRepository")
+async def test_verify_pending_agent_bad_signature_stays_generic(
+    mock_agent_repo: MagicMock,
+) -> None:
+    """Without proof of key possession the status is NOT revealed: a bad
+    signature gets the generic rejection regardless of the agent's status."""
+    ctx = _make_ctx()
+    _, jwks = _generate_keypair()
+    agent = _make_active_agent(jwks)
+    agent.status = "pending"
+    mock_agent_repo.get_by_id_for_update = AsyncMock(return_value=agent)
+
+    other_private_key = Ed25519PrivateKey.generate()
+    svc = AssertionService(ctx)
+    assertion = _make_assertion(other_private_key)
+    with pytest.raises(InvalidGrantError, match="Assertion is invalid"):
+        await svc.verify_and_exchange(assertion)
+
+
+@pytest.mark.parametrize("status", ["rejected", "disabled", "archived"])
+@patch("jentic_one.auth.services.assertion_service.AgentRepository")
+async def test_verify_terminal_statuses_stay_generic(
+    mock_agent_repo: MagicMock, status: str
+) -> None:
+    """Terminal (non-waitable) statuses keep the generic rejection even with a
+    valid signature — only PENDING gets a probe signal, because only PENDING
+    is worth polling on."""
+    ctx = _make_ctx()
+    private_key, jwks = _generate_keypair()
+    agent = _make_active_agent(jwks)
+    agent.status = status
+    mock_agent_repo.get_by_id_for_update = AsyncMock(return_value=agent)
+
+    svc = AssertionService(ctx)
+    assertion = _make_assertion(private_key)
+    with pytest.raises(InvalidGrantError, match="Assertion is invalid"):
         await svc.verify_and_exchange(assertion)
 
 


### PR DESCRIPTION
## Summary

On a self-hosted install, `jentic register` / `jentic setup` / the install wizard could never reach the approval wait. The flow died on first contact:

```
Registered: client_id=agnt_… status=pending
wizard: the backend rejected the signed assertion: Assertion is invalid
```

Root cause is a two-sided contract mismatch:

- The backend checked **approval status before verifying the signature** and returned the deliberately ambiguous `400 invalid_grant "Assertion is invalid"` for a pending agent — the same string as a real audience/signature failure (`auth/services/assertion_service.py`).
- The CLI treats that exact string as a **hard** failure (with an audience-mismatch hint) unless a claim token is outstanding (QA-9: don't poll forever on a real mismatch). Self-hosted backends mint **no claim tokens** (`get_claim_token_minter` is a no-op by default), so `claimPending` is always false and the wait aborts immediately.

### Fix

Reorder `verify_and_exchange`: verify **signature + audience + timing first**, then gate on status. A signature-verified PENDING agent now gets a distinct detail — `"Agent is not active yet (pending approval)"` — which the CLI already classifies as `PendingError`, so register/setup/wizard print the console approval link and poll until the operator approves in `/app`.

- **No information leak**: the distinct detail requires proof of key possession; a bad signature gets the generic rejection regardless of status, and terminal statuses (rejected/disabled/archived) stay generic — only PENDING is waitable, so only PENDING gets a probe signal.
- Status gate sits **before the jti replay cache**, so approval polling never populates it.
- CLI behavior unchanged by design; the `ClaimOutstanding` tolerance remains for claim-enabled backends that still return the ambiguous string. Stale comments corrected, and the shipped pending detail is pinned as `OutcomePending` in `bearer_test.go` so no future `isAssertionInvalidDetail` phrase can re-break the flow.

## Test plan

- [ ] `uv run pytest tests/unit` — 2510 passed, coverage gate met (new: pending-with-valid-sig → pending detail; pending-with-bad-sig and rejected/disabled/archived → generic)
- [ ] `go test ./...` in `cli/` — clean (new: `TestClassifyTokenError_ShippedPendingDetail`)
- [ ] ruff + mypy clean on touched files
- [ ] Manual: fresh install → wizard registers agent → console link printed, wizard polls → approve in `/app` → wizard completes and writes the skill

Reminder: squash + merge.

Made with [Cursor](https://cursor.com)