### PR TITLE
feat(ci): publish the Helm chart to Marketplace ECR as an OCI artifact

### DIFF
--- a/.github/workflows/marketplace-chart.yml
+++ b/.github/workflows/marketplace-chart.yml
@@ -1,0 +1,164 @@
+# Publishes the umbrella Helm chart as an OCI artifact to the AWS Marketplace
+# ECR repo — the chart URI the listing's deployment template points at.
+#
+# Why a separate workflow instead of a release.yml job: GoReleaser creates the
+# GitHub Release with GITHUB_TOKEN, which never triggers downstream workflows,
+# and the chart must only publish AFTER the release run fully succeeded (the
+# template references the image tag that run publishes). `workflow_run` gives
+# exactly that ordering; `workflow_dispatch` backfills already-released tags
+# (e.g. the first listed version) and re-runs after transient failures — a
+# re-push of the same chart version is a no-op registry-side.
+#
+# Same publish policy as the images (release.yml publish-image /
+# marketplace-mirror.yml): validation gates BEFORE login/push, cosign signs
+# the pushed digest after. Dormant until the repo VARIABLES (not secrets —
+# none of these values are sensitive, see deploy/README.md "AWS Marketplace
+# publishing") are set, so forks and pre-listing releases skip cleanly:
+#   MARKETPLACE_ECR_ROLE_ARN — IAM role trusting GitHub's OIDC provider
+#   MARKETPLACE_ECR_CHART    — full chart repo URI from the Marketplace portal
+#                              (709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one).
+#                              The final path segment MUST equal the chart
+#                              name (`helm push` derives it from Chart.yaml).
+#
+# Tag contract: the chart publishes at its Chart.yaml version (release-please
+# stamps it equal to the git tag minus the `v`), e.g. tag v0.32.1 → chart
+# 0.32.1. The deployment template pins that exact version — OCI chart
+# "tags" are chart versions and never float.
+name: marketplace-chart
+
+on:
+  workflow_run:
+    workflows: [release]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish the chart from (e.g. v0.32.1)"
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: marketplace-chart
+  cancel-in-progress: false
+
+jobs:
+  publish-chart:
+    name: Publish Helm chart to Marketplace ECR
+    # `if` on the job (not per-step) so unconfigured repos and failed release
+    # runs are a skip, not a red. workflow_run.head_branch carries the tag
+    # name for tag-triggered runs.
+    if: >-
+      vars.MARKETPLACE_ECR_ROLE_ARN != '' && vars.MARKETPLACE_ECR_CHART != '' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.workflow_run.conclusion == 'success' &&
+        startsWith(github.event.workflow_run.head_branch, 'v')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # configure-aws-credentials (OIDC) + cosign keyless
+    steps:
+      - name: Resolve the release tag
+        id: tag
+        env:
+          DISPATCH_TAG: ${{ inputs.tag }}
+          RUN_TAG: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          TAG="${DISPATCH_TAG:-${RUN_TAG}}"
+          [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::'${TAG}' is not a stable release tag (vX.Y.Z)"; exit 1; }
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      # Installers before any credential lands on disk — same posture as
+      # release.yml publish-image.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Install helm
+        uses: azure/setup-helm@v4
+
+      - name: Chart version must equal the tag
+        id: chart
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          ECR_CHART: ${{ vars.MARKETPLACE_ECR_CHART }}
+        run: |
+          set -euo pipefail
+          NAME="$(awk '/^name:/{print $2; exit}' deploy/helm/jentic-one/Chart.yaml)"
+          VERSION="$(awk '/^version:/{print $2; exit}' deploy/helm/jentic-one/Chart.yaml)"
+          if [ "${VERSION}" != "${TAG#v}" ]; then
+            echo "::error::Chart.yaml version (${VERSION}) != tag (${TAG#v})"; exit 1
+          fi
+          # helm push appends the chart name to the OCI path — the configured
+          # repo must already end with it or the push lands in the wrong repo.
+          if [ "${ECR_CHART##*/}" != "${NAME}" ]; then
+            echo "::error::MARKETPLACE_ECR_CHART (${ECR_CHART}) must end in the chart name (${NAME})"; exit 1
+          fi
+          echo "name=${NAME}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Build chart dependencies
+        run: helm dependency build deploy/helm/jentic-one
+
+      # Publish gate, mirroring tests/smoke/test_helm_render.py: the chart must
+      # render with the Marketplace overlay and reference ONLY ECR images —
+      # the Marketplace disallows docker.io/ghcr.io pulls at install time.
+      - name: Render gate — Marketplace overlay renders, all images from ECR
+        env:
+          VERSION: ${{ steps.chart.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Dummy values for the chart's `required` password guards — render-only.
+          PW_SETS=()
+          for db in registry control admin; do
+            PW_SETS+=(--set "global.databases.${db}.password=x") # pragma: allowlist secret
+          done
+          helm template jentic deploy/helm/jentic-one \
+            -f deploy/helm/values/aws-marketplace.yaml \
+            --set "global.image.tag=v${VERSION}" \
+            "${PW_SETS[@]}" \
+            > /tmp/rendered.yaml
+          BAD="$(awk -F'image:' '/^[[:space:]]*image:/{gsub(/^[[:space:]"]+|["[:space:]]+$/, "", $2); print $2}' /tmp/rendered.yaml \
+            | grep -v '^709825985650\.dkr\.ecr\.' || true)"
+          if [ -n "${BAD}" ]; then
+            echo "::error::non-ECR image(s) rendered:"; echo "${BAD}"; exit 1
+          fi
+          grep -c 'image:' /tmp/rendered.yaml >/dev/null
+
+      - name: Package the chart
+        env:
+          VERSION: ${{ steps.chart.outputs.version }}
+        run: |
+          set -euo pipefail
+          helm package deploy/helm/jentic-one -d /tmp/chart
+          test -f "/tmp/chart/jentic-one-${VERSION}.tgz"
+
+      # Credential-issuing steps after package + gate, directly before use.
+      - name: Configure AWS credentials (Marketplace ECR)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.MARKETPLACE_ECR_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Push the chart to Marketplace ECR and sign
+        env:
+          COSIGN_YES: "true"
+          ECR_CHART: ${{ vars.MARKETPLACE_ECR_CHART }}
+          VERSION: ${{ steps.chart.outputs.version }}
+        run: |
+          set -euo pipefail
+          aws ecr get-login-password --region us-east-1 \
+            | helm registry login --username AWS --password-stdin "${ECR_CHART%%/*}"
+          # helm push derives <repo>/<chart-name> from the chart, so the push
+          # target is the repo path MINUS the final segment (asserted above).
+          helm push "/tmp/chart/jentic-one-${VERSION}.tgz" "oci://${ECR_CHART%/*}" 2>&1 | tee /tmp/push.log
+          DIGEST="$(grep -oE 'sha256:[0-9a-f]{64}' /tmp/push.log | head -n1)"
+          test -n "${DIGEST}"
+          echo "Pushed ${ECR_CHART}:${VERSION} @ ${DIGEST}"
+          cosign sign "${ECR_CHART}@${DIGEST}"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,6 +133,15 @@
     }
   ],
   "results": {
+    ".github/workflows/marketplace-chart.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/marketplace-chart.yml",
+        "hashed_secret": "f5ecf3f594543c7b536ca23b1c15fb9cb35ac0ae",
+        "is_verified": false,
+        "line_number": 115
+      }
+    ],
     "cli/client/auth/apikey.go": [
       {
         "type": "Secret Keyword",
@@ -164,21 +173,21 @@
         "filename": "cli/client/generated/control/client.go",
         "hashed_secret": "36c46a098c7543cc8569553d4a8946bc7df395c9",
         "is_verified": false,
-        "line_number": 3324
+        "line_number": 3327
       },
       {
         "type": "Secret Keyword",
         "filename": "cli/client/generated/control/client.go",
         "hashed_secret": "dc0acf6e95f2dcba19616d63c275e8a749126f89",
         "is_verified": false,
-        "line_number": 4398
+        "line_number": 4401
       },
       {
         "type": "Secret Keyword",
         "filename": "cli/client/generated/control/client.go",
         "hashed_secret": "8cf6cb4d35e002c25f800782aab43af23d9e1f2c",
         "is_verified": false,
-        "line_number": 6537
+        "line_number": 6540
       }
     ],
     "cli/client/generated/control/spec.yaml": [
@@ -239,7 +248,7 @@
         "filename": "cli/internal/cli/ctlcmd/install_test.go",
         "hashed_secret": "489a836ba7d55b691a9614373dfe8d5199d4744b",
         "is_verified": false,
-        "line_number": 186
+        "line_number": 320
       }
     ],
     "cli/internal/cli/ux/redact_test.go": [
@@ -305,7 +314,7 @@
         "filename": "cli/internal/install/render_test.go",
         "hashed_secret": "5530a000e0696af2f05defa12f45933c43252268",
         "is_verified": false,
-        "line_number": 122
+        "line_number": 123
       }
     ],
     "cli/internal/install/reuse_test.go": [
@@ -1686,7 +1695,7 @@
         "filename": "tests/unit/test_config.py",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 280
+        "line_number": 281
       }
     ],
     "tests/web/admin/conftest.py": [
@@ -1921,5 +1930,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-25T10:13:34Z"
+  "generated_at": "2026-08-26T14:19:11Z"
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1070,7 +1070,7 @@ values are sensitive; the trust policy below is what protects the role):
 | -------- | ----- |
 | `MARKETPLACE_ECR_ROLE_ARN` | The IAM role below, e.g. `arn:aws:iam::<seller-account-id>:role/jentic-one-marketplace-publish` |
 | `MARKETPLACE_ECR_IMAGE` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app` |
-| `MARKETPLACE_ECR_POSTGRES` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql` — **leave unset: the listing is RDS-only** (decided 2026-08-26; the only chart-supported Postgres image is the frozen `bitnamilegacy` one, which fails the CVE gate). Setting this resumes the mirror if the chart ever moves to a maintained image |
+| `MARKETPLACE_ECR_POSTGRES` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql` — **leave unset: the listing is RDS-only** (decided 2026-08-26; the only chart-supported Postgres image is the frozen `bitnamilegacy` one, which fails the CVE gate). Resuming the mirror needs this variable **and** the repo's ARN re-added to the role policy below (removed for least-privilege) |
 | `MARKETPLACE_ECR_CHART` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one` — the Helm chart as an OCI artifact (the listing's deployment-template URI). The final path segment **must equal the chart name** (`jentic-one`): `helm push` derives it from `Chart.yaml` |
 
 Once set:
@@ -1167,7 +1167,6 @@ portal (`aws-marketplace` actions may be required by newer portal setups; add
       ],
       "Resource": [
         "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one-app",
-        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one-psql",
         "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one"
       ]
     }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1071,6 +1071,7 @@ values are sensitive; the trust policy below is what protects the role):
 | `MARKETPLACE_ECR_ROLE_ARN` | The IAM role below, e.g. `arn:aws:iam::<seller-account-id>:role/jentic-one-marketplace-publish` |
 | `MARKETPLACE_ECR_IMAGE` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app` |
 | `MARKETPLACE_ECR_POSTGRES` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql` — **leave unset: the listing is RDS-only** (decided 2026-08-26; the only chart-supported Postgres image is the frozen `bitnamilegacy` one, which fails the CVE gate). Setting this resumes the mirror if the chart ever moves to a maintained image |
+| `MARKETPLACE_ECR_CHART` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one` — the Helm chart as an OCI artifact (the listing's deployment-template URI). The final path segment **must equal the chart name** (`jentic-one`): `helm push` derives it from `Chart.yaml` |
 
 Once set:
 
@@ -1081,7 +1082,13 @@ Once set:
 - [`marketplace-mirror.yml`](../.github/workflows/marketplace-mirror.yml)
   (weekly + manual dispatch) mirrors the bundled Postgres image
   ([`postgres-mirror.Dockerfile`](docker/postgres-mirror.Dockerfile), digest
-  kept fresh by Dependabot) through the same Trivy gate.
+  kept fresh by Dependabot) through the same Trivy gate;
+- [`marketplace-chart.yml`](../.github/workflows/marketplace-chart.yml)
+  publishes the umbrella Helm chart as an OCI artifact after every successful
+  release run (chart version = tag minus the `v`), gated on a render check
+  that the Marketplace overlay resolves every image to the listing's ECR.
+  Backfill an already-released tag with
+  `gh workflow run marketplace-chart.yml -f tag=vX.Y.Z`.
 
 Publishing a new **listing version** stays a portal step (product → Request
 changes → *Add version*, pinning the pushed tag/digest); automate via the
@@ -1129,8 +1136,8 @@ doesn't have it):
 ```
 
 (The first statement covers the release workflow, which runs on `v*` tags;
-the second covers the scheduled/dispatched mirror workflow, which runs on
-`main`.)
+the second covers the mirror and chart workflows, which run on `main` —
+`workflow_run`/scheduled/dispatched workflows execute on the default branch.)
 
 Permissions policy — ECR push scoped to the listing's repos, which live in
 AWS's Marketplace registry account and are granted to the seller through the
@@ -1160,7 +1167,8 @@ portal (`aws-marketplace` actions may be required by newer portal setups; add
       ],
       "Resource": [
         "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one-app",
-        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one-psql"
+        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one-psql",
+        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one"
       ]
     }
   ]
@@ -1191,7 +1199,9 @@ and will be filled when the answers exist:
   and full re-runs strand untagged manifests; nothing prunes them yet. A
   scheduled `actions/delete-package-versions` for untagged + aged SHA tags
   is the likely shape.
-- **Helm chart publishing** — chart is built locally; no OCI-registry push
-  yet.
+- **Helm chart publishing** — the chart publishes to the AWS Marketplace ECR
+  as an OCI artifact on release
+  ([`marketplace-chart.yml`](../.github/workflows/marketplace-chart.yml));
+  there is no general-purpose (non-Marketplace) OCI-registry push yet.
 - **Real Terraform env values** — cluster/namespace/ingress are TODO
   placeholders.


### PR DESCRIPTION
## Summary

- The Marketplace deployment template needs the umbrella Helm chart as an **OCI artifact in the listing's ECR** (`jentic/jentic-one` — portal repo already exists); external chart URLs are disallowed, same rule as images. This automates it properly instead of a one-off manual `helm push`.
- New `marketplace-chart.yml`: runs via `workflow_run` after each **successful** release run (GoReleaser creates releases with `GITHUB_TOKEN`, which can't trigger workflows — this is the reliable ordering), plus `workflow_dispatch` with a `tag` input to backfill already-released versions (first use: `-f tag=v0.32.1`). Re-pushing the same chart version is a registry-side no-op.
- Same publish posture as `release.yml`/`marketplace-mirror.yml`: installers before credentials, gates before login — chart version must equal the tag, and a render gate (mirroring `tests/smoke/test_helm_render.py`) asserts the Marketplace overlay resolves **every** image to the listing's ECR. Cosign signs the pushed chart digest after.
- Dormant until the `MARKETPLACE_ECR_CHART` repo variable is set. Runbook updated: variable table, workflow description, chart repo ARN added to the publish role's permissions policy.

**Activation order (after merge):** infra adds `arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one` to the `jentic-one-marketplace-publish` role policy (one-line `infrastructure-live` follow-up; amendment written up in the internal infra ticket) → set `MARKETPLACE_ECR_CHART` → dispatch with `tag=v0.32.1` → paste the chart URI (`709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one:0.32.1`) into the portal's deployment template.

Part of #1132.

## Test plan

- [x] `actionlint` clean
- [x] Render gate verified locally against the current chart: only `…/jentic/jentic-one-app:v0.32.1` renders with the Marketplace overlay (RDS-only)
- [ ] Post-merge: dispatch with `tag=v0.32.1` once the role policy + variable exist

Made with [Cursor](https://cursor.com)