### PR TITLE
chore(helm): fill the portal-issued ECR seller namespace in the Marketplace values

### DIFF
--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -1,19 +1,20 @@
 # AWS Marketplace deployment values (container product listing).
 #
 # Overlay for the jentic-one umbrella chart when deploying from the AWS
-# Marketplace listing. Placeholders marked <…> are filled in when the listing
-# exists (plan PR 6): the Marketplace portal assigns the ECR registry path and
-# repository names when the product is created.
+# Marketplace listing. Remaining placeholders marked <…> are filled in as the
+# listing progresses (plan PR 6 / the release that pins the listing's tag).
+# The ECR registry path is portal-issued and recorded below (2026-08-25):
+# 709825985650 is AWS's shared Marketplace registry account; "jentic" is the
+# seller namespace assigned to this product.
 #
 # Marketplace rule of thumb: every image a deployment pulls must come from the
 # listing's ECR registry — no docker.io / ghcr.io pulls at install time.
 
 global:
   image:
-    # ECR registry path from the Marketplace portal, e.g.
-    # "709825985650.dkr.ecr.us-east-1.amazonaws.com/<seller>". Used as the
-    # fallback for any service without an explicit image.repository.
-    registry: "709825985650.dkr.ecr.us-east-1.amazonaws.com/<seller>"
+    # ECR registry path from the Marketplace portal. Used as the fallback for
+    # any service without an explicit image.repository.
+    registry: "709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic"
     # Pin per release, per the listing's deployment instructions (the
     # Marketplace does not allow floating tags like :latest).
     tag: ""
@@ -43,7 +44,7 @@ global:
 app:
   enabled: true
   image:
-    repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/<seller>/jentic-one-app"
+    repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app"
   # Entitlement gate wiring (plan PR 4). The listing is contract-priced with
   # dimensions `users` + `executions` (decided 2026-08-20); `contract` is the
   # config default so only the IDs need filling in. DO NOT uncomment until the
@@ -59,7 +60,7 @@ app:
 broker:
   enabled: true
   image:
-    repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/<seller>/jentic-one-app"
+    repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app"
   # extraEnv:  # same caveat as app.extraEnv above
   #   JENTIC__ENTITLEMENT__ENABLED: "true"
   #   JENTIC__ENTITLEMENT__PRODUCT_CODE: "<product code from the portal>"
@@ -76,13 +77,16 @@ gateway:
   enabled: false
 
 # In-cluster Postgres from the ECR-mirrored image (plan PR 6 mirrors it).
+# NOTE: only jentic/jentic-one-app exists in the portal so far — the
+# jentic/postgresql repository must be added via Server products → Request
+# changes → Add repositories before PR 6 can push the mirror.
 # RDS variant: set postgresql.enabled=false, global.postgresql.enabled=false,
 # and point global.databases.*.host at the RDS endpoint instead.
 postgresql:
   enabled: true
   image:
     registry: "709825985650.dkr.ecr.us-east-1.amazonaws.com"
-    repository: "<seller>/postgresql"
+    repository: "jentic/postgresql"
     tag: "17.2.0-debian-12-r6"
   auth:
     username: postgres


### PR DESCRIPTION
## Summary

- The Marketplace portal provisioned the product's ECR repository: `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app` — fills the `<seller>` placeholder in `deploy/helm/values/aws-marketplace.yaml` with the now-known namespace `jentic` (all 4 occurrences).
- Notes inline that the `jentic/postgresql` mirror repository doesn't exist in the portal yet (needs Request changes → Add repositories before the publish workflow can mirror it).
- The entitlement env block stays commented — it waits for a release containing #1041 (merged today), per the rollout note.

Part of #1132. Unblocks half of plan PR 6 (the repo path); the remaining PR-6 prerequisite is the IAM OIDC role in the seller account.

## Test plan

- [x] `tests/smoke/test_helm_render.py` (5 passed) — the Marketplace overlay renders and every image resolves to the ECR registry

Made with [Cursor](https://cursor.com)