### PR TITLE
fix(ci): docker login before cosign signs the Marketplace chart

### DIFF
--- a/.github/workflows/marketplace-chart.yml
+++ b/.github/workflows/marketplace-chart.yml
@@ -153,12 +153,29 @@ jobs:
           VERSION: ${{ steps.chart.outputs.version }}
         run: |
           set -euo pipefail
-          aws ecr get-login-password --region us-east-1 \
-            | helm registry login --username AWS --password-stdin "${ECR_CHART%%/*}"
+          REGISTRY="${ECR_CHART%%/*}"
+          # Two logins from one token: helm push reads Helm's registry config;
+          # cosign reads Docker's. Without the docker login the sign step 401s.
+          PASSWORD="$(aws ecr get-login-password --region us-east-1)"
+          helm registry login --username AWS --password-stdin "${REGISTRY}" <<<"${PASSWORD}"
+          docker login --username AWS --password-stdin "${REGISTRY}" <<<"${PASSWORD}"
           # helm push derives <repo>/<chart-name> from the chart, so the push
           # target is the repo path MINUS the final segment (asserted above).
-          helm push "/tmp/chart/jentic-one-${VERSION}.tgz" "oci://${ECR_CHART%/*}" 2>&1 | tee /tmp/push.log
-          DIGEST="$(grep -oE 'sha256:[0-9a-f]{64}' /tmp/push.log | head -n1)"
-          test -n "${DIGEST}"
-          echo "Pushed ${ECR_CHART}:${VERSION} @ ${DIGEST}"
+          # Marketplace ECR tags are immutable: if this exact chart version is
+          # already present (a re-run after a partial failure), skip the push
+          # and re-derive the digest from the registry so signing still runs.
+          if helm push "/tmp/chart/jentic-one-${VERSION}.tgz" "oci://${ECR_CHART%/*}" 2>&1 | tee /tmp/push.log; then
+            DIGEST="$(grep -oE 'sha256:[0-9a-f]{64}' /tmp/push.log | head -n1)"
+          elif grep -qiE 'tag.*immutable|already exists' /tmp/push.log; then
+            echo "Chart ${VERSION} already in the registry — signing the existing digest"
+            DIGEST="$(aws ecr batch-get-image --region us-east-1 \
+              --registry-id "${REGISTRY%%.*}" \
+              --repository-name "${ECR_CHART#*/}" \
+              --image-ids imageTag="${VERSION}" \
+              --query 'images[0].imageId.imageDigest' --output text)"
+          else
+            exit 1
+          fi
+          test -n "${DIGEST}" && [ "${DIGEST}" != "None" ]
+          echo "Chart ${ECR_CHART}:${VERSION} @ ${DIGEST}"
           cosign sign "${ECR_CHART}@${DIGEST}"


### PR DESCRIPTION
## Summary

First live dispatch of `marketplace-chart.yml` ([run 32982539829](https://github.com/jentic/jentic-one/actions/runs/32982539829)) got the chart **pushed** to `jentic/jentic-one` but failed at **signing** with 401: `helm registry login` writes Helm's registry config, while cosign reads Docker's config — the sign step ran unauthenticated. (The image publish in `release.yml` never hit this because it uses `docker login` throughout.)

- Log in to **both** Helm's and Docker's registry config from a single `aws ecr get-login-password` token.
- Make re-runs safe now that `0.32.1` exists: Marketplace ECR tags are immutable, so if the push reports the tag already exists, skip it and re-derive the digest via `aws ecr batch-get-image` so the signing half still completes — exactly the recovery this failed run needs.

Part of #1132; follow-up to #1145.

## Test plan

- [x] `actionlint` clean
- [ ] Post-merge: dispatch with `tag=v0.32.1` — should take the already-exists path and sign the existing digest

Made with [Cursor](https://cursor.com)