### PR TITLE
feat(helm): first-party bundled Postgres on the official image

### DIFF
--- a/.github/workflows/marketplace-chart.yml
+++ b/.github/workflows/marketplace-chart.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           set -euo pipefail
           # Dummy values for the chart's `required` password guards — render-only.
-          PW_SETS=()
+          PW_SETS=(--set "postgresql.auth.password=x") # pragma: allowlist secret
           for db in registry control admin; do
             PW_SETS+=(--set "global.databases.${db}.password=x") # pragma: allowlist secret
           done

--- a/.github/workflows/marketplace-mirror.yml
+++ b/.github/workflows/marketplace-mirror.yml
@@ -64,10 +64,9 @@ jobs:
 
       # Same CVE bar as everything else this repo publishes: fixable
       # HIGH/CRITICAL fail; overrides go in .trivyignore with justification +
-      # expiry. NOTE: the source image is Bitnami *legacy* (frozen, unpatched
-      # upstream — see the Dockerfile header), so expect this gate to start
-      # failing eventually; that is the signal to switch the chart's bundled
-      # DB or make RDS the Marketplace default, not to allowlist blindly.
+      # expiry. The source is the official library/postgres image (actively
+      # maintained); a red gate here normally just means Dependabot's next
+      # digest bump is due.
       - name: Trivy image scan (publish gate)
         uses: aquasecurity/trivy-action@v0.36.0
         with:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -823,8 +823,8 @@ into the kind cluster, to keep the deploy fast:
 | `parts`    | `registry`, `admin`, `control`, `broker` |
 | `broker`   | `broker`                               |
 
-The bundled PostgreSQL uses the stock Bitnami image pulled from Docker Hub, so
-no custom database image needs to be built or loaded.
+The bundled PostgreSQL runs the official `postgres` image pulled from Docker
+Hub, so no custom database image needs to be built or loaded.
 
 If you plan to switch modes back-and-forth and want to pre-warm everything
 once, run `uv run python -m tools.deploy load --all` after `cluster up` —
@@ -1070,7 +1070,7 @@ values are sensitive; the trust policy below is what protects the role):
 | -------- | ----- |
 | `MARKETPLACE_ECR_ROLE_ARN` | The IAM role below, e.g. `arn:aws:iam::<seller-account-id>:role/jentic-one-marketplace-publish` |
 | `MARKETPLACE_ECR_IMAGE` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app` |
-| `MARKETPLACE_ECR_POSTGRES` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql` — **leave unset: the listing is RDS-only** (decided 2026-08-26; the only chart-supported Postgres image is the frozen `bitnamilegacy` one, which fails the CVE gate). Resuming the mirror needs this variable **and** the repo's ARN re-added to the role policy below (removed for least-privilege) |
+| `MARKETPLACE_ECR_POSTGRES` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql` — the bundled-DB mirror of the official `postgres` image (the first-party `charts/postgresql` subchart). Needs the repo's ARN in the role policy below |
 | `MARKETPLACE_ECR_CHART` | `709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one` — the Helm chart as an OCI artifact (the listing's deployment-template URI). The final path segment **must equal the chart name** (`jentic-one`): `helm push` derives it from `Chart.yaml` |
 
 Once set:
@@ -1104,8 +1104,10 @@ override parameters (portal validation rejects paid products without them):
 
 plus the deployment values from
 [`aws-marketplace.yaml`](helm/values/aws-marketplace.yaml) (ECR image
-repositories, `broker.enabled=true`, the tag pin, and buyer-supplied
-`global.databases.*` host/password parameters).
+repositories, `broker.enabled=true`, the bundled Postgres, the tag pin, and
+buyer-supplied `postgresql.auth.password` + `global.databases.*.password`
+parameters — buyers preferring RDS instead disable the bundled DB and set
+the `global.databases.*.host` values).
 
 The IAM role lives in the **seller account** and trusts GitHub's OIDC
 provider — no long-lived AWS keys anywhere. Trust policy (create the
@@ -1180,6 +1182,7 @@ portal (`aws-marketplace` actions may be required by newer portal setups; add
       ],
       "Resource": [
         "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one-app",
+        "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one-psql",
         "arn:aws:ecr:us-east-1:709825985650:repository/jentic/jentic-one"
       ]
     }

--- a/deploy/docker/postgres-mirror.Dockerfile
+++ b/deploy/docker/postgres-mirror.Dockerfile
@@ -1,19 +1,17 @@
 # AWS Marketplace mirror of the bundled in-cluster Postgres.
 #
 # The Marketplace disallows docker.io pulls at install time, so the image the
-# postgresql subchart runs (pinned in deploy/helm/jentic-one/values.yaml and
-# deploy/helm/values/aws-marketplace.yaml) is mirrored into the listing's ECR
-# by .github/workflows/marketplace-mirror.yml, which builds this one-FROM
+# first-party postgresql subchart runs (pinned in
+# deploy/helm/jentic-one/values.yaml and deploy/helm/values/aws-marketplace.yaml)
+# is mirrored into the listing's ECR by
+# .github/workflows/marketplace-mirror.yml, which builds this one-FROM
 # Dockerfile (a retag that preserves layers byte-for-byte).
 #
 # This lives in deploy/docker/ so Dependabot's docker ecosystem tracks the
 # digest (same mechanism as the python-base ARG pins). Keep the tag in
 # lockstep with the Helm values files.
 #
-# KNOWN RISK: Bitnami moved free-tier images to `bitnamilegacy/` in Aug 2025
-# and no longer patches them — this digest is frozen, so its CVE count only
-# grows and AWS's continuous listing scan will eventually flag it. Before
-# public listing, either move the chart to a maintained postgres image or
-# make RDS the documented default for Marketplace deploys (the values file
-# already carries the RDS variant).
-FROM bitnamilegacy/postgresql:17.2.0-debian-12-r6@sha256:6c02546820ca8590cc9bd1109c73ee61e70c8d50122347178b47f951e38f096a
+# Official library/postgres — actively maintained (replaced the frozen
+# bitnamilegacy image, which failed the Trivy gate; 2026-08-26). The workflow
+# still Trivy-scans every mirror run before pushing.
+FROM postgres:17.11@sha256:0b657ff48d7f76a1e907f381b1693eb4f2bf54c1d2df4feb6743d7dc601768dd

--- a/deploy/helm/jentic-one/Chart.yaml
+++ b/deploy/helm/jentic-one/Chart.yaml
@@ -25,6 +25,5 @@ dependencies:
     version: 0.32.1 # x-release-please-version
     condition: gateway.enabled
   - name: postgresql
-    version: 16.4.3
-    repository: https://charts.bitnami.com/bitnami
+    version: 0.32.1 # x-release-please-version
     condition: postgresql.enabled

--- a/deploy/helm/jentic-one/charts/postgresql/Chart.yaml
+++ b/deploy/helm/jentic-one/charts/postgresql/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: postgresql
+description: >-
+  First-party single-instance PostgreSQL for the jentic-one umbrella chart,
+  running the official library/postgres image. Replaces the former Bitnami
+  subchart dependency: the free Bitnami images moved to the frozen
+  `bitnamilegacy` namespace in Aug 2025 and stopped receiving CVE fixes,
+  which both our Trivy publish gate and the AWS Marketplace image scan
+  reject. Dev/eval-grade by design — production deployments should use a
+  managed database (see deploy/README.md).
+type: application
+version: 0.32.1 # x-release-please-version

--- a/deploy/helm/jentic-one/charts/postgresql/templates/service.yaml
+++ b/deploy/helm/jentic-one/charts/postgresql/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- /*
+Named <release>-postgresql: common.db-env points every surface's
+JENTIC__DATABASES__*__HOST here when global.postgresql.enabled=true, and the
+former Bitnami subchart used the same name — do not rename.
+*/ -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-postgresql
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+  selector:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/helm/jentic-one/charts/postgresql/templates/statefulset.yaml
+++ b/deploy/helm/jentic-one/charts/postgresql/templates/statefulset.yaml
@@ -1,0 +1,99 @@
+{{- /*
+Single-instance PostgreSQL on the official library/postgres image.
+
+Contract preserved from the former Bitnami subchart (so common.db-env and
+the existing values files keep working unchanged):
+  - workload + service are named <release>-postgresql
+  - values keys: auth.{username,password,database},
+    primary.initdb.scriptsConfigMap, image.{registry,repository,tag}
+  - init scripts run once, on first boot with an empty data dir; if
+    roles/grants change, recreate the PVC (helm uninstall + delete pvc, or
+    a fresh kind cluster)
+
+Runs as the image's postgres user (uid/gid 999) — never root — which both
+our publish gate and the AWS Marketplace image scan require. PGDATA points
+one level below the mount so a provisioner's lost+found can't break initdb.
+*/ -}}
+{{- $registry := .Values.image.registry -}}
+{{- $image := ternary (printf "%s/%s:%s" $registry .Values.image.repository .Values.image.tag) (printf "%s:%s" .Values.image.repository .Values.image.tag) (ne $registry "") -}}
+{{- $initConfigMap := .Values.primary.initdb.scriptsConfigMap | default (printf "%s-pg-init" .Release.Name) -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-postgresql
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: 1
+  serviceName: {{ .Release.Name }}-postgresql
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgresql
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: postgresql
+          image: {{ $image | quote }}
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.auth.username | quote }}
+            - name: POSTGRES_PASSWORD
+              value: {{ required "postgresql.auth.password is required when postgresql.enabled=true — set it in your values file (dev files: deploy/helm/values/local-*.yaml)" .Values.auth.password | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.auth.database | quote }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: initdb
+              mountPath: /docker-entrypoint-initdb.d
+              readOnly: true
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.auth.username | quote }}, "-d", {{ .Values.auth.database | quote }}]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.auth.username | quote }}, "-d", {{ .Values.auth.database | quote }}]
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: initdb
+          configMap:
+            name: {{ $initConfigMap }}
+{{- if not .Values.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+{{- else }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- with .Values.persistence.storageClass }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/deploy/helm/jentic-one/charts/postgresql/values.yaml
+++ b/deploy/helm/jentic-one/charts/postgresql/values.yaml
@@ -1,0 +1,42 @@
+# Defaults for the bundled single-instance PostgreSQL. The umbrella chart's
+# `postgresql:` block (deploy/helm/jentic-one/values.yaml) overlays these —
+# keep the two in sync when adding keys.
+
+image:
+  registry: docker.io
+  # Set `repository` to a full path (and `registry` to "") when the image
+  # lives in a registry that embeds a namespace, e.g. the AWS Marketplace
+  # mirror: 709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql
+  repository: postgres
+  # The Marketplace mirror (deploy/docker/postgres-mirror.Dockerfile) pushes
+  # this same tag; Dependabot keeps the Dockerfile's digest pin fresh.
+  tag: "17.11"
+
+auth:
+  username: postgres
+  # No default password — the chart refuses to render without one (same
+  # posture as global.databases passwords; dev files: deploy/helm/values/
+  # local-*.yaml).
+  database: jentic
+
+primary:
+  initdb:
+    # ConfigMap with *.sql scripts mounted at /docker-entrypoint-initdb.d
+    # (they run once, on first boot with an empty data dir). Empty means the
+    # umbrella chart's auto-created init ConfigMap (<release>-pg-init, see
+    # templates/pg-init-configmap.yaml in the umbrella chart).
+    scriptsConfigMap: ""
+
+persistence:
+  enabled: true
+  size: 8Gi
+  # Empty = the cluster's default StorageClass.
+  storageClass: ""
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi

--- a/deploy/helm/jentic-one/templates/pg-init-configmap.yaml
+++ b/deploy/helm/jentic-one/templates/pg-init-configmap.yaml
@@ -17,10 +17,10 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 data:
   # Mirrors docker/local-setup/init-schemas.sql: create per-surface schemas
-  # AND the login roles + grants each surface uses to connect. The Bitnami
-  # initdb scripts only run on first boot (empty data dir); if roles/grants
-  # change, recreate the PVC (helm uninstall + delete pvc, or a fresh kind
-  # cluster). DEV-ONLY static passwords — see global.databases in values.yaml.
+  # AND the login roles + grants each surface uses to connect. initdb scripts
+  # only run on first boot (empty data dir); if roles/grants change, recreate
+  # the PVC (helm uninstall + delete pvc, or a fresh kind cluster). DEV-ONLY
+  # static passwords — see global.databases in values.yaml.
   init-schemas.sql: |
     CREATE SCHEMA IF NOT EXISTS registry;
     CREATE SCHEMA IF NOT EXISTS control;

--- a/deploy/helm/jentic-one/values.yaml
+++ b/deploy/helm/jentic-one/values.yaml
@@ -131,12 +131,6 @@ global:
   # IRSA-based entitlement gate does not read it. Empty = nothing rendered.
   awsmp:
     licenseSecret: ""
-  # Bitnami chart 16.4.x rejects images outside its expected registry; we
-  # need to pin `bitnamilegacy/postgresql` (see the postgresql block below)
-  # so this gate has to be opened. Production deployments that use a
-  # different registry/image can leave this off.
-  security:
-    allowInsecureImages: true
   # Database credentials. `password` has NO default — the chart refuses to
   # render without one (see common.db-env), so every deployment states its
   # credentials explicitly. Dev/kind values live in
@@ -166,22 +160,23 @@ global:
 
 postgresql:
   enabled: false
-  # Bitnami moved free-tier images to `bitnamilegacy/` in Aug 2025; the
-  # default `bitnami/postgresql:17.2.0-debian-12-r6` was pruned from Docker
-  # Hub and now ImagePullBackOffs. Pin to the legacy mirror until the
-  # bundled chart version is upgraded (or we vendor postgres ourselves).
-  # Production environments should override this with their own image.
+  # First-party subchart (charts/postgresql) on the official library/postgres
+  # image — the former Bitnami dependency pinned the frozen `bitnamilegacy`
+  # image (no CVE fixes since Aug 2025), which the Trivy publish gate and the
+  # AWS Marketplace scan both reject. Dev/eval-grade single instance;
+  # production should use a managed database (deploy/README.md).
   image:
     registry: docker.io
-    repository: bitnamilegacy/postgresql
-    tag: 17.2.0-debian-12-r6
+    repository: postgres
+    tag: "17.11"
   auth:
     username: postgres
     # No default password — set one in your values file (dev files:
-    # deploy/helm/values/local-*.yaml). Left unset, the Bitnami chart
-    # generates a random one, which breaks the pg-init scripts that the
-    # local deploys rely on.
+    # deploy/helm/values/local-*.yaml).
     database: jentic
   primary:
     initdb:
+      # Empty = the umbrella chart's auto-created <release>-pg-init ConfigMap
+      # (templates/pg-init-configmap.yaml) — per-surface schemas, roles and
+      # grants derived from global.databases.
       scriptsConfigMap: ""

--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -19,29 +19,28 @@ global:
     # Marketplace does not allow floating tags like :latest).
     tag: ""
 
-  # RDS-ONLY LISTING (decided 2026-08-26): the bundled in-cluster Postgres is
-  # disabled — buyers bring an external Postgres (RDS or equivalent) and point
-  # global.databases.*.host at it. Rationale: the only image the postgresql
-  # subchart supports is bitnamilegacy/postgresql, frozen upstream since
-  # Bitnami's Aug 2025 catalog change — it already fails our CVE gate (52
-  # fixable HIGH/CRITICAL on 2026-08-26) and would fail AWS's listing scan.
-  # Revisit if the chart moves to a maintained Postgres image.
+  # Bundled in-cluster Postgres: ON by default (decided 2026-08-26, reversing
+  # the brief RDS-only stance) — the first-party postgresql subchart runs the
+  # official library/postgres image mirrored into the listing's ECR, so a
+  # plain `helm install` is self-contained. Production buyers should still
+  # prefer RDS: set postgresql.enabled=false + global.postgresql.enabled=false
+  # and point global.databases.*.host at the endpoint instead.
   postgresql:
-    enabled: false
+    enabled: true
 
   # NOTE: global.observability.otel.enabled must stay false for Marketplace
   # deploys — the sidecar image (otel/opentelemetry-collector-contrib) is
   # pulled from docker.io, which the Marketplace disallows. Mirror it into
   # the listing's ECR first if observability is needed.
 
-  # No database password defaults ship with the chart; point the DBs at your
-  # external Postgres and set the passwords at install:
-  #   --set global.databases.registry.host=<rds-endpoint> \
+  # No database password defaults ship with the chart; set the per-surface
+  # passwords (used both by the app and by the bundled DB's init scripts) at
+  # install:
   #   --set global.databases.registry.password=… \
   #   --set global.databases.control.password=…  \
   #   --set global.databases.admin.password=…
-  # or (preferred) replace common.db-env with a Secret-backed env block —
-  # see deploy/README.md "Production secrets".
+  # RDS variant: also set the three global.databases.*.host values and
+  # disable the bundled DB (see the postgresql blocks).
 
   # AWS Marketplace launch wiring — the listing's delivery option carries
   # these two override parameters (values substituted by AWS at launch):
@@ -94,11 +93,12 @@ control:
 gateway:
   enabled: false
 
-# Bundled in-cluster Postgres: OFF for the Marketplace listing (RDS-only —
-# see the global.postgresql note above). The jentic/jentic-one-psql ECR repo
-# and the marketplace-mirror workflow exist but are parked: the mirror's CVE
-# gate correctly rejects the frozen bitnamilegacy image. If the chart ever
-# moves to a maintained Postgres image, re-enable this block and set the
-# MARKETPLACE_ECR_POSTGRES repo variable to resume mirroring.
+# Bundled in-cluster Postgres from the ECR-mirrored official image (the
+# marketplace-mirror workflow pushes it — repo jentic/jentic-one-psql). The
+# first-party subchart requires postgresql.auth.password at install.
 postgresql:
-  enabled: false
+  enabled: true
+  image:
+    registry: ""
+    repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql"
+    tag: "17.11"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -54,21 +54,64 @@
         {
           "type": "generic",
           "path": "deploy/helm/jentic-one/charts/common/Chart.yaml"
+        },
+        {
+          "type": "generic",
+          "path": "deploy/helm/jentic-one/charts/postgresql/Chart.yaml"
         }
       ]
     }
   },
   "changelog-sections": [
-    { "type": "feat", "section": "Features" },
-    { "type": "fix", "section": "Bug Fixes" },
-    { "type": "perf", "section": "Performance" },
-    { "type": "refactor", "section": "Refactors" },
-    { "type": "revert", "section": "Reverts" },
-    { "type": "docs", "section": "Documentation", "hidden": false },
-    { "type": "build", "section": "Build System", "hidden": false },
-    { "type": "ci", "section": "CI/CD", "hidden": true },
-    { "type": "test", "section": "Tests", "hidden": true },
-    { "type": "chore", "section": "Miscellaneous", "hidden": true },
-    { "type": "style", "section": "Styles", "hidden": true }
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance"
+    },
+    {
+      "type": "refactor",
+      "section": "Refactors"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": false
+    },
+    {
+      "type": "build",
+      "section": "Build System",
+      "hidden": false
+    },
+    {
+      "type": "ci",
+      "section": "CI/CD",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "section": "Styles",
+      "hidden": true
+    }
   ]
 }

--- a/tests/smoke/test_helm_render.py
+++ b/tests/smoke/test_helm_render.py
@@ -1,10 +1,9 @@
 """Render-only assertions for the Helm chart (no cluster required).
 
-These run inside the smoke matrix (tools.deploy ci-smoke builds the chart
-dependencies before invoking pytest), but they only shell out to
-``helm template`` — they skip cleanly when helm or the built dependencies
-are absent, so a bare local ``pytest tests/smoke`` stays green.
-"""
+These run inside the smoke matrix, but they only shell out to
+``helm template`` (the chart has no remote dependencies — every subchart
+lives in-tree) — they skip cleanly when helm is absent, so a bare local
+``pytest tests/smoke`` stays green."""
 
 from __future__ import annotations
 
@@ -32,8 +31,6 @@ DEV_PASSWORD_SETS = [
 def _helm_template(*args: str) -> subprocess.CompletedProcess[str]:
     if shutil.which("helm") is None:
         pytest.skip("helm not installed")
-    if not list((CHART_DIR / "charts").glob("postgresql-*.tgz")):
-        pytest.skip("chart dependencies not built (run: helm dependency build)")
     return subprocess.run(
         ["helm", "template", "jentic", str(CHART_DIR), *args],
         capture_output=True,
@@ -56,6 +53,26 @@ def test_render_dev_values(values: str) -> None:
     """The committed dev values files carry their own (dev-only) passwords."""
     result = _helm_template("-f", str(VALUES_DIR / f"{values}.yaml"))
     assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.smoke
+def test_render_bundled_postgres() -> None:
+    """The first-party postgresql subchart renders the pinned official image.
+
+    Contract checks for what common.db-env and the init flow depend on: the
+    service keeps the Bitnami-era name <release>-postgresql, the umbrella
+    chart's <release>-pg-init ConfigMap is mounted for first-boot init, and
+    the container runs as the image's postgres user (non-root — required by
+    both the publish gate and the AWS Marketplace image scan).
+    """
+    result = _helm_template("-f", str(VALUES_DIR / "local-combined.yaml"))
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "name: jentic-postgresql" in out
+    assert 'image: "docker.io/postgres:' in out
+    assert "mountPath: /docker-entrypoint-initdb.d" in out
+    assert "name: jentic-pg-init" in out
+    assert "runAsNonRoot: true" in out
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Summary

Replaces the Bitnami `postgresql` subchart dependency with a small first-party subchart (`charts/postgresql`) running the **official `library/postgres:17.11` image**, and reverses the RDS-only Marketplace decision that the frozen `bitnamilegacy` image had forced.

- **Why**: the free Bitnami images moved to the frozen `bitnamilegacy` namespace (Aug 2025) and stopped receiving CVE fixes — the mirror workflow's Trivy gate rejected it (52 fixable HIGH/CRITICAL), and AWS's listing scan would too. The official image is actively maintained.
- **Marketplace**: the bundled DB returns as the listing default (`aws-marketplace.yaml`), so a plain `helm install` is self-contained; RDS stays the documented production path (disable `postgresql.enabled` + `global.postgresql.enabled`, set `global.databases.*.host`).
- **Supply chain**: the chart now has **zero remote dependencies** — no more `charts.bitnami.com` download at `helm dependency build` time.

## Contract preserved (no changes needed in existing values files)

- Service/workload named `<release>-postgresql` (what `common.db-env` points hosts at)
- Values keys: `postgresql.auth.{username,password,database}`, `postgresql.primary.initdb.scriptsConfigMap`, `postgresql.image.{registry,repository,tag}`
- Init scripts run once on first boot (empty data dir), same PVC-recreate caveat

## New behavior

- Runs as the image's `postgres` user (uid/gid 999, `runAsNonRoot`) — Marketplace-scan friendly
- `primary.initdb.scriptsConfigMap` defaults to the umbrella chart's `<release>-pg-init` ConfigMap (no more hardcoded release-name coupling)
- `postgresql.auth.password` is `required` when enabled (same posture as the `global.databases` guards)
- `postgres-mirror.Dockerfile` pins `postgres:17.11@sha256:0b657f…` (Dependabot-tracked); mirror workflow's frozen-image caveat removed
- `marketplace-chart.yml` render gate now covers the bundled DB image; `global.security.allowInsecureImages` (Bitnami-only) dropped

## Test plan

- [x] 9/9 render tests pass (`tests/smoke/test_helm_render.py`), incl. new `test_render_bundled_postgres`
- [x] Marketplace overlay renders **only** ECR images (app + psql mirror)
- [x] Runtime check: official image boots as uid 999 with mounted initdb scripts; roles/schemas created; `pg_isready` OK
- [ ] CI smoke matrix (kind) exercises the new subchart end-to-end
- [ ] After merge: re-add `jentic/jentic-one-psql` ARN to the publish role (infra PR), re-set `MARKETPLACE_ECR_POSTGRES`, dispatch `marketplace-mirror.yml`

Part of #1132.

Made with [Cursor](https://cursor.com)