### PR TITLE
feat(helm): make the Marketplace listing RDS-only, park the postgres mirror

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1070,7 +1070,7 @@ values are sensitive; the trust policy below is what protects the role):
 | -------- | ----- |
 | `MARKETPLACE_ECR_ROLE_ARN` | The IAM role below, e.g. `arn:aws:iam::<seller-account-id>:role/jentic-one-marketplace-publish` |
 | `MARKETPLACE_ECR_IMAGE` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app` |
-| `MARKETPLACE_ECR_POSTGRES` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql` (only if the listing ships the bundled DB) |
+| `MARKETPLACE_ECR_POSTGRES` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql` — **leave unset: the listing is RDS-only** (decided 2026-08-26; the only chart-supported Postgres image is the frozen `bitnamilegacy` one, which fails the CVE gate). Setting this resumes the mirror if the chart ever moves to a maintained image |
 
 Once set:
 

--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -19,17 +19,24 @@ global:
     # Marketplace does not allow floating tags like :latest).
     tag: ""
 
-  # Combined mode: the app pod serves registry/admin/control; only the app
-  # and broker deployments (and their shared image) exist.
+  # RDS-ONLY LISTING (decided 2026-08-26): the bundled in-cluster Postgres is
+  # disabled — buyers bring an external Postgres (RDS or equivalent) and point
+  # global.databases.*.host at it. Rationale: the only image the postgresql
+  # subchart supports is bitnamilegacy/postgresql, frozen upstream since
+  # Bitnami's Aug 2025 catalog change — it already fails our CVE gate (52
+  # fixable HIGH/CRITICAL on 2026-08-26) and would fail AWS's listing scan.
+  # Revisit if the chart moves to a maintained Postgres image.
   postgresql:
-    enabled: true
+    enabled: false
 
   # NOTE: global.observability.otel.enabled must stay false for Marketplace
   # deploys — the sidecar image (otel/opentelemetry-collector-contrib) is
   # pulled from docker.io, which the Marketplace disallows. Mirror it into
   # the listing's ECR first if observability is needed.
 
-  # No database password defaults ship with the chart; set them at install:
+  # No database password defaults ship with the chart; point the DBs at your
+  # external Postgres and set the passwords at install:
+  #   --set global.databases.registry.host=<rds-endpoint> \
   #   --set global.databases.registry.password=… \
   #   --set global.databases.control.password=…  \
   #   --set global.databases.admin.password=…
@@ -76,25 +83,11 @@ control:
 gateway:
   enabled: false
 
-# In-cluster Postgres from the ECR-mirrored image (plan PR 6 mirrors it —
-# portal repo jentic/jentic-one-psql, created 2026-08-25).
-# RDS variant: set postgresql.enabled=false, global.postgresql.enabled=false,
-# and point global.databases.*.host at the RDS endpoint instead.
+# Bundled in-cluster Postgres: OFF for the Marketplace listing (RDS-only —
+# see the global.postgresql note above). The jentic/jentic-one-psql ECR repo
+# and the marketplace-mirror workflow exist but are parked: the mirror's CVE
+# gate correctly rejects the frozen bitnamilegacy image. If the chart ever
+# moves to a maintained Postgres image, re-enable this block and set the
+# MARKETPLACE_ECR_POSTGRES repo variable to resume mirroring.
 postgresql:
-  enabled: true
-  image:
-    registry: "709825985650.dkr.ecr.us-east-1.amazonaws.com"
-    repository: "jentic/jentic-one-psql"
-    tag: "17.2.0-debian-12-r6"
-  auth:
-    username: postgres
-    # password: set at install (--set postgresql.auth.password=…) or via
-    # auth.existingSecret; no default ships with the chart.
-    database: jentic
-  # The per-surface DB roles/schemas (registry/control/admin) must exist
-  # before the app boots — create a ConfigMap from
-  # docker/local-setup/init-schemas.sql (with real passwords) and reference
-  # it here, as the local deploy tooling does:
-  # primary:
-  #   initdb:
-  #     scriptsConfigMap: "jentic-pg-init"
+  enabled: false


### PR DESCRIPTION
## Summary

- First live run of `marketplace-mirror.yml` ([run 32974498648](https://github.com/jentic/jentic-one/actions/runs/32974498648)) hit the designed tripwire: the CVE gate rejected `bitnamilegacy/postgresql` with **52 fixable HIGH/CRITICAL CVEs** (OpenSSL heap overflow, libxml2 UAF, …). The image is frozen upstream, so this never gets better — and AWS's own listing scan would reject it too.
- Decision (2026-08-26): the Marketplace listing is **RDS-only**. `aws-marketplace.yaml` disables the bundled Postgres (`postgresql.enabled=false` + `global.postgresql.enabled=false`) and documents pointing `global.databases.*.host` at an external Postgres.
- The `jentic/jentic-one-psql` ECR repo and the mirror workflow stay in place but **parked**: `MARKETPLACE_ECR_POSTGRES` is documented as leave-unset (already removed from the repo variables), so the weekly cron skips instead of failing red. Re-enable path documented if the chart ever moves to a maintained Postgres image.

Part of #1132.

## Test plan

- [x] `tests/smoke/test_helm_render.py` (5 passed)

Made with [Cursor](https://cursor.com)