### PR TITLE
ci(release): publish release images to AWS Marketplace ECR (plan PR 6)

### DIFF
--- a/.github/workflows/marketplace-mirror.yml
+++ b/.github/workflows/marketplace-mirror.yml
@@ -1,0 +1,103 @@
+# Mirrors the bundled Postgres image into the AWS Marketplace ECR repo.
+#
+# The Marketplace disallows docker.io pulls at install time, so the postgresql
+# subchart's image (deploy/docker/postgres-mirror.Dockerfile — a one-FROM
+# retag whose digest Dependabot keeps fresh) must exist in the listing's ECR.
+# Weekly cron + manual dispatch: cheap to re-run, and a re-push of the same
+# digest is a no-op registry-side.
+#
+# Same publish policy as the release image (release.yml publish-image):
+# Trivy gates BEFORE login/push, cosign signs the pushed digest after. The
+# job is dormant until the repo variables exist (forks and pre-listing runs
+# skip cleanly):
+#   MARKETPLACE_ECR_ROLE_ARN     — IAM role trusting GitHub's OIDC provider
+#   MARKETPLACE_ECR_POSTGRES     — full mirror repo URI from the portal
+#                                  (709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/postgresql)
+#
+# Tag contract: pushes the source tag (matching the Helm values pin) and the
+# source digest as a tag suffix — tags float, digests pin, same as the app
+# image (release.yml).
+name: marketplace-mirror
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 6 * * 1" # Mondays 06:17 UTC — offset from the Dependabot run
+
+permissions: {}
+
+concurrency:
+  group: marketplace-mirror
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    name: Mirror postgres to Marketplace ECR
+    # `if` on the job (not per-step) so the scheduled run is a skip, not a red.
+    if: vars.MARKETPLACE_ECR_ROLE_ARN != '' && vars.MARKETPLACE_ECR_POSTGRES != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # configure-aws-credentials (OIDC) + cosign keyless
+    steps:
+      - uses: actions/checkout@v7
+
+      # Installers before any credential lands on disk — same posture as
+      # release.yml publish-image.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Resolve mirror tag from the Dockerfile pin
+        id: src
+        run: |
+          set -euo pipefail
+          FROM_LINE="$(grep -oE '^FROM [^ ]+' deploy/docker/postgres-mirror.Dockerfile | cut -d' ' -f2)"
+          TAG="$(sed -E 's/^[^:]+:([^@]+)@.*$/\1/' <<<"${FROM_LINE}")"
+          test -n "${TAG}"
+          echo "from=${FROM_LINE}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      # A single-FROM build is a retag: layers are preserved byte-for-byte
+      # from the pinned digest.
+      - name: Build the mirror image (retag of the pinned digest)
+        run: docker build -f deploy/docker/postgres-mirror.Dockerfile -t postgres-mirror:local deploy/docker
+
+      # Same CVE bar as everything else this repo publishes: fixable
+      # HIGH/CRITICAL fail; overrides go in .trivyignore with justification +
+      # expiry. NOTE: the source image is Bitnami *legacy* (frozen, unpatched
+      # upstream — see the Dockerfile header), so expect this gate to start
+      # failing eventually; that is the signal to switch the chart's bundled
+      # DB or make RDS the Marketplace default, not to allowlist blindly.
+      - name: Trivy image scan (publish gate)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: 'image'
+          image-ref: postgres-mirror:local
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '1'
+          trivyignores: .trivyignore
+
+      # Credential-issuing steps after build + scan, directly before use.
+      - name: Configure AWS credentials (Marketplace ECR)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.MARKETPLACE_ECR_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Push to Marketplace ECR and sign
+        env:
+          COSIGN_YES: "true"
+          ECR_POSTGRES: ${{ vars.MARKETPLACE_ECR_POSTGRES }}
+          TAG: ${{ steps.src.outputs.tag }}
+        run: |
+          set -euo pipefail
+          aws ecr get-login-password --region us-east-1 \
+            | docker login --username AWS --password-stdin "${ECR_POSTGRES%%/*}"
+          docker tag postgres-mirror:local "${ECR_POSTGRES}:${TAG}"
+          docker push "${ECR_POSTGRES}:${TAG}"
+          DIGEST="$(docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "${ECR_POSTGRES}:${TAG}" \
+            | grep -oE "^${ECR_POSTGRES}@sha256:[0-9a-f]+" | head -n1 | cut -d@ -f2)"
+          test -n "${DIGEST}"
+          echo "Mirrored ${ECR_POSTGRES}:${TAG} @ ${DIGEST}"
+          cosign sign "${ECR_POSTGRES}@${DIGEST}"

--- a/.github/workflows/marketplace-mirror.yml
+++ b/.github/workflows/marketplace-mirror.yml
@@ -12,7 +12,7 @@
 # skip cleanly):
 #   MARKETPLACE_ECR_ROLE_ARN     — IAM role trusting GitHub's OIDC provider
 #   MARKETPLACE_ECR_POSTGRES     — full mirror repo URI from the portal
-#                                  (709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/postgresql)
+#                                  (709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql)
 #
 # Tag contract: pushes the source tag (matching the Helm values pin) and the
 # source digest as a tag suffix — tags float, digests pin, same as the app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,6 +321,80 @@ jobs:
             echo "Prerelease tag — not moving :latest"
           fi
 
+      # ---- AWS Marketplace ECR (container listing) -------------------------
+      # Copies the exact signed GHCR index into the Marketplace ECR repo and
+      # signs that copy. GHCR stays the source of truth; these steps run LAST
+      # so a Marketplace failure can never strand the GHCR half of the release
+      # (rerunning the job is idempotent: every step re-pushes the same
+      # digest-addressed content).
+      #
+      # Dormant until the repo VARIABLES (not secrets — none of these values
+      # are sensitive, see deploy/README.md "AWS Marketplace publishing") are
+      # set, so forks and pre-listing releases skip cleanly:
+      #   MARKETPLACE_ECR_ROLE_ARN — IAM role trusting GitHub's OIDC provider,
+      #                              scoped to this repo's release workflow
+      #   MARKETPLACE_ECR_IMAGE    — full repo URI from the Marketplace portal
+      #                              (709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app)
+      #
+      # configure-aws-credentials is credential-issuing: it must stay after
+      # every third-party installer (same posture as the GHCR login above) and
+      # directly before the steps that use it.
+      - name: Configure AWS credentials (Marketplace ECR)
+        if: vars.MARKETPLACE_ECR_ROLE_ARN != '' && vars.MARKETPLACE_ECR_IMAGE != ''
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.MARKETPLACE_ECR_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Log in to Marketplace ECR
+        if: vars.MARKETPLACE_ECR_ROLE_ARN != '' && vars.MARKETPLACE_ECR_IMAGE != ''
+        env:
+          ECR_IMAGE: ${{ vars.MARKETPLACE_ECR_IMAGE }}
+        run: |
+          set -euo pipefail
+          aws ecr get-login-password --region us-east-1 \
+            | docker login --username AWS --password-stdin "${ECR_IMAGE%%/*}"
+
+      # `imagetools create` copies the multi-arch index registry-side (the
+      # index was pushed by buildx and is NOT in the local daemon; `docker
+      # tag`+`push` cannot ship it). The copy is byte-identical, so the ECR
+      # digest MUST equal the GHCR digest — asserted, because the digest is
+      # what the listing pins and what buyers `cosign verify`.
+      - name: Copy the signed index to Marketplace ECR
+        if: vars.MARKETPLACE_ECR_ROLE_ARN != '' && vars.MARKETPLACE_ECR_IMAGE != ''
+        id: ecr
+        env:
+          IMAGE: ${{ steps.push.outputs.image }}
+          VERSION: ${{ steps.push.outputs.version }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+          ECR_IMAGE: ${{ vars.MARKETPLACE_ECR_IMAGE }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create -t "${ECR_IMAGE}:${VERSION}" "${IMAGE}@${DIGEST}"
+          ECR_DIGEST="$(docker buildx imagetools inspect "${ECR_IMAGE}:${VERSION}" \
+            --format '{{json .Manifest.Digest}}' | jq -r .)"
+          echo "ECR index digest: ${ECR_DIGEST}"
+          if [ "${ECR_DIGEST}" != "${DIGEST}" ]; then
+            echo "::error::ECR digest (${ECR_DIGEST}) != GHCR digest (${DIGEST}) — copy was not byte-identical" >&2
+            exit 1
+          fi
+          echo "digest=${ECR_DIGEST}" >> "$GITHUB_OUTPUT"
+
+      # Sign the ECR reference too: cosign signatures live NEXT TO the image
+      # in its registry, so the GHCR signature is invisible to a buyer pulling
+      # from ECR. Same identity, same digest, same SBOM predicate (generated
+      # by the GHCR sign step above).
+      - name: Sign the ECR image and attest its SBOM (cosign keyless + syft)
+        if: vars.MARKETPLACE_ECR_ROLE_ARN != '' && vars.MARKETPLACE_ECR_IMAGE != ''
+        env:
+          COSIGN_YES: "true"
+          ECR_IMAGE: ${{ vars.MARKETPLACE_ECR_IMAGE }}
+          DIGEST: ${{ steps.ecr.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign sign "${ECR_IMAGE}@${DIGEST}"
+          cosign attest --type spdxjson --predicate sbom.spdx.json "${ECR_IMAGE}@${DIGEST}"
+
   release:
     name: GoReleaser (signed CLI binaries)
     # publish-image gates the binaries too: a release must not exist in a state

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1059,6 +1059,114 @@ credential endpoint, or EKS IRSA — no AWS SDK required in the image.
 
 Both the app and the broker run the gate (one image, every workload checks).
 
+### Marketplace publishing (maintainers)
+
+Publishing to the listing's ECR repos is automated but **dormant until two
+GitHub Actions repository *variables* exist** (Settings → Secrets and
+variables → Actions → Variables — variables, not secrets: none of these
+values are sensitive; the trust policy below is what protects the role):
+
+| Variable | Value |
+| -------- | ----- |
+| `MARKETPLACE_ECR_ROLE_ARN` | The IAM role below, e.g. `arn:aws:iam::<seller-account-id>:role/jentic-one-marketplace-publish` |
+| `MARKETPLACE_ECR_IMAGE` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app` |
+| `MARKETPLACE_ECR_POSTGRES` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/postgresql` (only if the listing ships the bundled DB) |
+
+Once set:
+
+- every release ([`release.yml`](../.github/workflows/release.yml)
+  `publish-image`) copies the **signed GHCR index byte-identically** into the
+  Marketplace repo (same digest — asserted) and cosign-signs the ECR
+  reference too;
+- [`marketplace-mirror.yml`](../.github/workflows/marketplace-mirror.yml)
+  (weekly + manual dispatch) mirrors the bundled Postgres image
+  ([`postgres-mirror.Dockerfile`](docker/postgres-mirror.Dockerfile), digest
+  kept fresh by Dependabot) through the same Trivy gate.
+
+Publishing a new **listing version** stays a portal step (product → Request
+changes → *Add version*, pinning the pushed tag/digest); automate via the
+Marketplace Catalog API only after the manual loop has worked once.
+
+The IAM role lives in the **seller account** and trusts GitHub's OIDC
+provider — no long-lived AWS keys anywhere. Trust policy (create the
+`token.actions.githubusercontent.com` OIDC provider first if the account
+doesn't have it):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<seller-account-id>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:jentic/jentic-one:ref:refs/tags/v*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<seller-account-id>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:jentic/jentic-one:ref:refs/heads/main"
+        }
+      }
+    }
+  ]
+}
+```
+
+(The first statement covers the release workflow, which runs on `v*` tags;
+the second covers the scheduled/dispatched mirror workflow, which runs on
+`main`.)
+
+Permissions policy — ECR push scoped to the listing's repos, which live in
+AWS's Marketplace registry account and are granted to the seller through the
+portal (`aws-marketplace` actions may be required by newer portal setups; add
+`"aws-marketplace:*ChangeSet*"` only when automating Add version):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:CompleteLayerUpload",
+        "ecr:InitiateLayerUpload",
+        "ecr:PutImage",
+        "ecr:UploadLayerPart",
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:DescribeImages"
+      ],
+      "Resource": [
+        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one-app",
+        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/postgresql"
+      ]
+    }
+  ]
+}
+```
+
 ## What's deferred
 
 The build system was scaffolded with explicit gaps; these are intentional

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1070,7 +1070,7 @@ values are sensitive; the trust policy below is what protects the role):
 | -------- | ----- |
 | `MARKETPLACE_ECR_ROLE_ARN` | The IAM role below, e.g. `arn:aws:iam::<seller-account-id>:role/jentic-one-marketplace-publish` |
 | `MARKETPLACE_ECR_IMAGE` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app` |
-| `MARKETPLACE_ECR_POSTGRES` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/postgresql` (only if the listing ships the bundled DB) |
+| `MARKETPLACE_ECR_POSTGRES` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql` (only if the listing ships the bundled DB) |
 
 Once set:
 
@@ -1160,7 +1160,7 @@ portal (`aws-marketplace` actions may be required by newer portal setups; add
       ],
       "Resource": [
         "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one-app",
-        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/postgresql"
+        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one-psql"
       ]
     }
   ]

--- a/deploy/docker/postgres-mirror.Dockerfile
+++ b/deploy/docker/postgres-mirror.Dockerfile
@@ -1,0 +1,19 @@
+# AWS Marketplace mirror of the bundled in-cluster Postgres.
+#
+# The Marketplace disallows docker.io pulls at install time, so the image the
+# postgresql subchart runs (pinned in deploy/helm/jentic-one/values.yaml and
+# deploy/helm/values/aws-marketplace.yaml) is mirrored into the listing's ECR
+# by .github/workflows/marketplace-mirror.yml, which builds this one-FROM
+# Dockerfile (a retag that preserves layers byte-for-byte).
+#
+# This lives in deploy/docker/ so Dependabot's docker ecosystem tracks the
+# digest (same mechanism as the python-base ARG pins). Keep the tag in
+# lockstep with the Helm values files.
+#
+# KNOWN RISK: Bitnami moved free-tier images to `bitnamilegacy/` in Aug 2025
+# and no longer patches them — this digest is frozen, so its CVE count only
+# grows and AWS's continuous listing scan will eventually flag it. Before
+# public listing, either move the chart to a maintained postgres image or
+# make RDS the documented default for Marketplace deploys (the values file
+# already carries the RDS variant).
+FROM bitnamilegacy/postgresql:17.2.0-debian-12-r6@sha256:6c02546820ca8590cc9bd1109c73ee61e70c8d50122347178b47f951e38f096a

--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -76,17 +76,15 @@ control:
 gateway:
   enabled: false
 
-# In-cluster Postgres from the ECR-mirrored image (plan PR 6 mirrors it).
-# NOTE: only jentic/jentic-one-app exists in the portal so far — the
-# jentic/postgresql repository must be added via Server products → Request
-# changes → Add repositories before PR 6 can push the mirror.
+# In-cluster Postgres from the ECR-mirrored image (plan PR 6 mirrors it —
+# portal repo jentic/jentic-one-psql, created 2026-08-25).
 # RDS variant: set postgresql.enabled=false, global.postgresql.enabled=false,
 # and point global.databases.*.host at the RDS endpoint instead.
 postgresql:
   enabled: true
   image:
     registry: "709825985650.dkr.ecr.us-east-1.amazonaws.com"
-    repository: "jentic/postgresql"
+    repository: "jentic/jentic-one-psql"
     tag: "17.2.0-debian-12-r6"
   auth:
     username: postgres


### PR DESCRIPTION
## Summary

Implements plan PR 6 (Workstreams B1+B2) for #1132 — chart delivery stays Option A (images only; the chart ships via the GitHub release tag, decided 2026-08-25):

- **`release.yml` publish-image**: after the GHCR half fully ships (push → sign → `:latest`), copy the signed multi-arch index **byte-identically** into `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app` (digest equality asserted — the digest is what the listing pins and buyers `cosign verify`) and sign the ECR reference + attest the same SBOM. Ordering means a Marketplace failure can never strand the GHCR release; reruns are idempotent.
- **`marketplace-mirror.yml`** (new, weekly + dispatch): mirrors the bundled Postgres image to `jentic/postgresql` through the same Trivy gate + cosign signing. The pin lives in `deploy/docker/postgres-mirror.Dockerfile` so Dependabot's existing docker ecosystem bumps the digest.
- **`deploy/README.md`**: maintainer runbook — the three activating repo variables, copy-paste IAM **trust + permissions policies** for the seller-account OIDC role (scoped to this repo's `v*` tags and `main`), and the note that "Add version" in the portal stays manual until the Catalog API loop is proven.

**Dormant by design**: every new step/job is gated on the `MARKETPLACE_ECR_*` repo *variables* being set (they're identifiers, not secrets), so forks and pre-listing releases skip cleanly. Setting the variables is the activation switch — no further code change.

### Flagged risk

The bundled Postgres source is `bitnamilegacy/postgresql` — **frozen since Bitnami's Aug 2025 catalog change**, so its CVE count only grows. The mirror's Trivy gate failing is the designed signal to either move the chart to a maintained image or document RDS as the Marketplace default. Called out in the Dockerfile header and the workflow.

### Deferred (from the impl guide)

Step 3 (scheduled rebuild of the latest release via a reusable-workflow refactor) is deliberately not in this PR — the guide itself marks the refactor as the risky diff, and it's orthogonal to getting the first listing version out. Follow-up tracked in #1132.

## Test plan

- [x] `actionlint` + YAML parse on both workflows (only pre-existing style warnings elsewhere in `release.yml`)
- [ ] After merge + variables set: dry-run rehearsal against a scratch ECR repo with an `-rc` tag, then `cosign verify` both registries' digests
- [ ] Manual dispatch of `marketplace-mirror.yml`; confirm ECR shows the signed image and AWS's scan is clean

Part of #1132.

Made with [Cursor](https://cursor.com)