### PR TITLE
feat(cli): one-command remote onboarding — --broker-url on register/setup

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -38,6 +38,17 @@ setting up a local agent, run `jentic setup` to create one (isolated account +
 registration + skills); if you're an agent that doesn't have a profile yet, run
 `jentic register`.
 
+**Connecting to a remote Jentic server?** You don't need `jenticctl` or a local
+install at all — the `jentic` binary is self-contained (it links none of the
+installer/lifecycle code; enforced by an arch test) and one command onboards it:
+
+```bash
+jentic register --url https://jentic.example.com --broker-url https://broker.jentic.example.com
+```
+
+Ask your operator for both URLs — the control plane and the broker often live on
+different hosts, and the CLI never derives one from the other.
+
 ## Install
 
 Fastest first. `jentic` (agent) and `jenticctl` (installer/server) are **separate
@@ -182,7 +193,7 @@ Notes:
 
 ```bash
 # Connect this machine to a Jentic install, browse the catalog, execute an operation.
-jentic register --url https://jentic.example.com
+jentic register --url https://jentic.example.com --broker-url https://broker.jentic.example.com
 jentic catalog
 jentic access whoami                                  # a fresh agent is bound to no APIs
 jentic access request --toolkit <vendor/name> --wait  # ask a human to grant access
@@ -190,16 +201,19 @@ jentic execute <operation>
 ```
 
 > **Remote install:** a remote control plane's broker usually lives on a
-> different host, so `jentic register` does **not** guess a `broker_url` for it.
-> Set it before `jentic execute` can reach a 2xx (otherwise execute fail-closes
-> with `RESOLVE_FAILED` rather than dialing your local default):
+> different host, so `jentic register` does **not** guess a `broker_url` for it
+> — pass `--broker-url` as above (ask your operator for it). Without a broker,
+> `jentic execute` fail-closes with `RESOLVE_FAILED` rather than dialing your
+> local default. Forgot it? Re-running register fills it in on the existing
+> environment:
 >
 > ```bash
-> jentic env add <env> --url https://jentic.example.com --broker-url https://broker.jentic.example --force
+> jentic register --url https://jentic.example.com --broker-url https://broker.jentic.example
 > ```
 >
-> (`--url` is required on `env add`.) See [Local setup](#local-setup) for the
-> loopback case, where `register` seeds the broker automatically.
+> (`jentic env add <env> --url <URL> --broker-url <URL> --force` does the same
+> without re-registering.) See [Local setup](#local-setup) for the loopback
+> case, where `register` seeds the broker automatically.
 
 ## Local setup
 
@@ -482,8 +496,9 @@ command:
 ```bash
 # Fresh machine → working setup, one command. Creates the environment,
 # identity and context, activates them, registers the key, waits for the
-# operator to approve, and mints a token.
-jentic register --url https://jentic.example.com
+# operator to approve, and mints a token. --broker-url points `jentic execute`
+# at the remote data plane (loopback installs seed it automatically).
+jentic register --url https://jentic.example.com --broker-url https://broker.jentic.example.com
 
 # Name things explicitly (defaults: identity = hostname, env = URL's first label)
 jentic register --url https://jentic.example.com --name crawler --env prod
@@ -491,8 +506,12 @@ jentic register --url https://jentic.example.com --name crawler --env prod
 # With a context already active, re-register / resume that identity:
 jentic register
 
-# Interactive: bare `jentic register` on a fresh machine prompts for the two
-# values (install URL + agent name) and does the rest.
+# Fill in a missing broker on the active environment while re-registering:
+jentic register --broker-url https://broker.jentic.example.com
+
+# Interactive: bare `jentic register` on a fresh machine prompts for the
+# install URL + agent name (and the broker URL, for a remote install) and
+# does the rest.
 ```
 
 Approval is a human, out-of-band step: `register` prints the console link
@@ -511,7 +530,7 @@ jentic catalog           # you're in business
 To work against several installs, add more environments and switch contexts:
 
 ```bash
-jentic env add staging --url https://staging.jentic.example.com
+jentic env add staging --url https://staging.jentic.example.com --broker-url https://broker.staging.jentic.example.com
 jentic context create staging --env staging --identity crawler
 jentic context use staging
 jentic register          # register the identity's key with the new env
@@ -608,3 +627,20 @@ Inspect and edit it with `jentic context/env/identity` rather than by hand;
 and `XDG_STATE_HOME` variables relocate the config and state directories (the
 XDG layout is enforced on every OS, including Windows, so paths stay
 predictable); the cache follows the platform's native cache dir.
+
+### File-less mode (orchestrators)
+
+An orchestrator that injects credentials can skip the config file entirely by
+setting environment variables — nothing is read from or written to disk:
+
+```bash
+export JENTIC_BASE_URL=https://jentic.example.com                # control plane
+export JENTIC_BEARER_TOKEN=<token minted for this agent>        # never persisted
+export JENTIC_BROKER_URL=https://broker.jentic.example.com      # required for execute on a remote install
+```
+
+`JENTIC_BROKER_URL` is the file-less counterpart of the environment's
+`broker_url`: without it, `jentic execute` against a remote `JENTIC_BASE_URL`
+fail-closes with `RESOLVE_FAILED` (it never falls back to the local default
+for a remote control plane). All three are required for a working remote
+data-plane loop; the control-plane commands need only the first two.

--- a/cli/internal/cli/binder/binder_test.go
+++ b/cli/internal/cli/binder/binder_test.go
@@ -127,6 +127,7 @@ func TestBindFlagsWithOptions_ExcludesAndHides(t *testing.T) {
 	f := cmd.Flags().Lookup("server-port")
 	if f == nil {
 		t.Fatal("expected --server-port to be registered")
+		return
 	}
 	if !f.Hidden {
 		t.Error("--server-port should be hidden when BindOptions.Hidden is set")

--- a/cli/internal/cli/cmdcore/register.go
+++ b/cli/internal/cli/cmdcore/register.go
@@ -17,6 +17,7 @@ type registerOptions struct {
 	url         string // install URL (fresh-machine setup arm)
 	env         string // environment name override (default: derived from --url)
 	name        string
+	brokerURL   string // explicit broker (data plane) URL for the environment
 	timeout     time.Duration
 	force       bool
 	yes         bool
@@ -45,9 +46,14 @@ func NewRegisterCmd(app *App) *cobra.Command {
 			"token-exchange audience is matched exactly against the backend's\n" +
 			"canonical_base_url, and a local backend uses 127.0.0.1. For a loopback URL,\n" +
 			"register also seeds the environment's broker_url (http://127.0.0.1:8100) so\n" +
-			"`jentic execute` works without extra flags.",
+			"`jentic execute` works without extra flags.\n\n" +
+			"Remote install: pass --broker-url too. The broker usually lives on its own\n" +
+			"host and is never derived from the control-plane URL; without it the\n" +
+			"environment has no broker and `jentic execute` fail-closes until one is set\n" +
+			"(ask your operator for the broker URL). Re-running register with\n" +
+			"--broker-url fills it in on an existing environment.",
 		Example: "  jentic register --url http://127.0.0.1:8000   # local install (use 127.0.0.1, not localhost)\n" +
-			"  jentic register --url https://jentic.example.com\n" +
+			"  jentic register --url https://jentic.example.com --broker-url https://broker.jentic.example.com\n" +
 			"  jentic register --url https://jentic.example.com --name crawler --env prod\n" +
 			"  jentic register                      # active context (or interactive setup)\n" +
 			"  jentic register --force              # re-register the active identity",
@@ -61,6 +67,7 @@ func NewRegisterCmd(app *App) *cobra.Command {
 	cmd.Flags().StringVar(&opts.url, "url", "", "Jentic install URL to connect to (creates environment/identity/context on first run)")
 	cmd.Flags().StringVar(&opts.env, "env", "", "environment name for --url (default: derived from the URL host)")
 	cmd.Flags().StringVar(&opts.name, "name", "", "agent name shown to the approving operator (default: hostname)")
+	cmd.Flags().StringVar(&opts.brokerURL, "broker-url", "", "broker (data plane) URL for the environment — execute needs it on a remote install; seeded automatically for loopback")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", 5*time.Minute, "how long to wait for approval")
 	cmd.Flags().BoolVar(&opts.force, "force", false, "re-register even if this identity already has a registration")
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "skip the interactive prompt; use flags + defaults")
@@ -84,7 +91,7 @@ func flagsAllowPrompt(cmd *cobra.Command, yes bool, fieldFlags ...string) bool {
 }
 
 // registerFieldFlags are the flags whose presence makes `register` non-interactive.
-var registerFieldFlags = []string{"url", "env", "name"}
+var registerFieldFlags = []string{"url", "env", "name", "broker-url"}
 
 // SetupFieldFlags extend the register set with the skill-target and
 // activation flags setup adds, so a flag-driven run (e.g. `--operator
@@ -133,10 +140,10 @@ func (a *App) registerE(ctx context.Context, opts *registerOptions) error {
 	// with whatever happened to be active.
 	if opts.url == "" {
 		if st := clictx.ActiveContext(ctx); st != nil {
-			return a.RegisterActive(ctx, st, opts.name, opts.timeout, opts.force)
+			return a.RegisterActive(ctx, st, opts.name, opts.brokerURL, opts.timeout, opts.force)
 		}
 	}
-	vals := SetupValues{URL: opts.url, Env: opts.env, Name: opts.name}
+	vals := SetupValues{URL: opts.url, Env: opts.env, Name: opts.name, BrokerURL: opts.brokerURL}
 	_, err := a.RegisterSetup(ctx, vals, opts.timeout, opts.force, opts.interactive)
 	if errors.Is(err, ErrOnboardCancelled) {
 		return nil

--- a/cli/internal/cli/cmdcore/register_derive.go
+++ b/cli/internal/cli/cmdcore/register_derive.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/jentic/jentic-one/cli/client/auth"
 	sdkconfig "github.com/jentic/jentic-one/cli/client/config"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
 	"github.com/jentic/jentic-one/cli/internal/config"
 )
 
@@ -18,6 +20,46 @@ func notEmptyField(label string) func(string) error {
 		}
 		return nil
 	}
+}
+
+// optionalBrokerField validates the interactive broker input: blank is allowed
+// (the field is optional — the post-registration warning covers it), anything
+// else must pass the same check as --broker-url so the form can't persist a
+// value the flag would reject.
+func optionalBrokerField() func(string) error {
+	return func(s string) error {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return nil
+		}
+		return validateBrokerURL(s)
+	}
+}
+
+// validateBrokerURL checks an explicit broker URL before it is persisted: it
+// must parse as an absolute http(s) URL with a host, and it obeys the SDK's
+// transport invariant (https required for any non-loopback host) — `jentic
+// execute` sends the agent bearer to this URL, so it must never be a plaintext
+// non-loopback target (SEC-1). auth.RequireSecureURL is the same guard the
+// token/broker transports enforce at send time; validating here fails fast at
+// onboarding instead of at the first execute.
+func validateBrokerURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return &ux.CodedError{
+			Code:       ux.CodeMissingArgument,
+			Msg:        fmt.Sprintf("invalid --broker-url %q: must be an absolute http(s) URL", raw),
+			Actionable: "Pass the broker's full URL, e.g. --broker-url https://broker.jentic.example.com.",
+		}
+	}
+	if err := auth.RequireSecureURL(raw); err != nil {
+		return &ux.CodedError{
+			Code:       ux.CodeMissingArgument,
+			Msg:        "invalid --broker-url: " + err.Error(),
+			Actionable: "Use https for a remote broker (http is allowed only for loopback addresses).",
+		}
+	}
+	return nil
 }
 
 // deriveEnvName proposes an environment name from the install URL: the first
@@ -33,6 +75,19 @@ func deriveEnvName(installURL string) string {
 		return s
 	}
 	return "default"
+}
+
+// seedBrokerURL resolves a NEW environment's broker_url: an explicit
+// --broker-url always wins (the one-command remote onboarding path); otherwise
+// a loopback control plane gets the co-located local broker seed. Remote
+// installs with no explicit broker get "" — the broker is never derived from a
+// remote base_url (it usually lives on its own host) and the caller warns
+// instead.
+func seedBrokerURL(explicit, installURL string) string {
+	if explicit != "" {
+		return explicit
+	}
+	return localBrokerURL(installURL)
 }
 
 // localBrokerURL returns the co-located local broker URL for a loopback control

--- a/cli/internal/cli/cmdcore/register_setup.go
+++ b/cli/internal/cli/cmdcore/register_setup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -31,14 +32,16 @@ import (
 //	identity register                   (key mint + RFC 7591 DCR)
 //	...wait for operator approval, then prove it with a token exchange.
 
-// SetupValues are the two things the fresh-machine arm must learn: where the
-// install lives and what to call this agent. Everything else is derived.
+// SetupValues are the things the fresh-machine arm must learn: where the
+// install lives, what to call this agent, and (for a remote install) where the
+// broker lives. Everything else is derived.
 // Exported (with exported fields) because setup now lives in the
 // localagentcmd package (ARCH-1) and constructs this to drive onboarding.
 type SetupValues struct {
-	URL  string // control-plane URL (becomes the environment's base_url)
-	Env  string // environment name ("" -> derived from the URL host)
-	Name string // identity + client name ("" -> derived from the hostname)
+	URL       string // control-plane URL (becomes the environment's base_url)
+	Env       string // environment name ("" -> derived from the URL host)
+	Name      string // identity + client name ("" -> derived from the hostname)
+	BrokerURL string // broker URL ("" -> loopback seed, or unset for remote — never derived)
 }
 
 // ErrOnboardCancelled signals a user-aborted interactive onboarding (Esc in
@@ -60,7 +63,7 @@ func (a *App) RegisterSetup(ctx context.Context, vals SetupValues, timeout time.
 		if vals.Name == "" {
 			vals.Name = defaultIdentityName()
 		}
-		if err := promptOnboarding(&vals.URL, &vals.Name); err != nil {
+		if err := promptOnboarding(&vals.URL, &vals.Name, &vals.BrokerURL); err != nil {
 			if errors.Is(err, huh.ErrUserAborted) {
 				fmt.Fprintln(a.Out, st.Dim.Render("Cancelled."))
 				return vals, ErrOnboardCancelled
@@ -102,6 +105,16 @@ func (a *App) RegisterSetup(ctx context.Context, vals SetupValues, timeout time.
 			}
 		}
 	}
+	// An explicit broker URL must be sane BEFORE anything is persisted: it is
+	// the target `jentic execute` sends the agent bearer to, so it obeys the
+	// same transport invariant as every other bearer-carrying URL (https
+	// required for any non-loopback host — SEC-1).
+	vals.BrokerURL = strings.TrimRight(strings.TrimSpace(vals.BrokerURL), "/")
+	if vals.BrokerURL != "" {
+		if err := validateBrokerURL(vals.BrokerURL); err != nil {
+			return vals, err
+		}
+	}
 
 	// Upsert the trio and activate it. The context is named per-identity-per-env
 	// (env "-" name) so registering a SECOND agent into the same env gets its own
@@ -130,18 +143,18 @@ func (a *App) RegisterSetup(ctx context.Context, vals SetupValues, timeout time.
 		}
 		if _, ok := cfg.Environments[envName]; !ok {
 			env := sdkconfig.Env{BaseURL: vals.URL}
-			// Local convenience: when the control plane is a loopback address,
-			// the broker is co-located on the standard local broker port over
-			// plain HTTP (jenticctl install stands both up together). Seeding it
-			// here means `jentic execute` works out of the box on a local install
-			// instead of falling back to the https default and hitting a TLS
-			// error. For REMOTE/enterprise URLs we leave broker_url unset — there
-			// the broker frequently lives on a different domain and MUST be set
-			// explicitly (`jentic env add --broker-url`); it is never derived.
-			if bu := localBrokerURL(vals.URL); bu != "" {
+			if bu := seedBrokerURL(vals.BrokerURL, vals.URL); bu != "" {
 				env.BrokerURL = bu
 			}
 			cfg.Environments[envName] = env
+		} else if vals.BrokerURL != "" {
+			// Existing env: an explicit --broker-url completes an env that has
+			// none, and refuses (without --force) to silently repoint one that
+			// already names a DIFFERENT broker — same shape as the base-URL
+			// mismatch guard above.
+			if err := applyBrokerURL(cfg, envName, vals.BrokerURL, force); err != nil {
+				return err
+			}
 		}
 		brokerConfigured = cfg.Environments[envName].BrokerURL != ""
 		// (Re)bind and activate the context. The context name is derived by
@@ -179,18 +192,21 @@ func (a *App) RegisterSetup(ctx context.Context, vals SetupValues, timeout time.
 	}
 
 	a.registerProgress(ctx, st.Successf("Environment %q → %s", envName, vals.URL))
+	if vals.BrokerURL != "" {
+		a.registerProgress(ctx, st.Successf("Broker → %s", vals.BrokerURL))
+	}
 	a.registerProgress(ctx, st.Successf("Identity %q (agent)", vals.Name))
 	a.registerProgress(ctx, st.Successf("Context %q (active)", contextName))
 
 	// Remote control plane with no broker → teach the mandatory next step now,
 	// at the moment it matters (remote-cli-usage F1/Phase B). `jentic execute`
 	// fail-closes when base_url is remote and broker_url is empty. Routed through
-	// registerProgress, so it goes to stderr and is suppressed in machine mode
-	// (never corrupts an agent's stdout stream).
+	// registerProgress, so it is suppressed in machine mode (never corrupts an
+	// agent's stdout stream).
 	if !brokerConfigured {
 		a.registerProgress(ctx, theme.Warnf("No broker_url set for remote environment %q. "+
-			"`jentic execute` needs one — set it with `jentic env add %s --url %s --broker-url https://<broker-host>:<port> --force` "+
-			"(ask your operator for the broker URL).", envName, envName, vals.URL))
+			"`jentic execute` needs one — re-run `jentic register --url %s --broker-url https://<broker-host>` to fill it in "+
+			"(ask your operator for the broker URL).", envName, vals.URL))
 	}
 
 	return vals, a.registerAndWait(ctx, vals.Name, envName, vals.URL, vals.Name, timeout, force)
@@ -198,8 +214,11 @@ func (a *App) RegisterSetup(ctx context.Context, vals SetupValues, timeout time.
 
 // RegisterActive registers the ACTIVE context's identity with its
 // environment — the same store `jentic identity register` writes, plus the
-// human-facing approval wait.
-func (a *App) RegisterActive(ctx context.Context, st *clictx.ActiveState, clientName string, timeout time.Duration, force bool) error {
+// human-facing approval wait. A non-empty brokerURL is applied to the active
+// environment first (fill-if-empty; a different existing broker refuses
+// without force), so `jentic register --broker-url …` is the one-line way to
+// complete a remote environment that was onboarded without one.
+func (a *App) RegisterActive(ctx context.Context, st *clictx.ActiveState, clientName, brokerURL string, timeout time.Duration, force bool) error {
 	if st.BaseURL == "" {
 		return &ux.CodedError{
 			Code:       ux.CodeResolveFailed,
@@ -207,16 +226,61 @@ func (a *App) RegisterActive(ctx context.Context, st *clictx.ActiveState, client
 			Actionable: "Set it with `jentic env add` / edit the environment.",
 		}
 	}
+	brokerURL = strings.TrimRight(strings.TrimSpace(brokerURL), "/")
+	if brokerURL != "" {
+		if err := validateBrokerURL(brokerURL); err != nil {
+			return err
+		}
+		if err := sdkconfig.MutateConfig(func(cfg *sdkconfig.Config) error {
+			return applyBrokerURL(cfg, st.EnvironmentName, brokerURL, force)
+		}); err != nil {
+			return err
+		}
+		a.registerProgress(ctx, theme.StylesFromContext(ctx).Successf(
+			"Broker → %s (environment %q)", brokerURL, st.EnvironmentName))
+	}
 	if clientName == "" {
 		clientName = st.IdentityName
 	}
 	return a.registerAndWait(ctx, st.IdentityName, st.EnvironmentName, st.BaseURL, clientName, timeout, force)
 }
 
-// promptOnboarding collects the two fresh-machine onboarding values, styled
-// like the legacy register wizard. Environment/context names are derived (and
-// overridable via flags), so the form stays two fields.
-func promptOnboarding(installURL, name *string) error {
+// applyBrokerURL sets envName's broker_url inside cfg with the semantics both
+// register arms share: filling an EMPTY broker_url is a completion and always
+// allowed; replacing a DIFFERENT non-empty one is a repoint and refuses
+// without force (an env's broker is load-bearing for every context bound to
+// it). Setting the same value again is a no-op, so re-running register stays
+// idempotent. The environment must already exist.
+func applyBrokerURL(cfg *sdkconfig.Config, envName, brokerURL string, force bool) error {
+	env, ok := cfg.Environments[envName]
+	if !ok {
+		return &ux.CodedError{
+			Code:       ux.CodeResolveFailed,
+			Msg:        fmt.Sprintf("environment %q does not exist", envName),
+			Actionable: "Create it first: `jentic env add " + envName + " --url <control-plane URL> --broker-url " + brokerURL + "`.",
+		}
+	}
+	if env.BrokerURL != "" && env.BrokerURL != brokerURL && !force {
+		return &ux.CodedError{
+			Code: ux.CodeMissingArgument,
+			Msg: fmt.Sprintf("environment %q already has broker_url %s, not %s",
+				envName, env.BrokerURL, brokerURL),
+			Actionable: "Pass --force to repoint it, or drop --broker-url to keep the existing broker.",
+		}
+	}
+	env.BrokerURL = brokerURL
+	cfg.Environments[envName] = env
+	return nil
+}
+
+// promptOnboarding collects the fresh-machine onboarding values, styled like
+// the legacy register wizard. Environment/context names are derived (and
+// overridable via flags), so the form stays small. The broker group only
+// appears for a non-loopback install URL (a loopback install seeds the broker
+// automatically); it is optional — leaving it blank falls through to the
+// post-registration warning rather than blocking onboarding on a value the
+// user may not know yet.
+func promptOnboarding(installURL, name, brokerURL *string) error {
 	return prompt.NewForm(
 		huh.NewGroup(
 			prompt.Input().Title("Jentic install URL").
@@ -226,5 +290,16 @@ func promptOnboarding(installURL, name *string) error {
 				Description("Identity name, shown to the operator approving this agent.").
 				Value(name).Validate(notEmptyField("name")),
 		),
+		huh.NewGroup(
+			prompt.Input().Title("Broker URL (recommended)").
+				Description("Data-plane URL `jentic execute` sends requests through — usually its own\nhost on a remote install; ask your operator. Leave blank to set later.").
+				Value(brokerURL).Validate(optionalBrokerField()),
+		).WithHideFunc(func() bool {
+			// Evaluated when the form reaches this group, i.e. AFTER the URL was
+			// typed: loopback installs seed the broker themselves, so only a
+			// remote URL needs the extra question.
+			u, err := url.Parse(strings.TrimSpace(*installURL))
+			return err != nil || isLoopbackHost(u.Hostname())
+		}),
 	).WithShowHelp(true).Run()
 }

--- a/cli/internal/cli/cmdcore/register_test.go
+++ b/cli/internal/cli/cmdcore/register_test.go
@@ -3,6 +3,7 @@ package cmdcore
 import (
 	"bytes"
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 
 	sdkconfig "github.com/jentic/jentic-one/cli/client/config"
 	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
+	"github.com/jentic/jentic-one/cli/internal/cli/ux"
 )
 
 func TestFlagsAllowPrompt(t *testing.T) {
@@ -19,6 +21,7 @@ func TestFlagsAllowPrompt(t *testing.T) {
 		c.Flags().String("url", "", "")
 		c.Flags().String("env", "", "")
 		c.Flags().String("name", "", "")
+		c.Flags().String("broker-url", "", "")
 		return c
 	}
 
@@ -49,6 +52,7 @@ func TestSetupFlagsAllowPrompt(t *testing.T) {
 		c.Flags().String("url", "", "")
 		c.Flags().String("env", "", "")
 		c.Flags().String("name", "", "")
+		c.Flags().String("broker-url", "", "")
 		c.Flags().StringSlice("operator", nil, "")
 		c.Flags().Bool("all", false, "")
 		c.Flags().String("scope", "", "")
@@ -178,6 +182,129 @@ func TestNormalizeLoopbackURL(t *testing.T) {
 			t.Errorf("normalizeLoopbackURL(%q) = (%q,%v), want (%q,%v)", c.in, got, changed, c.want, c.changed)
 		}
 	}
+}
+
+// TestValidateBrokerURL pins the --broker-url guard: an explicit broker must be
+// an absolute http(s) URL, and https is required for any non-loopback host —
+// `jentic execute` sends the agent bearer to this URL (SEC-1), so a plaintext
+// remote broker must be rejected at onboarding, not discovered at the first
+// execute.
+func TestValidateBrokerURL(t *testing.T) {
+	valid := []string{
+		"https://broker.jentic.example.com",
+		"https://broker.example.com:8443",
+		"http://127.0.0.1:8100", // plaintext allowed only for loopback
+		"http://localhost:8100",
+		"http://[::1]:8100",
+	}
+	for _, in := range valid {
+		if err := validateBrokerURL(in); err != nil {
+			t.Errorf("validateBrokerURL(%q) = %v, want nil", in, err)
+		}
+	}
+
+	invalid := []string{
+		"http://broker.example.com", // bearer over plaintext to a remote host
+		"http://10.0.0.5:8100",
+		"broker.example.com", // not absolute
+		"ftp://broker.example.com",
+		"https://", // no host
+		"not a url",
+	}
+	for _, in := range invalid {
+		err := validateBrokerURL(in)
+		if err == nil {
+			t.Errorf("validateBrokerURL(%q) = nil, want rejection", in)
+			continue
+		}
+		var coded *ux.CodedError
+		if !errors.As(err, &coded) || coded.Code != ux.CodeMissingArgument {
+			t.Errorf("validateBrokerURL(%q) error = %v, want coded MISSING_ARGUMENT", in, err)
+		}
+	}
+}
+
+// TestSeedBrokerURL pins the new-environment broker resolution: an explicit
+// --broker-url always wins (remote one-command onboarding), otherwise only a
+// loopback control plane gets the co-located seed — a remote URL with no
+// explicit broker stays empty (never derived).
+func TestSeedBrokerURL(t *testing.T) {
+	cases := []struct {
+		explicit, installURL, want string
+	}{
+		{"https://broker.example.com", "https://jentic.example.com", "https://broker.example.com"},
+		{"https://broker.example.com", "http://127.0.0.1:8000", "https://broker.example.com"}, // explicit beats the loopback seed
+		{"", "http://127.0.0.1:8000", "http://127.0.0.1:8100"},
+		{"", "https://jentic.example.com", ""},
+	}
+	for _, c := range cases {
+		if got := seedBrokerURL(c.explicit, c.installURL); got != c.want {
+			t.Errorf("seedBrokerURL(%q, %q) = %q, want %q", c.explicit, c.installURL, got, c.want)
+		}
+	}
+}
+
+// TestApplyBrokerURL pins the semantics both register arms share when an
+// explicit --broker-url meets an EXISTING environment: filling an empty
+// broker_url is a completion (always allowed), re-setting the same value is an
+// idempotent no-op, repointing a DIFFERENT broker refuses without --force
+// (every context bound to the env depends on it), --force repoints, and a
+// missing environment is a coded failure, never an implicit create.
+func TestApplyBrokerURL(t *testing.T) {
+	const envName = "prod"
+	newCfg := func(broker string) *sdkconfig.Config {
+		return &sdkconfig.Config{Environments: map[string]sdkconfig.Env{
+			envName: {BaseURL: "https://jentic.example.com", BrokerURL: broker},
+		}}
+	}
+
+	t.Run("fills an empty broker_url", func(t *testing.T) {
+		cfg := newCfg("")
+		if err := applyBrokerURL(cfg, envName, "https://broker.example.com", false); err != nil {
+			t.Fatalf("fill empty: %v", err)
+		}
+		if got := cfg.Environments[envName].BrokerURL; got != "https://broker.example.com" {
+			t.Errorf("broker_url = %q, want the filled value", got)
+		}
+	})
+
+	t.Run("same value is a no-op", func(t *testing.T) {
+		cfg := newCfg("https://broker.example.com")
+		if err := applyBrokerURL(cfg, envName, "https://broker.example.com", false); err != nil {
+			t.Fatalf("idempotent re-set: %v", err)
+		}
+	})
+
+	t.Run("different value refuses without force", func(t *testing.T) {
+		cfg := newCfg("https://broker-a.example.com")
+		err := applyBrokerURL(cfg, envName, "https://broker-b.example.com", false)
+		var coded *ux.CodedError
+		if !errors.As(err, &coded) || coded.Code != ux.CodeMissingArgument {
+			t.Fatalf("repoint without force = %v, want coded MISSING_ARGUMENT", err)
+		}
+		if got := cfg.Environments[envName].BrokerURL; got != "https://broker-a.example.com" {
+			t.Errorf("broker_url mutated on refusal: %q", got)
+		}
+	})
+
+	t.Run("force repoints", func(t *testing.T) {
+		cfg := newCfg("https://broker-a.example.com")
+		if err := applyBrokerURL(cfg, envName, "https://broker-b.example.com", true); err != nil {
+			t.Fatalf("force repoint: %v", err)
+		}
+		if got := cfg.Environments[envName].BrokerURL; got != "https://broker-b.example.com" {
+			t.Errorf("broker_url = %q, want the forced value", got)
+		}
+	})
+
+	t.Run("missing environment is a coded failure", func(t *testing.T) {
+		cfg := &sdkconfig.Config{Environments: map[string]sdkconfig.Env{}}
+		err := applyBrokerURL(cfg, envName, "https://broker.example.com", false)
+		var coded *ux.CodedError
+		if !errors.As(err, &coded) || coded.Code != ux.CodeResolveFailed {
+			t.Fatalf("missing env = %v, want coded RESOLVE_FAILED", err)
+		}
+	})
 }
 
 // TestAgentClaimURL pins the claim link the enterprise console expects: the SPA

--- a/cli/internal/cli/localagentcmd/setup.go
+++ b/cli/internal/cli/localagentcmd/setup.go
@@ -24,6 +24,7 @@ type setupOptions struct {
 	url       string // install URL (fresh-machine setup arm)
 	env       string // environment name override
 	name      string
+	brokerURL string // explicit broker (data plane) URL for the environment
 	timeout   time.Duration
 	force     bool
 	yes       bool
@@ -89,6 +90,7 @@ func NewSetupCmd(app *cmdcore.App) *cobra.Command {
 			"here you can't do by hand, just sequenced so you can start playing right\n" +
 			"away. Re-running refreshes everything idempotently.",
 		Example: "  jentic setup\n" +
+			"  jentic setup --url https://jentic.example.com --broker-url https://broker.jentic.example.com\n" +
 			"  jentic setup --url https://jentic.example.com --operator claude --yes\n" +
 			"  jentic setup --skip-skill   # identity only\n" +
 			"  jentic setup --dry-run",
@@ -102,6 +104,7 @@ func NewSetupCmd(app *cmdcore.App) *cobra.Command {
 	cmd.Flags().StringVar(&opts.url, "url", "", "Jentic install URL to connect to (creates environment/identity/context on first run)")
 	cmd.Flags().StringVar(&opts.env, "env", "", "environment name for --url (default: derived from the URL host)")
 	cmd.Flags().StringVar(&opts.name, "name", "", "agent client name shown to the approver")
+	cmd.Flags().StringVar(&opts.brokerURL, "broker-url", "", "broker (data plane) URL for the environment — execute needs it on a remote install; seeded automatically for loopback")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", 5*time.Minute, "how long to wait for approval")
 	cmd.Flags().BoolVar(&opts.force, "force", false, "re-register the agent even if the identity already has one (does not overwrite an edited skill block)")
 	cmd.Flags().BoolVar(&opts.skipSkill, "skip-skill", false, "provision identity only; do not write skill files")
@@ -221,12 +224,12 @@ func (a *Cmd) setupE(ctx context.Context, opts *setupOptions) error {
 		if identity == "" {
 			identity = st.IdentityName
 		}
-		if err := a.RegisterActive(ctx, st, opts.name, opts.timeout, opts.force); err != nil {
+		if err := a.RegisterActive(ctx, st, opts.name, opts.brokerURL, opts.timeout, opts.force); err != nil {
 			return err
 		}
 	} else {
 		vals, err := a.RegisterSetup(ctx,
-			cmdcore.SetupValues{URL: opts.url, Env: opts.env, Name: opts.name},
+			cmdcore.SetupValues{URL: opts.url, Env: opts.env, Name: opts.name, BrokerURL: opts.brokerURL},
 			opts.timeout, opts.force, opts.interactive)
 		if errors.Is(err, cmdcore.ErrOnboardCancelled) {
 			return nil

--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -34,6 +34,12 @@ to external APIs and handles credentials for you.
   and select it with `jentic context use <name>` (inspect via
   `jentic context view`). Onboard a fresh machine with `jentic register --url
   <URL>`. There is no `--base-url` flag on data-plane commands.
+- **Remote deployments:** if the environment's base URL is remote (an
+  `https://…` host in `jentic context view`), the broker must be set
+  explicitly too — `broker_url` on the environment (pass `--broker-url` to
+  `register`, or `jentic env add`), or `JENTIC_BROKER_URL` in file-less mode.
+  It is never derived from the control-plane URL. A loopback install seeds it
+  automatically.
 
 ## Procedure
 
@@ -400,9 +406,18 @@ failure** — usually exit **1**, but exit **2** (`resolve … failed`) when the
   install; otherwise set it on the environment, or override per call:
 
 ```
+jentic register --url <control-plane URL> --broker-url <broker URL>   # fills a missing broker_url
 jentic env add <env> --url http://127.0.0.1:8000 --broker-url http://127.0.0.1:8100 --force
 jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
 ```
+
+- **Missing broker on a remote install (`RESOLVE_FAILED`, exit 2).** If the
+  environment's base_url is remote and no `broker_url` is set, `execute`
+  refuses up front (it never dials the local default for a remote control
+  plane). This means the environment was onboarded without a broker: set it
+  with `jentic register --url <URL> --broker-url <broker URL>` (or
+  `JENTIC_BROKER_URL` in file-less mode) — ask the operator for the broker
+  URL; do **not** assume a local broker.
 
 - **Stopped instance (connection refused on a local target).** If the target
   is already local (`127.0.0.1` / `localhost`) and the connection is

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -59,14 +59,16 @@ stored and how one credential is shared across an API's operations.
 Give the agent its own identity. From the machine that will run the agent:
 
 ```bash
-jentic register --base-url http://127.0.0.1:8000
+jentic register --url http://127.0.0.1:8000
 ```
 
 This generates an Ed25519 keypair and registers the agent through dynamic client
 registration. **`register` then blocks, waiting for an operator to approve the
 agent.** On a single-operator install you are the operator: approve the pending
 agent in the UI at `/app`, and the command completes automatically once the
-agent is active. Re-running `register` is idempotent.
+agent is active. Re-running `register` is idempotent. (Registering with a
+**remote** deployment instead? Pass `--broker-url` too — see the
+[CLI README](../cli/README.md#usage).)
 
 ## 5. Grant access
 

--- a/skills/jentic/SKILL.md
+++ b/skills/jentic/SKILL.md
@@ -34,6 +34,12 @@ to external APIs and handles credentials for you.
   and select it with `jentic context use <name>` (inspect via
   `jentic context view`). Onboard a fresh machine with `jentic register --url
   <URL>`. There is no `--base-url` flag on data-plane commands.
+- **Remote deployments:** if the environment's base URL is remote (an
+  `https://…` host in `jentic context view`), the broker must be set
+  explicitly too — `broker_url` on the environment (pass `--broker-url` to
+  `register`, or `jentic env add`), or `JENTIC_BROKER_URL` in file-less mode.
+  It is never derived from the control-plane URL. A loopback install seeds it
+  automatically.
 
 ## Procedure
 
@@ -400,9 +406,18 @@ failure** — usually exit **1**, but exit **2** (`resolve … failed`) when the
   install; otherwise set it on the environment, or override per call:
 
 ```
+jentic register --url <control-plane URL> --broker-url <broker URL>   # fills a missing broker_url
 jentic env add <env> --url http://127.0.0.1:8000 --broker-url http://127.0.0.1:8100 --force
 jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
 ```
+
+- **Missing broker on a remote install (`RESOLVE_FAILED`, exit 2).** If the
+  environment's base_url is remote and no `broker_url` is set, `execute`
+  refuses up front (it never dials the local default for a remote control
+  plane). This means the environment was onboarded without a broker: set it
+  with `jentic register --url <URL> --broker-url <broker URL>` (or
+  `JENTIC_BROKER_URL` in file-less mode) — ask the operator for the broker
+  URL; do **not** assume a local broker.
 
 - **Stopped instance (connection refused on a local target).** If the target
   is already local (`127.0.0.1` / `localhost`) and the connection is

--- a/src/jentic_one/shared/web/content/jentic.md
+++ b/src/jentic_one/shared/web/content/jentic.md
@@ -34,6 +34,12 @@ to external APIs and handles credentials for you.
   and select it with `jentic context use <name>` (inspect via
   `jentic context view`). Onboard a fresh machine with `jentic register --url
   <URL>`. There is no `--base-url` flag on data-plane commands.
+- **Remote deployments:** if the environment's base URL is remote (an
+  `https://…` host in `jentic context view`), the broker must be set
+  explicitly too — `broker_url` on the environment (pass `--broker-url` to
+  `register`, or `jentic env add`), or `JENTIC_BROKER_URL` in file-less mode.
+  It is never derived from the control-plane URL. A loopback install seeds it
+  automatically.
 
 ## Procedure
 
@@ -400,9 +406,18 @@ failure** — usually exit **1**, but exit **2** (`resolve … failed`) when the
   install; otherwise set it on the environment, or override per call:
 
 ```
+jentic register --url <control-plane URL> --broker-url <broker URL>   # fills a missing broker_url
 jentic env add <env> --url http://127.0.0.1:8000 --broker-url http://127.0.0.1:8100 --force
 jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
 ```
+
+- **Missing broker on a remote install (`RESOLVE_FAILED`, exit 2).** If the
+  environment's base_url is remote and no `broker_url` is set, `execute`
+  refuses up front (it never dials the local default for a remote control
+  plane). This means the environment was onboarded without a broker: set it
+  with `jentic register --url <URL> --broker-url <broker URL>` (or
+  `JENTIC_BROKER_URL` in file-less mode) — ask the operator for the broker
+  URL; do **not** assume a local broker.
 
 - **Stopped instance (connection refused on a local target).** If the target
   is already local (`127.0.0.1` / `localhost`) and the connection is

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -13,7 +13,7 @@
           "use": "setup",
           "short": "Set up a new local agent (identity + skills + isolation) — start here if you're a person",
           "long": "setup takes a fresh machine from nothing to ready: it connects this\nmachine to a Jentic install (creating the environment, identity and context\nif needed), registers the agent (Dynamic Client Registration), prints an\napproval link and waits for a human to approve it, mints and saves tokens,\nand generates the Jentic CLI-usage skill into your agent runtime's native\nlayout. It also offers to isolate the coding agent behind its own Unix user.\n\nIt is a thin orchestration of `jentic register` and `jentic skill`: nothing\nhere you can't do by hand, just sequenced so you can start playing right\naway. Re-running refreshes everything idempotently.",
-          "example": "  jentic setup\n  jentic setup --url https://jentic.example.com --operator claude --yes\n  jentic setup --skip-skill   # identity only\n  jentic setup --dry-run",
+          "example": "  jentic setup\n  jentic setup --url https://jentic.example.com --broker-url https://broker.jentic.example.com\n  jentic setup --url https://jentic.example.com --operator claude --yes\n  jentic setup --skip-skill   # identity only\n  jentic setup --dry-run",
           "group_title": "Identity \u0026 access",
           "flags": [
             {
@@ -21,6 +21,11 @@
               "type": "bool",
               "default": "false",
               "usage": "target every supported operator"
+            },
+            {
+              "name": "broker-url",
+              "type": "string",
+              "usage": "broker (data plane) URL for the environment — execute needs it on a remote install; seeded automatically for loopback"
             },
             {
               "name": "context",
@@ -101,10 +106,15 @@
           "path": "jentic register",
           "use": "register",
           "short": "Obtain tokens for an existing agent identity (identity only, no skills) — agents run this",
-          "long": "register connects this machine to a Jentic install: it generates an\nEd25519 keypair (if absent), performs Dynamic Client Registration, waits\nfor an operator to approve the agent, then mints and saves tokens.\n\nWith an active context (`jentic context use`), it registers that context's\nidentity with its environment. On a fresh machine, pass --url (or answer\nthe prompt) and register creates the environment, identity and context in\none step, activates them, and registers.\n\nLocal install: use http://127.0.0.1:8000 (NOT http://localhost:8000) — the\ntoken-exchange audience is matched exactly against the backend's\ncanonical_base_url, and a local backend uses 127.0.0.1. For a loopback URL,\nregister also seeds the environment's broker_url (http://127.0.0.1:8100) so\n`jentic execute` works without extra flags.",
-          "example": "  jentic register --url http://127.0.0.1:8000   # local install (use 127.0.0.1, not localhost)\n  jentic register --url https://jentic.example.com\n  jentic register --url https://jentic.example.com --name crawler --env prod\n  jentic register                      # active context (or interactive setup)\n  jentic register --force              # re-register the active identity",
+          "long": "register connects this machine to a Jentic install: it generates an\nEd25519 keypair (if absent), performs Dynamic Client Registration, waits\nfor an operator to approve the agent, then mints and saves tokens.\n\nWith an active context (`jentic context use`), it registers that context's\nidentity with its environment. On a fresh machine, pass --url (or answer\nthe prompt) and register creates the environment, identity and context in\none step, activates them, and registers.\n\nLocal install: use http://127.0.0.1:8000 (NOT http://localhost:8000) — the\ntoken-exchange audience is matched exactly against the backend's\ncanonical_base_url, and a local backend uses 127.0.0.1. For a loopback URL,\nregister also seeds the environment's broker_url (http://127.0.0.1:8100) so\n`jentic execute` works without extra flags.\n\nRemote install: pass --broker-url too. The broker usually lives on its own\nhost and is never derived from the control-plane URL; without it the\nenvironment has no broker and `jentic execute` fail-closes until one is set\n(ask your operator for the broker URL). Re-running register with\n--broker-url fills it in on an existing environment.",
+          "example": "  jentic register --url http://127.0.0.1:8000   # local install (use 127.0.0.1, not localhost)\n  jentic register --url https://jentic.example.com --broker-url https://broker.jentic.example.com\n  jentic register --url https://jentic.example.com --name crawler --env prod\n  jentic register                      # active context (or interactive setup)\n  jentic register --force              # re-register the active identity",
           "group_title": "Identity \u0026 access",
           "flags": [
+            {
+              "name": "broker-url",
+              "type": "string",
+              "usage": "broker (data plane) URL for the environment — execute needs it on a remote install; seeded automatically for loopback"
+            },
             {
               "name": "context",
               "type": "string",


### PR DESCRIPTION
## Summary

Connecting the `jentic` binary to a **remote** deployment was a two-command dance: `register` onboarded the environment without a broker, warned after the fact, and the fix was a separate `jentic env add … --force` re-typing the base URL. This implements Phases 1+2 of the register/setup onboarding redesign (plan: `jentic-one-plans/research/cli-register-setup-redesign-impl.md`): one command now takes a fresh machine to a fully working remote setup:

```bash
jentic register --url https://jentic.example.com --broker-url https://broker.jentic.example.com --name my-agent
```

## Changes

- **cli** `register` / `setup` gain `--broker-url`, validated before anything persists: absolute http(s) URL, https required for any non-loopback host (same SEC-1 transport invariant as the token/broker transports, via `auth.RequireSecureURL`).
- **cli** New-env semantics: explicit `--broker-url` wins over the loopback seed (`seedBrokerURL`). Existing-env semantics (`applyBrokerURL`, shared by both register arms): filling an **empty** `broker_url` is allowed (completion), re-setting the same value is a no-op, repointing a **different** one refuses without `--force`, missing env is a coded `RESOLVE_FAILED`.
- **cli** Active-context arm: `jentic register --broker-url <URL>` (no `--url`) completes a remote environment that was onboarded without a broker — the one-line remedy the warning now teaches (instead of `env add … --force`).
- **cli** Interactive onboarding adds a third, optional **Broker URL** field — shown only when the typed install URL is non-loopback (loopback installs seed the broker themselves; `huh` hide-func evaluated after the URL is typed).
- **cli** `--broker-url` joins the register/setup field-flag sets, so passing it suppresses the interactive prompt like the other field flags.
- **docs** README: remote one-command quickstart in the opening + Usage sections, `--broker-url` in the register section, new "File-less mode (orchestrators)" block documenting `JENTIC_BASE_URL` / `JENTIC_BEARER_TOKEN` / `JENTIC_BROKER_URL`, standalone-binary statement. Agent skill (`jentic.md`): remote-broker prerequisite + a dedicated `RESOLVE_FAILED` (missing remote broker) failure branch. `docs/quickstart.md`: stale `--base-url` → `--url`. `cli-reference.json` regenerated.
- Out of scope (later phases of the plan): server-advertised broker discovery, `jentic env set`, `setup --isolate/--no-isolate`.

## Risk & rollback

- No breaking changes: all existing invocations behave identically; the new flag is opt-in, and the only behavioural deltas are the extra interactive field (remote URLs only), the broker progress line, and the reworded warning.
- Auth/credential surface: the new flag writes `broker_url` (where `jentic execute` sends the agent bearer) — guarded by the fail-fast https validation and the fill/refuse/force semantics above; the existing fail-closed remote-broker guard on `execute` is unchanged and remains defence in depth.
- Rollback: revert the squash commit.

## Test plan

- `GOWORK=off go test ./...` in `cli/` — green (includes arch gates: standalone-binary boundary, fencing, form-constructor guard).
- New unit tests: `TestValidateBrokerURL`, `TestSeedBrokerURL`, `TestApplyBrokerURL` (fill / idempotent / refuse / force / missing-env), field-flag prompt suppression extended to `--broker-url`.
- Manual (isolated `XDG_CONFIG_HOME`, built binary): fresh remote register persists `broker_url` + prints the Broker progress line; conflicting `--broker-url` refuses without `--force` and leaves config untouched; `--force` repoints; remote register without broker warns with the new one-line remedy; loopback register still seeds `http://127.0.0.1:8100` with no warning; active-context `register --broker-url` fills the empty broker; plaintext remote broker rejected with a coded error before any write.

Made with [Cursor](https://cursor.com)