### PR TITLE
fix(install): build the server from source for a non-release Docker install

### DIFF
--- a/cli/internal/cli/ctlcmd/doctor_test.go
+++ b/cli/internal/cli/ctlcmd/doctor_test.go
@@ -195,6 +195,7 @@ func TestDoctorReportsDockerDaemonDown(t *testing.T) {
 	}
 	if daemon == nil {
 		t.Fatalf("deploy check did not record a `docker daemon` row: %+v", d.checks)
+		return
 	}
 	if daemon.status != statusWarn {
 		t.Errorf("down daemon should be statusWarn (CI-safe, zero exit), got %v", daemon.status)
@@ -242,6 +243,7 @@ func TestDoctorReportsDockerNotInstalled(t *testing.T) {
 	}
 	if row == nil {
 		t.Fatalf("deploy check did not record a `docker` row for a missing binary: %+v", d.checks)
+		return
 	}
 	if row.status != statusWarn {
 		t.Errorf("missing docker should be statusWarn (CI-safe), got %v", row.status)

--- a/cli/internal/cli/ctlcmd/install.go
+++ b/cli/internal/cli/ctlcmd/install.go
@@ -512,6 +512,17 @@ func (a *app) offerWizard(cmd *cobra.Command, opts *installOptions, started bool
 	}
 }
 
+// shouldBuildNonRelease reports whether the Docker path should build the server
+// image from source because the CLI is a NON-RELEASE build (dev / main / a
+// branch / a commit) and the operator has not pinned a specific image. Such a
+// ref has no matching published server image, and pulling the last release
+// would pair this (newer) CLI with an OLDER server; building from the same ref
+// keeps the stack coherent. An explicit image pin (--image-tag /
+// $JENTIC_APP_IMAGE_TAG) means "pull exactly this", so it disables the build.
+func shouldBuildNonRelease(version string, imagePinned bool) bool {
+	return !imagePinned && !install.IsReleaseVersion(version)
+}
+
 // resolveStackBuildRef resolves which git ref a --build-local managed-clone
 // build should target. An explicit --ref wins (pinned). Otherwise fall back to
 // the ref this CLI was installed from (the install manifest, written by
@@ -647,13 +658,27 @@ func (a *app) installDocker(ctx context.Context, draft *install.Draft, configPat
 	// Build locally when explicitly asked (--build-local / --ref), or when a
 	// source checkout is in play (cwd repo-root walk / $JENTIC_SRC) — a
 	// contributor iterating on local changes should not silently run a
-	// published image. Otherwise pull the signed release image and thread it
-	// into compose.
+	// published image. Also build locally for a NON-RELEASE build (dev / main /
+	// a branch / a commit) with no explicit image pin: there is no matching
+	// published server image for such a ref, and pulling the last release would
+	// pair this (newer) CLI with an OLDER server — so build the server from the
+	// same ref the CLI came from, keeping the stack coherent. An explicit
+	// --image-tag / $JENTIC_APP_IMAGE_TAG always means "pull exactly this", so
+	// it still takes the pull path even for a non-release build.
 	_, haveSrc := install.RepoRoot()
-	buildLocal := opts.buildLocal || haveSrc || opts.ref != ""
+	imagePinned := opts.imageTag != "" || os.Getenv(install.AppImageTagEnv) != ""
+	nonReleaseNeedsBuild := shouldBuildNonRelease(cmdcore.Version(), imagePinned)
+	buildLocal := opts.buildLocal || haveSrc || opts.ref != "" || nonReleaseNeedsBuild
 
 	var appImage string
 	if buildLocal {
+		if nonReleaseNeedsBuild && !opts.buildLocal && !haveSrc && opts.ref == "" {
+			fmt.Fprintln(a.Out)
+			fmt.Fprintln(a.Out, theme.Dimf(
+				"note: non-release build (%s) — no published server image matches this ref, "+
+					"so the server is built from source to match this CLI. "+
+					"Pin a published image with --image-tag <tag> to pull instead.", cmdcore.Version()))
+		}
 		ref, pinned := a.resolveStackBuildRef(opts.ref)
 		plan := install.PlanLocalBuild(a.Paths.VenvPath(), a.Paths.SrcPath()).AtRef(ref, pinned)
 		if plan.PinnedRefIgnored() {

--- a/cli/internal/cli/ctlcmd/install_test.go
+++ b/cli/internal/cli/ctlcmd/install_test.go
@@ -49,6 +49,34 @@ func TestResolveStackBuildRef(t *testing.T) {
 	})
 }
 
+// TestShouldBuildNonRelease pins the Docker path's auto-build decision: a
+// NON-RELEASE CLI build (dev / main / a branch / a commit) with no explicit
+// image pin builds the server from source (no matching published image exists,
+// and pulling the last release would pair a newer CLI with an older server); a
+// real semver release pulls the published :X.Y.Z image, and any explicit image
+// pin (--image-tag / $JENTIC_APP_IMAGE_TAG) always means "pull exactly this".
+func TestShouldBuildNonRelease(t *testing.T) {
+	cases := []struct {
+		version     string
+		imagePinned bool
+		want        bool
+	}{
+		{"main", false, true},
+		{"dev", false, true},
+		{"cli-v2-release", false, true},
+		{"9a858218", false, true},
+		{"v0.31.1", false, false}, // real release -> pull the published image
+		{"0.31.1", false, false},  // v-less semver is still a release
+		{"main", true, false},     // explicit image pin overrides the build
+		{"v0.31.1", true, false},  // release + pin still pulls the pin
+	}
+	for _, c := range cases {
+		if got := shouldBuildNonRelease(c.version, c.imagePinned); got != c.want {
+			t.Errorf("shouldBuildNonRelease(%q, %v) = %v, want %v", c.version, c.imagePinned, got, c.want)
+		}
+	}
+}
+
 // TestRecordManifestStackRef verifies that a build-local install records the
 // ref the stack was really built from (Draft.StackRef), while other paths keep
 // recording the CLI version. Without this, the first successful install would

--- a/cli/internal/install/image.go
+++ b/cli/internal/install/image.go
@@ -28,8 +28,9 @@ const (
 //
 //	override (a full ref, a bare tag, or an @sha256: digest) — from --image-tag
 //	         or $JENTIC_APP_IMAGE_TAG
-//	CLI build version, when it is a real release (not "dev"/empty) → :X.Y.Z
-//	"latest"
+//	CLI build version, when it is a real semver release → :X.Y.Z
+//	"latest" — for any non-release version ("dev", "main", a branch, a commit),
+//	         since the release workflow only ever publishes :X.Y.Z (and :latest)
 //
 // The repository defaults to DefaultAppImageRepo and is overridable via
 // $JENTIC_APP_IMAGE. An override that already looks like a full reference
@@ -52,10 +53,47 @@ func ResolveAppImage(version, override string) string {
 	}
 
 	tag := "latest"
-	if v := strings.TrimSpace(version); v != "" && v != "dev" {
-		tag = strings.TrimPrefix(v, "v")
+	if v := releaseTag(version); v != "" {
+		tag = v
 	}
 	return repo + ":" + tag
+}
+
+// IsReleaseVersion reports whether a CLI build version is a real published
+// release (a semver the release workflow tags an image with). It is false for
+// "dev"/"main"/a branch/a commit — the cases where the Docker pull path falls
+// back to :latest — so callers can explain that fallback to the user.
+func IsReleaseVersion(version string) bool { return releaseTag(version) != "" }
+
+// releaseTag returns the image tag for a CLI build version when that version is
+// a real published release — a semver `X.Y.Z` (optionally `v`-prefixed, with an
+// optional `-prerelease`/`+build` suffix), which is the only shape the release
+// workflow ever pushes as an image tag. It returns "" for anything else
+// ("dev", "main", a branch name, or a bare commit SHA from a `JENTIC_REF=…`
+// install), so the caller falls back to :latest instead of pulling a
+// `:main`/`:<sha>` tag that is never published (jentic-one Docker install from
+// a non-release ref). Testers who need the server built from that exact ref use
+// `--build-local`.
+func releaseTag(version string) string {
+	v := strings.TrimPrefix(strings.TrimSpace(version), "v")
+	if v == "" {
+		return ""
+	}
+	// Require a leading MAJOR.MINOR.PATCH; a trailing -prerelease/+build is fine.
+	core := v
+	if i := strings.IndexAny(core, "-+"); i >= 0 {
+		core = core[:i]
+	}
+	parts := strings.Split(core, ".")
+	if len(parts) != 3 {
+		return ""
+	}
+	for _, p := range parts {
+		if p == "" || strings.TrimLeft(p, "0123456789") != "" {
+			return ""
+		}
+	}
+	return v
 }
 
 // applyRef joins a repo with a bare tag or an @sha256: digest.

--- a/cli/internal/install/image_test.go
+++ b/cli/internal/install/image_test.go
@@ -18,8 +18,13 @@ func TestResolveAppImage(t *testing.T) {
 	}{
 		{"released version maps to :X.Y.Z", "v0.31.0", "", DefaultAppImageRepo + ":0.31.0"},
 		{"released version without v prefix", "0.31.0", "", DefaultAppImageRepo + ":0.31.0"},
+		{"prerelease semver keeps its tag", "v0.32.0-rc1", "", DefaultAppImageRepo + ":0.32.0-rc1"},
 		{"dev falls back to :latest", "dev", "", DefaultAppImageRepo + ":latest"},
 		{"empty version falls back to :latest", "", "", DefaultAppImageRepo + ":latest"},
+		{"main ref falls back to :latest (no :main image is published)", "main", "", DefaultAppImageRepo + ":latest"},
+		{"branch name falls back to :latest", "cli-v2-release", "", DefaultAppImageRepo + ":latest"},
+		{"commit sha falls back to :latest", "9a858218", "", DefaultAppImageRepo + ":latest"},
+		{"non-semver version falls back to :latest", "0.31", "", DefaultAppImageRepo + ":latest"},
 		{"bare-tag override wins over version", "v0.31.0", "edge", DefaultAppImageRepo + ":edge"},
 		{"digest override applied to default repo", "v0.31.0", "@sha256:abc123", DefaultAppImageRepo + "@sha256:abc123"},
 		{"digest override without @ prefix", "v0.31.0", "sha256:abc123", DefaultAppImageRepo + "@sha256:abc123"},


### PR DESCRIPTION
## Summary

Installing from a non-release ref (e.g. `curl … | JENTIC_REF=main sh`, which we use to get people testing the CLI V2 line **before** cutting a release) stamps the CLI version as `main`. The Docker install path then tried to `docker pull ghcr.io/jentic/jentic-one-app:main` — an image the release workflow never publishes (it only pushes `:X.Y.Z` and moves `:latest` on `v*.*.*` tags) — so the install died with `not found`. And silently pulling the last **release** image would be worse: it pairs this newer CLI with an **older, pre-cli-v2 server**, so a "test main" run wouldn't actually be testing main's server.

Fix: for a non-release CLI build with no explicit image pin, **build the server image from the same ref the CLI came from** (the managed-clone build-local path — it self-clones and builds inside Docker, so no host toolchain is needed), giving a coherent main-CLI + main-server stack. A real semver release still pulls its published `:X.Y.Z` image, and an explicit `--image-tag` / `$JENTIC_APP_IMAGE_TAG` always means "pull exactly this".

Context: there is no released version of the cli-v2 work yet — it lives only in `main` — so a non-release Docker install must build the server, not pull a mismatched release. (This supersedes the earlier `:latest`-fallback approach on this branch, which would have run new CLI against the old released server.)

## Changes

- **cli/install** `ResolveAppImage` maps only a real semver `X.Y.Z` (optionally `v`-prefixed, `-prerelease`/`+build` suffix allowed) to `:X.Y.Z`; everything else (`dev`/`main`/branch/commit) resolves to `:latest` as a safety net. New `IsReleaseVersion` helper.
- **cli/ctlcmd** `shouldBuildNonRelease` drives the Docker path to build from source for a non-release, unpinned build; prints a note explaining the choice and how to pull a published image instead (`--image-tag`).
- **tests** `releaseTag` truth table (main/branch/commit/non-semver → `:latest`; prerelease kept) and a `shouldBuildNonRelease` matrix (build for non-release unless pinned; pull for a real release).
- Out of scope: publishing a rolling `:main`/`:edge` server image (a release-pipeline decision, not an installer one). Cutting a real release off `main` remains the way to give the default `curl` (release) path the full V2 stack.

## Risk & rollback

- Behaviour change is narrow: it only affects **non-release** Docker installs with no explicit image pin — a path that previously always failed at the pull step, so this can only fix it. Released installs (`:X.Y.Z`) and explicit `--image-tag` / `$JENTIC_APP_IMAGE_TAG` overrides are unchanged.
- The non-release path now runs a Docker build (a few minutes) instead of a fast pull. It needs `docker` + `git` (both already required/preflight-checked for this path); no host Go/Python toolchain (the build runs inside Docker).
- No auth/credential/permission surface touched.
- Rollback: revert the squash commit.

## Test plan

- `GOWORK=off go build ./...` — green.
- `GOWORK=off go test ./...` — green (full suite incl. arch + golden gates); new `releaseTag` + `shouldBuildNonRelease` tables.
- `golangci-lint v2.12.2 run ./internal/install/... ./internal/cli/ctlcmd/...` — 0 issues.
- Manual repro: `curl … | JENTIC_REF=main sh` previously failed with `pull ghcr.io/jentic/jentic-one-app:main … not found`; with this change the Docker path builds the server from `main` and prints the non-release note. A released install and `--image-tag <tag>` still pull.