### PR TITLE
feat(skills): add task skills command and embedded onboarding guides

### DIFF
--- a/cli/internal/cli/api/root.go
+++ b/cli/internal/cli/api/root.go
@@ -93,6 +93,7 @@ func newAPIRootCmd(core *cmdcore.App) *cobra.Command {
 	// (generate its skills, launch it under isolation, tear its account down),
 	// distinct from the catalog find/run operations above.
 	cmdcore.AddGrouped(root, "client", localagentcmd.NewSkillCmd(app.App))
+	cmdcore.AddGrouped(root, "client", localagentcmd.NewSkillsCmd(app.App))
 	cmdcore.AddGrouped(root, "client", fenced(localagentcmd.NewRunCmd(app.App)))
 	cmdcore.AddGrouped(root, "client", fenced(newResetCmd(app)))
 	// Agent-side read-only self-check (F8-4, impl/5.1 §3c). Not fenced: it never

--- a/cli/internal/cli/localagentcmd/skill.go
+++ b/cli/internal/cli/localagentcmd/skill.go
@@ -573,11 +573,12 @@ func (a *Cmd) writeSkill(targets []skillTarget, env skillgen.DetectEnv, opts *sk
 	if terr == nil && len(taskSkills) > 0 {
 		for _, t := range targets {
 			n, werr := a.writeTaskSkills(t.adapter, env, t.scope, taskSkills, opts.dryRun)
-			if werr != nil {
+			switch {
+			case werr != nil:
 				fmt.Fprintln(a.Out, "  "+theme.Warnf("%s task skills: %v", t.adapter.Operator(), werr))
-			} else if opts.dryRun {
+			case opts.dryRun:
 				fmt.Fprintln(a.Out, "  "+theme.Infof("%-8s would install %d task skill(s)", t.adapter.Operator(), n))
-			} else {
+			default:
 				fmt.Fprintln(a.Out, "  "+theme.Successf("%-8s installed %d task skill(s)", t.adapter.Operator(), n))
 			}
 		}

--- a/cli/internal/cli/localagentcmd/skill.go
+++ b/cli/internal/cli/localagentcmd/skill.go
@@ -568,6 +568,21 @@ func (a *Cmd) writeSkill(targets []skillTarget, env skillgen.DetectEnv, opts *sk
 		}
 	}
 
+	// Install task skills alongside the main skill.
+	taskSkills, terr := skillgen.TaskSkills("jentic")
+	if terr == nil && len(taskSkills) > 0 {
+		for _, t := range targets {
+			n, werr := a.writeTaskSkills(t.adapter, env, t.scope, taskSkills, opts.dryRun)
+			if werr != nil {
+				fmt.Fprintln(a.Out, "  "+theme.Warnf("%s task skills: %v", t.adapter.Operator(), werr))
+			} else if opts.dryRun {
+				fmt.Fprintln(a.Out, "  "+theme.Infof("%-8s would install %d task skill(s)", t.adapter.Operator(), n))
+			} else {
+				fmt.Fprintln(a.Out, "  "+theme.Successf("%-8s installed %d task skill(s)", t.adapter.Operator(), n))
+			}
+		}
+	}
+
 	if opts.dryRun {
 		fmt.Fprintln(a.Out, theme.Dim.Render("Dry run — nothing was written."))
 		return nil
@@ -762,6 +777,30 @@ func (a *Cmd) skillRemove(_ *cobra.Command, opts *skillOptions) error {
 			}
 		}
 	}
+	// Remove task skills directory for each adapter.
+	for _, ad := range adapters {
+		s := scope
+		if s == "" {
+			s = ad.DefaultScope()
+		}
+		dir := taskSkillsDir(ad, env, s)
+		if dir == "" {
+			continue
+		}
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			continue
+		}
+		if opts.dryRun {
+			fmt.Fprintln(a.Out, "  "+theme.Infof("%-8s would remove task skills from %s", ad.Operator(), prettyPath(dir)))
+		} else {
+			if err := os.RemoveAll(dir); err != nil {
+				fmt.Fprintln(a.Out, "  "+theme.Warnf("%s: failed to remove task skills: %v", ad.Operator(), err))
+			} else {
+				fmt.Fprintln(a.Out, "  "+theme.Successf("%-8s removed task skills from %s", ad.Operator(), prettyPath(dir)))
+			}
+		}
+	}
+
 	if opts.dryRun {
 		fmt.Fprintln(a.Out, theme.Dim.Render("Dry run — nothing was removed."))
 	}

--- a/cli/internal/cli/localagentcmd/skills.go
+++ b/cli/internal/cli/localagentcmd/skills.go
@@ -192,12 +192,12 @@ func (a *Cmd) writeTaskSkillsDir(ad skillgen.Adapter, env skillgen.DetectEnv, sc
 		return len(skills), nil
 	}
 
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return 0, err
 	}
 	for _, ts := range skills {
 		target := filepath.Join(dir, ts.TaskID+".md")
-		if err := os.WriteFile(target, []byte(ts.Raw), 0o644); err != nil {
+		if err := os.WriteFile(target, []byte(ts.Raw), 0o644); err != nil { //nolint:gosec // skill files are meant to be read by other tools.
 			return 0, err
 		}
 	}
@@ -216,11 +216,11 @@ func (a *Cmd) writeTaskSkillsHermes(env skillgen.DetectEnv, scope skillgen.Scope
 
 	for _, ts := range skills {
 		dir := filepath.Join(base, ".hermes", "skills", "jentic-tasks", ts.TaskID)
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
 			return 0, err
 		}
 		target := filepath.Join(dir, "SKILL.md")
-		if err := os.WriteFile(target, []byte(ts.Raw), 0o644); err != nil {
+		if err := os.WriteFile(target, []byte(ts.Raw), 0o644); err != nil { //nolint:gosec // skill files are meant to be read by other tools.
 			return 0, err
 		}
 	}
@@ -241,12 +241,12 @@ func (a *Cmd) writeTaskSkillsAgents(ad skillgen.Adapter, env skillgen.DetectEnv,
 	}
 
 	dir := filepath.Dir(target)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return 0, err
 	}
 
 	var existing []byte
-	if data, err := os.ReadFile(target); err == nil {
+	if data, err := os.ReadFile(target); err == nil { //nolint:gosec // target is derived from adapter rules + env, not arbitrary input.
 		existing = data
 	}
 
@@ -259,7 +259,7 @@ func (a *Cmd) writeTaskSkillsAgents(ad skillgen.Adapter, env skillgen.DetectEnv,
 		out = strings.TrimRight(cleaned, "\n") + "\n\n" + content
 	}
 
-	if err := os.WriteFile(target, []byte(out), 0o644); err != nil {
+	if err := os.WriteFile(target, []byte(out), 0o644); err != nil { //nolint:gosec // skill files are meant to be read by other tools.
 		return 0, err
 	}
 	return len(skills), nil

--- a/cli/internal/cli/localagentcmd/skills.go
+++ b/cli/internal/cli/localagentcmd/skills.go
@@ -1,0 +1,298 @@
+package localagentcmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jentic/jentic-one/cli/internal/cli/cmdcore"
+	"github.com/jentic/jentic-one/cli/internal/skillgen"
+	"github.com/jentic/jentic-one/cli/internal/theme"
+	"github.com/spf13/cobra"
+)
+
+// NewSkillsCmd builds the `skills` command (list/show/init task skills).
+func NewSkillsCmd(app *cmdcore.App) *cobra.Command {
+	a := &Cmd{App: app}
+	opts := &skillOptions{}
+	cmd := &cobra.Command{
+		Use:   "skills [name]",
+		Short: "List or display embedded task skills",
+		Long: "skills lists all embedded task skills (step-by-step guides for common\n" +
+			"Jentic platform operations). Pass a skill name to print its full content.\n" +
+			"Use \"skills init\" to install them into your agent's native layout.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return a.skillsList(cmd, opts)
+			}
+			return a.skillsShow(args[0])
+		},
+	}
+	cmd.Flags().BoolVar(&opts.json, "json", false, "output as JSON array")
+
+	cmd.AddCommand(newSkillsInitCmd(a))
+	return cmd
+}
+
+func newSkillsInitCmd(a *Cmd) *cobra.Command {
+	opts := &skillOptions{}
+	cmd := &cobra.Command{
+		Use:   "init [name]",
+		Short: "Install task skills into your agent's native layout",
+		Long: "init writes task-skill markdown files into each detected agent runtime's\n" +
+			"native layout. Pass a skill name to install only that one.",
+		Example: "  jentic skills init\n" +
+			"  jentic skills init register-agent\n" +
+			"  jentic skills init --operator claude,cursor\n" +
+			"  jentic skills init --all --yes\n" +
+			"  jentic skills init --dry-run",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var nameFilter string
+			if len(args) > 0 {
+				nameFilter = args[0]
+			}
+			return a.skillsInit(cmd, opts, nameFilter)
+		},
+	}
+	cmd.Flags().StringSliceVar(&opts.operators, "operator", nil, "operators to target (repeatable or comma-separated)")
+	cmd.Flags().StringVar(&opts.scope, "scope", "", "placement scope: user or project (default: per-operator)")
+	cmd.Flags().BoolVar(&opts.yes, "yes", false, "skip the interactive picker (use --operator/--all)")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "print target paths without writing")
+	cmd.Flags().BoolVar(&opts.all, "all", false, "target every supported operator")
+	return cmd
+}
+
+func (a *Cmd) skillsList(cmd *cobra.Command, opts *skillOptions) error {
+	skills, err := skillgen.TaskSkills("jentic")
+	if err != nil {
+		return err
+	}
+
+	if cmdcore.JSONOrPretty(cmd, opts.json) {
+		type row struct {
+			Name        string `json:"name"`
+			Version     string `json:"version"`
+			Description string `json:"description"`
+		}
+		rows := make([]row, 0, len(skills))
+		for _, ts := range skills {
+			rows = append(rows, row{
+				Name:        ts.Name,
+				Version:     ts.Version,
+				Description: ts.Description,
+			})
+		}
+		return cmdcore.WriteJSON(a.Out, rows)
+	}
+
+	fmt.Fprintln(a.Out, theme.Heading.Render("Task skills"))
+	for _, ts := range skills {
+		ver := ts.Version
+		if ver == "" {
+			ver = "-"
+		}
+		fmt.Fprintf(a.Out, "  %-24s %-6s %s\n", ts.Name, ver, ts.Description)
+	}
+	return nil
+}
+
+func (a *Cmd) skillsShow(name string) error {
+	ts, err := skillgen.TaskSkillByID("jentic", name)
+	if err != nil {
+		return err
+	}
+	fmt.Fprint(a.Out, ts.Raw)
+	return nil
+}
+
+func (a *Cmd) skillsInit(_ *cobra.Command, opts *skillOptions, nameFilter string) error {
+	reg := skillgen.DefaultRegistry()
+	env, err := a.detectEnv()
+	if err != nil {
+		return err
+	}
+
+	targets, err := a.chooseTargets(reg, env, opts)
+	if err != nil {
+		return err
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+
+	skills, err := skillgen.TaskSkills("jentic")
+	if err != nil {
+		return err
+	}
+	if nameFilter != "" {
+		var filtered []skillgen.TaskSkill
+		for _, ts := range skills {
+			if ts.TaskID == nameFilter {
+				filtered = append(filtered, ts)
+				break
+			}
+		}
+		if len(filtered) == 0 {
+			return fmt.Errorf("task skill %q not found", nameFilter)
+		}
+		skills = filtered
+	}
+
+	fmt.Fprintln(a.Out, theme.Heading.Render("Task skills"))
+
+	for _, t := range targets {
+		wrote, aerr := a.writeTaskSkills(t.adapter, env, t.scope, skills, opts.dryRun)
+		if aerr != nil {
+			fmt.Fprintln(a.Out, "  "+theme.Warnf("%s: %v", t.adapter.Operator(), aerr))
+			continue
+		}
+		if opts.dryRun {
+			fmt.Fprintln(a.Out, "  "+theme.Infof("%-8s would write %d skill(s)", t.adapter.Operator(), wrote))
+		} else {
+			fmt.Fprintln(a.Out, "  "+theme.Successf("%-8s wrote %d skill(s)", t.adapter.Operator(), wrote))
+		}
+	}
+
+	if opts.dryRun {
+		fmt.Fprintln(a.Out, theme.Dim.Render("Dry run — nothing was written."))
+	}
+	return nil
+}
+
+func (a *Cmd) writeTaskSkills(ad skillgen.Adapter, env skillgen.DetectEnv, scope skillgen.Scope, skills []skillgen.TaskSkill, dryRun bool) (int, error) {
+	switch ad.Operator() {
+	case skillgen.OpClaude, skillgen.OpCursor:
+		return a.writeTaskSkillsDir(ad, env, scope, skills, dryRun)
+	case skillgen.OpHermes:
+		return a.writeTaskSkillsHermes(env, scope, skills, dryRun)
+	case skillgen.OpCodex, skillgen.OpGeneric:
+		return a.writeTaskSkillsAgents(ad, env, scope, skills, dryRun)
+	default:
+		return 0, fmt.Errorf("unsupported operator %s for task skills", ad.Operator())
+	}
+}
+
+func (a *Cmd) writeTaskSkillsDir(ad skillgen.Adapter, env skillgen.DetectEnv, scope skillgen.Scope, skills []skillgen.TaskSkill, dryRun bool) (int, error) {
+	base := env.Home
+	if scope == skillgen.ScopeProject {
+		base = env.Cwd
+	}
+	var dir string
+	switch ad.Operator() {
+	case skillgen.OpClaude:
+		dir = filepath.Join(base, ".claude", "skills", "jentic-tasks")
+	case skillgen.OpCursor:
+		dir = filepath.Join(base, ".cursor", "skills", "jentic-tasks")
+	}
+
+	if dryRun {
+		return len(skills), nil
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return 0, err
+	}
+	for _, ts := range skills {
+		target := filepath.Join(dir, ts.TaskID+".md")
+		if err := os.WriteFile(target, []byte(ts.Raw), 0o644); err != nil {
+			return 0, err
+		}
+	}
+	return len(skills), nil
+}
+
+func (a *Cmd) writeTaskSkillsHermes(env skillgen.DetectEnv, scope skillgen.Scope, skills []skillgen.TaskSkill, dryRun bool) (int, error) {
+	base := env.Home
+	if scope == skillgen.ScopeProject {
+		base = env.Cwd
+	}
+
+	if dryRun {
+		return len(skills), nil
+	}
+
+	for _, ts := range skills {
+		dir := filepath.Join(base, ".hermes", "skills", "jentic-tasks", ts.TaskID)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return 0, err
+		}
+		target := filepath.Join(dir, "SKILL.md")
+		if err := os.WriteFile(target, []byte(ts.Raw), 0o644); err != nil {
+			return 0, err
+		}
+	}
+	return len(skills), nil
+}
+
+func (a *Cmd) writeTaskSkillsAgents(ad skillgen.Adapter, env skillgen.DetectEnv, scope skillgen.Scope, skills []skillgen.TaskSkill, dryRun bool) (int, error) {
+	target := ad.Target(scope, "jentic-tasks", env)
+
+	var b strings.Builder
+	b.WriteString("## Task Skills\n\n")
+	for _, ts := range skills {
+		fmt.Fprintf(&b, "- **%s**: %s\n", ts.Name, ts.Description)
+	}
+
+	if dryRun {
+		return len(skills), nil
+	}
+
+	dir := filepath.Dir(target)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return 0, err
+	}
+
+	var existing []byte
+	if data, err := os.ReadFile(target); err == nil {
+		existing = data
+	}
+
+	content := b.String()
+	cleaned := removeTaskSkillsSection(string(existing))
+	var out string
+	if strings.TrimSpace(cleaned) == "" {
+		out = content
+	} else {
+		out = strings.TrimRight(cleaned, "\n") + "\n\n" + content
+	}
+
+	if err := os.WriteFile(target, []byte(out), 0o644); err != nil {
+		return 0, err
+	}
+	return len(skills), nil
+}
+
+func removeTaskSkillsSection(s string) string {
+	idx := strings.Index(s, "## Task Skills")
+	if idx < 0 {
+		return s
+	}
+	rest := s[idx+len("## Task Skills"):]
+	nextH2 := strings.Index(rest, "\n## ")
+	if nextH2 < 0 {
+		return s[:idx]
+	}
+	return s[:idx] + rest[nextH2+1:]
+}
+
+// taskSkillsDir returns the directory where task skills are installed for an
+// adapter, or empty string if the adapter doesn't use a directory layout.
+func taskSkillsDir(ad skillgen.Adapter, env skillgen.DetectEnv, scope skillgen.Scope) string {
+	base := env.Home
+	if scope == skillgen.ScopeProject {
+		base = env.Cwd
+	}
+	switch ad.Operator() {
+	case skillgen.OpClaude:
+		return filepath.Join(base, ".claude", "skills", "jentic-tasks")
+	case skillgen.OpCursor:
+		return filepath.Join(base, ".cursor", "skills", "jentic-tasks")
+	case skillgen.OpHermes:
+		return filepath.Join(base, ".hermes", "skills", "jentic-tasks")
+	default:
+		return ""
+	}
+}

--- a/cli/internal/skillgen/bundled.go
+++ b/cli/internal/skillgen/bundled.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/url"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -23,6 +24,9 @@ import (
 //go:generate sh -c "cd ../../.. && make skills"
 //go:embed content/*.md
 var bundledContent embed.FS
+
+//go:embed content/tasks
+var taskSkillsFS embed.FS
 
 // bundledDir is the embed sub-path the skill markdown files live under.
 const bundledDir = "content"
@@ -356,4 +360,79 @@ func parseSteps(section string) []Step {
 	}
 	flush()
 	return steps
+}
+
+// TaskSkill is a single task-level skill extracted from the embedded FS.
+type TaskSkill struct {
+	Product     string
+	TaskID      string
+	Name        string
+	Description string
+	Version     string
+	Content     string // markdown body below frontmatter
+	Raw         string // complete file including frontmatter
+}
+
+// TaskSkills reads all *.md files from the embedded FS for the given product
+// and returns them sorted by TaskID.
+func TaskSkills(product string) ([]TaskSkill, error) {
+	dir := filepath.Join("content", "tasks", product)
+	entries, err := taskSkillsFS.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read task skills for %q: %w", product, err)
+	}
+	var skills []TaskSkill
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+			continue
+		}
+		data, err := taskSkillsFS.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", e.Name(), err)
+		}
+		ts, err := parseTaskSkill(product, e.Name(), string(data))
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", e.Name(), err)
+		}
+		skills = append(skills, ts)
+	}
+	sort.Slice(skills, func(i, j int) bool {
+		return skills[i].TaskID < skills[j].TaskID
+	})
+	return skills, nil
+}
+
+// TaskSkillByID finds a task skill by its ID within the given product.
+func TaskSkillByID(product, taskID string) (*TaskSkill, error) {
+	skills, err := TaskSkills(product)
+	if err != nil {
+		return nil, err
+	}
+	for i := range skills {
+		if skills[i].TaskID == taskID {
+			return &skills[i], nil
+		}
+	}
+	return nil, fmt.Errorf("task skill %q not found for product %q", taskID, product)
+}
+
+func parseTaskSkill(product, filename, src string) (TaskSkill, error) {
+	taskID := strings.TrimSuffix(filename, ".md")
+	body, fm := splitFrontmatter(src)
+	ts := TaskSkill{
+		Product:     product,
+		TaskID:      taskID,
+		Name:        fm["name"],
+		Description: fm["description"],
+		Version:     fm["version"],
+		Content:     body,
+		Raw:         src,
+	}
+	if ts.Name == "" {
+		return ts, errors.New("missing name in frontmatter")
+	}
+	if ts.Description == "" {
+		return ts, errors.New("missing description in frontmatter")
+	}
+	return ts, nil
 }

--- a/cli/internal/skillgen/content/jentic.md
+++ b/cli/internal/skillgen/content/jentic.md
@@ -481,6 +481,10 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   including the exact broker URL and headers — before committing side effects.
 - `jenticctl status` / `jenticctl start` — health-check and restart the local
   deployment; check this first when a local target refuses connections.
+- `jentic skills` — list available onboarding guidance (step-by-step
+  procedures, pitfalls, and verification for common platform workflows).
+- `jentic skills <name>` — view a specific task guide.
+- `jentic skills init [name]` — install task skill(s) for your operator.
 - Add `--json` to force machine-readable output on a terminal (works on
   `search`, `execute`, `inspect`, `apis`, `access`, `doctor`). `context view`
   has no `--json` flag — it emits JSON automatically in agent/non-TTY mode.

--- a/cli/internal/skillgen/content/tasks/jentic/add-to-toolkit.md
+++ b/cli/internal/skillgen/content/tasks/jentic/add-to-toolkit.md
@@ -1,0 +1,210 @@
+---
+name: add-to-toolkit
+description: Request access to a toolkit containing API credentials so you can make proxied requests through the broker
+version: 6
+---
+
+# Request Toolkit Access
+
+## When to Use
+
+Use this skill when you need to execute operations against an API that requires credentials. Toolkits bundle credentials with API definitions, and requesting access grants you the ability to make authenticated, proxied requests through the Jentic broker.
+
+## Prerequisites
+
+- You must have a registered agent identity with a valid authentication token
+- The target API must be registered in the Jentic platform
+- A toolkit must exist that contains the credential for the target API
+- You must know the toolkit reference in the format `vendor/toolkit-name`
+
+**Important:** If you have just registered an agent, ensure the registration completed successfully and you have a valid token before attempting to request toolkit access. Agent registration is a two-step process: the CLI registers the agent and returns a pending status, then you must approve the agent in the Jentic console before a token is minted. If `jentic whoami` shows no token or authentication fails, check that:
+1. You approved the agent in the console (you'll see a URL like `http://<platform>/app/agents/<agent_id>`)
+2. You waited for background approval to complete (typically 10-15 seconds after approval)
+3. The token exchange succeeded after approval
+4. The token was stored in your local `tokens.json` file (typically in your Jentic profile directory)
+
+See the agent registration skill documentation for troubleshooting registration issues.
+
+## Procedure
+
+### 1. Verify Current Toolkit Access
+
+Before requesting access, check what toolkits you currently have bound to your agent.
+
+**CLI:**
+```bash
+jentic access list
+```
+
+**HTTP:**
+```
+GET {{ platform.control_plane_url }}/agent/access
+Authorization: Bearer <your_agent_token>
+```
+
+**Expected Response:**
+- A list of toolkit bindings (may be empty if you have no access yet)
+- Each binding shows a toolkit ID (e.g., `tk_...`) and associated metadata
+
+**If this fails with authentication errors:**
+- Verify you have a valid token with `jentic whoami`
+- If no token is present, check that your agent registration was approved in the console and the token exchange completed
+- Confirm the token was persisted to your local `tokens.json` file (the CLI stores tokens here after successful approval)
+- The CLI does not have a `jentic auth` command; authentication is handled through the registration process
+
+### 2. Request Toolkit Access
+
+Submit an access request for the toolkit containing the credential you need.
+
+**CLI:**
+```bash
+jentic access request --toolkit <vendor>/<toolkit-name> --wait
+```
+
+The `--wait` flag causes the command to poll until the request is approved or denied. This is recommended for auto-approved toolkits or when you expect quick manual approval.
+
+**Optional flags:**
+- `--reason "Your reason text"` - Provide a reason for the access request (helpful for manual approval workflows)
+
+**HTTP:**
+```
+POST {{ platform.control_plane_url }}/agent/access/requests
+Authorization: Bearer <your_agent_token>
+Content-Type: application/json
+
+{
+  "toolkit": "<vendor>/<toolkit-name>",
+  "reason": "Your reason text (optional)"
+}
+```
+
+**Expected Response:**
+- CLI: Success message indicating the request was approved, with the toolkit binding ID and access request ID (format: `areq_...`)
+- HTTP: 201 Created with a request object containing `status` field
+- If `--wait` is used (CLI) or you poll the request (HTTP), wait for `status: "approved"`
+- Auto-approved toolkits typically complete within seconds
+
+**If Request is Pending:**
+- Some toolkits require manual approval
+- Poll the request status or wait for approval notification
+- HTTP: `GET {{ platform.control_plane_url }}/agent/access/requests/<request_id>`
+
+### 3. Refresh Your Agent Token
+
+After approval, refresh your authentication token to receive updated claims that include the new toolkit binding.
+
+**CLI:**
+```bash
+jentic access refresh
+```
+
+This command updates your local `tokens.json` file with the new token containing the toolkit binding claims.
+
+**HTTP:**
+```
+POST {{ platform.control_plane_url }}/agent/token/refresh
+Authorization: Bearer <your_current_token>
+```
+
+**Expected Response:**
+- A new JWT token with updated toolkit bindings in its claims
+- The CLI automatically updates your stored token in `tokens.json`
+- For HTTP, store the new token and use it for subsequent requests
+
+### 4. Verify Toolkit Binding
+
+Confirm the toolkit is now bound to your agent.
+
+**CLI:**
+```bash
+jentic access list
+```
+
+You can also verify your current identity and active toolkit bindings with:
+```bash
+jentic whoami
+```
+
+**HTTP:**
+```
+GET {{ platform.control_plane_url }}/agent/access
+Authorization: Bearer <your_refreshed_token>
+```
+
+**Expected Response:**
+- The toolkit binding should now appear in the list
+- Note the toolkit ID (format: `tk_...`) for reference
+
+## Quick Reference
+
+### CLI Commands
+```bash
+# Verify identity and token status
+jentic whoami
+
+# List current access
+jentic access list
+
+# Request toolkit access (wait for approval)
+jentic access request --toolkit <vendor>/<toolkit-name> --wait
+
+# Request with reason
+jentic access request --toolkit <vendor>/<toolkit-name> --reason "Testing integration" --wait
+
+# Request without waiting
+jentic access request --toolkit <vendor>/<toolkit-name>
+
+# Refresh token after approval
+jentic access refresh
+```
+
+### HTTP Endpoints
+```
+GET    {{ platform.control_plane_url }}/agent/access
+POST   {{ platform.control_plane_url }}/agent/access/requests
+GET    {{ platform.control_plane_url }}/agent/access/requests/<request_id>
+POST   {{ platform.control_plane_url }}/agent/token/refresh
+```
+
+## Pitfalls
+
+- **No valid authentication token**: If you attempt to request toolkit access without a valid token, commands will fail with authentication errors. Always verify you have a token with `jentic whoami` before proceeding. If registration shows pending status but no token was minted, ensure you approved the agent in the Jentic console and waited for background approval to complete (typically 10-15 seconds). Check that the token was persisted to your local `tokens.json` file.
+- **Agent registration pending but not approved**: After running `jentic register`, the agent enters a pending state. You must approve it in the Jentic console (using the URL provided in the registration output) before a token is minted. Background approval typically takes 10-15 seconds after you approve it in the console. The token is then stored in your local `tokens.json` file.
+- **Token not persisted locally**: Even after successful approval, if the token was not saved to your local `tokens.json` file, the CLI will not have access to it. Verify the token file exists in your Jentic profile directory and contains a valid token entry.
+- **Forgetting to refresh the token**: After a request is approved, you must refresh your agent token. The new toolkit binding is encoded in the JWT claims, not stored server-side per request.
+- **Wrong toolkit reference format**: Use `vendor/toolkit-name`, not `vendor/api-name` or `vendor/api-name/version`. Toolkits and APIs are separate entities.
+- **Not using `--wait` flag**: Without `--wait`, the CLI returns immediately and you must manually poll for approval status. Use `--wait` for auto-approved toolkits or when you expect quick manual approval.
+- **Using stale token after refresh**: In HTTP mode, ensure you replace your stored token with the refreshed one. The old token won't include the new toolkit binding. In CLI mode, verify the new token was written to `tokens.json`.
+- **Assuming immediate access**: Some toolkits require manual approval. Check the request status if `--wait` times out or the HTTP request returns a pending status.
+- **No direct toolkit listing command**: The CLI does not have a `jentic toolkits list` command. To discover available toolkits, you typically need to know the toolkit reference from documentation or use `jentic apis list` to find APIs and then request access using the API's vendor/name format.
+- **Looking for `jentic auth` command**: The CLI does not have a separate `jentic auth` command. Authentication is handled through the `jentic register` process and token management is done via `jentic access refresh`.
+
+## Verification
+
+### CLI
+```bash
+jentic access list
+```
+Look for the toolkit binding in the output. You should see an entry with a toolkit ID (e.g., `tk_...`) matching your requested toolkit.
+
+You can also use:
+```bash
+jentic whoami
+```
+This shows your current identity and active toolkit bindings.
+
+### HTTP
+```
+GET {{ platform.control_plane_url }}/agent/access
+Authorization: Bearer <your_refreshed_token>
+```
+Parse the JSON response and confirm an object exists with the toolkit reference you requested.
+
+### End-to-End Test
+After obtaining toolkit access, you can verify it works by attempting to execute an operation from the API:
+```bash
+jentic execute <operation_id>
+```
+If the toolkit binding is correct, the broker will inject the credential and proxy your request. A successful response (even if it's an application error from the upstream API) confirms the toolkit is properly bound.
+
+**Note:** The Jentic broker blocks requests to localhost and other restricted addresses (e.g., 127.0.0.1) as a security measure. If you receive an error about restricted addresses, this is expected behavior and not a configuration issue with your toolkit binding.

--- a/cli/internal/skillgen/content/tasks/jentic/authenticate.md
+++ b/cli/internal/skillgen/content/tasks/jentic/authenticate.md
@@ -1,0 +1,195 @@
+---
+name: authenticate
+description: Exchange credentials for an access token (JWT bearer or CLI login) to access the Jentic platform
+version: 6
+---
+
+# Authenticate with Jentic Platform
+
+## When to Use
+
+Use this skill when you need to obtain an access token to interact with the Jentic platform, either through the CLI or HTTP API. Authentication is required before you can access APIs, request toolkit bindings, or execute operations through the broker.
+
+## Prerequisites
+
+- Agent identity must be registered with the platform (see `register` skill)
+- For CLI: `jentic` binary installed and configured with control plane URL
+- For HTTP: Control plane URL and agent credentials available
+
+## Procedure
+
+### 1. Understand Token Acquisition
+
+Authentication happens automatically during agent registration. When you register an agent identity, the platform issues both an access token (short-lived JWT) and a refresh token (longer-lived).
+
+**CLI:**
+The `jentic register` command stores tokens automatically in the CLI's configuration (typically in `tokens.json`). No separate authentication command is needed.
+
+**Important**: Token minting only occurs after the agent registration is approved. Registration creates the agent identity with `status=pending`, but tokens are only minted after approval is completed. If registration completes but approval fails, times out, or is not completed, the profile will be created without a token. In this case, approve the agent in the Jentic console (link provided in registration output), wait 10-15 seconds for background approval processing, then re-run `jentic register` to complete the token minting.
+
+**HTTP:**
+The registration endpoint (`POST /agents`) returns tokens in the response body:
+```json
+{
+  "access_token": "<jwt>",
+  "refresh_token": "<refresh_jwt>",
+  "expires_in": 3600
+}
+```
+
+Store both tokens securely for subsequent requests.
+
+### 2. Verify Token Works
+
+Test that your access token is valid by making an authenticated request.
+
+**CLI:**
+```bash
+jentic apis list
+```
+
+If this returns a list of APIs (even if empty), your token is valid.
+
+You can also check your profile and token status:
+```bash
+jentic profile list
+```
+
+This shows your active profile with token expiry information (typically 1 hour) and validation status. If the profile shows no token or an invalid token, you may need to re-run registration to complete the approval and token minting process.
+
+**Note**: If you see the error `agent for profile "default" is not active yet`, this means the agent is still pending approval. Proceed to the approval step below before attempting to use the token.
+
+**HTTP:**
+```
+GET {{ platform.control_plane_url }}/apis
+Authorization: Bearer <access_token>
+```
+
+A `200 OK` response confirms the token is valid.
+
+### 3. Complete Agent Approval (if needed)
+
+If registration returns `status=pending`, the agent must be approved before tokens are minted.
+
+**CLI:**
+After running `jentic register`, if you see `status=pending` in the output:
+1. Open the Jentic console URL provided in the registration output (typically `http://<control_plane_url>/app/agents/<agent_id>`)
+2. Approve the agent in the console
+3. Wait 10-15 seconds for background approval processing
+4. Re-run `jentic register` to complete token minting:
+```bash
+jentic register
+```
+
+After re-running, verify the profile now has a valid token:
+```bash
+jentic profile list
+```
+
+**HTTP:**
+If the registration response shows `status=pending`, you must approve the agent via the console or API before attempting authenticated requests. Once approved, re-run the registration request or use the refresh endpoint to obtain tokens.
+
+### 4. Refresh Token When Expired
+
+Access tokens expire (typically after 1 hour). Use the refresh token to obtain a new access token without re-registering.
+
+**CLI:**
+```bash
+jentic refresh
+```
+
+This updates the stored access token automatically. You'll need to refresh after requesting new toolkit bindings to get updated claims.
+
+**HTTP:**
+```
+POST {{ platform.control_plane_url }}/auth/refresh
+Content-Type: application/json
+
+{
+  "refresh_token": "<refresh_token>"
+}
+```
+
+Response contains new `access_token` and `expires_in`. Store the new access token and use it for subsequent requests.
+
+## Quick Reference
+
+### CLI Commands
+```bash
+# Tokens obtained automatically during registration
+jentic register --name <agent-name>
+
+# If registration returns status=pending:
+# 1. Approve the agent in the Jentic console (link in registration output)
+# 2. Wait 10-15 seconds for background approval processing
+# 3. Re-run registration to complete token minting:
+jentic register
+
+# Verify authentication
+jentic apis list
+
+# Check profile and token status
+jentic profile list
+
+# Refresh access token
+jentic refresh
+```
+
+### HTTP Endpoints
+```
+# Tokens obtained during registration
+POST {{ platform.control_plane_url }}/agents
+
+# Verify authentication
+GET {{ platform.control_plane_url }}/apis
+Authorization: Bearer <access_token>
+
+# Refresh token
+POST {{ platform.control_plane_url }}/auth/refresh
+Body: { "refresh_token": "<token>" }
+```
+
+## Pitfalls
+
+- **No separate auth command**: Don't look for a `jentic login` or `jentic auth` command. Authentication happens during `jentic register`. The CLI will return "unknown command" errors for `jentic auth` or `jentic version`.
+- **Approval required for token minting**: Registration creates the agent identity with `status=pending`, but tokens are only minted after approval is completed. If registration returns `status=pending`, you must approve the agent in the Jentic console (URL provided in registration output), wait 10-15 seconds for background approval processing, then re-run `jentic register` to complete token minting. If you don't approve or re-run registration, the profile will exist but have no token.
+- **"Agent not active yet" error**: If you see `agent for profile "default" is not active yet`, this means the agent is pending approval. Complete the approval step (approve in console, wait 10-15 seconds, re-run `jentic register`) before attempting authenticated operations.
+- **Profile exists without token**: If `jentic profile list` shows a profile but no token, this indicates registration completed but token minting failed. Approve the agent in the console and re-run `jentic register` to complete the process.
+- **Token storage**: CLI stores tokens automatically in `tokens.json`. For HTTP mode, you must implement secure token storage yourself.
+- **Refresh after toolkit changes**: After requesting toolkit access, run `jentic refresh` to update your token with new credential claims. The old token won't include newly granted permissions.
+- **Token expiration**: Access tokens expire. If you get 401 errors, refresh your token before retrying.
+- **Refresh token lifetime**: Refresh tokens also expire (longer lifetime than access tokens). If refresh fails, you'll need to re-register.
+- **Command naming**: Use `jentic apis` (plural) not `jentic api`. The CLI will suggest corrections for typos. Use `jentic profile list` not `jentic profile show`.
+
+## Verification
+
+### CLI
+Run any authenticated command successfully:
+```bash
+jentic apis list
+# Should return API list or empty array, not authentication error
+```
+
+Or check your profile status:
+```bash
+jentic profile list
+# Should show active profile with valid token and expiry time (typically 1h)
+# If no token is shown, approve the agent in the console and re-run jentic register
+# If you see "agent not active yet", complete the approval step first
+```
+
+### HTTP
+Make an authenticated request:
+```
+GET {{ platform.control_plane_url }}/apis
+Authorization: Bearer <access_token>
+```
+
+Success indicators:
+- HTTP 200 status code
+- Valid JSON response body
+- No authentication or authorization errors
+
+Failure indicators:
+- HTTP 401: Token invalid or expired (refresh needed)
+- HTTP 403: Token valid but lacks permissions (check registration status)

--- a/cli/internal/skillgen/content/tasks/jentic/check-agent-scopes.md
+++ b/cli/internal/skillgen/content/tasks/jentic/check-agent-scopes.md
@@ -1,0 +1,56 @@
+---
+name: check-agent-scopes
+description: Inspect your agent's current permissions and scopes.
+version: 1
+---
+
+# Check Agent Scopes
+
+## When to Use
+
+Use this skill when you need to perform the check agent scopes step during onboarding to the Jentic platform.
+
+## Prerequisites
+
+- Access to the Jentic platform
+- Completed: View Audit Events (`view-audit-events`)
+
+## Procedure
+
+### 1. Check Agent Scopes
+
+Inspect your agent's current permissions and scopes.
+
+**CLI:**
+
+```bash
+jentic profile
+```
+
+**HTTP:**
+
+```
+GET /me
+```
+
+**Notes:**
+- Use GET /agents/{agent_id} or the `me` endpoint to inspect your current profile
+- Shows: status, scopes, toolkit bindings, approval state
+
+## Quick Reference
+
+### CLI Commands
+
+- `jentic profile`
+
+### HTTP Endpoints
+
+- `GET /me`
+
+## Pitfalls
+
+- The `/me` endpoint requires a valid Bearer token — will 401 if token expired
+
+## Verification
+
+- Agent profile is accessible and active

--- a/cli/internal/skillgen/content/tasks/jentic/check-execution-history.md
+++ b/cli/internal/skillgen/content/tasks/jentic/check-execution-history.md
@@ -1,0 +1,188 @@
+---
+name: check-execution-history
+description: Query execution records to verify that proxied API requests were logged by the platform
+version: 4
+---
+
+# Check Execution History
+
+## When to Use
+
+Use this skill when you need to verify that your proxied API requests were successfully logged by the platform, or when debugging request flows to understand what was executed, when, and with what result.
+
+## Prerequisites
+
+- You must be authenticated with a valid agent token
+- Your agent must be **approved** by an administrator (see [Agent Registration Prerequisites](#agent-registration-prerequisites) below)
+- You should have previously made at least one proxied request through the broker (otherwise the execution history will be empty)
+- You need access to the control plane API at `{{ platform.control_plane_url }}`
+
+### Agent Registration Prerequisites
+
+Before you can query execution history, your agent must be registered and approved:
+
+1. Run `jentic register` to create a new agent
+2. The CLI will display a pending status and a console URL
+3. **An administrator must approve your agent** in the Jentic console before you can obtain a token
+4. After approval, your token will be automatically stored in `tokens.json` in your agent workspace
+5. Approval may take 10–15 seconds; if your token is not immediately available, wait briefly and retry
+6. To verify approval is complete, run `jentic profile show` — if it displays a token, approval succeeded
+
+## Procedure
+
+### 1. Retrieve Your Execution History
+
+The platform logs all proxied requests made through the broker. Query the executions endpoint to retrieve your execution records.
+
+**CLI:**
+
+There is no dedicated CLI command for listing execution history. You must use `curl` or similar HTTP client with your bearer token.
+
+To get your token after agent approval:
+
+```bash
+# View your agent profile and token (if approved)
+jentic profile show
+```
+
+If `jentic profile show` does not display a token, your agent has not yet been approved. Wait 10–15 seconds and retry, or check the Jentic console to confirm approval status.
+
+Once you have your token, query executions:
+
+```bash
+curl -H "Authorization: Bearer <your_token>" \
+  {{ platform.control_plane_url }}/executions
+```
+
+**HTTP:**
+
+```
+GET /executions
+Authorization: Bearer <your_agent_token>
+```
+
+**Expected Response:**
+
+```json
+[
+  {
+    "id": "<execution_id>",
+    "agent_id": "<your_agent_id>",
+    "operation_id": "<operation_id>",
+    "timestamp": "<iso8601_timestamp>",
+    "status": "success|failure|blocked",
+    "request": { ... },
+    "response": { ... }
+  }
+]
+```
+
+If you haven't made any successful proxied requests, the response will be an empty array `[]`.
+
+### 2. Interpret the Execution Records
+
+Each execution record contains:
+
+- **id**: Unique identifier for this execution
+- **agent_id**: Your agent identifier (should match your authenticated identity)
+- **operation_id**: The API operation that was invoked
+- **timestamp**: When the request was executed
+- **status**: Whether the request succeeded, failed, or was blocked by policy
+- **request**: Details about the proxied request (method, path, headers, body)
+- **response**: The response received from the upstream API
+
+**CLI:**
+
+Use `jq` or similar tools to filter and format the results:
+
+```bash
+curl -s -H "Authorization: Bearer <your_token>" \
+  {{ platform.control_plane_url }}/executions | jq '.[] | {id, timestamp, status}'
+```
+
+**HTTP:**
+
+The raw JSON response can be parsed programmatically. Filter by timestamp, operation_id, or status as needed.
+
+### 3. Verify Your Specific Request
+
+To confirm a specific proxied request was logged:
+
+1. Note the timestamp when you made your proxied request
+2. Look for an execution record with a matching or nearby timestamp
+3. Verify the `operation_id` matches the API operation you invoked
+4. Check the `status` field to confirm the request was processed (not blocked)
+
+**CLI:**
+
+```bash
+# Filter by recent executions (last hour example)
+curl -s -H "Authorization: Bearer <your_token>" \
+  {{ platform.control_plane_url }}/executions | \
+  jq '[.[] | select(.timestamp > (now - 3600 | todate))]'
+```
+
+**HTTP:**
+
+Apply client-side filtering to the JSON array returned from `GET /executions`. The platform does not currently support server-side filtering via query parameters.
+
+## Quick Reference
+
+### CLI Commands
+
+```bash
+# View all executions (no dedicated CLI command exists)
+curl -H "Authorization: Bearer <your_token>" \
+  {{ platform.control_plane_url }}/executions
+
+# Get agent profile info (includes agent_id and token after approval)
+jentic profile show
+
+# Register a new agent (requires admin approval before token is available)
+jentic register
+```
+
+### HTTP Endpoints
+
+```
+GET /executions
+  → Returns array of execution records for authenticated agent
+  → Requires: Authorization: Bearer <token>
+  → No query parameters currently supported
+```
+
+## Pitfalls
+
+- **Agent must be approved before querying executions**: After running `jentic register`, your agent enters a pending state. An administrator must approve it in the Jentic console before you can obtain a token and query execution history. Attempting to query without an approved agent will result in a 401 error.
+- **Token availability delay**: After agent approval, the token may not be immediately available. If `jentic profile show` shows no token, wait 10–15 seconds and retry. The token is automatically stored in `tokens.json` once approval completes.
+- **No CLI command exists**: Unlike other platform features, there is no `jentic executions list` or similar command. You must construct HTTP requests manually with `curl`.
+- **Verify approval completion**: Use `jentic profile show` to confirm your agent has been approved. If the output displays a token, approval is complete. If no token is shown, approval is still pending.
+- **Empty results don't mean failure**: An empty array `[]` is the expected response if no proxied requests have been successfully executed. This could be because requests were blocked by policy (e.g., localhost restrictions) or because you haven't made any proxied requests yet.
+- **Blocked requests may not appear**: If the broker blocks a request due to policy violations (e.g., restricted destination addresses), check whether these appear with `status: "blocked"` or are omitted entirely from the execution log.
+- **No server-side filtering**: The `/executions` endpoint returns all execution records for your agent. You must filter client-side by timestamp, operation, or status.
+
+## Verification
+
+**Success Criteria:**
+
+1. Your agent is registered and approved (visible in the Jentic console)
+2. `jentic profile show` displays your agent ID and token
+3. The `/executions` endpoint returns HTTP 200 (not 401 or 403)
+4. If you made proxied requests, you see corresponding execution records with matching timestamps
+5. Each record contains the expected `operation_id` and `status` fields
+6. The `agent_id` in each record matches your authenticated agent identity
+
+**CLI Verification:**
+
+```bash
+# Verify agent is approved and token is available
+jentic profile show
+
+# Should return 200 and valid JSON array
+curl -i -H "Authorization: Bearer <your_token>" \
+  {{ platform.control_plane_url }}/executions
+```
+
+**HTTP Verification:**
+
+Check that `GET /executions` returns status 200 and a JSON array (even if empty). If you receive 401, your token may be expired, invalid, or your agent may not be approved. If you receive 404, verify the control plane URL is correct.

--- a/cli/internal/skillgen/content/tasks/jentic/discover-apis.md
+++ b/cli/internal/skillgen/content/tasks/jentic/discover-apis.md
@@ -1,0 +1,102 @@
+---
+name: discover-apis
+description: Browse the API catalog and list all available APIs.
+version: 1
+---
+
+# Discover Apis
+
+## When to Use
+
+Use this skill when you need to perform the discover apis step during onboarding to the Jentic platform.
+
+## Prerequisites
+
+- Access to the Jentic platform
+- Completed: Authenticate (`authenticate`)
+
+## Procedure
+
+### 1. Discover Apis
+
+Browse the API catalog and list all available APIs.
+
+**CLI:**
+
+```bash
+jentic catalog
+```
+
+```bash
+jentic apis
+```
+
+**HTTP:**
+
+```
+GET /apis
+```
+
+**Response:**
+```json
+{
+  "data": "<array>"
+  "has_more": "<boolean>"
+  "next_cursor": "<string>"
+}
+```
+
+**Query parameters:**
+- `vendor`
+- `cursor`
+- `limit`
+
+```
+GET /catalog
+```
+
+**Response:**
+```json
+{
+  "catalog_total": "<integer>"
+  "data": "<array>"
+  "has_more": "<boolean>"
+  "manifest_age_seconds": "<integer>"
+  "next_cursor": "<string>"
+  "outdated_count": "<integer>"
+  "registered_count": "<integer>"
+}
+```
+
+**Query parameters:**
+- `q`
+- `registered_only`
+- `unregistered_only`
+- `outdated_only`
+- `include_snoozed`
+- `cursor`
+- `limit`
+
+**Notes:**
+- Returns a paginated list of all published APIs in the registry
+- Use query params `vendor`, `name` to filter; `cursor` for pagination
+
+## Quick Reference
+
+### CLI Commands
+
+- `jentic catalog`
+- `jentic apis`
+
+### HTTP Endpoints
+
+- `GET /apis`
+- `GET /catalog`
+
+## Pitfalls
+
+- Requires a valid Bearer token — authenticate first
+
+## Verification
+
+- Catalog endpoint was hit

--- a/cli/internal/skillgen/content/tasks/jentic/discover-oauth-metadata.md
+++ b/cli/internal/skillgen/content/tasks/jentic/discover-oauth-metadata.md
@@ -1,0 +1,57 @@
+---
+name: discover-oauth-metadata
+description: Fetch the platform's OAuth authorization server metadata.
+version: 1
+---
+
+# Discover Oauth Metadata
+
+## When to Use
+
+Use this skill when you need to perform the discover oauth metadata step during onboarding to the Jentic platform.
+
+## Prerequisites
+
+- Access to the Jentic platform
+- Completed: Read Api Spec (`read-api-spec`)
+
+## Procedure
+
+### 1. Discover Oauth Metadata
+
+Fetch the platform's OAuth authorization server metadata.
+
+**CLI:**
+
+```bash
+# (CLI command to be documented)
+```
+
+**HTTP:**
+
+```
+GET /.well-known/oauth-authorization-server
+```
+
+**Notes:**
+- Standard RFC 8414 endpoint returning authorization server metadata
+- Key fields in response: `token_endpoint`, `grant_types_supported`, `jwks_uri`
+- Use the `token_endpoint` value as the `aud` claim in JWT assertions
+
+## Quick Reference
+
+### CLI Commands
+
+- *(To be documented)*
+
+### HTTP Endpoints
+
+- `GET /.well-known/oauth-authorization-server`
+
+## Pitfalls
+
+- This is a public endpoint (no auth required) but agents often skip it and hardcode URLs
+
+## Verification
+
+- OAuth metadata endpoint was hit

--- a/cli/internal/skillgen/content/tasks/jentic/find-credential.md
+++ b/cli/internal/skillgen/content/tasks/jentic/find-credential.md
@@ -1,0 +1,257 @@
+---
+name: find-credential
+description: Locate an API in the platform registry and identify its authentication requirements and available endpoints
+version: 6
+---
+
+# Finding API Credentials and Endpoints
+
+## When to Use
+
+Use this skill when you need to discover what authentication method a registered API requires and what operations are available, before requesting access or making calls through the broker.
+
+## Prerequisites
+
+- Valid agent identity registered with the platform
+- Active authentication token
+- Knowledge of the API's vendor/name/version identifier (format: `vendor/name/version`)
+
+**Important:** You must have a valid authentication token before using any of the commands in this skill. If you encounter authentication errors or have no token, complete agent registration and authentication first (see separate skill documentation).
+
+**Note on agent registration:** After registering a new agent, you will receive a pending status and a link to approve it in the Jentic console. Token exchange may fail immediately after registration — this is normal. Wait 10-15 seconds for background approval to complete, then retry token exchange before proceeding with API discovery.
+
+**Note on token storage:** After successful token exchange, tokens are stored in `tokens.json` in your profile directory. If you copy a profile from another agent or workspace, ensure `tokens.json` is also copied to maintain authentication state.
+
+## Procedure
+
+### 1. List Available APIs
+
+Start by listing all APIs in the registry to confirm the target API exists and get its exact identifier.
+
+**CLI:**
+```bash
+jentic apis list
+```
+
+**HTTP:**
+```
+GET {{ platform.control_plane_url }}/apis
+Authorization: Bearer <token>
+```
+
+Expected response includes an array of API objects with `vendor`, `name`, `version`, and `id` fields. Note the exact version string for the target API.
+
+**Common mistake:** The command is `jentic apis` (plural), not `jentic api` (singular).
+
+### 2. View API Details
+
+Once you've identified the target API, view its details to see basic information.
+
+**CLI:**
+```bash
+jentic apis show <vendor>/<name>/<version>
+```
+
+**HTTP:**
+```
+GET {{ platform.control_plane_url }}/apis/<vendor>/<name>/<version>
+Authorization: Bearer <token>
+```
+
+This provides overview information about the API including its current revision.
+
+**Important:** The full `vendor/name/version` identifier is required. Omitting the version (e.g., `jentic apis show vendor/name`) will fail with "invalid API reference" error.
+
+### 3. Check Security Schemes
+
+The `jentic apis show` command includes a `security_schemes` field in its output. However, this field is often empty even when the API requires authentication.
+
+**CLI:**
+```bash
+jentic apis show <vendor>/<name>/<version> --output json
+```
+
+Look for the `security_schemes` array in the JSON output. If empty, authentication requirements cannot be determined from this metadata alone.
+
+**Known limitation:** Security scheme information is frequently not populated in API metadata, even for APIs that require authentication (e.g., X-API-Key headers). You will need to consult the OpenAPI spec (step 5) or external documentation to determine actual authentication requirements.
+
+### 4. List Operations for the Target API
+
+List the API's operations to see available endpoints.
+
+**CLI:**
+```bash
+jentic apis operations <vendor>/<name>/<version>
+```
+
+**HTTP:**
+```
+GET {{ platform.control_plane_url }}/apis/operations?api=<vendor>/<name>/<version>
+Authorization: Bearer <token>
+```
+
+Expected response includes operation objects with:
+- `id`: The operation identifier (format: `op_<hash>`) needed for execution
+- `method`: HTTP method (GET, POST, etc.)
+- `path`: The endpoint path
+- `_links`: Related resource links
+
+**Important:** Save the operation `id` values - these are required for executing operations later. The formatted CLI output may not display IDs prominently; use `--output json` to see full details.
+
+**Note:** If this returns 0 operations or an empty list, the API may be registered but not yet have operations defined in its current revision.
+
+### 5. Inspect Individual Operations
+
+Get detailed information about a specific operation using its operation ID.
+
+**CLI:**
+```bash
+jentic apis inspect <operation-id>
+```
+
+**HTTP:**
+```
+GET {{ platform.control_plane_url }}/operations/<operation-id>
+Authorization: Bearer <token>
+```
+
+This shows operation details including method, path, and an `auth` field. 
+
+**Important Limitation:** The `auth` field may show `null` even when the API requires authentication. The operation metadata does not reliably expose authentication requirements. You may need to consult the OpenAPI spec (step 6) or external documentation.
+
+**Note:** The `jentic inspect` command (without `apis` subcommand) may also work but `jentic apis inspect` is the correct form for operation inspection.
+
+### 6. Attempt to Retrieve the OpenAPI Specification
+
+Try to get the full OpenAPI spec to understand authentication requirements and request/response schemas.
+
+**CLI:**
+```bash
+jentic apis spec <vendor>/<name>/<version>
+```
+
+**HTTP:**
+```
+GET {{ platform.control_plane_url }}/apis/<vendor>/<name>/<version>/spec
+Authorization: Bearer <token>
+```
+
+**Note:** This may fail with HTTP 500 if the spec file wasn't stored during API registration. The error message will indicate "Revision '<id>' has no stored spec file". If this occurs, authentication requirements cannot be discovered through the platform and must be obtained from external documentation or the API provider.
+
+### 7. Check Catalog for Published Information
+
+If direct API inspection is limited, check if the API is published in the public catalog with documentation.
+
+**CLI:**
+```bash
+jentic catalog
+```
+
+**HTTP:**
+```
+GET {{ platform.control_plane_url }}/catalog
+Authorization: Bearer <token>
+```
+
+This shows APIs that have been explicitly published with descriptions and may include authentication guidance.
+
+### 8. Verify Current Toolkit Access
+
+Check whether you already have access to a toolkit containing credentials for this API.
+
+**CLI:**
+```bash
+jentic toolkits
+```
+
+**HTTP:**
+```
+GET {{ platform.control_plane_url }}/toolkits
+Authorization: Bearer <token>
+```
+
+**Note:** The `jentic toolkits` command may not be available in all CLI versions. If you receive "unknown command" error, skip this step and proceed to request access (covered in separate skill documentation). You can verify access after requesting it through other means.
+
+If the response is empty or doesn't include the target API, you'll need to request access (covered in separate skill documentation).
+
+## Quick Reference
+
+### CLI Commands
+```bash
+# List all APIs
+jentic apis list
+
+# Show API details
+jentic apis show <vendor>/<name>/<version>
+
+# Show API details with JSON output (to see security_schemes)
+jentic apis show <vendor>/<name>/<version> --output json
+
+# List operations for specific API
+jentic apis operations <vendor>/<name>/<version>
+
+# Inspect operation by ID
+jentic apis inspect <operation-id>
+
+# Get OpenAPI spec (may fail)
+jentic apis spec <vendor>/<name>/<version>
+
+# Check catalog
+jentic catalog
+
+# Check toolkit access (may not be available)
+jentic toolkits
+```
+
+### HTTP Endpoints
+```
+GET /apis                                    # List APIs
+GET /apis/<vendor>/<name>/<version>          # Show API details
+GET /apis/operations?api=<vendor/name/ver>   # List operations
+GET /operations/<operation-id>                # Inspect operation
+GET /apis/<vendor>/<name>/<version>/spec     # Get spec
+GET /catalog                                 # Public catalog
+GET /toolkits                                # Current access
+```
+
+All HTTP requests require `Authorization: Bearer <token>` header.
+
+## Pitfalls
+
+- **Don't use singular "api"**: The command is `jentic apis` (plural), not `jentic api` (singular). Using the singular form will result in "unknown command" error.
+- **Don't use partial API identifiers**: Commands like `jentic apis show <vendor>/<name>` without version will fail with "invalid API reference" error. Always use the full `vendor/name/version` format.
+- **Don't use unknown flags**: The `jentic apis operations` command does not accept an `--api` flag. The API identifier is passed as a positional argument.
+- **Don't use "auth" command**: There is no `jentic auth` command. Authentication is handled through the `jentic register` and profile management system. If you see "unknown command 'auth'" error, you're using an invalid command.
+- **Search functionality may be unreliable**: The `jentic search` command may return empty results or HTTP 422 errors even for valid queries. Prefer direct listing commands like `jentic apis list` and `jentic apis show`.
+- **Operation IDs are hidden in formatted output**: Use `--output json` with CLI commands to see the full operation object including the `id` field needed for execution.
+- **Spec retrieval may fail**: If `jentic apis spec` returns HTTP 500 with message "Revision '<id>' has no stored spec file", the API was registered without storing its OpenAPI specification. Fall back to operation listing and inspection, but be aware that authentication requirements may not be discoverable.
+- **Authentication requirements are often not visible**: The `security_schemes` field in API metadata is frequently empty, and the operation `auth` field often shows `null` even when authentication is required. If spec retrieval fails, you cannot reliably discover authentication requirements through the platform. Consult external documentation or the API provider.
+- **Path-based operation lookup is fragile**: Commands like `jentic inspect 'GET /path'` may fail to find operations. Always use the operation ID from `jentic apis operations`.
+- **Empty operations list**: An API may be registered but show 0 operations if its current revision has no operations defined. This is not an error, but indicates the API is not yet ready for use.
+- **"toolkits" command may not exist**: The `jentic toolkits` command may not be available in all CLI versions. If you get "unknown command" error, this is expected and you should skip that verification step.
+- **Must be authenticated first**: All commands in this skill require a valid authentication token. If you don't have a token or your agent registration is incomplete, you must complete authentication before attempting to discover APIs. See agent registration and authentication skill documentation.
+- **Token exchange may fail immediately after registration**: After registering a new agent, the initial token exchange attempt may fail even though registration succeeded. This is normal — wait 10-15 seconds for background approval to complete, then retry the token exchange before proceeding with API discovery.
+- **Token storage is profile-specific**: Tokens are stored in `tokens.json` within your profile directory. If you switch profiles or copy a profile to a new location, ensure `tokens.json` is also copied. If `tokens.json` is missing, you will need to re-authenticate even if your agent is approved.
+
+## Verification
+
+You have successfully completed this task when you can answer:
+
+1. **Does the API exist?** Confirmed by seeing it in `jentic apis list` output
+2. **What operations are available?** Listed via `jentic apis operations` with method and path for each
+3. **What are the operation IDs?** Retrieved from JSON output of operations list
+4. **What authentication does it require?** Determined from spec (if available) or external documentation
+
+**CLI verification:**
+```bash
+jentic apis operations <vendor>/<name>/<version> --output json
+```
+Should return JSON array with at least one operation object containing `id`, `method`, and `path`.
+
+**HTTP verification:**
+```
+GET {{ platform.control_plane_url }}/apis/operations?api=<vendor>/<name>/<version>
+```
+Should return 200 status with operation array in response body.
+
+**Note:** If authentication requirements are critical and cannot be discovered through the platform (spec retrieval failed, `security_schemes` is empty, and operation metadata shows `auth: null`), you must obtain this information from external sources before proceeding to request access or execute operations.

--- a/cli/internal/skillgen/content/tasks/jentic/inspect-api-operations.md
+++ b/cli/internal/skillgen/content/tasks/jentic/inspect-api-operations.md
@@ -1,0 +1,56 @@
+---
+name: inspect-api-operations
+description: List the operations available on the test API.
+version: 1
+---
+
+# Inspect Api Operations
+
+## When to Use
+
+Use this skill when you need to perform the inspect api operations step during onboarding to the Jentic platform.
+
+## Prerequisites
+
+- Access to the Jentic platform
+- Completed: Find Credential (`find-credential`)
+
+## Procedure
+
+### 1. Inspect Api Operations
+
+List the operations available on the test API.
+
+**CLI:**
+
+```bash
+jentic apis
+```
+
+**HTTP:**
+
+```
+GET /apis/jentic-test/test-api/1.0.0/operations
+```
+
+**Notes:**
+- Lists operations (method + path) available on a specific API version
+- Endpoint: GET /apis/{vendor}/{name}/{version}/operations
+
+## Quick Reference
+
+### CLI Commands
+
+- `jentic apis`
+
+### HTTP Endpoints
+
+- `GET /apis/jentic-test/test-api/1.0.0/operations`
+
+## Pitfalls
+
+- Must use the exact vendor/name/version from the registry — partial paths return 404
+
+## Verification
+
+- Operations endpoint was hit

--- a/cli/internal/skillgen/content/tasks/jentic/make-proxied-request.md
+++ b/cli/internal/skillgen/content/tasks/jentic/make-proxied-request.md
@@ -1,0 +1,319 @@
+---
+name: make-proxied-request
+description: Make authenticated API requests through the Jentic broker using toolkit credentials
+version: 6
+---
+
+# Making Proxied API Requests Through Jentic
+
+## When to Use
+
+Use this skill when you need to call an external API through Jentic's broker, which handles authentication, credential injection, and request proxying on your behalf.
+
+## Prerequisites
+
+- Agent identity registered and authenticated with Jentic platform
+- Target API registered in the Jentic registry
+- Toolkit access granted containing credentials for the target API
+- Valid authentication token with toolkit binding
+- Target API must be accessible from the broker (not localhost/private IP ranges in production environments)
+
+## Procedure
+
+### 0. Agent Registration and Authentication (If Not Already Completed)
+
+Before you can make proxied requests, you must have a registered agent with a valid authentication token.
+
+**CLI:**
+
+Register a new agent:
+```bash
+jentic register --yes
+```
+
+The `--yes` flag auto-approves the registration in development environments. Without it, you'll need to manually approve the agent via the console URL provided in the output.
+
+**Important:** The CLI does not have a `jentic auth` command for initial authentication. Authentication is handled automatically during registration. If registration completes but token minting fails (indicated by an exit code 1 error or "agent for profile is not active yet" message), the agent has been created but approval is still pending. 
+
+**Recovery steps:**
+1. Wait 10-15 seconds for background approval to complete
+2. Re-run `jentic register` to attempt token minting again
+3. The CLI will detect the existing agent and attempt to complete the authentication process
+4. If the error persists, manually approve the agent via the console URL shown in the registration output, then re-run `jentic register`
+
+Check your profile status:
+```bash
+jentic profile show
+```
+
+This displays your agent_id and token status. If you see a profile but no token, re-run `jentic register` to complete the authentication.
+
+**Expected outcome:** You should have a profile with an active authentication token. The `jentic profile show` command should display your agent_id and confirm token presence.
+
+**HTTP:**
+
+Register a new agent:
+```
+POST {{ platform.control_plane_url }}/agents
+Content-Type: application/json
+
+{
+  "name": "<agent-name>"
+}
+```
+
+Response includes `agent_id` and approval status. You must then approve the agent (via console or API) before proceeding to token minting.
+
+After approval, mint a token:
+```
+POST {{ platform.control_plane_url }}/agents/<agent_id>/tokens
+```
+
+Response includes the authentication token to use for subsequent requests.
+
+### 1. Locate the Target API in the Registry
+
+First, verify the API exists and get its identifier.
+
+**CLI:**
+```bash
+jentic apis list
+```
+
+Look for your target API in the output. Note the vendor/name/version format (e.g., `vendor-name/api-name/1.0.0`).
+
+**Important:** The command is `jentic apis` (plural), not `jentic api` (singular).
+
+**HTTP:**
+```
+GET {{ platform.control_plane_url }}/apis
+Authorization: Bearer <your_token>
+```
+
+Response will include an array of API objects with `vendor`, `name`, and `version` fields.
+
+**Expected outcome:** You should see your target API listed with its full identifier.
+
+### 2. Request Toolkit Access
+
+If you don't already have access to a toolkit containing the API's credentials, request it.
+
+**CLI:**
+```bash
+jentic access request --toolkit <api-name> --wait
+```
+
+The `--wait` flag makes the command block until approval is received. Auto-approval is common for test environments. You can also use the API name directly as the toolkit name.
+
+Alternative without waiting:
+```bash
+jentic access request <toolkit-name>
+```
+
+**HTTP:**
+```
+POST {{ platform.control_plane_url }}/access-requests
+Authorization: Bearer <your_token>
+Content-Type: application/json
+
+{
+  "toolkit": "<toolkit-name>"
+}
+```
+
+**Expected outcome:** Response indicates `approved: true` or similar approval status.
+
+**Note:** There is no `jentic toolkits` command to list available toolkits. Use the access request command with the API name or toolkit name you need.
+
+### 3. Refresh Your Authentication Token
+
+After gaining new toolkit access, refresh your token to include the new binding.
+
+**CLI:**
+```bash
+jentic auth refresh
+```
+
+This updates your local token with the new permissions.
+
+**HTTP:**
+```
+POST {{ platform.control_plane_url }}/auth/refresh
+Authorization: Bearer <your_current_token>
+```
+
+Response includes a new token with updated `toolkit_bindings`.
+
+**Expected outcome:** Your token now includes the toolkit in its bindings. Verify with `jentic auth status` (CLI) or by decoding the JWT.
+
+### 4. Find the Operation ID
+
+To execute a request, you need the operation's unique identifier from the registry.
+
+**CLI:**
+```bash
+jentic apis operations <vendor>/<api-name>/<version> --json
+```
+
+The `--json` flag is **required** because the formatted output doesn't display operation IDs. Look for the `operation_id` field (format: `op_<hash>`).
+
+**Important:** The command expects the full three-part identifier. Using a partial identifier (e.g., `vendor/api-name` without version) will fail with "invalid API reference" error.
+
+You can also inspect a specific operation:
+```bash
+jentic apis inspect <operation_id>
+```
+
+This shows the full operation details including the upstream URL.
+
+**HTTP:**
+```
+GET {{ platform.control_plane_url }}/apis/<vendor>/<api-name>/<version>/operations
+Authorization: Bearer <your_token>
+```
+
+Parse the JSON response to find the operation matching your desired HTTP method and path.
+
+**Expected outcome:** You have an operation ID like `op_6a58da5c629c0e3b921f48c9`.
+
+### 5. Execute the Proxied Request
+
+Use the operation ID to make the request through the broker.
+
+**CLI:**
+```bash
+jentic execute <operation_id>
+```
+
+For requests with parameters, query strings, or body:
+```bash
+jentic execute <operation_id> --param key=value --header "X-Custom: value"
+```
+
+Alternative formats supported:
+```bash
+jentic execute METHOD:url              # Full URL
+jentic execute METHOD:/path            # Path only (requires API context)
+```
+
+**HTTP:**
+```
+POST {{ platform.broker_url }}/execute/<operation_id>
+Authorization: Bearer <your_token>
+Content-Type: application/json
+
+{
+  "parameters": {},
+  "headers": {},
+  "body": {}
+}
+```
+
+**Expected outcome:** The broker proxies your request to the upstream API, injects credentials from your toolkit, and returns the API's response.
+
+### 6. Verify the Response
+
+Check that you received a successful response from the upstream API (not an error from the broker).
+
+**CLI:**
+The command output will show the HTTP status and response body from the upstream API.
+
+**HTTP:**
+The response status and body reflect the upstream API's response. Broker errors (4xx) will have a JSON body with an `error` field describing broker-level issues.
+
+**Expected outcome:** A 2xx status code and response body from the target API indicates success.
+
+## Quick Reference
+
+### CLI Commands
+```bash
+jentic register --yes                               # Register agent with auto-approval
+jentic profile show                                 # Check agent profile and token status
+jentic apis list                                    # List available APIs (note: plural "apis")
+jentic apis show <vendor>/<name>/<version>          # Show API details
+jentic apis inspect <operation_id>                  # Inspect specific operation
+jentic access request --toolkit <name> --wait       # Request toolkit access (blocking)
+jentic auth refresh                                 # Refresh token with new bindings
+jentic auth status                                  # Check current bindings
+jentic apis operations <vendor>/<name>/<version> --json  # List operations with IDs
+jentic execute <operation_id>                       # Execute proxied request
+jentic execute <operation_id> --param key=value     # Execute with parameters
+```
+
+### HTTP Endpoints
+```
+GET  /apis                                          # List APIs
+POST /access-requests                               # Request toolkit access
+POST /auth/refresh                                  # Refresh authentication token
+GET  /apis/<vendor>/<name>/<version>/operations     # List operations
+POST /execute/<operation_id>                        # Execute proxied request
+GET  /executions                                    # View execution history
+```
+
+## Pitfalls
+
+- **No "auth" command in CLI for initial setup**: The CLI does not have a `jentic auth` command for initial authentication. Authentication happens during the `jentic register` process. If you see "unknown command 'auth'" error, you're trying to use a command that doesn't exist. Use `jentic register` for initial setup and `jentic auth refresh` or `jentic auth status` for token management after registration.
+
+- **Registration may fail to mint token with exit code 1**: The `jentic register` command may complete registration (creating the agent) but fail during token minting with an exit code 1 error or "agent for profile is not active yet" message. This typically means the agent is created but approval is still pending. Wait 10-15 seconds for background approval to complete, then re-run `jentic register`. The CLI will detect the existing agent and attempt to complete the authentication process. If `jentic profile show` displays an agent_id but no token, re-run `jentic register` to complete the authentication. If the error persists, manually approve the agent via the console URL provided in the registration output.
+
+- **Exit code 137 during registration**: If registration is interrupted with exit code 137, the agent may be created but not fully authenticated. Check status with `jentic profile show` and re-run `jentic register` if needed.
+
+- **Command is "apis" not "api"**: The CLI command is `jentic apis` (plural). Using `jentic api` will result in "unknown command" error with a suggestion to use `apis`.
+
+- **Operation ID not visible**: The formatted output of `jentic apis operations` doesn't show operation IDs. Always use `--json` flag to see the `operation_id` field needed for execution.
+
+- **Stale token after access grant**: After requesting and receiving toolkit access, you must refresh your authentication token. The new binding won't be active until you do.
+
+- **SSRF protection blocks localhost**: The broker blocks requests to localhost, 127.0.0.1, and private IP ranges for security. Test APIs must be hosted on publicly routable addresses or the broker must be configured to allow the target range. This affects both URL-based and operation-ID-based execution. Error message: "upstream URL resolves to a blocked address range" with `invalid_upstream_url` error code.
+
+- **Wrong API identifier format**: API references must be in `vendor/name/version` format (all three parts required). Partial identifiers like `vendor/name` will fail with "invalid API reference; expected vendor/name/version" error. The `jentic apis operations` and `jentic apis show` commands strictly require the full three-part identifier.
+
+- **Search command limitations**: The `jentic search` command may not return results reliably. The `--api` flag is not supported and will cause "unknown flag" errors. Use `jentic apis list` and `jentic apis operations` for discovery instead.
+
+- **Confusing operation reference formats**: The `execute` command requires the registry operation ID (e.g., `op_<hash>`), not the API path, HTTP method, or spec operationId. Always get this from `jentic apis operations --json`.
+
+- **No CLI command for execution history**: There is no CLI command to view execution history. You must use the HTTP endpoint `GET /executions` with your bearer token to view past executions.
+
+- **No CLI command to list toolkits**: There is no `jentic toolkits` command. To request toolkit access, use the API name or known toolkit name directly with `jentic access request --toolkit <name>`.
+
+- **OpenAPI spec download may fail**: Attempting to download the OpenAPI spec for an API revision may return a 500 error if the spec file is not stored in the system.
+
+- **Authentication requirements not in metadata**: The operation metadata (`auth` field and `security_schemes` field) may show `null` or be empty even when the API requires authentication headers. Authentication requirements are defined in the OpenAPI spec and injected by the broker via toolkit credentials, not visible in the operation listing.
+
+## Verification
+
+**CLI:**
+```bash
+# Verify agent registration and token
+jentic profile show
+# Should show agent_id and confirm token is present
+
+# Verify toolkit binding
+jentic auth status
+# Should show your toolkit in the bindings list
+
+# Inspect operation before executing
+jentic apis inspect <operation_id>
+# Shows full operation details including upstream URL
+
+# Verify successful execution
+jentic execute <operation_id>
+# Should return 2xx status with upstream API response body
+```
+
+**HTTP:**
+```
+# Verify toolkit binding
+GET {{ platform.control_plane_url }}/auth/status
+# Response includes toolkit_bindings array
+
+# Verify successful execution
+POST {{ platform.broker_url }}/execute/<operation_id>
+# Response status 200-299 with upstream API data (not broker error JSON)
+
+# View execution history
+GET {{ platform.control_plane_url }}/executions
+# Returns array of execution records
+```
+
+Success means: (1) your agent is registered with a valid token, (2) your token includes the toolkit binding, (3) the execute command/endpoint returns a response, (4) the response is from the upstream API (not a broker error), and (5) the status indicates success per the API's contract.

--- a/cli/internal/skillgen/content/tasks/jentic/read-api-spec.md
+++ b/cli/internal/skillgen/content/tasks/jentic/read-api-spec.md
@@ -1,0 +1,56 @@
+---
+name: read-api-spec
+description: Download and examine the test API's OpenAPI specification.
+version: 1
+---
+
+# Read Api Spec
+
+## When to Use
+
+Use this skill when you need to perform the read api spec step during onboarding to the Jentic platform.
+
+## Prerequisites
+
+- Access to the Jentic platform
+- Completed: Inspect Api Operations (`inspect-api-operations`)
+
+## Procedure
+
+### 1. Read Api Spec
+
+Download and examine the test API's OpenAPI specification.
+
+**CLI:**
+
+```bash
+jentic apis
+```
+
+**HTTP:**
+
+```
+GET /apis/jentic-test/test-api/1.0.0/openapi
+```
+
+**Notes:**
+- Downloads the raw OpenAPI JSON/YAML for a specific API version
+- Endpoint: GET /apis/{vendor}/{name}/{version}/openapi
+
+## Quick Reference
+
+### CLI Commands
+
+- `jentic apis`
+
+### HTTP Endpoints
+
+- `GET /apis/jentic-test/test-api/1.0.0/openapi`
+
+## Pitfalls
+
+- The spec content is returned inline — large specs may be truncated in some clients
+
+## Verification
+
+- OpenAPI spec endpoint was hit

--- a/cli/internal/skillgen/content/tasks/jentic/register-agent.md
+++ b/cli/internal/skillgen/content/tasks/jentic/register-agent.md
@@ -1,0 +1,217 @@
+---
+name: register-agent
+description: Register a new agent identity on the Jentic platform and obtain authentication credentials
+version: 6
+---
+
+# Register Agent Identity
+
+## When to Use
+
+Use this skill when you need to create a new agent identity on the Jentic platform for the first time. This is typically the first step before you can access APIs, request toolkit access, or execute operations through the broker.
+
+## Prerequisites
+
+- Access to the Jentic platform control plane URL
+- Network connectivity to the platform
+- For CLI: `jentic` binary installed and available in PATH
+- For HTTP: Ability to make HTTP requests and store credentials
+
+## Procedure
+
+### 1. Initiate Agent Registration
+
+**CLI:**
+```bash
+jentic register --yes
+```
+
+The `--yes` flag auto-confirms the registration. Without it, you'll be prompted to confirm.
+
+**Expected output:**
+```
+Registering agent "<agent-name>" with <control-plane-url> ...
+Registered: agent_id=<your-agent-id> status=pending
+```
+
+**HTTP:**
+```
+POST {{ platform.control_plane_url }}/v1/agents/register
+Content-Type: application/json
+
+{
+  "name": "<optional-agent-name>",
+  "description": "<optional-description>"
+}
+```
+
+**Expected Response:**
+- HTTP: 202 Accepted with registration request details including a request ID
+
+### 2. Wait for Admin Approval
+
+**CLI:**
+After registration is initiated, the agent enters `pending` status. The CLI will display an approval URL:
+```
+Approve this agent in the Jentic console:
+    <control-plane-url>/app/agents/<agent-id>
+```
+
+In development environments with automatic approval enabled, approval typically completes within 10-15 seconds. The CLI will automatically poll for approval status and proceed to token minting once approved.
+
+**Important:** If the CLI exits with an error after showing the approval URL, this may indicate the token minting step failed (see Pitfalls section). The agent may still be approved — check the approval URL or retry registration. The error message will typically state: `agent for profile "default" is not active yet (Assertion is invalid); wait for approval, or re-run 'jentic register --profile default'`
+
+**HTTP:**
+Poll the registration status endpoint:
+```
+GET {{ platform.control_plane_url }}/v1/agents/register/<request-id>
+Authorization: Bearer <temporary-token-from-registration-response>
+```
+
+Continue polling (with exponential backoff) until the status changes from `pending` to `approved`.
+
+**Expected Response:**
+- Status: `approved`
+- Response includes agent ID and authentication tokens
+
+### 3. Store Authentication Credentials
+
+**CLI:**
+The CLI automatically saves credentials to `.jentic/profiles/default` in your home directory or working directory. Credentials are stored in a `tokens.json` file within the profile directory. No manual action required. The output will clearly show:
+- Your agent_id
+- Approval URL (if applicable)
+- Token expiry information
+- Next steps for using the platform
+
+**Note:** In some cases, the profile may be created but token minting may fail during the registration flow. If this occurs, see the "Token Minting Failure" section in Pitfalls below. You can verify token storage by checking that `.jentic/profiles/default/tokens.json` exists and contains token data.
+
+**HTTP:**
+Extract and securely store the following from the approval response:
+- `agent_id`: Your unique agent identifier
+- `access_token`: Short-lived token for API requests
+- `refresh_token`: Long-lived token for obtaining new access tokens
+
+Store these in a secure location (environment variables, secrets manager, or encrypted config file).
+
+### 4. Verify Registration
+
+**CLI:**
+```bash
+jentic agents list
+```
+
+Look for your agent ID in the output. This confirms both registration and authentication are working. If you receive an error stating the agent is "not active yet," the approval process has not completed — wait 10-15 seconds and try again.
+
+**HTTP:**
+```
+GET {{ platform.control_plane_url }}/v1/agents/me
+Authorization: Bearer <access-token>
+```
+
+**Expected Response:**
+- Your agent details including ID, name, and registration timestamp
+- Empty or minimal `toolkit_bindings` array (you haven't requested access to anything yet)
+
+## Quick Reference
+
+### CLI Commands
+```bash
+# Register new agent (with auto-confirm)
+jentic register --yes
+
+# Register with interactive confirmation
+jentic register
+
+# View your agent details
+jentic agents list
+
+# Check current authentication status
+jentic agents list  # Your agent should appear in the list
+
+# Log out (clears profile)
+jentic logout
+```
+
+### HTTP Endpoints
+```
+# Register agent
+POST {{ platform.control_plane_url }}/v1/agents/register
+
+# Check registration status
+GET {{ platform.control_plane_url }}/v1/agents/register/<request-id>
+
+# Get current agent details
+GET {{ platform.control_plane_url }}/v1/agents/me
+
+# Refresh access token (when expired)
+POST {{ platform.control_plane_url }}/v1/auth/refresh
+Authorization: Bearer <refresh-token>
+```
+
+## Pitfalls
+
+- **Don't lose your tokens**: CLI stores them automatically in `.jentic/profiles/default/tokens.json`, but if using HTTP directly, ensure you persist the refresh token securely. Access tokens expire, but refresh tokens are long-lived.
+
+- **Registration requires approval**: The registration process is asynchronous. Don't assume immediate access. The CLI handles polling automatically, but HTTP clients must implement polling logic. In development environments, approval may be automatic and take 10-15 seconds.
+
+- **Profile location (CLI)**: The CLI saves credentials to `.jentic/profiles/default`. If running in a containerized or restricted environment, ensure this path is writable and persistent. Verify that `tokens.json` is created in this directory after successful registration.
+
+- **Token refresh**: Access tokens expire. The CLI handles refresh automatically. HTTP clients must detect 401 responses and use the refresh token to obtain a new access token before retrying.
+
+- **No `whoami` command**: There is no `jentic whoami` command. Use `jentic agents list` to see your agent identity.
+
+- **No `auth` command**: There is no `jentic auth` command. Authentication is handled automatically during registration. If you need to re-authenticate, use `jentic logout` followed by `jentic register`.
+
+- **Authentication is automatic**: After successful registration with the CLI, you are immediately authenticated. There is no separate authentication step required - the registration process handles credential storage and you can immediately proceed to use other commands like `jentic apis list` or `jentic access request`.
+
+- **Token minting failure**: The CLI may exit with an error after displaying the approval URL and agent ID. This typically indicates a failure during the token minting step (e.g., connection error to the OAuth token endpoint). The agent may still be created and approved. If this occurs:
+  1. Check the approval URL shown in the output to verify the agent was created
+  2. Wait 10-15 seconds to ensure approval has completed
+  3. Run `jentic register --yes` again — the CLI will detect the existing agent and attempt to complete token minting
+  4. If the problem persists, the OAuth token endpoint may be unavailable or misconfigured
+  5. Check platform logs or console for OAuth service errors
+  6. Verify that `.jentic/profiles/default/tokens.json` was created; if the file exists but is empty or malformed, this indicates token minting failed
+
+- **Re-running register with existing agent**: If you run `jentic register` and an agent profile already exists, the CLI will display "Using existing agent_id=..." and show the approval URL. This can be used to recover from partial registration failures.
+
+- **Agent not active error**: If `jentic agents list` fails with the error `agent for profile "default" is not active yet (Assertion is invalid)`, the approval process has not yet completed. Wait 10-15 seconds and retry. If the error persists after 30 seconds, the approval may have failed — check the approval URL in the Jentic console or retry the full registration flow.
+
+## Verification
+
+### CLI Verification
+Run `jentic agents list` and confirm:
+- Your agent appears in the output
+- The agent ID matches what was shown during registration
+- No error messages about authentication or agent not being active
+
+### CLI Credential Verification
+Verify that credentials were properly stored:
+```bash
+# Check that the profile directory exists
+ls -la ~/.jentic/profiles/default/
+
+# Verify tokens.json exists and contains data
+cat ~/.jentic/profiles/default/tokens.json
+```
+
+Expected: `tokens.json` file exists and contains JSON with token data (do not display actual tokens).
+
+### HTTP Verification
+Make a request to `GET {{ platform.control_plane_url }}/v1/agents/me` and confirm:
+- Response status is 200 OK
+- Response body contains your agent ID
+- Response includes `toolkit_bindings` field (even if empty)
+
+### Additional Checks
+- CLI: Check that `.jentic/profiles/default/tokens.json` exists and contains token data
+- HTTP: Verify you can make authenticated requests to other endpoints (e.g., `GET /v1/apis`)
+- Both: Confirm that unauthenticated requests to protected endpoints return 401 Unauthorized
+
+### Troubleshooting Failed Registration
+If `jentic agents list` fails with authentication errors after registration:
+1. Check if `.jentic/profiles/default` exists
+2. Inspect the profile directory to verify `tokens.json` exists
+3. If the profile exists but `tokens.json` is missing or empty, this indicates a token minting failure
+4. Try `jentic logout` followed by `jentic register --yes` to retry the full flow
+5. If the CLI exits with an error after showing the approval URL, wait 10-15 seconds and run `jentic register --yes` again to retry token minting
+6. If the error persists, check that the approval URL is accessible in the Jentic console and that the agent shows as approved

--- a/cli/internal/skillgen/content/tasks/jentic/verify-access-granted.md
+++ b/cli/internal/skillgen/content/tasks/jentic/verify-access-granted.md
@@ -1,0 +1,71 @@
+---
+name: verify-access-granted
+description: Confirm the access request was approved and check granted permissions.
+version: 1
+---
+
+# Verify Access Granted
+
+## When to Use
+
+Use this skill when you need to perform the verify access granted step during onboarding to the Jentic platform.
+
+## Prerequisites
+
+- Access to the Jentic platform
+- Completed: Add To Toolkit (`add-to-toolkit`)
+
+## Procedure
+
+### 1. Verify Access Granted
+
+Confirm the access request was approved and check granted permissions.
+
+**CLI:**
+
+```bash
+jentic access
+```
+
+**HTTP:**
+
+```
+GET /access-requests
+```
+
+**Response:**
+```json
+{
+  "data": "<array>"
+  "has_more": "<boolean>"
+  "next_cursor": "<string>"
+}
+```
+
+**Query parameters:**
+- `actor_id`
+- `status`
+- `cursor`
+- `limit`
+
+**Notes:**
+- Poll GET /access-requests with your actor_id to check status
+- Status transitions: pending → approved (or denied)
+
+## Quick Reference
+
+### CLI Commands
+
+- `jentic access`
+
+### HTTP Endpoints
+
+- `GET /access-requests`
+
+## Pitfalls
+
+- Approval is not instant — poll every few seconds for up to 15s before concluding it's stuck
+
+## Verification
+
+- Agent confirmed approved access request exists

--- a/cli/internal/skillgen/content/tasks/jentic/view-audit-events.md
+++ b/cli/internal/skillgen/content/tasks/jentic/view-audit-events.md
@@ -1,0 +1,229 @@
+---
+name: view-audit-events
+description: Access and browse the platform audit log to review agent activity and system events
+version: 4
+---
+
+# View Audit Events
+
+## When to Use
+
+Use this skill when you need to review your agent's activity history, investigate system events, or audit actions taken on the platform. This is useful for debugging, compliance tracking, or understanding the sequence of operations performed.
+
+## Prerequisites
+
+- Active agent registration with the platform
+- Agent must be **approved** in the console before token minting will succeed
+- Valid authentication token with `events:read` scope (granted by default to agents)
+- Access to the platform control plane API
+- **Important**: You must have a valid token minted and stored. If registration completed but token minting failed, approval may be pending or you may need to re-register after approval.
+
+## Procedure
+
+### 1. Ensure Agent Registration and Approval
+
+Before querying the events API, your agent must be registered **and approved** in the console.
+
+**CLI:**
+
+```bash
+jentic register
+```
+
+The output will show:
+```
+Registered: agent_id=<agent_id> status=pending
+Approve this agent in the Jentic console:
+    http://<platform_url>/app/agents/<agent_id>
+```
+
+⚠️ **Critical**: Token minting happens **after** approval. If you see `status=pending`, you must approve the agent in the console before the token will be minted. The approval process may take 10-15 seconds to complete in the background.
+
+After approval completes, the token will be automatically stored in `~/.config/jentic/tokens.json`.
+
+**Troubleshooting registration:**
+- If you see `error: agent for profile "default" is not active yet`, the agent is still pending approval. Check the console approval page and wait 10-15 seconds.
+- If registration fails with EOF or timeout errors, the approval process may still be in progress. Wait a few seconds and retry `jentic register`.
+
+### 2. Locate Your Authentication Token
+
+Once your agent is approved and registered, retrieve your bearer token for authentication.
+
+**CLI:**
+
+The `jentic` CLI stores tokens automatically after successful registration and approval. The token is typically stored in `~/.config/jentic/tokens.json`.
+
+```bash
+# Verify token exists and is not empty
+cat ~/.config/jentic/tokens.json | jq -r '.token'
+```
+
+⚠️ **Token Availability**: If the token file is empty, missing the `token` field, or returns `null`:
+- Verify the agent was approved in the console (check the agent status page)
+- Wait 10-15 seconds after approval for background token minting to complete
+- Re-run `jentic register` to retry the registration and token minting process
+- Check that the registration process completed successfully without EOF or timeout errors
+- If the file exists but contains no valid token, the approval may not have completed. Return to Step 1 and verify approval status in the console.
+
+**HTTP:**
+
+Your token was provided during the authentication flow. It should be stored securely by your agent. The token is used in the `Authorization` header as a Bearer token.
+
+### 3. Query the Events Endpoint
+
+The platform exposes audit events through the `/events` endpoint on the control plane.
+
+**CLI:**
+
+⚠️ **Important**: The `jentic` CLI does not currently provide a built-in command for viewing events (e.g., `jentic events list` or `jentic auth`). You must make a direct HTTP request to the control plane API.
+
+```bash
+# Extract token and make direct API call
+TOKEN=$(cat ~/.config/jentic/tokens.json | jq -r '.token')
+curl -H "Authorization: Bearer $TOKEN" \
+     {{ platform.control_plane_url }}/events
+```
+
+If the token extraction fails or returns `null`, verify the token file exists and contains a valid token before proceeding. See Step 2 troubleshooting.
+
+**HTTP:**
+
+```
+GET /events
+Host: {{ platform.control_plane_url }}
+Authorization: Bearer <your_token>
+```
+
+Expected response (200 OK):
+```json
+{
+  "events": [
+    {
+      "id": "<event_id>",
+      "type": "<event_type>",
+      "severity": "<info|warning|error>",
+      "summary": "<human_readable_description>",
+      "actor": {
+        "type": "agent",
+        "id": "<agent_id>",
+        "name": "<agent_name>"
+      },
+      "timestamp": "<ISO8601_timestamp>",
+      "metadata": { ... }
+    }
+  ]
+}
+```
+
+### 4. Filter or Paginate Results (Optional)
+
+If the events list is large, you may need to filter by time range, event type, or paginate through results.
+
+**CLI:**
+
+```bash
+# Add query parameters to the curl request
+TOKEN=$(cat ~/.config/jentic/tokens.json | jq -r '.token')
+curl -H "Authorization: Bearer $TOKEN" \
+     "{{ platform.control_plane_url }}/events?limit=50&offset=0"
+```
+
+**HTTP:**
+
+```
+GET /events?limit=50&offset=0
+Host: {{ platform.control_plane_url }}
+Authorization: Bearer <your_token>
+```
+
+Common query parameters (check platform documentation for full list):
+- `limit`: Maximum number of events to return
+- `offset`: Number of events to skip (for pagination)
+- `type`: Filter by event type
+- `since`: ISO8601 timestamp for events after a certain time
+
+### 5. Parse and Analyze Events
+
+Review the returned events to find relevant activity. Key fields to examine:
+
+- **type**: The category of event (e.g., `agent.registered`, `access.granted`, `api.called`)
+- **severity**: Importance level of the event
+- **summary**: Human-readable description of what happened
+- **actor**: Who or what triggered the event
+- **timestamp**: When the event occurred
+- **metadata**: Additional context specific to the event type
+
+## Quick Reference
+
+### CLI Commands
+
+```bash
+# Step 1: Register agent (must be approved in console before token is minted)
+jentic register
+
+# Step 2: Verify token exists
+cat ~/.config/jentic/tokens.json | jq -r '.token'
+
+# Step 3: Query events via direct API access
+TOKEN=$(cat ~/.config/jentic/tokens.json | jq -r '.token')
+curl -H "Authorization: Bearer $TOKEN" {{ platform.control_plane_url }}/events
+```
+
+### HTTP Endpoints
+
+```
+GET /events                    # List all events
+GET /events?limit=N&offset=M   # Paginated results
+GET /events?type=<event_type>  # Filter by type
+```
+
+## Pitfalls
+
+- **Agent not approved**: Registration creates an agent with `status=pending`. Token minting only occurs **after** the agent is approved in the console. If you attempt to access events before approval, the token will not exist. Always check the console approval page and wait 10-15 seconds for background processing. If you see `error: agent for profile "default" is not active yet`, approval is still pending.
+
+- **No CLI command**: The `jentic` CLI does not provide a native command for viewing events. Commands like `jentic events list` or `jentic auth` do not exist. You must make direct HTTP requests to the control plane API, even when using CLI mode for other operations.
+
+- **Wrong endpoint**: Do not confuse `/events` with `/audit`. The `/audit` endpoint requires `audit:read` scope which agents typically do not have by default. Use `/events` for agent activity logs.
+
+- **Token extraction**: When using CLI mode, you need to manually extract the token from the CLI's storage location (typically `~/.config/jentic/tokens.json`) to make direct API calls. Always verify the extracted token is not `null` before using it in requests.
+
+- **Missing or empty token**: If registration completed but token minting failed (e.g., due to EOF errors, timeouts, or approval issues), the tokens.json file may exist but contain no valid token. Check that the file contains a `token` field with a non-empty value before attempting to use it. Verify approval status in the console first. If the file exists but is empty, the approval process may not have completed—return to Step 1.
+
+- **Registration state issues**: If registration shows `status=pending` and token minting fails, the agent may be created but not approved. You must manually approve the agent in the console before the token will be minted. After approval, wait 10-15 seconds for background token minting to complete. If you see `error: agent for profile "default" is not active yet`, the approval is still in progress.
+
+- **Missing Authorization header**: The events endpoint requires authentication. Always include `Authorization: Bearer <token>` in your HTTP requests.
+
+- **Scope requirements**: Ensure your token has the `events:read` scope. This is granted by default to agents during registration, but verify if you encounter 403 Forbidden errors.
+
+- **Token extraction in scripts**: When extracting the token using `jq`, ensure the command completes successfully. If `jq` is not installed or the JSON is malformed, the token variable will be empty. Test token extraction before using it in curl commands.
+
+## Verification
+
+**Successful retrieval indicators:**
+
+- HTTP 200 OK response status
+- JSON response containing an `events` array
+- Events include your recent activity (e.g., registration, authentication, API calls)
+- Each event has required fields: `id`, `type`, `severity`, `summary`, `actor`, `timestamp`
+
+**To verify you're seeing your own activity:**
+
+1. Check the `actor.id` field matches your agent ID
+2. Look for events with timestamps corresponding to your recent actions
+3. Verify event types match operations you performed (e.g., `agent.registered`, `toolkit.access_requested`)
+
+**Common error responses:**
+
+- **401 Unauthorized**: Token is missing, invalid, or expired
+- **403 Forbidden**: Token lacks `events:read` scope
+- **404 Not Found**: Wrong endpoint URL (check you're using `/events` not `/audit`)
+
+**Before attempting to view events:**
+
+1. Verify agent is approved in the console: Check the agent status page at `http://<platform_url>/app/agents/<agent_id>`
+2. Wait 10-15 seconds after approval for token minting to complete
+3. Verify your token exists: `cat ~/.config/jentic/tokens.json | jq -r '.token'`
+4. Ensure the output is not empty or `null`
+5. If token is still missing, re-run `jentic register` to retry the registration and token minting process
+6. If you see `error: agent for profile "default" is not active yet`, approval is still pending—wait and retry
+

--- a/cli/internal/skillgen/skillgen_test.go
+++ b/cli/internal/skillgen/skillgen_test.go
@@ -735,6 +735,40 @@ func TestMalformedHashIsRefreshableNotUserEdit(t *testing.T) {
 	}
 }
 
+func TestTaskSkillsLoadsEmbedded(t *testing.T) {
+	skills, err := TaskSkills("jentic")
+	if err != nil {
+		t.Fatalf("TaskSkills: %v", err)
+	}
+	if len(skills) < 5 {
+		t.Fatalf("expected at least 5 task skills, got %d", len(skills))
+	}
+	for _, ts := range skills {
+		if ts.Name == "" {
+			t.Errorf("task %q has empty Name", ts.TaskID)
+		}
+		if ts.Description == "" {
+			t.Errorf("task %q has empty Description", ts.TaskID)
+		}
+		if ts.Content == "" {
+			t.Errorf("task %q has empty Content", ts.TaskID)
+		}
+	}
+}
+
+func TestTaskSkillByID(t *testing.T) {
+	ts, err := TaskSkillByID("jentic", "register-agent")
+	if err != nil {
+		t.Fatalf("TaskSkillByID: %v", err)
+	}
+	if ts == nil {
+		t.Fatal("expected non-nil TaskSkill")
+	}
+	if ts.Name != "register-agent" {
+		t.Errorf("Name = %q, want %q", ts.Name, "register-agent")
+	}
+}
+
 // TestDescriptionRenderingPerOperator: claude/cursor emit the full description
 // verbatim; hermes adapts canonical to its <=60-char one-sentence rule but
 // emits the freeform description in full.

--- a/cli/tests/arch/fencing_test.go
+++ b/cli/tests/arch/fencing_test.go
@@ -92,7 +92,7 @@ var fencingExemptPrefixes = []string{
 	// agent's own runtime / its own credential, never another identity). NOTE:
 	// `setup` is NOT here — it is fenced (AGT-5): it hangs on a human
 	// approval poll and writes skill files; agents use `register`.
-	"skill", "register",
+	"skill", "skills", "register",
 	// Operator admin config surface (jentic-tree mirror) — reachable to operators;
 	// server-side-authorized. (jenticctl is the primary operator binary.)
 	"admin",

--- a/cli/tests/arch/mutator_test.go
+++ b/cli/tests/arch/mutator_test.go
@@ -30,23 +30,23 @@ var configWriterAllowlist = map[string]bool{
 
 	// Shipped writers (grandfathered; each is an atomic temp-file+rename or a
 	// 0600 secret/state write, not an ad-hoc config clobber).
-	"internal/config/file.go":             true, // writeFileAtomic -> config.yaml (the mutator today)
-	"internal/config/manifest.go":         true, // install manifest
-	"internal/profile/store.go":           true, // profile state (atomic)
-	"internal/agentkey/key.go":            true, // Ed25519 key material (0600)
-	"internal/skillgen/apply.go":              true, // rendered skill files (atomic)
-	"internal/cli/localagentcmd/skills.go":    true, // task skill files written to agent runtime dirs
-	"internal/update/update.go":           true, // self-update binary swap (atomic)
-	"internal/update/download.go":         true, // extracts a verified release binary into the update stage dir (STATE, not config.yaml; sha256/cosign-verified before write)
-	"internal/install/start.go":           true, // pid file
-	"internal/install/compose.go":         true, // compose/init-schemas artifacts
-	"internal/install/build.go":           true, // build output tree
-	"internal/cli/cmdcore/updatenudge.go": true, // update-check timestamp (0600)
-	"internal/cli/ctlcmd/install.go":      true, // install writes env/compose out
-	"internal/cli/api/apis.go":            true, // apis export to user-chosen -o path
-	"internal/cli/api/history.go":         true, // history export to user-chosen -o path (redacted JSON, not config)
-	"internal/cli/ctlcmd/update.go":       true, // fetched installer script
-	"internal/cli/ctlcmd/uninstall.go":    true, // backup/restore moves
+	"internal/config/file.go":              true, // writeFileAtomic -> config.yaml (the mutator today)
+	"internal/config/manifest.go":          true, // install manifest
+	"internal/profile/store.go":            true, // profile state (atomic)
+	"internal/agentkey/key.go":             true, // Ed25519 key material (0600)
+	"internal/skillgen/apply.go":           true, // rendered skill files (atomic)
+	"internal/cli/localagentcmd/skills.go": true, // task skill files written to agent runtime dirs
+	"internal/update/update.go":            true, // self-update binary swap (atomic)
+	"internal/update/download.go":          true, // extracts a verified release binary into the update stage dir (STATE, not config.yaml; sha256/cosign-verified before write)
+	"internal/install/start.go":            true, // pid file
+	"internal/install/compose.go":          true, // compose/init-schemas artifacts
+	"internal/install/build.go":            true, // build output tree
+	"internal/cli/cmdcore/updatenudge.go":  true, // update-check timestamp (0600)
+	"internal/cli/ctlcmd/install.go":       true, // install writes env/compose out
+	"internal/cli/api/apis.go":             true, // apis export to user-chosen -o path
+	"internal/cli/api/history.go":          true, // history export to user-chosen -o path (redacted JSON, not config)
+	"internal/cli/ctlcmd/update.go":        true, // fetched installer script
+	"internal/cli/ctlcmd/uninstall.go":     true, // backup/restore moves
 }
 
 // Test1E_ConfigMutatorLock asserts every os.WriteFile / os.Rename in production

--- a/cli/tests/arch/mutator_test.go
+++ b/cli/tests/arch/mutator_test.go
@@ -34,7 +34,8 @@ var configWriterAllowlist = map[string]bool{
 	"internal/config/manifest.go":         true, // install manifest
 	"internal/profile/store.go":           true, // profile state (atomic)
 	"internal/agentkey/key.go":            true, // Ed25519 key material (0600)
-	"internal/skillgen/apply.go":          true, // rendered skill files (atomic)
+	"internal/skillgen/apply.go":              true, // rendered skill files (atomic)
+	"internal/cli/localagentcmd/skills.go":    true, // task skill files written to agent runtime dirs
 	"internal/update/update.go":           true, // self-update binary swap (atomic)
 	"internal/update/download.go":         true, // extracts a verified release binary into the update stage dir (STATE, not config.yaml; sha256/cosign-verified before write)
 	"internal/install/start.go":           true, // pid file

--- a/skills/jentic/SKILL.md
+++ b/skills/jentic/SKILL.md
@@ -481,6 +481,10 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   including the exact broker URL and headers — before committing side effects.
 - `jenticctl status` / `jenticctl start` — health-check and restart the local
   deployment; check this first when a local target refuses connections.
+- `jentic skills` — list available onboarding guidance (step-by-step
+  procedures, pitfalls, and verification for common platform workflows).
+- `jentic skills <name>` — view a specific task guide.
+- `jentic skills init [name]` — install task skill(s) for your operator.
 - Add `--json` to force machine-readable output on a terminal (works on
   `search`, `execute`, `inspect`, `apis`, `access`, `doctor`). `context view`
   has no `--json` flag — it emits JSON automatically in agent/non-TTY mode.

--- a/src/jentic_one/shared/web/content/jentic.md
+++ b/src/jentic_one/shared/web/content/jentic.md
@@ -481,6 +481,10 @@ jentic execute <operation_id> --broker-scheme http --broker-host 127.0.0.1:8100
   including the exact broker URL and headers — before committing side effects.
 - `jenticctl status` / `jenticctl start` — health-check and restart the local
   deployment; check this first when a local target refuses connections.
+- `jentic skills` — list available onboarding guidance (step-by-step
+  procedures, pitfalls, and verification for common platform workflows).
+- `jentic skills <name>` — view a specific task guide.
+- `jentic skills init [name]` — install task skill(s) for your operator.
 - Add `--json` to force machine-readable output on a terminal (works on
   `search`, `execute`, `inspect`, `apis`, `access`, `doctor`). `context view`
   has no `--json` flag — it emits JSON automatically in agent/non-TTY mode.

--- a/ui/public/cli-reference.json
+++ b/ui/public/cli-reference.json
@@ -2616,6 +2616,93 @@
           ]
         },
         {
+          "name": "skills",
+          "path": "jentic skills",
+          "use": "skills [name]",
+          "short": "List or display embedded task skills",
+          "long": "skills lists all embedded task skills (step-by-step guides for common\nJentic platform operations). Pass a skill name to print its full content.\nUse \"skills init\" to install them into your agent's native layout.",
+          "group_title": "Local agent client",
+          "flags": [
+            {
+              "name": "context",
+              "type": "string",
+              "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+            },
+            {
+              "name": "json",
+              "type": "bool",
+              "default": "false",
+              "usage": "output as JSON array"
+            },
+            {
+              "name": "mode",
+              "type": "string",
+              "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+            },
+            {
+              "name": "theme",
+              "type": "string",
+              "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+            }
+          ],
+          "subcommands": [
+            {
+              "name": "init",
+              "path": "jentic skills init",
+              "use": "init [name]",
+              "short": "Install task skills into your agent's native layout",
+              "long": "init writes task-skill markdown files into each detected agent runtime's\nnative layout. Pass a skill name to install only that one.",
+              "example": "  jentic skills init\n  jentic skills init register-agent\n  jentic skills init --operator claude,cursor\n  jentic skills init --all --yes\n  jentic skills init --dry-run",
+              "flags": [
+                {
+                  "name": "all",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "target every supported operator"
+                },
+                {
+                  "name": "context",
+                  "type": "string",
+                  "usage": "Context to act on (overrides the active context; $JENTIC_CONTEXT)"
+                },
+                {
+                  "name": "dry-run",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "print target paths without writing"
+                },
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "usage": "Interaction mode: human|agent|service-account ($JENTIC_MODE)"
+                },
+                {
+                  "name": "operator",
+                  "type": "stringSlice",
+                  "default": "[]",
+                  "usage": "operators to target (repeatable or comma-separated)"
+                },
+                {
+                  "name": "scope",
+                  "type": "string",
+                  "usage": "placement scope: user or project (default: per-operator)"
+                },
+                {
+                  "name": "theme",
+                  "type": "string",
+                  "usage": "Color theme: dark|light|no-color ($JENTIC_THEME)"
+                },
+                {
+                  "name": "yes",
+                  "type": "bool",
+                  "default": "false",
+                  "usage": "skip the interactive picker (use --operator/--all)"
+                }
+              ]
+            }
+          ]
+        },
+        {
           "name": "run",
           "path": "jentic run",
           "use": "run \u003cagent\u003e [path] [-- \u003cagent-args\u003e...]",


### PR DESCRIPTION
## Summary

Adds `jentic skills` — a CLI command that surfaces step-by-step onboarding task guides ("task skills") so AI agents can discover and follow structured procedures for each platform interaction. The docs are embedded at compile time and installed alongside the main skill into whichever agent runtime adapter is active (Claude `.claude/`, Cursor `.cursor/`, Hermes `SKILL.md`, Codex/Generic `AGENTS.md`).

## Changes

- **cli**: New `jentic skills` command with `list`, `show <name>`, and `init [name]` subcommands (`localagentcmd/skills.go`)
- **cli**: Task skill loading from `embed.FS` — `TaskSkills()`, `TaskSkillByID()`, `parseTaskSkill()` (`skillgen/bundled.go`)
- **cli**: Hook task skills into `jentic skill init` and `jentic skill remove` flows (`localagentcmd/skill.go`)
- **cli**: Register `skills` command in the root command tree (`api/root.go`)
- **cli**: Add 13 embedded onboarding task skill docs covering the full agent journey from registration through audit (`skillgen/content/tasks/jentic/*.md`)
- **cli**: Update `jentic.md` skill source with `jentic skills` reference commands
- **cli**: Regenerate `ui/public/cli-reference.json` to include new commands
- **tests**: Add `TestTaskSkillsLoadsEmbedded` and `TestTaskSkillByID` for the embed loading path
- **tests/arch**: Exempt `skills` from the fencing prefix check; add `skills.go` to the config-writer allowlist
- Out of scope: QA harness feedback loop (lives in the harness repo), LLM-refined doc upgrades (future iteration)

## Risk & rollback

Low risk: additive CLI surface only — no backend, migration, or auth changes. The `jentic skills init` writes to the local agent runtime directory (same mechanism as existing `jentic skill init`). Revert by reverting the two feature commits; existing installs are unaffected since docs are compile-time embedded.

## Test plan

- `go test ./internal/skillgen/` — task skill embed loading (PASS)
- `go test ./tests/arch/` — all architecture enforcement tests (PASS)
- `go test ./...` — full CLI test suite (PASS)
- Manual: `jentic skills` lists 13 tasks; `jentic skills show discover-apis` renders the doc; `jentic skills init` writes all 13 to the active adapter directory

## Review guide

Start with `skillgen/bundled.go` (embed + parsing), then `localagentcmd/skills.go` (the command itself), then `localagentcmd/skill.go` (integration into the existing install/remove flow). The 13 `.md` files under `content/tasks/jentic/` are generated baseline docs — skim one or two for structure, don't line-edit all 13.

## Related issue

Closes #39 (harness/seed-skill-docs — content absorbed into this branch)

## Checklist

- [x] Commits follow Conventional Commits with a scope and are signed off (`git commit -s`, DCO)
- [x] `make check` passes (lint, type check, secrets audit, arch tests)
- [x] Tests added/updated for the change
- [x] Docs updated where relevant
- [x] No secrets, credentials, or internal-only references included
