### PR TITLE
feat(cli): prefill the interactive onboarding URL with the local-install default

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -510,8 +510,9 @@ jentic register
 jentic register --broker-url https://broker.jentic.example.com
 
 # Interactive: bare `jentic register` on a fresh machine prompts for the
-# install URL + agent name (and the broker URL, for a remote install) and
-# does the rest.
+# install URL (prefilled with the local default — just confirm after a local
+# install) + agent name (and the broker URL, for a remote install) and does
+# the rest.
 ```
 
 Approval is a human, out-of-band step: `register` prints the console link

--- a/cli/internal/cli/cmdcore/register_setup.go
+++ b/cli/internal/cli/cmdcore/register_setup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jentic/jentic-one/cli/internal/cli/clictx"
 	"github.com/jentic/jentic-one/cli/internal/cli/prompt"
 	"github.com/jentic/jentic-one/cli/internal/cli/ux"
+	"github.com/jentic/jentic-one/cli/internal/config"
 	"github.com/jentic/jentic-one/cli/internal/theme"
 )
 
@@ -62,6 +63,14 @@ func (a *App) RegisterSetup(ctx context.Context, vals SetupValues, timeout time.
 		fmt.Fprintln(a.Out, st.Dim.Render("Connect this machine to a Jentic install; an operator approves it, then tokens mint."))
 		if vals.Name == "" {
 			vals.Name = defaultIdentityName()
+		}
+		// Prefill the install-URL field with the local-install default so a user
+		// who just ran a local install can confirm with Enter instead of retyping
+		// the well-known loopback URL. It stays fully editable (a remote install
+		// types over it), and because the default is loopback the broker field
+		// stays hidden and the broker is seeded automatically.
+		if vals.URL == "" {
+			vals.URL = config.DefaultBaseURL
 		}
 		if err := promptOnboarding(&vals.URL, &vals.Name, &vals.BrokerURL); err != nil {
 			if errors.Is(err, huh.ErrUserAborted) {
@@ -284,7 +293,7 @@ func promptOnboarding(installURL, name, brokerURL *string) error {
 	return prompt.NewForm(
 		huh.NewGroup(
 			prompt.Input().Title("Jentic install URL").
-				Description("The control-plane URL this agent registers with and talks to.").
+				Description("The control-plane URL this agent registers with and talks to.\nDefaults to a local install — edit it for a remote one.").
 				Value(installURL).Validate(notEmptyField("url")),
 			prompt.Input().Title("Agent name").
 				Description("Identity name, shown to the operator approving this agent.").


### PR DESCRIPTION
## Summary

After a local install, running bare `jentic register` / `jentic setup` still made the user type the well-known loopback control-plane URL into the very first onboarding field — even though a local install always lives at the same address. This prefills the "Jentic install URL" field with the local default (`http://127.0.0.1:8000`), so a local-install user can just confirm it with Enter instead of retyping it. The confirm-to-proceed prompt is kept (people liked seeing/verifying the value); only the empty field is now seeded.

## Changes

- **cli** `RegisterSetup` seeds `vals.URL` from `config.DefaultBaseURL` before the interactive form renders — only on the interactive, empty-`--url` arm. The field stays fully editable, so a remote install just types over it.
- **cli** The URL field's description notes it defaults to a local install and to edit it for a remote one.
- **docs** README interactive-onboarding note mentions the prefilled default.
- Out of scope: no change to the broker field or to non-interactive behaviour (see Risk & rollback).

## Risk & rollback

- No behavioural change to the credential/auth surface. The seeded value is the existing canonical local URL; because it is loopback the broker question stays hidden and `broker_url` is seeded to `http://127.0.0.1:8100` automatically, exactly as before.
- Non-interactive runs are untouched: with no `--url` they still fail fast with a coded `MISSING_ARGUMENT`, so automation/CI must stay explicit (the seeding is gated on `interactive && vals.URL == ""`).
- Rollback: revert the squash commit.

## Test plan

- `GOWORK=off go build ./...` — green.
- `GOWORK=off go test ./internal/cli/cmdcore/...` — green (existing onboarding/broker-seed tests unaffected).
- `golangci-lint v2.12.2 run ./internal/cli/cmdcore/...` — 0 issues.
- Manual (built binary, isolated `XDG_CONFIG_HOME`): bare `jentic register` on a fresh machine shows the URL field pre-populated with `http://127.0.0.1:8000`; pressing Enter proceeds and seeds the loopback broker with no broker prompt; typing a remote URL over it reveals the broker field as before. `promptOnboarding` is an interactive TUI form, so it is exercised manually rather than by a unit test.

Made with [Cursor](https://cursor.com)