### PR TITLE
fix(auth): re-check actor status on every token verdict so disable kills outstanding tokens

### DIFF
--- a/src/jentic_one/auth/services/service_account_auth_service.py
+++ b/src/jentic_one/auth/services/service_account_auth_service.py
@@ -6,6 +6,7 @@ import hmac
 
 from jentic_one.admin.repos import (
     ActorScopeGrantRepository,
+    AgentRepository,
     ServiceAccountCredentialRepository,
     ServiceAccountRepository,
 )
@@ -160,6 +161,9 @@ class ServiceAccountAuthService:
         """Mint a short-lived ephemeral token for a task/agent.
 
         Security-critical: requested_scopes MUST be a subset of host_sa_scopes.
+        The target agent must exist and be ACTIVE — resolvers re-check actor
+        status on every verdict (#1136), so minting for a non-active agent
+        would return a token that is dead on arrival; fail fast instead.
         Returns an opaque access token (no refresh token for ephemeral mints).
         """
         host_scope_set = set(host_sa_scopes)
@@ -176,6 +180,14 @@ class ServiceAccountAuthService:
             raise InvalidGrantError(
                 f"invalid_request: ttl_seconds must be between"
                 f" {_MINT_TTL_MIN_SECONDS} and {_MINT_TTL_MAX_SECONDS}"
+            )
+
+        # One message for missing and non-active: no oracle for probing agent ids.
+        async with self._ctx.admin_db.session() as session:
+            agent = await AgentRepository.get_by_id(session, target_agent_id)
+        if agent is None or agent.status != ActorStatus.ACTIVE:
+            raise InvalidGrantError(
+                "invalid_request: target_agent_id does not resolve to an active agent"
             )
 
         return await self._token_svc.issue_access_only(

--- a/src/jentic_one/auth/services/token_service.py
+++ b/src/jentic_one/auth/services/token_service.py
@@ -200,9 +200,12 @@ class TokenService:
                     origin=None,
                 )
             else:
-                # A disabled/archived actor must not rotate its way to fresh
-                # access tokens — refresh is a mint path, gate it like the
-                # jwt-bearer exchange does (#1136).
+                # A non-active actor must not rotate its way to fresh access
+                # tokens — refresh is a mint path, so it gets a status gate
+                # too (#1136). Unlike the jwt-bearer exchange, PENDING gets no
+                # distinct detail here: a refresh token only exists after a
+                # successful exchange, so pending-approval polling never
+                # reaches this path.
                 if not await _actor_is_active(session, rt.actor_id, rt.actor_type):
                     raise InvalidGrantError("actor is not active")
 

--- a/src/jentic_one/auth/services/token_service.py
+++ b/src/jentic_one/auth/services/token_service.py
@@ -13,13 +13,15 @@ from jentic_one.admin.repos import (
     ActorScopeGrantRepository,
     AgentRepository,
     RefreshTokenRepository,
+    ServiceAccountRepository,
+    UserRepository,
 )
 from jentic_one.auth.services.errors import InvalidGrantError
 from jentic_one.shared.audit import AuditAction, AuditTargetType, record_audit
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.context import Context
 from jentic_one.shared.db.ids import generate_ksuid
-from jentic_one.shared.models import ActorType
+from jentic_one.shared.models import ActorStatus, ActorType
 
 ACCESS_TOKEN_PREFIX = "at_"
 REFRESH_TOKEN_PREFIX = "rt_"
@@ -31,6 +33,27 @@ def _hash_token(token: str) -> str:
 
 def _generate_token(prefix: str) -> str:
     return f"{prefix}{secrets.token_urlsafe(32)}"
+
+
+async def _actor_is_active(session: AsyncSession, actor_id: str, actor_type: str) -> bool:
+    """Whether the token's actor is currently allowed to authenticate.
+
+    Disabling an actor must kill its *outstanding* tokens, not just block new
+    mints (#1136) — so every token verdict re-checks the actor row. Fails
+    closed when the actor row is missing (e.g. a hard-deleted user whose
+    tokens were never revoked). Unknown actor types are left to their token's
+    own revocation/expiry checks.
+    """
+    if actor_type == ActorType.AGENT:
+        agent = await AgentRepository.get_by_id(session, actor_id)
+        return agent is not None and agent.status == ActorStatus.ACTIVE
+    if actor_type == ActorType.SERVICE_ACCOUNT:
+        sa = await ServiceAccountRepository.get_by_id(session, actor_id)
+        return sa is not None and sa.status == ActorStatus.ACTIVE
+    if actor_type == ActorType.USER:
+        user = await UserRepository.get_by_id(session, actor_id)
+        return user is not None and user.active
+    return True
 
 
 class TokenService:
@@ -177,6 +200,12 @@ class TokenService:
                     origin=None,
                 )
             else:
+                # A disabled/archived actor must not rotate its way to fresh
+                # access tokens — refresh is a mint path, gate it like the
+                # jwt-bearer exchange does (#1136).
+                if not await _actor_is_active(session, rt.actor_id, rt.actor_type):
+                    raise InvalidGrantError("actor is not active")
+
                 access_plain = _generate_token(ACCESS_TOKEN_PREFIX)
                 refresh_plain = _generate_token(REFRESH_TOKEN_PREFIX)
                 now = datetime.now(UTC)
@@ -259,7 +288,12 @@ class TokenService:
                 )
 
     async def introspect(self, token: str) -> dict[str, bool | str | int | None]:
-        """Introspect a token per RFC 7662."""
+        """Introspect a token per RFC 7662.
+
+        ``active`` reflects the same verdict the resolvers enforce — including
+        the actor-status check — so an operator inspecting a token after a
+        disable sees the truth, not just the token row's own state.
+        """
         token_hash = _hash_token(token)
         now = datetime.now(UTC)
 
@@ -268,7 +302,11 @@ class TokenService:
                 at = await AccessTokenRepository.get_by_hash(session, token_hash)
                 if at is None:
                     return {"active": False}
-                active = at.revoked_at is None and at.expires_at > now
+                active = (
+                    at.revoked_at is None
+                    and at.expires_at > now
+                    and await _actor_is_active(session, at.actor_id, at.actor_type)
+                )
                 return {
                     "active": active,
                     "sub": at.actor_id,
@@ -280,7 +318,12 @@ class TokenService:
                 rt = await RefreshTokenRepository.get_by_hash(session, token_hash)
                 if rt is None:
                     return {"active": False}
-                active = rt.revoked_at is None and rt.consumed_at is None and rt.expires_at > now
+                active = (
+                    rt.revoked_at is None
+                    and rt.consumed_at is None
+                    and rt.expires_at > now
+                    and await _actor_is_active(session, rt.actor_id, rt.actor_type)
+                )
                 return {
                     "active": active,
                     "sub": rt.actor_id,
@@ -307,6 +350,11 @@ class TokenService:
         deliberate downscoped subset of the host's grants and must not be
         re-broadened. User tokens also keep their snapshot (their permissions do
         not come from ``ActorScopeGrant``).
+
+        The verdict also re-checks the actor's own status (#1136): a disabled
+        or archived actor's outstanding tokens resolve as inactive immediately,
+        so disable alone is a working kill switch — no separate token-family
+        revocation required.
         """
         if not token.startswith(ACCESS_TOKEN_PREFIX):
             return None
@@ -323,9 +371,12 @@ class TokenService:
             scopes = list(at.scopes)
             parent_actor_id: str | None = None
             if at.actor_type == ActorType.AGENT:
+                # One lookup serves both parent resolution and the status check.
                 agent = await AgentRepository.get_by_id(session, at.actor_id)
-                if agent is not None:
-                    parent_actor_id = agent.owner_id
+                parent_actor_id = agent.owner_id if agent is not None else None
+                actor_active = agent is not None and agent.status == ActorStatus.ACTIVE
+            else:
+                actor_active = await _actor_is_active(session, at.actor_id, at.actor_type)
 
             if not at.is_ephemeral and at.actor_type in (
                 ActorType.AGENT,
@@ -336,7 +387,7 @@ class TokenService:
                 )
                 scopes = [g.scope for g in grants]
 
-        active = at.revoked_at is None and at.expires_at > now
+        active = at.revoked_at is None and at.expires_at > now and actor_active
         return Identity(
             sub=at.actor_id,
             actor_type=ActorType(at.actor_type),

--- a/src/jentic_one/broker/repos/token_resolver.py
+++ b/src/jentic_one/broker/repos/token_resolver.py
@@ -32,10 +32,26 @@ class InProcessTokenResolver:
         token_hash = hashlib.sha256(token.encode()).hexdigest()
         now = datetime.now(UTC)
 
+        # actor_status re-checks the actor row on every resolve (#1136): a
+        # disabled/archived agent's outstanding token must stop resolving as
+        # active, bounded only by the broker's short verdict-cache TTL. NULL
+        # (actor row missing) fails closed; the users table models "disabled"
+        # as active=false, normalised here to the same status string.
         stmt = text(
-            "SELECT actor_id, actor_type, scopes, is_ephemeral, expires_at, revoked_at"
-            " FROM access_tokens"
-            " WHERE token_hash = :token_hash"
+            "SELECT t.actor_id, t.actor_type, t.scopes, t.is_ephemeral,"
+            " t.expires_at, t.revoked_at,"
+            " CASE t.actor_type"
+            "  WHEN 'agent' THEN"
+            "   (SELECT a.status FROM agents a WHERE a.id = t.actor_id)"
+            "  WHEN 'service_account' THEN"
+            "   (SELECT sa.status FROM service_accounts sa WHERE sa.id = t.actor_id)"
+            "  WHEN 'user' THEN"
+            "   (SELECT CASE WHEN u.active THEN 'active' ELSE 'disabled' END"
+            "    FROM users u WHERE u.id = t.actor_id)"
+            "  ELSE 'active'"
+            " END AS actor_status"
+            " FROM access_tokens t"
+            " WHERE t.token_hash = :token_hash"
         ).columns(is_ephemeral=Boolean)
         async with self._admin_db.session() as session:
             result = await session.execute(stmt, {"token_hash": token_hash})
@@ -70,7 +86,7 @@ class InProcessTokenResolver:
         expires_at = _as_aware_datetime(row.expires_at)
         revoked_at = _as_aware_datetime(row.revoked_at) if row.revoked_at is not None else None
 
-        active = revoked_at is None and expires_at > now
+        active = revoked_at is None and expires_at > now and row.actor_status == "active"
         return Identity(
             sub=row.actor_id,
             actor_type=ActorType(row.actor_type),

--- a/tests/integration/auth/test_token_endpoints.py
+++ b/tests/integration/auth/test_token_endpoints.py
@@ -12,8 +12,17 @@ from sqlalchemy.exc import OperationalError
 
 from jentic_one.admin.core.schema.access_tokens import AccessToken
 from jentic_one.admin.core.schema.actor_scope_grants import ActorScopeGrant
+from jentic_one.admin.core.schema.agents import Agent
 from jentic_one.admin.core.schema.refresh_tokens import RefreshToken
-from jentic_one.admin.repos import AccessTokenRepository, ActorScopeGrantRepository
+from jentic_one.admin.core.schema.service_accounts import ServiceAccount
+from jentic_one.admin.core.schema.users import User
+from jentic_one.admin.repos import (
+    AccessTokenRepository,
+    ActorScopeGrantRepository,
+    AgentRepository,
+    ServiceAccountRepository,
+    UserRepository,
+)
 from jentic_one.auth.services.errors import InvalidGrantError
 from jentic_one.auth.services.token_service import TokenService, _hash_token
 from jentic_one.auth.web.routers.oauth import token_endpoint
@@ -21,24 +30,79 @@ from jentic_one.auth.web.schemas.oauth import TokenRequest
 from jentic_one.shared.auth.identity import Identity
 from jentic_one.shared.context import Context
 from jentic_one.shared.db.errors import DatabaseUnavailableError
-from jentic_one.shared.models import ActorType
+from jentic_one.shared.models import ActorStatus, ActorType
 
 pytestmark = pytest.mark.integration
+
+# Marker for actor rows seeded by this file, so cleanup never touches
+# bootstrap rows or other files' fixtures.
+_SEED_MARKER = "usr_tok_seed"
 
 
 @pytest.fixture()
 async def clean_tokens(integration_context: Context) -> AsyncGenerator[None, None]:
-    async with integration_context.admin_db.session() as session:
-        await session.execute(delete(AccessToken))
-        await session.execute(delete(RefreshToken))
-        await session.execute(delete(ActorScopeGrant))
-        await session.commit()
+    async def _truncate() -> None:
+        async with integration_context.admin_db.session() as session:
+            await session.execute(delete(AccessToken))
+            await session.execute(delete(RefreshToken))
+            await session.execute(delete(ActorScopeGrant))
+            await session.execute(delete(Agent).where(Agent.created_by == _SEED_MARKER))
+            await session.execute(
+                delete(ServiceAccount).where(ServiceAccount.created_by == _SEED_MARKER)
+            )
+            await session.execute(delete(User).where(User.created_by == _SEED_MARKER))
+            await session.commit()
+
+    await _truncate()
     yield
-    async with integration_context.admin_db.session() as session:
-        await session.execute(delete(AccessToken))
-        await session.execute(delete(RefreshToken))
-        await session.execute(delete(ActorScopeGrant))
+    await _truncate()
+
+
+async def _seed_user(ctx: Context, user_id: str, *, active: bool = True) -> str:
+    async with ctx.admin_db.session() as session:
+        user = await UserRepository.create(
+            session,
+            id=user_id,
+            email=f"{user_id}@tokens.test",
+            first_name="Token",
+            last_name="Test",
+            active=active,
+            created_by=_SEED_MARKER,
+        )
         await session.commit()
+        return user.id
+
+
+async def _seed_agent(
+    ctx: Context, *, owner_id: str, status: ActorStatus = ActorStatus.ACTIVE
+) -> str:
+    async with ctx.admin_db.session() as session:
+        agent = await AgentRepository.create(
+            session,
+            name="token-test-agent",
+            owner_id=owner_id,
+            registered_by=owner_id,
+            created_by=_SEED_MARKER,
+            status=status,
+        )
+        await session.commit()
+        return agent.id
+
+
+async def _seed_service_account(
+    ctx: Context, *, owner_id: str, status: ActorStatus = ActorStatus.ACTIVE
+) -> str:
+    async with ctx.admin_db.session() as session:
+        sa = await ServiceAccountRepository.create(
+            session,
+            name="token-test-sa",
+            owner_id=owner_id,
+            registered_by=owner_id,
+            created_by=_SEED_MARKER,
+        )
+        await ServiceAccountRepository.update_status(session, sa.id, status)
+        await session.commit()
+        return sa.id
 
 
 @pytest.fixture()
@@ -46,27 +110,33 @@ def token_service(integration_context: Context) -> TokenService:
     return TokenService(integration_context)
 
 
-async def test_issue_pair_lifecycle(token_service: TokenService, clean_tokens: None) -> None:
+async def test_issue_pair_lifecycle(
+    token_service: TokenService, integration_context: Context, clean_tokens: None
+) -> None:
     """Full lifecycle: issue -> introspect (active) -> revoke -> introspect (inactive)."""
-    access, refresh = await token_service.issue_pair("usr_test1", ActorType.USER, ["read", "write"])
+    user_id = await _seed_user(integration_context, "usr_test1")
+    access, refresh = await token_service.issue_pair(user_id, ActorType.USER, ["read", "write"])
 
     assert access.startswith("at_")
     assert refresh.startswith("rt_")
 
     result = await token_service.introspect(access)
     assert result["active"] is True
-    assert result["sub"] == "usr_test1"
+    assert result["sub"] == user_id
     assert result["scope"] == "read write"
 
-    await token_service.revoke(access, identity=Identity(sub="usr_test1", email="test@local"))
+    await token_service.revoke(access, identity=Identity(sub=user_id, email="test@local"))
 
     result = await token_service.introspect(access)
     assert result["active"] is False
 
 
-async def test_refresh_rotation(token_service: TokenService, clean_tokens: None) -> None:
+async def test_refresh_rotation(
+    token_service: TokenService, integration_context: Context, clean_tokens: None
+) -> None:
     """Issue -> refresh -> verify new pair works, old is consumed."""
-    access1, refresh1 = await token_service.issue_pair("usr_test2", ActorType.USER, ["read"])
+    user_id = await _seed_user(integration_context, "usr_test2")
+    access1, refresh1 = await token_service.issue_pair(user_id, ActorType.USER, ["read"])
 
     access2, refresh2 = await token_service.refresh(refresh1)
 
@@ -82,9 +152,12 @@ async def test_refresh_rotation(token_service: TokenService, clean_tokens: None)
     assert old_rt_result["active"] is False
 
 
-async def test_reuse_detection(token_service: TokenService, clean_tokens: None) -> None:
+async def test_reuse_detection(
+    token_service: TokenService, integration_context: Context, clean_tokens: None
+) -> None:
     """Issue -> refresh -> replay old refresh -> entire family revoked."""
-    _access1, refresh1 = await token_service.issue_pair("usr_test3", ActorType.USER, ["read"])
+    user_id = await _seed_user(integration_context, "usr_test3")
+    _access1, refresh1 = await token_service.issue_pair(user_id, ActorType.USER, ["read"])
 
     access2, _refresh2 = await token_service.refresh(refresh1)
 
@@ -142,10 +215,12 @@ async def test_resolve_access_token(
     immediately. Seed the grant that a real ``issue_pair`` would have derived
     from.
     """
+    owner_id = await _seed_user(integration_context, "usr_resolve_owner")
+    agent_id = await _seed_agent(integration_context, owner_id=owner_id)
     async with integration_context.admin_db.session() as session:
         await ActorScopeGrantRepository.grant(
             session,
-            actor_id="agnt_resolve1",
+            actor_id=agent_id,
             actor_type=ActorType.AGENT,
             scope="execute",
             granted_by="usr_test",
@@ -153,13 +228,14 @@ async def test_resolve_access_token(
         )
         await session.commit()
 
-    access, _refresh = await token_service.issue_pair("agnt_resolve1", ActorType.AGENT, ["execute"])
+    access, _refresh = await token_service.issue_pair(agent_id, ActorType.AGENT, ["execute"])
 
     resolved = await token_service.resolve_access_token(access)
     assert resolved is not None
     assert resolved.active is True
-    assert resolved.sub == "agnt_resolve1"
+    assert resolved.sub == agent_id
     assert resolved.actor_type == "agent"
+    assert resolved.parent_actor_id == owner_id
     assert resolved.permissions == ["execute"]
 
 
@@ -168,10 +244,12 @@ async def test_resolve_reflects_scope_grant_without_remint(
 ) -> None:
     """Regression for #531: adding a scope grant takes effect on the *existing*
     token pair — no re-mint required."""
+    owner_id = await _seed_user(integration_context, "usr_scope_owner")
+    agent_id = await _seed_agent(integration_context, owner_id=owner_id)
     async with integration_context.admin_db.session() as session:
         await ActorScopeGrantRepository.grant(
             session,
-            actor_id="agnt_scope",
+            actor_id=agent_id,
             actor_type=ActorType.AGENT,
             scope="apis:read",
             granted_by="usr_owner",
@@ -179,7 +257,7 @@ async def test_resolve_reflects_scope_grant_without_remint(
         )
         await session.commit()
 
-    access, _refresh = await token_service.issue_pair("agnt_scope", ActorType.AGENT, ["apis:read"])
+    access, _refresh = await token_service.issue_pair(agent_id, ActorType.AGENT, ["apis:read"])
     resolved = await token_service.resolve_access_token(access)
     assert resolved is not None
     assert resolved.permissions == ["apis:read"]
@@ -188,7 +266,7 @@ async def test_resolve_reflects_scope_grant_without_remint(
     async with integration_context.admin_db.session() as session:
         await ActorScopeGrantRepository.grant(
             session,
-            actor_id="agnt_scope",
+            actor_id=agent_id,
             actor_type=ActorType.AGENT,
             scope="apis:write",
             granted_by="usr_owner",
@@ -206,11 +284,13 @@ async def test_resolve_reflects_scope_revocation_without_remint(
     token_service: TokenService, integration_context: Context, clean_tokens: None
 ) -> None:
     """Revoking a scope also takes effect on the existing token pair immediately."""
+    owner_id = await _seed_user(integration_context, "usr_revoke_owner")
+    agent_id = await _seed_agent(integration_context, owner_id=owner_id)
     async with integration_context.admin_db.session() as session:
         for scope in ("apis:read", "apis:write"):
             await ActorScopeGrantRepository.grant(
                 session,
-                actor_id="agnt_revoke",
+                actor_id=agent_id,
                 actor_type=ActorType.AGENT,
                 scope=scope,
                 granted_by="usr_owner",
@@ -219,11 +299,11 @@ async def test_resolve_reflects_scope_revocation_without_remint(
         await session.commit()
 
     access, _refresh = await token_service.issue_pair(
-        "agnt_revoke", ActorType.AGENT, ["apis:read", "apis:write"]
+        agent_id, ActorType.AGENT, ["apis:read", "apis:write"]
     )
 
     async with integration_context.admin_db.session() as session:
-        await ActorScopeGrantRepository.revoke(session, actor_id="agnt_revoke", scope="apis:write")
+        await ActorScopeGrantRepository.revoke(session, actor_id=agent_id, scope="apis:write")
         await session.commit()
 
     resolved = await token_service.resolve_access_token(access)
@@ -255,9 +335,10 @@ async def test_issue_pair_transient_lock_exhausted_raises_db_unavailable(
 
 
 async def test_issue_pair_transient_lock_then_success(
-    token_service: TokenService, clean_tokens: None
+    token_service: TokenService, integration_context: Context, clean_tokens: None
 ) -> None:
     """A transient lock on the first attempt is retried and the mint then succeeds."""
+    user_id = await _seed_user(integration_context, "usr_retry")
     real_create = AccessTokenRepository.create
     calls = {"n": 0}
 
@@ -268,7 +349,7 @@ async def test_issue_pair_transient_lock_then_success(
         return await real_create(*args, **kwargs)  # type: ignore[arg-type]
 
     with patch.object(AccessTokenRepository, "create", side_effect=_flaky_create):
-        access, refresh = await token_service.issue_pair("usr_retry", ActorType.USER, ["read"])
+        access, refresh = await token_service.issue_pair(user_id, ActorType.USER, ["read"])
 
     assert access.startswith("at_")
     assert refresh.startswith("rt_")
@@ -290,3 +371,140 @@ async def test_revoke_refresh_token_revokes_family(
 
     rt_result = await token_service.introspect(refresh)
     assert rt_result["active"] is False
+
+
+# --- actor-status kill switch (#1136) -------------------------------------
+# Disabling an actor must invalidate its *outstanding* tokens immediately —
+# not just block new mints. Two steps (disable + revoke family) must no
+# longer be required.
+
+
+async def _set_agent_status(ctx: Context, agent_id: str, status: ActorStatus) -> None:
+    async with ctx.admin_db.session() as session:
+        await AgentRepository.update_status(session, agent_id, status)
+        await session.commit()
+
+
+async def test_disable_agent_kills_outstanding_access_token(
+    token_service: TokenService, integration_context: Context, clean_tokens: None
+) -> None:
+    """The #1136 regression: an unexpired, unrevoked token resolves as inactive
+    the moment its agent is disabled — and works again after re-enable."""
+    owner_id = await _seed_user(integration_context, "usr_kill_owner")
+    agent_id = await _seed_agent(integration_context, owner_id=owner_id)
+    access, _refresh = await token_service.issue_pair(agent_id, ActorType.AGENT, [])
+
+    resolved = await token_service.resolve_access_token(access)
+    assert resolved is not None and resolved.active is True
+
+    await _set_agent_status(integration_context, agent_id, ActorStatus.DISABLED)
+
+    resolved = await token_service.resolve_access_token(access)
+    assert resolved is not None
+    assert resolved.active is False, "disable alone must kill the outstanding token"
+    assert (await token_service.introspect(access))["active"] is False
+
+    # The kill switch is reversible: enable restores the same token.
+    await _set_agent_status(integration_context, agent_id, ActorStatus.ACTIVE)
+    resolved = await token_service.resolve_access_token(access)
+    assert resolved is not None and resolved.active is True
+
+
+async def test_archived_agent_token_is_inactive(
+    token_service: TokenService, integration_context: Context, clean_tokens: None
+) -> None:
+    owner_id = await _seed_user(integration_context, "usr_arch_owner")
+    agent_id = await _seed_agent(integration_context, owner_id=owner_id)
+    access, _refresh = await token_service.issue_pair(agent_id, ActorType.AGENT, [])
+
+    await _set_agent_status(integration_context, agent_id, ActorStatus.ARCHIVED)
+
+    resolved = await token_service.resolve_access_token(access)
+    assert resolved is not None
+    assert resolved.active is False
+
+
+async def test_disabled_agent_cannot_refresh_to_fresh_tokens(
+    token_service: TokenService, integration_context: Context, clean_tokens: None
+) -> None:
+    """A disabled agent holding a refresh token must not rotate its way to a
+    fresh access token (otherwise the exposure window is the refresh TTL, not
+    the access TTL). Re-enabling makes the same refresh token work again."""
+    owner_id = await _seed_user(integration_context, "usr_rot_owner")
+    agent_id = await _seed_agent(integration_context, owner_id=owner_id)
+    _access, refresh = await token_service.issue_pair(agent_id, ActorType.AGENT, [])
+
+    await _set_agent_status(integration_context, agent_id, ActorStatus.DISABLED)
+
+    with pytest.raises(InvalidGrantError, match="not active"):
+        await token_service.refresh(refresh)
+
+    # The rejected attempt must not have consumed the refresh token: after
+    # re-enable, the same token still rotates normally (no reuse trip).
+    await _set_agent_status(integration_context, agent_id, ActorStatus.ACTIVE)
+    access2, refresh2 = await token_service.refresh(refresh)
+    assert access2.startswith("at_")
+    assert refresh2.startswith("rt_")
+
+
+async def test_disabled_service_account_token_is_inactive(
+    token_service: TokenService, integration_context: Context, clean_tokens: None
+) -> None:
+    owner_id = await _seed_user(integration_context, "usr_sa_owner")
+    sa_id = await _seed_service_account(integration_context, owner_id=owner_id)
+    access, refresh = await token_service.issue_pair(sa_id, ActorType.SERVICE_ACCOUNT, [])
+
+    resolved = await token_service.resolve_access_token(access)
+    assert resolved is not None and resolved.active is True
+
+    async with integration_context.admin_db.session() as session:
+        await ServiceAccountRepository.update_status(session, sa_id, ActorStatus.DISABLED)
+        await session.commit()
+
+    resolved = await token_service.resolve_access_token(access)
+    assert resolved is not None
+    assert resolved.active is False
+    with pytest.raises(InvalidGrantError, match="not active"):
+        await token_service.refresh(refresh)
+
+
+async def test_deactivated_user_token_is_inactive(
+    token_service: TokenService, integration_context: Context, clean_tokens: None
+) -> None:
+    user_id = await _seed_user(integration_context, "usr_deact")
+    access, refresh = await token_service.issue_pair(user_id, ActorType.USER, ["openid"])
+
+    resolved = await token_service.resolve_access_token(access)
+    assert resolved is not None and resolved.active is True
+
+    async with integration_context.admin_db.session() as session:
+        await UserRepository.update(session, user_id, active=False)
+        await session.commit()
+
+    resolved = await token_service.resolve_access_token(access)
+    assert resolved is not None
+    assert resolved.active is False
+    with pytest.raises(InvalidGrantError, match="not active"):
+        await token_service.refresh(refresh)
+
+
+async def test_token_for_missing_actor_row_fails_closed(
+    token_service: TokenService, integration_context: Context, clean_tokens: None
+) -> None:
+    """A token whose actor row was hard-deleted must not remain usable."""
+    async with integration_context.admin_db.transaction() as session:
+        await AccessTokenRepository.create(
+            session,
+            token_hash=_hash_token("at_orphaned_actor"),
+            actor_id="agnt_never_existed",
+            actor_type="agent",
+            scopes=[],
+            token_family_id="tfam_orphan",
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+            created_by="usr_test",
+            is_ephemeral=False,
+        )
+
+    resolved = await token_service.resolve_access_token("at_orphaned_actor")
+    assert resolved is not None
+    assert resolved.active is False

--- a/tests/integration/auth/test_token_endpoints.py
+++ b/tests/integration/auth/test_token_endpoints.py
@@ -172,11 +172,14 @@ async def test_introspect_expired_returns_inactive(
     integration_context: Context, clean_tokens: None
 ) -> None:
     """Expired token introspection returns inactive."""
+    # Seed the actor active so this pins *expiry*, not the missing-actor
+    # fail-closed path (#1136).
+    user_id = await _seed_user(integration_context, "usr_expired")
     async with integration_context.admin_db.transaction() as session:
         await AccessTokenRepository.create(
             session,
             token_hash=_hash_token("at_expired_test"),
-            actor_id="usr_expired",
+            actor_id=user_id,
             actor_type="user",
             scopes=["read"],
             token_family_id="tfam_expired",
@@ -359,12 +362,16 @@ async def test_issue_pair_transient_lock_then_success(
 
 
 async def test_revoke_refresh_token_revokes_family(
-    token_service: TokenService, clean_tokens: None
+    token_service: TokenService, integration_context: Context, clean_tokens: None
 ) -> None:
     """Revoking a refresh token revokes the entire token family."""
-    access, refresh = await token_service.issue_pair("usr_fam1", ActorType.USER, ["read"])
+    # Seed the actor active so the inactive verdicts below can only come from
+    # the revocation itself, not the missing-actor fail-closed path (#1136).
+    user_id = await _seed_user(integration_context, "usr_fam1")
+    access, refresh = await token_service.issue_pair(user_id, ActorType.USER, ["read"])
+    assert (await token_service.introspect(access))["active"] is True
 
-    await token_service.revoke(refresh, identity=Identity(sub="usr_fam1", email="test@local"))
+    await token_service.revoke(refresh, identity=Identity(sub=user_id, email="test@local"))
 
     at_result = await token_service.introspect(access)
     assert at_result["active"] is False

--- a/tests/integration/broker/test_auth_e2e.py
+++ b/tests/integration/broker/test_auth_e2e.py
@@ -10,16 +10,18 @@ end-to-end through the real ``InProcessTokenResolver``.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
 
 import jwt
 import pytest
-from sqlalchemy import delete
+from sqlalchemy import delete, update
 
 from jentic_one.admin.core.schema.access_tokens import AccessToken
 from jentic_one.admin.core.schema.actor_scope_grants import ActorScopeGrant
+from jentic_one.admin.core.schema.agents import Agent
 from jentic_one.admin.core.schema.refresh_tokens import RefreshToken
 from jentic_one.admin.repos.access_token_repo import AccessTokenRepository
 from jentic_one.admin.repos.actor_scope_grant_repo import ActorScopeGrantRepository
@@ -34,6 +36,7 @@ from jentic_one.shared.scopes import BROKER_EXECUTE_SCOPE
 pytestmark = pytest.mark.integration
 
 _JWT_SECRET = "integration-test-secret-key-32-bytes!!"  # pragma: allowlist secret
+_SEED_MARKER = "usr_broker_e2e_seed"
 
 
 @pytest.fixture()
@@ -43,6 +46,7 @@ async def clean_access_tokens(admin_db: DatabaseSession) -> AsyncGenerator[None,
             await session.execute(delete(AccessToken))
             await session.execute(delete(RefreshToken))
             await session.execute(delete(ActorScopeGrant))
+            await session.execute(delete(Agent).where(Agent.created_by == _SEED_MARKER))
             await session.commit()
 
     await _truncate()
@@ -56,6 +60,27 @@ def _dual(admin_db: DatabaseSession, *, with_jwt: bool = True) -> DualTokenValid
         JwtTokenValidator(verifier=JwtVerifier(secret=_JWT_SECRET)) if with_jwt else None
     )
     return DualTokenValidator(opaque=opaque, jwt=jwt_validator)
+
+
+async def _seed_agent(admin_db: DatabaseSession, agent_id: str, *, status: str = "active") -> None:
+    """Seed the actor row that token resolution re-checks on every resolve (#1136)."""
+    async with admin_db.session() as session:
+        session.add(
+            Agent(
+                id=agent_id,
+                name=f"e2e-{agent_id}",
+                registered_by=_SEED_MARKER,
+                created_by=_SEED_MARKER,
+                status=status,
+            )
+        )
+        await session.commit()
+
+
+async def _set_agent_status(admin_db: DatabaseSession, agent_id: str, status: str) -> None:
+    async with admin_db.session() as session:
+        await session.execute(update(Agent).where(Agent.id == agent_id).values(status=status))
+        await session.commit()
 
 
 async def _seed_opaque_token(admin_db: DatabaseSession, *, plaintext: str) -> None:
@@ -78,6 +103,7 @@ async def _seed_opaque_token(admin_db: DatabaseSession, *, plaintext: str) -> No
 async def test_opaque_token_resolves_via_db(
     admin_db: DatabaseSession, clean_access_tokens: None
 ) -> None:
+    await _seed_agent(admin_db, "agnt_opaque")
     await _seed_opaque_token(admin_db, plaintext="at_live_opaque")
 
     resolved = await _dual(admin_db).validate("at_live_opaque")
@@ -191,6 +217,7 @@ async def test_long_lived_token_resolves_live_grants(
 ) -> None:
     """A long-lived agent token (is_ephemeral=False) resolves the actor's
     current grants, not the frozen snapshot — the broker sees scope edits."""
+    await _seed_agent(admin_db, "agnt_ll")
     await _seed_pair_and_grants(
         admin_db,
         plaintext="at_longlived",
@@ -211,6 +238,7 @@ async def test_ephemeral_minted_token_keeps_downscoped_snapshot(
 ) -> None:
     """An ephemeral minted token (is_ephemeral=True) must NOT be re-broadened to
     the actor's full grants — its downscoped snapshot is a security guarantee."""
+    await _seed_agent(admin_db, "agnt_eph")
     now = datetime.now(UTC)
     async with admin_db.session() as session:
         await AccessTokenRepository.create(
@@ -240,3 +268,70 @@ async def test_ephemeral_minted_token_keeps_downscoped_snapshot(
 
     assert resolved.sub == "agnt_eph"
     assert resolved.permissions == [BROKER_EXECUTE_SCOPE]
+
+
+# --- actor-status kill switch on the execute path (#1136) ------------------
+
+
+async def test_disabled_agent_token_rejected_by_broker(
+    admin_db: DatabaseSession, clean_access_tokens: None
+) -> None:
+    """A disabled agent's unexpired, unrevoked token must not validate — the
+    broker resolver re-checks the agent row, not just revocation + expiry."""
+    await _seed_agent(admin_db, "agnt_opaque", status="disabled")
+    await _seed_opaque_token(admin_db, plaintext="at_disabled_agent")
+
+    with pytest.raises(TokenValidationError, match="token_inactive"):
+        await _dual(admin_db).validate("at_disabled_agent")
+
+
+@pytest.mark.parametrize("status", ["pending", "rejected", "archived"])
+async def test_non_active_agent_token_rejected_by_broker(
+    admin_db: DatabaseSession, clean_access_tokens: None, status: str
+) -> None:
+    await _seed_agent(admin_db, "agnt_opaque", status=status)
+    await _seed_opaque_token(admin_db, plaintext="at_non_active_agent")
+
+    with pytest.raises(TokenValidationError):
+        await _dual(admin_db).validate("at_non_active_agent")
+
+
+async def test_token_with_missing_agent_row_rejected_by_broker(
+    admin_db: DatabaseSession, clean_access_tokens: None
+) -> None:
+    """No agent row at all fails closed (hard-deleted actor, orphaned token)."""
+    await _seed_opaque_token(admin_db, plaintext="at_orphan_agent")
+
+    with pytest.raises(TokenValidationError):
+        await _dual(admin_db).validate("at_orphan_agent")
+
+
+async def test_disable_mid_life_kills_token_after_cache_ttl(
+    admin_db: DatabaseSession, clean_access_tokens: None
+) -> None:
+    """The issue's regression pin: disable an agent while its token is in use;
+    the broker keeps honouring the *cached* verdict only until the verdict-cache
+    TTL lapses, then rejects — disable alone kills within ~the cache TTL."""
+    await _seed_agent(admin_db, "agnt_opaque", status="active")
+    await _seed_opaque_token(admin_db, plaintext="at_kill_me")
+
+    validator = CachedTokenValidator(
+        resolver=InProcessTokenResolver(admin_db), cache_ttl_seconds=0.05
+    )
+
+    resolved = await validator.validate("at_kill_me")
+    assert resolved.sub == "agnt_opaque"
+
+    await _set_agent_status(admin_db, "agnt_opaque", "disabled")
+
+    # Within the TTL the stale cached verdict may still pass; after it lapses
+    # the resolver re-checks the actor row and the token dies.
+    await asyncio.sleep(0.06)
+    with pytest.raises(TokenValidationError, match="token_inactive"):
+        await validator.validate("at_kill_me")
+
+    # Re-enable: the same token validates again once the negative verdict ages out.
+    await _set_agent_status(admin_db, "agnt_opaque", "active")
+    await asyncio.sleep(0.06)
+    resolved = await validator.validate("at_kill_me")
+    assert resolved.sub == "agnt_opaque"

--- a/tests/integration/broker/test_auth_e2e.py
+++ b/tests/integration/broker/test_auth_e2e.py
@@ -23,6 +23,8 @@ from jentic_one.admin.core.schema.access_tokens import AccessToken
 from jentic_one.admin.core.schema.actor_scope_grants import ActorScopeGrant
 from jentic_one.admin.core.schema.agents import Agent
 from jentic_one.admin.core.schema.refresh_tokens import RefreshToken
+from jentic_one.admin.core.schema.service_accounts import ServiceAccount
+from jentic_one.admin.core.schema.users import User
 from jentic_one.admin.repos.access_token_repo import AccessTokenRepository
 from jentic_one.admin.repos.actor_scope_grant_repo import ActorScopeGrantRepository
 from jentic_one.admin.repos.refresh_token_repo import RefreshTokenRepository
@@ -47,6 +49,10 @@ async def clean_access_tokens(admin_db: DatabaseSession) -> AsyncGenerator[None,
             await session.execute(delete(RefreshToken))
             await session.execute(delete(ActorScopeGrant))
             await session.execute(delete(Agent).where(Agent.created_by == _SEED_MARKER))
+            await session.execute(
+                delete(ServiceAccount).where(ServiceAccount.created_by == _SEED_MARKER)
+            )
+            await session.execute(delete(User).where(User.created_by == _SEED_MARKER))
             await session.commit()
 
     await _truncate()
@@ -83,18 +89,56 @@ async def _set_agent_status(admin_db: DatabaseSession, agent_id: str, status: st
         await session.commit()
 
 
-async def _seed_opaque_token(admin_db: DatabaseSession, *, plaintext: str) -> None:
+async def _seed_user_row(admin_db: DatabaseSession, user_id: str, *, active: bool = True) -> None:
+    async with admin_db.session() as session:
+        session.add(
+            User(
+                id=user_id,
+                email=f"{user_id}@e2e.test",
+                first_name="Broker",
+                last_name="E2E",
+                active=active,
+                created_by=_SEED_MARKER,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_service_account_row(
+    admin_db: DatabaseSession, sa_id: str, *, owner_id: str, status: str = "active"
+) -> None:
+    async with admin_db.session() as session:
+        session.add(
+            ServiceAccount(
+                id=sa_id,
+                name=f"e2e-{sa_id}",
+                owner_id=owner_id,
+                registered_by=owner_id,
+                created_by=_SEED_MARKER,
+                status=status,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_opaque_token(
+    admin_db: DatabaseSession,
+    *,
+    plaintext: str,
+    actor_id: str = "agnt_opaque",
+    actor_type: str = "agent",
+) -> None:
     token_hash = hashlib.sha256(plaintext.encode()).hexdigest()
     async with admin_db.session() as session:
         await AccessTokenRepository.create(
             session,
             token_hash=token_hash,
-            actor_id="agnt_opaque",
-            actor_type="agent",
+            actor_id=actor_id,
+            actor_type=actor_type,
             scopes=[BROKER_EXECUTE_SCOPE],
             token_family_id="fam_test",
             expires_at=datetime.now(UTC) + timedelta(hours=1),
-            created_by="agnt_opaque",
+            created_by=actor_id,
             is_ephemeral=True,
         )
         await session.commit()
@@ -304,6 +348,47 @@ async def test_token_with_missing_agent_row_rejected_by_broker(
 
     with pytest.raises(TokenValidationError):
         await _dual(admin_db).validate("at_orphan_agent")
+
+
+@pytest.mark.parametrize("user_active,should_pass", [(True, True), (False, False)])
+async def test_user_token_follows_user_active_flag(
+    admin_db: DatabaseSession, clean_access_tokens: None, user_active: bool, should_pass: bool
+) -> None:
+    """The SQL's `user` CASE branch: the boolean `users.active` column is
+    normalised to the shared status string — dialect-sensitive, so pinned on
+    both backends via the parametrized backend fixtures."""
+    await _seed_user_row(admin_db, "usr_broker", active=user_active)
+    await _seed_opaque_token(
+        admin_db, plaintext="at_user_token", actor_id="usr_broker", actor_type="user"
+    )
+
+    if should_pass:
+        resolved = await _dual(admin_db).validate("at_user_token")
+        assert resolved.sub == "usr_broker"
+    else:
+        with pytest.raises(TokenValidationError, match="token_inactive"):
+            await _dual(admin_db).validate("at_user_token")
+
+
+@pytest.mark.parametrize("sa_status,should_pass", [("active", True), ("disabled", False)])
+async def test_service_account_token_follows_sa_status(
+    admin_db: DatabaseSession, clean_access_tokens: None, sa_status: str, should_pass: bool
+) -> None:
+    """The SQL's `service_account` CASE branch."""
+    await _seed_user_row(admin_db, "usr_sa_owner")
+    await _seed_service_account_row(
+        admin_db, "sva_broker", owner_id="usr_sa_owner", status=sa_status
+    )
+    await _seed_opaque_token(
+        admin_db, plaintext="at_sa_token", actor_id="sva_broker", actor_type="service_account"
+    )
+
+    if should_pass:
+        resolved = await _dual(admin_db).validate("at_sa_token")
+        assert resolved.sub == "sva_broker"
+    else:
+        with pytest.raises(TokenValidationError, match="token_inactive"):
+            await _dual(admin_db).validate("at_sa_token")
 
 
 async def test_disable_mid_life_kills_token_after_cache_ttl(

--- a/tests/unit/auth/test_service_account_auth_service.py
+++ b/tests/unit/auth/test_service_account_auth_service.py
@@ -161,10 +161,19 @@ async def test_authenticate_client_credentials_sa_not_active(
         await svc.authenticate_client_credentials("sva_test123", "jcs_anything")
 
 
+def _make_agent_row(*, status: str = "active") -> MagicMock:
+    row = MagicMock()
+    row.id = "agnt_task1"
+    row.status = status
+    return row
+
+
 @pytest.mark.asyncio
-async def test_mint_task_token_success() -> None:
+@patch("jentic_one.auth.services.service_account_auth_service.AgentRepository")
+async def test_mint_task_token_success(mock_agent_repo: MagicMock) -> None:
     ctx = _make_ctx()
     svc = ServiceAccountAuthService(ctx)
+    mock_agent_repo.get_by_id = AsyncMock(return_value=_make_agent_row())
 
     with patch.object(svc._token_svc, "issue_access_only", new_callable=AsyncMock) as mock_issue:
         mock_issue.return_value = "at_ephemeral"
@@ -211,9 +220,11 @@ async def test_mint_task_token_rejects_empty_scopes() -> None:
 
 
 @pytest.mark.asyncio
-async def test_mint_task_token_default_ttl() -> None:
+@patch("jentic_one.auth.services.service_account_auth_service.AgentRepository")
+async def test_mint_task_token_default_ttl(mock_agent_repo: MagicMock) -> None:
     ctx = _make_ctx()
     svc = ServiceAccountAuthService(ctx)
+    mock_agent_repo.get_by_id = AsyncMock(return_value=_make_agent_row())
 
     with patch.object(svc._token_svc, "issue_access_only", new_callable=AsyncMock) as mock_issue:
         mock_issue.return_value = "at_ephemeral"
@@ -256,6 +267,50 @@ async def test_mint_task_token_rejects_ttl_zero() -> None:
             requested_scopes=["capabilities:execute"],
             target_agent_id="agnt_task1",
             ttl_seconds=0,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["pending", "rejected", "disabled", "archived"])
+@patch("jentic_one.auth.services.service_account_auth_service.AgentRepository")
+async def test_mint_task_token_rejects_non_active_target_agent(
+    mock_agent_repo: MagicMock, status: str
+) -> None:
+    """Resolvers reject non-active agents' tokens (#1136), so minting one would
+    be dead on arrival — the mint must fail fast instead of returning it."""
+    ctx = _make_ctx()
+    svc = ServiceAccountAuthService(ctx)
+    mock_agent_repo.get_by_id = AsyncMock(return_value=_make_agent_row(status=status))
+
+    with (
+        patch.object(svc._token_svc, "issue_access_only", new_callable=AsyncMock) as mock_issue,
+        pytest.raises(InvalidGrantError, match="active agent"),
+    ):
+        await svc.mint_task_token(
+            host_sa_id="sva_host",
+            host_sa_scopes=["capabilities:execute"],
+            requested_scopes=["capabilities:execute"],
+            target_agent_id="agnt_task1",
+        )
+
+    mock_issue.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("jentic_one.auth.services.service_account_auth_service.AgentRepository")
+async def test_mint_task_token_rejects_missing_target_agent(
+    mock_agent_repo: MagicMock,
+) -> None:
+    ctx = _make_ctx()
+    svc = ServiceAccountAuthService(ctx)
+    mock_agent_repo.get_by_id = AsyncMock(return_value=None)
+
+    with pytest.raises(InvalidGrantError, match="active agent"):
+        await svc.mint_task_token(
+            host_sa_id="sva_host",
+            host_sa_scopes=["capabilities:execute"],
+            requested_scopes=["capabilities:execute"],
+            target_agent_id="agnt_never_existed",
         )
 
 

--- a/tests/unit/auth/test_token_service.py
+++ b/tests/unit/auth/test_token_service.py
@@ -89,6 +89,28 @@ def _make_refresh_token_row(
     return row
 
 
+def _make_agent_row(*, status: str = "active", owner_id: str = "usr_owner") -> MagicMock:
+    row = MagicMock()
+    row.id = "agnt_x"
+    row.status = status
+    row.owner_id = owner_id
+    return row
+
+
+def _make_user_row(*, active: bool = True) -> MagicMock:
+    row = MagicMock()
+    row.id = "usr_test123"
+    row.active = active
+    return row
+
+
+def _make_service_account_row(*, status: str = "active") -> MagicMock:
+    row = MagicMock()
+    row.id = "sva_x"
+    row.status = status
+    return row
+
+
 @patch("jentic_one.auth.services.token_service.RefreshTokenRepository")
 @patch("jentic_one.auth.services.token_service.AccessTokenRepository")
 async def test_issue_pair_returns_prefixed_tokens(
@@ -127,10 +149,11 @@ async def test_issue_pair_stores_hashed_tokens(
     assert at_call_kwargs["scopes"] == ["read"]
 
 
+@patch("jentic_one.auth.services.token_service.UserRepository")
 @patch("jentic_one.auth.services.token_service.RefreshTokenRepository")
 @patch("jentic_one.auth.services.token_service.AccessTokenRepository")
 async def test_refresh_rotation_returns_new_pair(
-    mock_at_repo: MagicMock, mock_rt_repo: MagicMock
+    mock_at_repo: MagicMock, mock_rt_repo: MagicMock, mock_user_repo: MagicMock
 ) -> None:
     ctx = _make_ctx()
     rt_row = _make_refresh_token_row()
@@ -138,6 +161,7 @@ async def test_refresh_rotation_returns_new_pair(
     mock_rt_repo.create = AsyncMock(return_value=_make_refresh_token_row())
     mock_rt_repo.consume = AsyncMock()
     mock_at_repo.create = AsyncMock(return_value=_make_access_token_row())
+    mock_user_repo.get_by_id = AsyncMock(return_value=_make_user_row())
 
     svc = TokenService(ctx)
     access, refresh = await svc.refresh("rt_oldtoken")
@@ -267,11 +291,15 @@ async def test_revoke_correct_owner_succeeds(
     mock_at_repo.revoke.assert_called_once()
 
 
+@patch("jentic_one.auth.services.token_service.UserRepository")
 @patch("jentic_one.auth.services.token_service.AccessTokenRepository")
-async def test_introspect_active_access_token(mock_at_repo: MagicMock) -> None:
+async def test_introspect_active_access_token(
+    mock_at_repo: MagicMock, mock_user_repo: MagicMock
+) -> None:
     ctx = _make_ctx()
     at_row = _make_access_token_row()
     mock_at_repo.get_by_hash = AsyncMock(return_value=at_row)
+    mock_user_repo.get_by_id = AsyncMock(return_value=_make_user_row())
 
     svc = TokenService(ctx)
     result = await svc.introspect("at_validtoken")
@@ -316,11 +344,15 @@ async def test_introspect_not_found_returns_inactive(mock_at_repo: MagicMock) ->
     assert result["active"] is False
 
 
+@patch("jentic_one.auth.services.token_service.UserRepository")
 @patch("jentic_one.auth.services.token_service.AccessTokenRepository")
-async def test_resolve_valid_token_returns_identity(mock_at_repo: MagicMock) -> None:
+async def test_resolve_valid_token_returns_identity(
+    mock_at_repo: MagicMock, mock_user_repo: MagicMock
+) -> None:
     ctx = _make_ctx()
     at_row = _make_access_token_row()
     mock_at_repo.get_by_hash = AsyncMock(return_value=at_row)
+    mock_user_repo.get_by_id = AsyncMock(return_value=_make_user_row())
 
     svc = TokenService(ctx)
     resolved = await svc.resolve_access_token("at_validtoken")
@@ -331,11 +363,15 @@ async def test_resolve_valid_token_returns_identity(mock_at_repo: MagicMock) -> 
     assert resolved.permissions == at_row.scopes
 
 
+@patch("jentic_one.auth.services.token_service.UserRepository")
 @patch("jentic_one.auth.services.token_service.AccessTokenRepository")
-async def test_resolve_expired_token_returns_inactive(mock_at_repo: MagicMock) -> None:
+async def test_resolve_expired_token_returns_inactive(
+    mock_at_repo: MagicMock, mock_user_repo: MagicMock
+) -> None:
     ctx = _make_ctx()
     at_row = _make_access_token_row(expires_at=datetime.now(UTC) - timedelta(hours=1))
     mock_at_repo.get_by_hash = AsyncMock(return_value=at_row)
+    mock_user_repo.get_by_id = AsyncMock(return_value=_make_user_row())
 
     svc = TokenService(ctx)
     resolved = await svc.resolve_access_token("at_expired")
@@ -378,7 +414,7 @@ async def test_resolve_long_lived_agent_token_uses_live_grants(
         actor_id="agnt_x", actor_type="agent", scopes=["apis:read"], is_ephemeral=False
     )
     mock_at_repo.get_by_hash = AsyncMock(return_value=at_row)
-    mock_agent_repo.get_by_id = AsyncMock(return_value=None)
+    mock_agent_repo.get_by_id = AsyncMock(return_value=_make_agent_row())
     mock_grant_repo.list_for_actor = AsyncMock(
         return_value=[MagicMock(scope="apis:read"), MagicMock(scope="apis:write")]
     )
@@ -387,6 +423,8 @@ async def test_resolve_long_lived_agent_token_uses_live_grants(
     resolved = await svc.resolve_access_token("at_agenttoken")
 
     assert resolved is not None
+    assert resolved.active is True
+    assert resolved.parent_actor_id == "usr_owner"
     assert resolved.permissions == ["apis:read", "apis:write"]
     mock_grant_repo.list_for_actor.assert_awaited_once()
 
@@ -409,7 +447,7 @@ async def test_resolve_ephemeral_minted_token_keeps_snapshot(
         is_ephemeral=True,
     )
     mock_at_repo.get_by_hash = AsyncMock(return_value=at_row)
-    mock_agent_repo.get_by_id = AsyncMock(return_value=None)
+    mock_agent_repo.get_by_id = AsyncMock(return_value=_make_agent_row())
     mock_grant_repo.list_for_actor = AsyncMock()
 
     svc = TokenService(ctx)
@@ -420,17 +458,20 @@ async def test_resolve_ephemeral_minted_token_keeps_snapshot(
     mock_grant_repo.list_for_actor.assert_not_awaited()
 
 
+@patch("jentic_one.auth.services.token_service.UserRepository")
 @patch("jentic_one.auth.services.token_service.ActorScopeGrantRepository")
 @patch("jentic_one.auth.services.token_service.AccessTokenRepository")
 async def test_resolve_user_token_keeps_snapshot(
     mock_at_repo: MagicMock,
     mock_grant_repo: MagicMock,
+    mock_user_repo: MagicMock,
 ) -> None:
     """User tokens do not draw scopes from actor_scope_grants."""
     ctx = _make_ctx()
     at_row = _make_access_token_row(actor_id="usr_x", actor_type="user", scopes=["openid"])
     mock_at_repo.get_by_hash = AsyncMock(return_value=at_row)
     mock_grant_repo.list_for_actor = AsyncMock()
+    mock_user_repo.get_by_id = AsyncMock(return_value=_make_user_row())
 
     svc = TokenService(ctx)
     resolved = await svc.resolve_access_token("at_usertoken")
@@ -438,3 +479,187 @@ async def test_resolve_user_token_keeps_snapshot(
     assert resolved is not None
     assert resolved.permissions == ["openid"]
     mock_grant_repo.list_for_actor.assert_not_awaited()
+
+
+# --- actor-status checks (#1136): disable must kill outstanding tokens ---
+
+
+@pytest.mark.parametrize("status", ["pending", "rejected", "disabled", "archived"])
+@patch("jentic_one.auth.services.token_service.ActorScopeGrantRepository")
+@patch("jentic_one.auth.services.token_service.AgentRepository")
+@patch("jentic_one.auth.services.token_service.AccessTokenRepository")
+async def test_resolve_non_active_agent_token_is_inactive(
+    mock_at_repo: MagicMock,
+    mock_agent_repo: MagicMock,
+    mock_grant_repo: MagicMock,
+    status: str,
+) -> None:
+    """A valid, unexpired token resolves as inactive once its agent leaves ACTIVE."""
+    ctx = _make_ctx()
+    at_row = _make_access_token_row(actor_id="agnt_x", actor_type="agent")
+    mock_at_repo.get_by_hash = AsyncMock(return_value=at_row)
+    mock_agent_repo.get_by_id = AsyncMock(return_value=_make_agent_row(status=status))
+    mock_grant_repo.list_for_actor = AsyncMock(return_value=[])
+
+    svc = TokenService(ctx)
+    resolved = await svc.resolve_access_token("at_agenttoken")
+
+    assert resolved is not None
+    assert resolved.active is False
+
+
+@patch("jentic_one.auth.services.token_service.ActorScopeGrantRepository")
+@patch("jentic_one.auth.services.token_service.AgentRepository")
+@patch("jentic_one.auth.services.token_service.AccessTokenRepository")
+async def test_resolve_missing_agent_row_fails_closed(
+    mock_at_repo: MagicMock,
+    mock_agent_repo: MagicMock,
+    mock_grant_repo: MagicMock,
+) -> None:
+    """An agent token whose agent row no longer exists must not stay active."""
+    ctx = _make_ctx()
+    at_row = _make_access_token_row(actor_id="agnt_gone", actor_type="agent")
+    mock_at_repo.get_by_hash = AsyncMock(return_value=at_row)
+    mock_agent_repo.get_by_id = AsyncMock(return_value=None)
+    mock_grant_repo.list_for_actor = AsyncMock(return_value=[])
+
+    svc = TokenService(ctx)
+    resolved = await svc.resolve_access_token("at_orphan")
+
+    assert resolved is not None
+    assert resolved.active is False
+
+
+@patch("jentic_one.auth.services.token_service.ActorScopeGrantRepository")
+@patch("jentic_one.auth.services.token_service.ServiceAccountRepository")
+@patch("jentic_one.auth.services.token_service.AccessTokenRepository")
+async def test_resolve_disabled_service_account_token_is_inactive(
+    mock_at_repo: MagicMock,
+    mock_sa_repo: MagicMock,
+    mock_grant_repo: MagicMock,
+) -> None:
+    ctx = _make_ctx()
+    at_row = _make_access_token_row(actor_id="sva_x", actor_type="service_account")
+    mock_at_repo.get_by_hash = AsyncMock(return_value=at_row)
+    mock_sa_repo.get_by_id = AsyncMock(return_value=_make_service_account_row(status="disabled"))
+    mock_grant_repo.list_for_actor = AsyncMock(return_value=[])
+
+    svc = TokenService(ctx)
+    resolved = await svc.resolve_access_token("at_satoken")
+
+    assert resolved is not None
+    assert resolved.active is False
+
+
+@patch("jentic_one.auth.services.token_service.UserRepository")
+@patch("jentic_one.auth.services.token_service.AccessTokenRepository")
+async def test_resolve_deactivated_user_token_is_inactive(
+    mock_at_repo: MagicMock, mock_user_repo: MagicMock
+) -> None:
+    ctx = _make_ctx()
+    at_row = _make_access_token_row(actor_id="usr_x", actor_type="user")
+    mock_at_repo.get_by_hash = AsyncMock(return_value=at_row)
+    mock_user_repo.get_by_id = AsyncMock(return_value=_make_user_row(active=False))
+
+    svc = TokenService(ctx)
+    resolved = await svc.resolve_access_token("at_usertoken")
+
+    assert resolved is not None
+    assert resolved.active is False
+
+
+@patch("jentic_one.auth.services.token_service.AgentRepository")
+@patch("jentic_one.auth.services.token_service.RefreshTokenRepository")
+@patch("jentic_one.auth.services.token_service.AccessTokenRepository")
+async def test_refresh_disabled_agent_rejected_without_minting(
+    mock_at_repo: MagicMock, mock_rt_repo: MagicMock, mock_agent_repo: MagicMock
+) -> None:
+    """A disabled agent must not rotate its refresh token into fresh access tokens."""
+    ctx = _make_ctx()
+    rt_row = _make_refresh_token_row(actor_id="agnt_x", actor_type="agent")
+    mock_rt_repo.get_by_hash = AsyncMock(return_value=rt_row)
+    mock_rt_repo.create = AsyncMock()
+    mock_rt_repo.consume = AsyncMock()
+    mock_at_repo.create = AsyncMock()
+    mock_agent_repo.get_by_id = AsyncMock(return_value=_make_agent_row(status="disabled"))
+
+    svc = TokenService(ctx)
+    with pytest.raises(InvalidGrantError, match="not active"):
+        await svc.refresh("rt_disabledagent")
+
+    mock_at_repo.create.assert_not_called()
+    mock_rt_repo.create.assert_not_called()
+    mock_rt_repo.consume.assert_not_called()
+
+
+@patch("jentic_one.auth.services.token_service.UserRepository")
+@patch("jentic_one.auth.services.token_service.RefreshTokenRepository")
+@patch("jentic_one.auth.services.token_service.AccessTokenRepository")
+async def test_refresh_deactivated_user_rejected(
+    mock_at_repo: MagicMock, mock_rt_repo: MagicMock, mock_user_repo: MagicMock
+) -> None:
+    ctx = _make_ctx()
+    rt_row = _make_refresh_token_row()
+    mock_rt_repo.get_by_hash = AsyncMock(return_value=rt_row)
+    mock_user_repo.get_by_id = AsyncMock(return_value=_make_user_row(active=False))
+
+    svc = TokenService(ctx)
+    with pytest.raises(InvalidGrantError, match="not active"):
+        await svc.refresh("rt_deactivateduser")
+
+
+@patch("jentic_one.auth.services.token_service.AgentRepository")
+@patch("jentic_one.auth.services.token_service.RefreshTokenRepository")
+@patch("jentic_one.auth.services.token_service.AccessTokenRepository")
+async def test_refresh_reuse_detection_wins_over_disabled_actor(
+    mock_at_repo: MagicMock, mock_rt_repo: MagicMock, mock_agent_repo: MagicMock
+) -> None:
+    """Replaying a consumed refresh token still revokes the family even when the
+    actor is disabled — reuse detection must not be short-circuited."""
+    ctx = _make_ctx()
+    rt_row = _make_refresh_token_row(
+        actor_id="agnt_x", actor_type="agent", consumed_at=datetime.now(UTC)
+    )
+    mock_rt_repo.get_by_hash = AsyncMock(return_value=rt_row)
+    mock_rt_repo.revoke_family = AsyncMock()
+    mock_at_repo.revoke_family = AsyncMock()
+    mock_agent_repo.get_by_id = AsyncMock(return_value=_make_agent_row(status="disabled"))
+
+    svc = TokenService(ctx)
+    with pytest.raises(InvalidGrantError, match="reuse detected"):
+        await svc.refresh("rt_replayed")
+
+    mock_rt_repo.revoke_family.assert_called_once()
+    mock_at_repo.revoke_family.assert_called_once()
+
+
+@patch("jentic_one.auth.services.token_service.AgentRepository")
+@patch("jentic_one.auth.services.token_service.AccessTokenRepository")
+async def test_introspect_disabled_agent_access_token_inactive(
+    mock_at_repo: MagicMock, mock_agent_repo: MagicMock
+) -> None:
+    ctx = _make_ctx()
+    at_row = _make_access_token_row(actor_id="agnt_x", actor_type="agent")
+    mock_at_repo.get_by_hash = AsyncMock(return_value=at_row)
+    mock_agent_repo.get_by_id = AsyncMock(return_value=_make_agent_row(status="disabled"))
+
+    svc = TokenService(ctx)
+    result = await svc.introspect("at_disabledagent")
+
+    assert result["active"] is False
+
+
+@patch("jentic_one.auth.services.token_service.AgentRepository")
+@patch("jentic_one.auth.services.token_service.RefreshTokenRepository")
+async def test_introspect_disabled_agent_refresh_token_inactive(
+    mock_rt_repo: MagicMock, mock_agent_repo: MagicMock
+) -> None:
+    ctx = _make_ctx()
+    rt_row = _make_refresh_token_row(actor_id="agnt_x", actor_type="agent")
+    mock_rt_repo.get_by_hash = AsyncMock(return_value=rt_row)
+    mock_agent_repo.get_by_id = AsyncMock(return_value=_make_agent_row(status="disabled"))
+
+    svc = TokenService(ctx)
+    result = await svc.introspect("rt_disabledagent")
+
+    assert result["active"] is False


### PR DESCRIPTION
## Summary

Disabling an agent only blocked *future* token mints: both per-request `at_` token resolvers derived `active` purely from revocation + expiry, so a disabled actor's outstanding access token kept working for up to `access_ttl_seconds` (1 h) — and, worse, the refresh grant never re-checked actor status either, so a disabled actor could keep rotating fresh access tokens for up to `refresh_ttl_seconds` (7 days). Every token verdict now re-checks the actor row, making disable alone a working kill switch: outstanding tokens die within the broker's verdict-cache TTL (≤ ~3 s by default), no separate token-family revocation required.

## Changes

- **auth** `TokenService.resolve_access_token` (control plane): folds actor status into `Identity.active` — agents/service accounts must be `ACTIVE`, users must have `active=true`, a missing actor row fails closed. Agents cost zero extra queries (row was already loaded for `parent_actor_id`).
- **broker** `InProcessTokenResolver` (execute path): the raw SQL now resolves an `actor_status` via per-actor-type subqueries (stays decoupled from `auth/`); `NULL` fails closed; users' boolean is normalised to the same status string. Dialect-independent (Postgres + SQLite).
- **auth** `TokenService.refresh`: gates the refresh grant on actor status (`InvalidGrantError`, no mint, refresh token not consumed) — closes the rotation loophole beyond the issue's 1 h window. Refresh-token reuse detection deliberately still wins, so a replayed token always revokes the family.
- **auth** `TokenService.introspect`: RFC 7662 `active` now agrees with what the resolvers enforce, so an operator inspecting a token after a disable sees the truth.
- Out of scope: `jak_`/`sak_` API keys (already status-gated in `ApiKeyResolver`); JWT-path validation (no DB backing by design); MCP/plan work this was found under.

## Risk & rollback

- Auth surface: token verdicts get stricter — tokens whose actor is non-`ACTIVE` (or whose actor row is missing, e.g. hard-deleted) stop resolving as active. Intended; re-enabling an actor revives its outstanding tokens.
- Refresh grant now returns `invalid_grant` for non-active actors (previously succeeded).
- One extra indexed lookup per verdict for service-account/user tokens on the control plane; one subquery in the broker's resolve (amortised by the 3 s verdict cache). Agents: no extra query on the control plane.
- No migrations, no config changes, no API-shape changes. Rollback: revert the squash commit.

## Test plan

- New regression pins: disable agent → broker validate rejected once the verdict-cache TTL lapses (the issue's pinned test), and re-enable revives the same token; control-plane mint → disable → inactive → enable → active; disabled actor's refresh rejected *without* consuming the refresh token; disabled SA / deactivated user / archived-pending-rejected agent / missing actor row all inactive; reuse detection still revokes the family for disabled actors.
- Ran: `uv run pytest tests/unit/ tests/arch/` (2928 passed), `make test-integration` (961 passed, Postgres), `make test-integration-sqlite` (644 passed), `ruff check`, `ruff format --check`, `mypy` — all green.

## Review guide

- Start with the two resolver seams: `src/jentic_one/auth/services/token_service.py` (`_actor_is_active` + its three call sites) and `src/jentic_one/broker/repos/token_resolver.py` (the `actor_status` CASE). The test churn is mostly mechanical: existing tests now seed real actor rows because orphaned tokens fail closed.

Closes #1136

Made with [Cursor](https://cursor.com)