### PR TITLE
ci(release-please.yml): regenerate the CLI vendored spec on release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -66,9 +66,10 @@ jobs:
 
       # When release-please opens/updates its "chore(main): release X.Y.Z" PR,
       # the version bump can invalidate generated artifacts (the control-plane
-      # OpenAPI spec + the UI client derived from it). Regenerate them on the PR
-      # branch and push back so the Release PR is self-consistent and does not
-      # trip the openapi-client-drift / conformance gates when merged.
+      # OpenAPI spec + the UI client and Go CLI client derived from it).
+      # Regenerate them on the PR branch and push back so the Release PR is
+      # self-consistent and does not trip the openapi-client-drift /
+      # check-cli-gen / conformance gates when merged.
       - name: Set up toolchain
         if: ${{ steps.release.outputs.pr }}
         uses: astral-sh/setup-uv@v7
@@ -86,6 +87,15 @@ jobs:
           node-version: "22"
           cache: npm
           cache-dependency-path: ui/package-lock.json
+
+      # Needed for `make -C cli generate-api` below (oapi-codegen + specgen run
+      # via `go run`). Mirrors the cli job in ci.yml.
+      - name: Set up Go
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
 
       - name: Regenerate OpenAPI specs
         if: ${{ steps.release.outputs.pr }}
@@ -114,6 +124,12 @@ jobs:
           cd ui && npm ci && npm run codegen
           cd ..
 
+          # Refresh the Go CLI's vendored spec copies + generated clients from
+          # the bumped specs, or the check-cli-gen / check-vendored-specs drift
+          # gates fail on the Release PR (the spec's info.version is bumped
+          # above but the vendored client/generated/*/spec.yaml copies are not).
+          make -C cli generate-api
+
           # Attribute the commit to the release-please App's bot user (the token
           # actually pushing this), matching GitHub's <slug>[bot] convention:
           #   name  = <slug>[bot]
@@ -122,7 +138,7 @@ jobs:
           BOT_USER_ID="$(gh api "/users/${BOT_NAME}" --jq .id)"
           git config user.name "$BOT_NAME"
           git config user.email "${BOT_USER_ID}+${BOT_NAME}@users.noreply.github.com"
-          git add openapi/ ui/
+          git add openapi/ ui/ cli/client/generated/
 
           if ! git diff --staged --quiet; then
             git commit -m "chore(release-please): regenerate openapi specs for version bump"


### PR DESCRIPTION
## Summary

Release PR #1095 fails the `Go CLI lint & test` job: release-please bumps `info.version` in `openapi/control/control.openapi.yaml`, but the release-please workflow's regenerate step only refreshes the backend spec and the UI client — not the Go CLI's vendored spec copies under `cli/client/generated/` introduced by the CLI V2 rebuild (#1094). The `check-cli-gen` drift gate then sees `cli/client/generated/control/spec.yaml` differ from the bumped source spec and fails. Every future Release PR hits this until the workflow regenerates the CLI side too.

## Changes

- `.github/workflows/release-please.yml`: run `make -C cli generate-api` in the "Regenerate OpenAPI specs" step (after the backend + UI regeneration) and include `cli/client/generated/` in the `git add`, so the Release PR carries consistent vendored specs and generated clients.
- Add a `Set up Go` step (`go-version-file: cli/go.mod`, mirroring the `cli` job in `ci.yml`) — `generate-api` runs oapi-codegen and specgen via `go run`.
- Out of scope: unblocking the current release PR #1095 — once this merges to main, the release-please workflow re-runs and pushes the regenerated artifacts onto the existing Release PR branch automatically.

## Risk & rollback

- Low risk: touches only the release-please workflow's regenerate step; no product code. If the Go step misbehaves, revert the squash commit — release PRs are then back to failing `check-cli-gen`, no worse than today.

## Test plan

- `make -C cli generate-api` run locally on a fresh `main` checkout (with `GOWORK=off`, matching CI which has no `go.work`): completes cleanly and `git status --porcelain` shows no drift — i.e. the exact command CI will run is a no-op when specs are already consistent, and regenerates the vendored copies when they are not.
- Workflow YAML validated with a parser.
- End-to-end verification happens on merge: the release-please run on main should push a "regenerate openapi specs" commit to the standing Release PR that updates `cli/client/generated/control/spec.yaml` to 0.32.0, turning its `Go CLI lint & test` job green.

Made with [Cursor](https://cursor.com)