### PR TITLE
feat(helm): Marketplace launch wiring — service account + license secret

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1094,6 +1094,19 @@ Publishing a new **listing version** stays a portal step (product → Request
 changes → *Add version*, pinning the pushed tag/digest); automate via the
 Marketplace Catalog API only after the manual loop has worked once.
 
+The version's **Helm delivery option** must carry two AWS-substituted
+override parameters (portal validation rejects paid products without them):
+
+| Override parameter key | DefaultValue |
+| ---------------------- | ------------ |
+| `global.serviceAccount.name` | `${AWSMP_SERVICE_ACCOUNT}` — the buyer's (IRSA) service account; the app/broker pods run under it (chart support: `global.serviceAccount`) |
+| `global.awsmp.licenseSecret` | `${AWSMP_LICENSE_SECRET}` — an AWS-created Secret, mounted read-only at `/var/run/secrets/aws-marketplace/license` (chart support: `global.awsmp.licenseSecret`) |
+
+plus the deployment values from
+[`aws-marketplace.yaml`](helm/values/aws-marketplace.yaml) (ECR image
+repositories, `broker.enabled=true`, the tag pin, and buyer-supplied
+`global.databases.*` host/password parameters).
+
 The IAM role lives in the **seller account** and trusts GitHub's OIDC
 provider — no long-lived AWS keys anywhere. Trust policy (create the
 `token.actions.githubusercontent.com` OIDC provider first if the account

--- a/deploy/helm/jentic-one/charts/app/templates/deployment.yaml
+++ b/deploy/helm/jentic-one/charts/app/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
       {{- include "common.pod-annotations" . | nindent 6 }}
     spec:
+      {{- with (include "common.service-account-name" . | trim) }}
+      {{ . }}
+      {{- end }}
       containers:
         - name: app
           image: {{ include "common.image" . | quote }}
@@ -32,9 +35,16 @@ spec:
 {{ include "common.logging-env" . | indent 12 }}
 {{ include "common.metrics-env" . | indent 12 }}
 {{ include "common.db-env" . | indent 12 }}
-{{- with (include "common.config-file.mount" . | trim) }}
+{{- $cfgMount := (include "common.config-file.mount" . | trim) }}
+{{- $licMount := (include "common.awsmp-license.mount" . | trim) }}
+{{- if or $cfgMount $licMount }}
           volumeMounts:
+{{- with $cfgMount }}
 {{ . | indent 12 }}
+{{- end }}
+{{- with $licMount }}
+{{ . | indent 12 }}
+{{- end }}
 {{- end }}
           readinessProbe:
             httpGet:
@@ -55,12 +65,16 @@ spec:
         {{- end }}
       {{- $otel := .Values.global.observability.otel.enabled }}
       {{- $cfg := (include "common.config-file.volume" . | trim) }}
-      {{- if or $otel $cfg }}
+      {{- $lic := (include "common.awsmp-license.volume" . | trim) }}
+      {{- if or $otel $cfg $lic }}
       volumes:
       {{- if $otel }}
 {{ include "common.otel-config-volume" . | indent 8 }}
       {{- end }}
       {{- with $cfg }}
+{{ . | indent 8 }}
+      {{- end }}
+      {{- with $lic }}
 {{ . | indent 8 }}
       {{- end }}
       {{- end }}

--- a/deploy/helm/jentic-one/charts/broker/templates/deployment.yaml
+++ b/deploy/helm/jentic-one/charts/broker/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
       {{- include "common.pod-annotations" . | nindent 6 }}
     spec:
+      {{- with (include "common.service-account-name" . | trim) }}
+      {{ . }}
+      {{- end }}
       containers:
         - name: broker
           image: {{ include "common.image" . | quote }}
@@ -32,9 +35,16 @@ spec:
 {{ include "common.logging-env" . | indent 12 }}
 {{ include "common.metrics-env" . | indent 12 }}
 {{ include "common.db-env" . | indent 12 }}
-{{- with (include "common.config-file.mount" . | trim) }}
+{{- $cfgMount := (include "common.config-file.mount" . | trim) }}
+{{- $licMount := (include "common.awsmp-license.mount" . | trim) }}
+{{- if or $cfgMount $licMount }}
           volumeMounts:
+{{- with $cfgMount }}
 {{ . | indent 12 }}
+{{- end }}
+{{- with $licMount }}
+{{ . | indent 12 }}
+{{- end }}
 {{- end }}
           readinessProbe:
             httpGet:
@@ -55,12 +65,16 @@ spec:
         {{- end }}
       {{- $otel := .Values.global.observability.otel.enabled }}
       {{- $cfg := (include "common.config-file.volume" . | trim) }}
-      {{- if or $otel $cfg }}
+      {{- $lic := (include "common.awsmp-license.volume" . | trim) }}
+      {{- if or $otel $cfg $lic }}
       volumes:
       {{- if $otel }}
 {{ include "common.otel-config-volume" . | indent 8 }}
       {{- end }}
       {{- with $cfg }}
+{{ . | indent 8 }}
+      {{- end }}
+      {{- with $lic }}
 {{ . | indent 8 }}
       {{- end }}
       {{- end }}

--- a/deploy/helm/jentic-one/charts/common/templates/_awsmp-license.tpl
+++ b/deploy/helm/jentic-one/charts/common/templates/_awsmp-license.tpl
@@ -1,0 +1,28 @@
+{{/*
+common.awsmp-license.{volume,mount} — AWS Marketplace license secret.
+
+The Marketplace launch experience substitutes the name of a Kubernetes
+Secret it creates into global.awsmp.licenseSecret (delivery-option override
+parameter with DefaultValue ${AWSMP_LICENSE_SECRET}). When set, the secret
+is mounted read-only into the app/broker pods; when unset (every
+non-Marketplace deployment) both helpers emit nothing.
+
+The mount is reserved for AWS's license-file flows (e.g. EKS Anywhere) —
+the IRSA-based entitlement gate calls the AWS APIs directly and does not
+read it.
+*/}}
+{{- define "common.awsmp-license.volume" -}}
+{{- with (((.Values.global).awsmp).licenseSecret) -}}
+- name: awsmp-license
+  secret:
+    secretName: {{ . }}
+{{- end -}}
+{{- end -}}
+
+{{- define "common.awsmp-license.mount" -}}
+{{- if (((.Values.global).awsmp).licenseSecret) -}}
+- name: awsmp-license
+  mountPath: /var/run/secrets/aws-marketplace/license
+  readOnly: true
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/jentic-one/charts/common/templates/_service-account.tpl
+++ b/deploy/helm/jentic-one/charts/common/templates/_service-account.tpl
@@ -1,0 +1,15 @@
+{{/*
+common.service-account-name — pod-spec fragment selecting the service
+account the app/broker pods run under. Emits nothing when unset (pods use
+the namespace default), so non-Marketplace deployments are unchanged.
+
+The AWS Marketplace launch experience substitutes the buyer-chosen account
+into global.serviceAccount.name (delivery-option override parameter with
+DefaultValue ${AWSMP_SERVICE_ACCOUNT}); on EKS that account carries the IAM
+role (IRSA) the entitlement gate uses to call AWS.
+*/}}
+{{- define "common.service-account-name" -}}
+{{- with (((.Values.global).serviceAccount).name) -}}
+serviceAccountName: {{ . }}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/jentic-one/templates/serviceaccount.yaml
+++ b/deploy/helm/jentic-one/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{/*
+Created only when explicitly asked for (manual installs without an
+out-of-band account). EKS QuickLaunch and IRSA setups create the service
+account themselves (with the IAM role annotation) and only pass its name
+via global.serviceAccount.name — creating it here too would make the
+install collide with the pre-existing object.
+*/}}
+{{- $sa := .Values.global.serviceAccount | default dict }}
+{{- if $sa.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ required "global.serviceAccount.name is required when global.serviceAccount.create=true" $sa.name }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/helm/jentic-one/values.yaml
+++ b/deploy/helm/jentic-one/values.yaml
@@ -111,6 +111,26 @@ global:
       exporter: otlp
   postgresql:
     enabled: false
+  # Pod service account for the app and broker deployments. `name` — when
+  # set, those pods run under this service account (on EKS typically an
+  # IRSA-annotated account carrying the IAM role the AWS Marketplace
+  # entitlement gate calls AWS with); empty means the namespace default and
+  # zero rendered change. The Marketplace launch experience substitutes the
+  # buyer-chosen account into `name` (delivery-option override parameter
+  # with DefaultValue ${AWSMP_SERVICE_ACCOUNT}). `create` — set true for
+  # manual installs to have the chart create the (un-annotated) account;
+  # leave false when it's created out of band (EKS QuickLaunch creates it
+  # with the IAM role attached — creating it here too would collide).
+  serviceAccount:
+    create: false
+    name: ""
+  # AWS Marketplace license secret (delivery-option override parameter with
+  # DefaultValue ${AWSMP_LICENSE_SECRET}): when set, mounted read-only into
+  # the app and broker pods at /var/run/secrets/aws-marketplace/license.
+  # Reserved for AWS's license-file flows (e.g. EKS Anywhere); the
+  # IRSA-based entitlement gate does not read it. Empty = nothing rendered.
+  awsmp:
+    licenseSecret: ""
   # Bitnami chart 16.4.x rejects images outside its expected registry; we
   # need to pin `bitnamilegacy/postgresql` (see the postgresql block below)
   # so this gate has to be opened. Production deployments that use a

--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -43,6 +43,17 @@ global:
   # or (preferred) replace common.db-env with a Secret-backed env block —
   # see deploy/README.md "Production secrets".
 
+  # AWS Marketplace launch wiring — the listing's delivery option carries
+  # these two override parameters (values substituted by AWS at launch):
+  #   global.serviceAccount.name = ${AWSMP_SERVICE_ACCOUNT}
+  #     the buyer's (IRSA) service account the app/broker pods run under —
+  #     on EKS this carries the IAM role the entitlement gate calls AWS with
+  #   global.awsmp.licenseSecret = ${AWSMP_LICENSE_SECRET}
+  #     a Secret AWS creates at launch, mounted read-only at
+  #     /var/run/secrets/aws-marketplace/license (license-file flows)
+  # Manual installs: set serviceAccount.name + serviceAccount.create=true to
+  # have the chart create the account, then attach IAM out of band.
+
 # app and broker run the same jentic-one-app image, differentiated by the
 # JENTIC__APPS env each subchart sets. If the Marketplace portal provisions a
 # single ECR repository for the product, keep the explicit repository values

--- a/tests/smoke/test_helm_render.py
+++ b/tests/smoke/test_helm_render.py
@@ -80,3 +80,62 @@ def test_render_marketplace_images_all_ecr() -> None:
     assert images, "no image references rendered"
     for image in images:
         assert image.startswith("709825985650.dkr.ecr."), f"non-ECR image rendered: {image}"
+
+
+@pytest.mark.smoke
+def test_render_awsmp_launch_parameters() -> None:
+    """The Marketplace launch substitutions render into the pod specs.
+
+    The listing's delivery option passes the buyer's service account
+    (${AWSMP_SERVICE_ACCOUNT}) into global.serviceAccount.name and the
+    AWS-created license secret (${AWSMP_LICENSE_SECRET}) into
+    global.awsmp.licenseSecret — both must land on the app AND broker pods.
+    """
+    result = _helm_template(
+        "-f",
+        str(VALUES_DIR / "aws-marketplace.yaml"),
+        "--set",
+        "global.image.tag=0.0.0-test",
+        "--set",
+        "global.serviceAccount.name=buyer-sa",
+        "--set",
+        "global.awsmp.licenseSecret=buyer-license",
+        *DEV_PASSWORD_SETS,
+    )
+    assert result.returncode == 0, result.stderr
+    # Both enabled deployments (app + broker) carry the account and mount.
+    assert result.stdout.count("serviceAccountName: buyer-sa") == 2
+    assert result.stdout.count("secretName: buyer-license") == 2
+    assert result.stdout.count("mountPath: /var/run/secrets/aws-marketplace/license") == 2
+
+
+@pytest.mark.smoke
+def test_render_awsmp_defaults_are_inert() -> None:
+    """Unset, the Marketplace launch values must render nothing at all."""
+    result = _helm_template(
+        "-f",
+        str(VALUES_DIR / "aws-marketplace.yaml"),
+        "--set",
+        "global.image.tag=0.0.0-test",
+        *DEV_PASSWORD_SETS,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "serviceAccountName" not in result.stdout
+    assert "awsmp-license" not in result.stdout
+    assert "kind: ServiceAccount" not in result.stdout
+
+
+@pytest.mark.smoke
+def test_render_service_account_create_requires_name() -> None:
+    """create=true without a name must fail loudly, not render a broken SA."""
+    result = _helm_template(
+        "-f",
+        str(VALUES_DIR / "aws-marketplace.yaml"),
+        "--set",
+        "global.image.tag=0.0.0-test",
+        "--set",
+        "global.serviceAccount.create=true",
+        *DEV_PASSWORD_SETS,
+    )
+    assert result.returncode != 0
+    assert "global.serviceAccount.name is required" in result.stderr


### PR DESCRIPTION
## Summary

Submitting the listing's Helm delivery option surfaced two portal validation errors for paid products — each requires an override parameter backed by a real chart value, which the chart didn't have:

> No Service Account Configuration — Provide one service account configuration OverrideParameter with DefaultValue of `${AWSMP_SERVICE_ACCOUNT}`
> No License Secret Keys — Provide one license secret key OverrideParameter with DefaultValue of `${AWSMP_LICENSE_SECRET}`

- **`global.serviceAccount.{create,name}`** — when `name` is set, the **app and broker** pods run under that service account (on EKS the IRSA account carrying the IAM role the entitlement gate calls AWS with — the buyer-side half of the #1041 credential chain, which already supports `AssumeRoleWithWebIdentity`). `create=true` makes the umbrella chart create the (un-annotated) account for manual installs; off by default because EKS QuickLaunch creates the account itself and passes only the name. `create` without `name` fails render loudly.
- **`global.awsmp.licenseSecret`** — when set, mounted read-only into the app and broker pods at `/var/run/secrets/aws-marketplace/license`. Reserved for AWS's license-file flows (e.g. EKS Anywhere); the IRSA-based entitlement gate calls the AWS APIs directly and doesn't read it.
- Both are **inert when unset** — non-Marketplace renders are byte-identical (asserted by the new `test_render_awsmp_defaults_are_inert`).
- Runbook: documents the two delivery-option override parameters; Marketplace overlay comments updated.

The listing's delivery option then carries: `global.serviceAccount.name = ${AWSMP_SERVICE_ACCOUNT}` and `global.awsmp.licenseSecret = ${AWSMP_LICENSE_SECRET}`.

Chart `0.32.1` is immutably published, so this ships with the next release (v0.32.2) — `marketplace-chart.yml` publishes the new chart version automatically on release.

Part of #1132.

## Test plan

- [x] `tests/smoke/test_helm_render.py` — 8 passed: launch parameters land on both pods (SA name ×2, secret mount ×2), defaults render nothing, `create` without `name` fails, existing ECR/password-guard tests unchanged

Made with [Cursor](https://cursor.com)