### PR TITLE
fix(registry): make trailing-slash paths matchable in the broker URL index

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1342,7 +1342,7 @@
         "filename": "tests/integration/registry/ingest/test_ingestor_openapi.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 83
+        "line_number": 84
       }
     ],
     "tests/integration/shared/auth/test_verify.py": [
@@ -1943,5 +1943,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-14T13:58:13Z"
+  "generated_at": "2026-08-19T15:47:48Z"
 }

--- a/src/jentic_one/migrations/registry/versions/e6f7a8b9c0d1_normalize_url_index_path_templates.py
+++ b/src/jentic_one/migrations/registry/versions/e6f7a8b9c0d1_normalize_url_index_path_templates.py
@@ -1,0 +1,219 @@
+"""normalize url index path templates and regexes
+
+Revision ID: e6f7a8b9c0d1
+Revises: d6e7f8a9b0c1
+Create Date: 2026-08-19
+
+Repairs ``operation_url_indexes`` rows written before #1085 was fixed:
+``build_index_entry`` used to compile ``path_regex`` from the **raw** path
+template, while ``URLLookupService.resolve`` normalizes the incoming request
+path (which strips trailing slashes). A template ending in ``/`` therefore
+produced a regex that could never match any normalized request path, making
+every trailing-slash operation unreachable through the broker
+(``operation_not_found``).
+
+The fixed ingest code canonicalizes the template before deriving the regex,
+but URL-index rows are only rebuilt when their revision is re-ingested — so
+already-published revisions keep the broken rows forever. This migration
+recomputes ``path_template``, ``path_regex``, and ``segment_count`` for every
+existing row using the same canonicalization the fixed code applies.
+
+The normalization helpers below are **frozen copies** of the pure functions in
+``jentic_one.registry.core.url_index`` at the time of this migration. They are
+deliberately not imported: a later refactor of the live module must not
+silently change what this historical migration does. A canary test
+(``tests/unit/test_migrations.py``) asserts the copies still agree with the
+live functions — if it fails, normalization semantics changed and a **new**
+data migration is required.
+
+Collision handling: the table has a global unique constraint on
+``(method, host, host_regex, path_template)``. If normalizing a row's template
+lands on a key an already-canonical row occupies, the stale row is deleted —
+the surviving row is exactly what a fresh ingest would have written, and the
+next re-ingest of the stale row's revision rebuilds its index anyway.
+
+The repair is idempotent: rows already canonical are left untouched.
+
+Downgrade is a no-op by design: the original trailing-slash templates cannot
+be reconstructed (normalization is lossy), and the canonical rows remain
+correct under pre-fix code — the old lookup path normalizes the request the
+same way, so canonical rows match strictly more URLs than the broken ones did.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from urllib.parse import unquote
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e6f7a8b9c0d1"  # pragma: allowlist secret
+down_revision: str | None = "d6e7f8a9b0c1"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# --- Frozen copies of jentic_one.registry.core.url_index helpers (see module
+# --- docstring). Do not "fix" these to track the live module.
+
+_PATH_PARAM_RE = re.compile(r"\{([^}]+)\}")
+_PERCENT_ENCODED_RE = re.compile(r"%[0-9A-Fa-f]{2}")
+_UNRESERVED_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+_RFC6570_OPERATORS = frozenset("+#./;?&")
+
+
+def _normalize_percent_encoding(path: str) -> str:
+    def _replace(match: re.Match[str]) -> str:
+        encoded = match.group(0)
+        char = chr(int(encoded[1:], 16))
+        if char in _UNRESERVED_CHARS:
+            return char
+        return encoded.upper()
+
+    return _PERCENT_ENCODED_RE.sub(_replace, path)
+
+
+def _resolve_dot_segments(path: str) -> str:
+    segments = path.split("/")
+    output: list[str] = []
+    for segment in segments:
+        if segment == ".":
+            continue
+        elif segment == "..":
+            if output:
+                output.pop()
+        else:
+            output.append(segment)
+    resolved = "/".join(output)
+    if path.startswith("/") and not resolved.startswith("/"):
+        resolved = "/" + resolved
+    return resolved
+
+
+def _normalize_path(path: str) -> str:
+    decoded = unquote(path)
+    resolved = _resolve_dot_segments(decoded)
+    normalized = _normalize_percent_encoding(resolved)
+    if normalized and not normalized.startswith("/"):
+        normalized = "/" + normalized
+    return normalized.rstrip("/") or "/"
+
+
+def _normalize_path_template(template: str) -> str:
+    parts = _PATH_PARAM_RE.split(template)
+    tokens: list[str] = []
+    shielded: list[str] = []
+    for i, part in enumerate(parts):
+        if i % 2 == 0:
+            shielded.append(part)
+        else:
+            tokens.append(part)
+            shielded.append(f"\x00{len(tokens) - 1}\x00")
+    normalized = _normalize_path("".join(shielded))
+    for idx, token in enumerate(tokens):
+        normalized = normalized.replace(f"\x00{idx}\x00", "{" + token + "}")
+    return normalized
+
+
+def _safe_param_name(name: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_]", "_", name)
+
+
+def _split_param_token(token: str) -> tuple[str, bool]:
+    is_catch_all = token.startswith("+")
+    if token and token[0] in _RFC6570_OPERATORS:
+        return token[1:], is_catch_all
+    return token, is_catch_all
+
+
+def _build_path_regex_pattern(path_template: str) -> str:
+    parts = _PATH_PARAM_RE.split(path_template)
+    regex_parts: list[str] = []
+    for i, part in enumerate(parts):
+        if i % 2 == 0:
+            regex_parts.append(re.escape(part))
+        else:
+            name, is_catch_all = _split_param_token(part)
+            safe_name = _safe_param_name(name)
+            matcher = ".+" if is_catch_all else "[^/]+"
+            regex_parts.append(f"(?P<{safe_name}>{matcher})")
+    return "^" + "".join(regex_parts) + "$"
+
+
+def _count_segments(path: str) -> int:
+    if "**" in path or "{+" in path:
+        return -1
+    stripped = path.strip("/")
+    if not stripped:
+        return 0
+    return len(stripped.split("/"))
+
+
+# --- Repair body (kept as a function taking a connection so the integration
+# --- test can exercise it directly against a real database).
+
+_URL_INDEX = sa.table(
+    "operation_url_indexes",
+    sa.column("id"),
+    sa.column("method"),
+    sa.column("host"),
+    sa.column("host_regex"),
+    sa.column("path_template"),
+    sa.column("path_regex"),
+    sa.column("segment_count"),
+)
+
+
+def repair_url_index(bind: sa.engine.Connection) -> None:
+    """Recompute canonical template/regex/segment-count for every stale row.
+
+    Idempotent; deletes a stale row instead of updating it when its canonical
+    key is already occupied (see module docstring for why deletion is safe).
+    """
+    rows = bind.execute(sa.select(_URL_INDEX)).all()
+
+    for row in rows:
+        template = _normalize_path_template(row.path_template)
+        regex = _build_path_regex_pattern(template)
+        segment_count = _count_segments(template)
+        if (template, regex, segment_count) == (
+            row.path_template,
+            row.path_regex,
+            row.segment_count,
+        ):
+            continue
+
+        collision = bind.execute(
+            sa.select(_URL_INDEX.c.id).where(
+                _URL_INDEX.c.method == row.method,
+                _URL_INDEX.c.host.is_not_distinct_from(row.host),
+                _URL_INDEX.c.host_regex.is_not_distinct_from(row.host_regex),
+                _URL_INDEX.c.path_template == template,
+                _URL_INDEX.c.id != row.id,
+            )
+        ).first()
+
+        if collision is not None:
+            bind.execute(sa.delete(_URL_INDEX).where(_URL_INDEX.c.id == row.id))
+        else:
+            bind.execute(
+                sa.update(_URL_INDEX)
+                .where(_URL_INDEX.c.id == row.id)
+                .values(
+                    path_template=template,
+                    path_regex=regex,
+                    segment_count=segment_count,
+                )
+            )
+
+
+def upgrade() -> None:
+    repair_url_index(op.get_bind())
+
+
+def downgrade() -> None:
+    # Lossy data repair — the pre-fix trailing-slash forms cannot be restored,
+    # and canonical rows remain valid (and resolvable) under pre-fix code.
+    pass

--- a/src/jentic_one/registry/core/url_index.py
+++ b/src/jentic_one/registry/core/url_index.py
@@ -90,15 +90,33 @@ def normalize_path(path: str) -> str:
 
 
 def normalize_path_template(template: str) -> str:
-    """Normalize a path template, preserving parameter placeholders."""
+    """Normalize a path template to the same canonical form as ``normalize_path``.
+
+    ``{...}`` parameter tokens are preserved verbatim (including RFC 6570
+    operators such as ``{+param}``); everything else — trailing slash, dot
+    segments, percent-encoding — is normalized exactly as ``normalize_path``
+    normalizes a request path. This symmetry is what lets an index entry built
+    from the template match a request path normalized at lookup time (#1085).
+
+    Tokens are shielded behind NUL-delimited sentinels while the whole template
+    goes through ``normalize_path`` in one pass; normalizing literal chunks
+    individually would strip the slash *before* a token (``/pets/{petId}`` →
+    ``/pets{petId}``), because each chunk's trailing slash looks like a
+    trailing slash to ``normalize_path``.
+    """
     parts = PATH_PARAM_RE.split(template)
-    normalized_parts: list[str] = []
+    tokens: list[str] = []
+    shielded: list[str] = []
     for i, part in enumerate(parts):
         if i % 2 == 0:
-            normalized_parts.append(normalize_path(part) if part else "")
+            shielded.append(part)
         else:
-            normalized_parts.append("{" + part + "}")
-    return "".join(normalized_parts)
+            tokens.append(part)
+            shielded.append(f"\x00{len(tokens) - 1}\x00")
+    normalized = normalize_path("".join(shielded))
+    for idx, token in enumerate(tokens):
+        normalized = normalized.replace(f"\x00{idx}\x00", "{" + token + "}")
+    return normalized
 
 
 def normalise_host(host: str, scheme: str = "https") -> str:
@@ -318,17 +336,27 @@ def build_index_entry(
     path_template: str,
     scheme: str = "https",
 ) -> URLIndexEntry:
-    """Build a complete URL index entry for an operation."""
+    """Build a complete URL index entry for an operation.
+
+    The template is canonicalized through ``normalize_path_template`` first and
+    every derived field (regex, params, segment count, stored pattern) comes
+    from that canonical form. ``URLLookupService.resolve`` normalizes the
+    incoming request path with ``normalize_path`` before matching, so both
+    sides of the comparison must agree on one canonical form — building the
+    regex from the raw template made any trailing-slash path unmatchable
+    (#1085).
+    """
     normalized_host = normalise_host(host, scheme)
     host_regex = build_host_regex(normalized_host)
-    path_regex = build_path_regex(path_template)
-    param_names = extract_param_names(path_template)
-    segment_count = count_segments(path_template)
+    normalized_template = normalize_path_template(path_template)
+    path_regex = build_path_regex(normalized_template)
+    param_names = extract_param_names(normalized_template)
+    segment_count = count_segments(normalized_template)
 
     return URLIndexEntry(
         host_pattern=normalized_host,
         host_regex=host_regex,
-        path_pattern=path_template,
+        path_pattern=normalized_template,
         path_regex=path_regex,
         segment_count=segment_count,
         param_names=param_names,

--- a/src/jentic_one/registry/ingest/stages/url_index.py
+++ b/src/jentic_one/registry/ingest/stages/url_index.py
@@ -65,7 +65,10 @@ class BuildURLIndexStage(BasePipelineStage):
                 full_path = merge_paths(parsed.path, op.path)
                 entry = build_index_entry(parsed.host, full_path, parsed.scheme)
 
-                struct_form = structural_regex(full_path)
+                # Dedup on the entry's canonical template, not the raw merged
+                # path, so `/a/` and `/a` collapse to one structural key —
+                # matching the canonical form the entry itself was built from.
+                struct_form = structural_regex(entry.path_pattern)
                 dedup_key = (op.method.upper(), entry.host_pattern, struct_form)
                 if dedup_key in seen:
                     continue

--- a/tests/integration/registry/ingest/test_ingestor_openapi.py
+++ b/tests/integration/registry/ingest/test_ingestor_openapi.py
@@ -27,6 +27,7 @@ from jentic_one.registry.ingest.pipeline.stage_registry import (
     register_pipeline_stage,
 )
 from jentic_one.registry.ingest.stages.base import BasePipelineStage
+from jentic_one.registry.services.inspect.url_lookup import URLLookupService
 from jentic_one.shared.context import Context
 from jentic_one.shared.db.session import DatabaseSession
 from jentic_one.shared.models import ApiRevisionSourceType
@@ -152,6 +153,89 @@ async def test_ingest_full_pipeline(
 
         url_entries = (await session.execute(select(OperationURLIndex))).unique().scalars().all()
         assert len(url_entries) >= 3
+
+
+async def test_ingest_trailing_slash_spec_produces_resolvable_index(
+    ingest_context: Context,
+    registry_db: DatabaseSession,
+    clean_registry: None,
+) -> None:
+    """A spec with trailing-slash paths ingests into a canonical, resolvable
+    URL index (#1085).
+
+    Django/DRF-style APIs (e.g. the Fantasy Premier League API) template every
+    path with a trailing slash. Pre-fix, the index baked the slash into the
+    regex while the lookup normalized it off the request, so every operation
+    of such an API failed discovery with ``operation_not_found``.
+    """
+    trailing_slash_spec = {
+        "openapi": "3.1.0",
+        "info": {"title": "FPL", "version": "1.0.0"},
+        "servers": [{"url": "https://fantasy.premierleague.com/api"}],
+        "paths": {
+            "/bootstrap-static/": {
+                "get": {
+                    "operationId": "bootstrapStatic",
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+            "/element-summary/{elementId}/": {
+                "get": {
+                    "operationId": "elementSummary",
+                    "parameters": [
+                        {
+                            "name": "elementId",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "integer"},
+                        }
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+        },
+    }
+    spec = IngestSpecification(
+        spec_type=SpecType.OPENAPI,
+        api_identifier=ApiIdentifier(vendor="premierleague", name="fpl", version="1.0.0"),
+        sha="fpl1085",
+        content=trailing_slash_spec,
+        source_type=ApiRevisionSourceType.INLINE,
+        source_url=None,
+        source_filename="openapi.json",
+        submitted_by="test-harness",
+    )
+
+    ingestor = Ingestor(ingest_context)
+    result = await ingestor.ingest(spec, created_by="usr_test")
+    assert result.operation_count == 2
+
+    async with registry_db.session() as session:
+        entries = (await session.execute(select(OperationURLIndex))).unique().scalars().all()
+        # Stored templates and regexes are canonical (no trailing slash).
+        by_template = {e.path_template: e for e in entries}
+        assert set(by_template) == {
+            "/api/bootstrap-static",
+            "/api/element-summary/{elementId}",
+        }
+        assert by_template["/api/bootstrap-static"].path_regex == r"^/api/bootstrap\-static$"
+
+        revision_id = entries[0].revision_id
+        svc = URLLookupService(session)
+        for url in (
+            "https://fantasy.premierleague.com/api/bootstrap-static/",
+            "https://fantasy.premierleague.com/api/bootstrap-static",
+        ):
+            resolved = await svc.resolve(method="GET", url=url, revision_id=revision_id)
+            assert resolved is not None, f"unresolved: {url}"
+
+        resolved = await svc.resolve(
+            method="GET",
+            url="https://fantasy.premierleague.com/api/element-summary/42/",
+            revision_id=revision_id,
+        )
+        assert resolved is not None
+        assert resolved.path_params == {"elementId": "42"}
 
 
 async def test_ingest_warns_when_schemes_declared_but_nothing_resolves(

--- a/tests/integration/registry/repos/test_url_index_migration_repair.py
+++ b/tests/integration/registry/repos/test_url_index_migration_repair.py
@@ -1,0 +1,231 @@
+"""Integration tests for the e6f7a8b9c0d1 URL-index repair migration (#1085).
+
+Seeds ``operation_url_indexes`` rows exactly as the pre-fix ingest code wrote
+them (trailing slash baked into ``path_template`` and ``path_regex``), runs the
+migration's ``repair_url_index`` body against the real database, and asserts
+the rows become canonical — including the unique-constraint collision path and
+idempotency.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from jentic_one.migrations.registry.versions import (
+    e6f7a8b9c0d1_normalize_url_index_path_templates as repair_migration,
+)
+from jentic_one.registry.core.schema.api_revisions import ApiRevision
+from jentic_one.registry.core.schema.apis import Api
+from jentic_one.registry.core.schema.operation_url_index import OperationURLIndex
+from jentic_one.registry.core.url_index import build_host_regex
+from jentic_one.registry.repos.operation_repo import OperationInput, OperationRepository
+from jentic_one.registry.services.inspect.url_lookup import URLLookupService
+from jentic_one.shared.db.session import DatabaseSession
+
+pytestmark = pytest.mark.integration
+
+HOST = "fantasy.premierleague.com"
+HOST_REGEX = build_host_regex(HOST).pattern
+
+
+def _run_repair(sync_session: Session) -> None:
+    repair_migration.repair_url_index(sync_session.connection())
+
+
+async def _seed_stale_row(
+    registry_db: DatabaseSession,
+    rev: ApiRevision,
+    *,
+    path: str,
+    path_template: str,
+    path_regex: str,
+    param_names: list[str],
+    segment_count: int,
+    method: str = "GET",
+) -> str:
+    """Insert a URL-index row exactly as the pre-#1085 ingest code wrote it."""
+    async with registry_db.session() as session:
+        op_ids = await OperationRepository.bulk_create(
+            session, rev.id, [OperationInput(path=path, method=method)], created_by="usr_test"
+        )
+        session.add(
+            OperationURLIndex(
+                operation_id=op_ids[0],
+                revision_id=rev.id,
+                method=method,
+                host=HOST,
+                host_regex=HOST_REGEX,
+                path_template=path_template,
+                path_regex=path_regex,
+                param_names=param_names,
+                segment_count=segment_count,
+                created_by="usr_test",
+            )
+        )
+        await session.commit()
+    return op_ids[0]
+
+
+async def test_repair_normalizes_stale_trailing_slash_row(
+    registry_db: DatabaseSession, sample_revision: tuple[Api, ApiRevision]
+) -> None:
+    """A pre-fix trailing-slash row becomes canonical and resolvable.
+
+    The seeded values are the verbatim broken state from #1085: the stored
+    regex demands a trailing slash the lookup's normalization has removed.
+    """
+    _, rev = sample_revision
+    op_id = await _seed_stale_row(
+        registry_db,
+        rev,
+        path="/api/bootstrap-static/",
+        path_template="/api/bootstrap-static/",
+        path_regex=r"^/api/bootstrap\-static/$",
+        param_names=[],
+        segment_count=2,
+    )
+
+    # Pre-condition: the stale row is unresolvable (the bug).
+    async with registry_db.session() as session:
+        assert (
+            await URLLookupService(session).resolve(
+                method="GET", url=f"https://{HOST}/api/bootstrap-static/", revision_id=rev.id
+            )
+            is None
+        )
+
+    async with registry_db.session() as session:
+        await session.run_sync(_run_repair)
+        await session.commit()
+
+    async with registry_db.session() as session:
+        row = (await session.execute(select(OperationURLIndex))).scalar_one()
+        assert row.path_template == "/api/bootstrap-static"
+        assert row.path_regex == r"^/api/bootstrap\-static$"
+        assert row.segment_count == 2
+
+        for request_path in ("/api/bootstrap-static/", "/api/bootstrap-static"):
+            result = await URLLookupService(session).resolve(
+                method="GET", url=f"https://{HOST}{request_path}", revision_id=rev.id
+            )
+            assert result is not None
+            assert result.operation_id == op_id
+
+
+async def test_repair_normalizes_stale_parameterized_row(
+    registry_db: DatabaseSession, sample_revision: tuple[Api, ApiRevision]
+) -> None:
+    """Parameter tokens survive the repair; path params still extract."""
+    _, rev = sample_revision
+    op_id = await _seed_stale_row(
+        registry_db,
+        rev,
+        path="/element-summary/{elementId}/",
+        path_template="/api/element-summary/{elementId}/",
+        path_regex=r"^/api/element\-summary/(?P<elementId>[^/]+)/$",
+        param_names=["elementId"],
+        segment_count=3,
+    )
+
+    async with registry_db.session() as session:
+        await session.run_sync(_run_repair)
+        await session.commit()
+
+    async with registry_db.session() as session:
+        row = (await session.execute(select(OperationURLIndex))).scalar_one()
+        assert row.path_template == "/api/element-summary/{elementId}"
+        assert row.param_names == ["elementId"]
+
+        result = await URLLookupService(session).resolve(
+            method="GET", url=f"https://{HOST}/api/element-summary/42/", revision_id=rev.id
+        )
+        assert result is not None
+        assert result.operation_id == op_id
+        assert result.path_params == {"elementId": "42"}
+
+
+async def test_repair_is_idempotent_and_skips_canonical_rows(
+    registry_db: DatabaseSession, sample_revision: tuple[Api, ApiRevision]
+) -> None:
+    """Running the repair twice converges; already-canonical rows are untouched."""
+    _, rev = sample_revision
+    await _seed_stale_row(
+        registry_db,
+        rev,
+        path="/api/bootstrap-static/",
+        path_template="/api/bootstrap-static/",
+        path_regex=r"^/api/bootstrap\-static/$",
+        param_names=[],
+        segment_count=2,
+    )
+    await _seed_stale_row(
+        registry_db,
+        rev,
+        path="/api/fixtures",
+        path_template="/api/fixtures",
+        path_regex=r"^/api/fixtures$",
+        param_names=[],
+        segment_count=2,
+        method="POST",
+    )
+
+    async def _snapshot() -> list[tuple[str, str, str, int]]:
+        async with registry_db.session() as session:
+            rows = (await session.execute(select(OperationURLIndex))).scalars().all()
+            return sorted((r.method, r.path_template, r.path_regex, r.segment_count) for r in rows)
+
+    async with registry_db.session() as session:
+        await session.run_sync(_run_repair)
+        await session.commit()
+    first = await _snapshot()
+
+    async with registry_db.session() as session:
+        await session.run_sync(_run_repair)
+        await session.commit()
+    second = await _snapshot()
+
+    assert first == second
+    assert ("POST", "/api/fixtures", r"^/api/fixtures$", 2) in first
+    assert ("GET", "/api/bootstrap-static", r"^/api/bootstrap\-static$", 2) in first
+
+
+async def test_repair_deletes_stale_row_on_canonical_collision(
+    registry_db: DatabaseSession, sample_revision: tuple[Api, ApiRevision]
+) -> None:
+    """When a canonical row already occupies the target unique key, the stale
+    row is deleted rather than violating the constraint.
+
+    The unique key is global — ``(method, host, host_regex, path_template)``
+    without revision — so a slash-less row (e.g. written after a manual
+    re-import workaround) can already own the key a stale row normalizes onto.
+    """
+    _, rev = sample_revision
+    await _seed_stale_row(
+        registry_db,
+        rev,
+        path="/api/bootstrap-static/",
+        path_template="/api/bootstrap-static/",
+        path_regex=r"^/api/bootstrap\-static/$",
+        param_names=[],
+        segment_count=2,
+    )
+    canonical_op_id = await _seed_stale_row(
+        registry_db,
+        rev,
+        path="/api/bootstrap-static",
+        path_template="/api/bootstrap-static",
+        path_regex=r"^/api/bootstrap\-static$",
+        param_names=[],
+        segment_count=2,
+    )
+
+    async with registry_db.session() as session:
+        await session.run_sync(_run_repair)
+        await session.commit()
+
+    async with registry_db.session() as session:
+        row = (await session.execute(select(OperationURLIndex))).scalar_one()
+        assert row.operation_id == canonical_op_id
+        assert row.path_template == "/api/bootstrap-static"

--- a/tests/integration/registry/services/test_registry_service.py
+++ b/tests/integration/registry/services/test_registry_service.py
@@ -17,7 +17,7 @@ from jentic_one.registry.core.schema.api_revisions import ApiRevision
 from jentic_one.registry.core.schema.apis import Api
 from jentic_one.registry.core.schema.operation_url_index import OperationURLIndex
 from jentic_one.registry.core.schema.operations import Operation
-from jentic_one.registry.core.url_index import build_index_entry
+from jentic_one.registry.core.url_index import build_index_entry, merge_paths
 from jentic_one.registry.repos.operation_repo import OperationInput, OperationRepository
 from jentic_one.registry.repos.url_index_repo import UrlIndexRepository
 from jentic_one.registry.services.errors import AmbiguousMatchError
@@ -218,3 +218,99 @@ async def test_resolve_operation_ambiguous_match_raises(
         svc = RegistryService(session)
         with pytest.raises(AmbiguousMatchError):
             await svc.resolve_operation(method="GET", url="https://api.acme.com/v1/thing")
+
+
+@pytest.mark.parametrize("path_template", ["/api/bootstrap-static", "/api/bootstrap-static/"])
+@pytest.mark.parametrize("request_path", ["/api/bootstrap-static", "/api/bootstrap-static/"])
+async def test_resolve_operation_trailing_slash_combinations(
+    registry_db: DatabaseSession,
+    clean_url_index: None,
+    path_template: str,
+    request_path: str,
+) -> None:
+    """All four spec/request trailing-slash combinations resolve (#1085).
+
+    Before the fix, a template ending in ``/`` baked the slash into the stored
+    regex while the lookup normalized it off the request path, so operations
+    of trailing-slash APIs (Django/DRF style, e.g. the Fantasy Premier League
+    API) always failed discovery with ``operation_not_found``.
+    """
+    op_id = await _seed_operation(
+        registry_db,
+        vendor="premierleague.com",
+        name="fpl",
+        version="v1",
+        host="fantasy.premierleague.com",
+        path_template=path_template,
+    )
+
+    async with registry_db.session() as session:
+        svc = RegistryService(session)
+        result = await svc.resolve_operation(
+            method="GET", url=f"https://fantasy.premierleague.com{request_path}"
+        )
+
+    assert result is not None
+    assert result.operation_id == op_id
+
+
+@pytest.mark.parametrize("path_template", ["/v1/pets/{petId}", "/v1/pets/{petId}/"])
+@pytest.mark.parametrize("request_path", ["/v1/pets/123", "/v1/pets/123/"])
+async def test_resolve_operation_parameterized_trailing_slash_combinations(
+    registry_db: DatabaseSession,
+    clean_url_index: None,
+    path_template: str,
+    request_path: str,
+) -> None:
+    """Parameterized templates resolve across all trailing-slash combinations,
+    with path params extracted intact."""
+    op_id = await _seed_operation(
+        registry_db,
+        vendor="acme.com",
+        name="pets-api",
+        version="v1",
+        host="api.acme.com",
+        path_template=path_template,
+    )
+
+    async with registry_db.session() as session:
+        svc = RegistryService(session)
+        result = await svc.resolve_operation(
+            method="GET", url=f"https://api.acme.com{request_path}"
+        )
+
+    assert result is not None
+    assert result.operation_id == op_id
+    assert result.path_params == {"petId": "123"}
+
+
+async def test_advertised_url_round_trip_for_trailing_slash_spec(
+    registry_db: DatabaseSession, clean_url_index: None
+) -> None:
+    """The URL that search/inspect advertise for a trailing-slash spec resolves.
+
+    ``search``/``inspect`` build the advertised URL from the *raw* spec path
+    via ``merge_paths`` (trailing slash preserved, so upstreams that 301 the
+    slash-less form keep working), while the URL index matches on the
+    canonical form. This pins the advertise → execute round trip both halves
+    rely on.
+    """
+    template = "/api/bootstrap-static/"
+    op_id = await _seed_operation(
+        registry_db,
+        vendor="premierleague.com",
+        name="fpl",
+        version="v1",
+        host="fantasy.premierleague.com",
+        path_template=template,
+    )
+
+    advertised = merge_paths("https://fantasy.premierleague.com", template)
+    assert advertised == "https://fantasy.premierleague.com/api/bootstrap-static/"
+
+    async with registry_db.session() as session:
+        svc = RegistryService(session)
+        result = await svc.resolve_operation(method="GET", url=advertised)
+
+    assert result is not None
+    assert result.operation_id == op_id

--- a/tests/unit/registry/ingest/test_url_index.py
+++ b/tests/unit/registry/ingest/test_url_index.py
@@ -2,6 +2,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from jentic_one.registry.core.url_index import (
     build_index_entry,
     build_path_regex,
@@ -10,6 +12,7 @@ from jentic_one.registry.core.url_index import (
     extract_param_names,
     normalise_host,
     normalize_path,
+    normalize_path_template,
     structural_regex,
 )
 
@@ -103,6 +106,91 @@ def test_normalize_path_trailing_slash_stripped() -> None:
 
 def test_normalize_path_root_preserved() -> None:
     assert normalize_path("/") == "/"
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        # Trailing slash stripped, matching normalize_path on the request side (#1085).
+        ("/api/bootstrap-static/", "/api/bootstrap-static"),
+        ("/api/v1/", "/api/v1"),
+        # Slashes adjacent to parameter tokens are preserved.
+        ("/pets/{petId}", "/pets/{petId}"),
+        ("/users/{id}/", "/users/{id}"),
+        ("/users/{id}/posts/{postId}/", "/users/{id}/posts/{postId}"),
+        # RFC 6570 operator tokens survive verbatim.
+        ("/files/{+path}", "/files/{+path}"),
+        ("/files/{+path}/", "/files/{+path}"),
+        # Root is preserved, never emptied.
+        ("/", "/"),
+        # Literal normalization (percent-encoding, dot segments) still applies.
+        ("/foo%20bar/{id}", "/foo bar/{id}"),
+        ("/a/b/../c/{id}/", "/a/c/{id}"),
+        # Already-canonical templates pass through unchanged.
+        ("/v1/pets", "/v1/pets"),
+    ],
+)
+def test_normalize_path_template(template: str, expected: str) -> None:
+    assert normalize_path_template(template) == expected
+
+
+@pytest.mark.parametrize("template", ["/api/thing", "/api/thing/"])
+@pytest.mark.parametrize("request_path", ["/api/thing", "/api/thing/"])
+def test_index_entry_matches_all_trailing_slash_combinations(
+    template: str, request_path: str
+) -> None:
+    """The 4-quadrant matrix from #1085: template and request, each with and
+    without a trailing slash, must all resolve to a match."""
+    entry = build_index_entry("api.example.com", template, "https")
+    assert entry.path_regex.fullmatch(normalize_path(request_path))
+
+
+@pytest.mark.parametrize("template", ["/v1/pets/{petId}", "/v1/pets/{petId}/"])
+@pytest.mark.parametrize("request_path", ["/v1/pets/123", "/v1/pets/123/"])
+def test_index_entry_matches_parameterized_trailing_slash_combinations(
+    template: str, request_path: str
+) -> None:
+    entry = build_index_entry("api.example.com", template, "https")
+    match = entry.path_regex.fullmatch(normalize_path(request_path))
+    assert match
+    assert match.groupdict() == {"petId": "123"}
+
+
+def test_build_index_entry_trailing_slash_template_regression() -> None:
+    """The exact #1085 repro: a Fantasy Premier League trailing-slash path.
+
+    Before the fix the stored regex kept the trailing slash while the request
+    path lost it at lookup time, so the two could never agree.
+    """
+    entry = build_index_entry("fantasy.premierleague.com", "/api/bootstrap-static/", "https")
+    assert entry.path_pattern == "/api/bootstrap-static"
+    assert entry.path_regex.pattern == r"^/api/bootstrap\-static$"
+    assert entry.path_regex.fullmatch(normalize_path("/api/bootstrap-static/"))
+    assert entry.segment_count == count_segments(normalize_path("/api/bootstrap-static/"))
+
+
+def test_build_index_entry_stores_canonical_template() -> None:
+    """Every derived field comes from the canonical template, keeping the
+    stored pattern, regex, params, and segment count internally consistent."""
+    entry = build_index_entry("api.example.com", "/users/{id}/", "https")
+    assert entry.path_pattern == "/users/{id}"
+    assert entry.param_names == ["id"]
+    assert entry.segment_count == 2
+
+
+def test_build_index_entry_root_path() -> None:
+    entry = build_index_entry("api.example.com", "/", "https")
+    assert entry.path_pattern == "/"
+    assert entry.segment_count == 0
+    assert entry.path_regex.fullmatch(normalize_path("/"))
+
+
+def test_structural_regex_agrees_for_trailing_slash_variants() -> None:
+    """Dedup in BuildURLIndexStage keys on the canonical template, so `/a/`
+    and `/a` must collapse to one structural form."""
+    assert structural_regex(normalize_path_template("/v1/pets/{id}/")) == structural_regex(
+        normalize_path_template("/v1/pets/{id}")
+    )
 
 
 def test_expand_server_variables_none_default_preserves_placeholder() -> None:

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -8,12 +8,16 @@ from pathlib import Path
 import pytest
 from sqlalchemy import MetaData
 
+from jentic_one.migrations.registry.versions import (
+    e6f7a8b9c0d1_normalize_url_index_path_templates as url_index_repair_migration,
+)
 from jentic_one.migrations.targets import (
     DB_METADATA,
     DB_TARGETS,
     MigrationTarget,
     register_target,
 )
+from jentic_one.registry.core import url_index as live_url_index
 from jentic_one.shared.db.base import AdminBase, ControlBase, RegistryBase
 
 
@@ -166,3 +170,42 @@ def test_admin_migration_seeds_no_credentials() -> None:
         # than the broad "values(" substring, which false-positives on benign
         # server_default / comment text.
         assert "insert into" not in lowered, f"{name} inserts seed rows; first run must stay empty"
+
+
+# Canary corpus for the URL-index repair migration: representative templates
+# covering trailing slashes, parameters, RFC 6570 operators, percent-encoding,
+# dot segments, and the root path.
+_URL_INDEX_CANARY_TEMPLATES = [
+    "/api/bootstrap-static/",
+    "/api/v1/",
+    "/v1/pets",
+    "/pets/{petId}",
+    "/users/{id}/",
+    "/users/{id}/posts/{postId}/",
+    "/files/{+path}",
+    "/files/{+path}/",
+    "/v1beta/{+property}:runReport",
+    "/foo%20bar/{id}",
+    "/a/b/../c/{id}/",
+    "/",
+]
+
+
+@pytest.mark.parametrize("template", _URL_INDEX_CANARY_TEMPLATES)
+def test_url_index_repair_migration_matches_live_normalization(template: str) -> None:
+    """The e6f7a8b9c0d1 data migration's frozen helpers must agree with the
+    live ``registry.core.url_index`` functions.
+
+    The migration deliberately inlines frozen copies instead of importing the
+    live module, so a later refactor can't silently rewrite what the
+    historical migration did. If this test fails, normalization semantics
+    changed: do NOT edit the frozen copies — write a NEW data migration that
+    re-canonicalizes existing ``operation_url_indexes`` rows.
+    """
+    mig = url_index_repair_migration
+    live = live_url_index
+
+    canonical = live.normalize_path_template(template)
+    assert mig._normalize_path_template(template) == canonical
+    assert mig._build_path_regex_pattern(canonical) == live.build_path_regex(canonical).pattern
+    assert mig._count_segments(canonical) == live.count_segments(canonical)


### PR DESCRIPTION
## Summary

Any API whose paths end in a trailing slash (the Django/DRF default — e.g. the Fantasy Premier League API) is completely unreachable through the broker: `build_index_entry` bakes the trailing slash into the stored `path_regex`, while `URLLookupService.resolve` strips it off the incoming request path, so the two sides can never agree and every execution dies with a misleading `operation_not_found`. This PR canonicalizes the template once at the ingest boundary so index and lookup share one canonical form, and ships a data migration that repairs already-ingested index rows in place.

## Changes

- **`registry/core/url_index.py`** — fixed `normalize_path_template` (previously unused *and* broken: it ate the slash before a `{param}` token); `build_index_entry` now canonicalizes the template first and derives **all** fields (`path_regex`, `param_names`, `segment_count`, stored `path_pattern`) from that canonical form. All four spec/request trailing-slash combinations now match.
- **`registry/ingest/stages/url_index.py`** — the structural dedup key is computed from the entry's canonical template, so `/a/` and `/a` collapse to one key.
- **`migrations/registry/versions/e6f7a8b9c0d1_…`** — data migration recomputing `path_template` / `path_regex` / `segment_count` for existing rows. Uses **frozen copies** of the normalization helpers (never imports the live module, so later refactors can't rewrite history); idempotent; on a unique-key collision with an already-canonical row it deletes the stale row. Downgrade is a documented no-op (lossy repair; canonical rows remain valid under pre-fix code).
- **Deliberately out of scope:** the broker still forwards the client's raw URL verbatim (no path rewriting — silent URL mutation is wrong for a credential-injecting proxy), `follow_redirects=False` stays (redirects could leak injected credentials), and advertised URLs from `search`/`inspect` still carry the spec's raw trailing-slash form so upstreams that 301 the slash-less form keep working. #701 (slashes in path *parameter values*) is a distinct bug and untouched.

## Risk & rollback

- **Migration** (`registry` DB, data-only): idempotent, no schema change; stale-row deletion only fires when a canonical duplicate already owns the unique key, and a re-ingest of that revision rebuilds its index anyway. Rollback: revert the squash commit — already-normalized rows stay fully resolvable under pre-fix code (the old lookup normalizes requests the same way).
- A canary test pins the migration's frozen helpers against the live functions: if normalization semantics ever change, it fails with instructions to write a *new* data migration rather than edit history.

## Test plan

- `make test-fast` — 2828 passed (unit + arch), including new unit tests: `normalize_path_template` contract, the 4-quadrant template×request trailing-slash matrix (plain + parameterized), the verbatim #1085 FPL repro, and the migration canary.
- `make test-integration` (Postgres) — 930 passed; `make test-integration-sqlite` — 620 passed. New integration coverage:
  - spec → ingest → resolve end-to-end for a trailing-slash OpenAPI spec (canonical index rows, both slash forms resolve, path params extract);
  - `RegistryService.resolve_operation` across all four slash combinations + the advertise→execute round trip (`merge_paths` URL still ends in `/` and resolves);
  - migration repair against the real DB: seeded pre-fix rows become canonical and resolvable, idempotency, and the collision-deletes-stale-row path.
- `make lint` (ruff + mypy), `make detect-secrets`, `make test-arch` — clean. `make score` fails identically on pristine `main` (unpublished npm package `@jentic/api-scorecard-cli`) — environmental, unrelated.

## Review guide

- Start with `build_index_entry` + `normalize_path_template` in `registry/core/url_index.py` — the whole fix is "canonicalize once, derive everything"; the rest is consequences.
- Then the migration's module docstring: it states the frozen-copy rationale, the collision rule, and why downgrade is a no-op.

Closes #1085

Made with [Cursor](https://cursor.com)