### PR TITLE
fix(docker): harden the Marketplace postgres mirror to pass the Trivy gate

### DIFF
--- a/.github/workflows/marketplace-mirror.yml
+++ b/.github/workflows/marketplace-mirror.yml
@@ -1,8 +1,9 @@
 # Mirrors the bundled Postgres image into the AWS Marketplace ECR repo.
 #
 # The Marketplace disallows docker.io pulls at install time, so the postgresql
-# subchart's image (deploy/docker/postgres-mirror.Dockerfile — a one-FROM
-# retag whose digest Dependabot keeps fresh) must exist in the listing's ECR.
+# subchart's image (deploy/docker/postgres-mirror.Dockerfile — a lightly
+# hardened build of the official image, digest kept fresh by Dependabot) must
+# exist in the listing's ECR.
 # Weekly cron + manual dispatch: cheap to re-run, and a re-push of the same
 # digest is a no-op registry-side.
 #
@@ -57,9 +58,10 @@ jobs:
           echo "from=${FROM_LINE}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
-      # A single-FROM build is a retag: layers are preserved byte-for-byte
-      # from the pinned digest.
-      - name: Build the mirror image (retag of the pinned digest)
+      # Not a pure retag: the Dockerfile strips dead-code binaries that only
+      # accumulate CVE findings (gosu, snakeoil key) and applies Debian
+      # security updates on top of the pinned digest — see its header.
+      - name: Build the mirror image (hardened build of the pinned digest)
         run: docker build -f deploy/docker/postgres-mirror.Dockerfile -t postgres-mirror:local deploy/docker
 
       # Same CVE bar as everything else this repo publishes: fixable

--- a/deploy/docker/postgres-mirror.Dockerfile
+++ b/deploy/docker/postgres-mirror.Dockerfile
@@ -4,14 +4,25 @@
 # first-party postgresql subchart runs (pinned in
 # deploy/helm/jentic-one/values.yaml and deploy/helm/values/aws-marketplace.yaml)
 # is mirrored into the listing's ECR by
-# .github/workflows/marketplace-mirror.yml, which builds this one-FROM
-# Dockerfile (a retag that preserves layers byte-for-byte).
+# .github/workflows/marketplace-mirror.yml, which builds this Dockerfile.
 #
 # This lives in deploy/docker/ so Dependabot's docker ecosystem tracks the
 # digest (same mechanism as the python-base ARG pins). Keep the tag in
 # lockstep with the Helm values files.
 #
-# Official library/postgres — actively maintained (replaced the frozen
-# bitnamilegacy image, which failed the Trivy gate; 2026-08-26). The workflow
-# still Trivy-scans every mirror run before pushing.
+# The build hardens the official image just enough to pass the Trivy publish
+# gate (the workflow scans every mirror run before pushing):
+#   - drop gosu: only used by the entrypoint to step down from root, and the
+#     chart always starts the container as the postgres user (uid 999), so it
+#     is dead code — and its Go-stdlib CVE findings are a permanent treadmill
+#     (upstream rebuilds it rarely).
+#   - drop the Debian snakeoil placeholder TLS key: unused (the chart does
+#     not enable ssl), but Trivy's secret scanner flags any private key.
+#   - apt-get upgrade: picks up Debian security fixes published since the
+#     pinned digest's last upstream rebuild.
 FROM postgres:17.11@sha256:0b657ff48d7f76a1e907f381b1693eb4f2bf54c1d2df4feb6743d7dc601768dd
+RUN rm -f /usr/local/bin/gosu /etc/ssl/private/ssl-cert-snakeoil.key \
+ && apt-get update \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+USER postgres


### PR DESCRIPTION
## Summary

First live run of `marketplace-mirror.yml` on the official `postgres:17.11` image [failed the Trivy publish gate](https://github.com/jentic/jentic-one/actions/runs/33064600188) on three findings — all dead code or already-fixed-by-Debian in our deployment:

| Finding | Why it's noise for us | Fix |
|---|---|---|
| Secret: `/etc/ssl/private/ssl-cert-snakeoil.key` | Debian's auto-generated placeholder key; chart doesn't enable ssl | deleted |
| 22 Go-stdlib findings in `/usr/local/bin/gosu` | only used by the entrypoint to step down from root; the chart runs the container as uid 999, so it never executes — and upstream rebuilds gosu rarely (permanent allowlist treadmill) | deleted |
| 3 fixable HIGH in `libssl3t64` etc. | Debian published fixes after the image's last upstream rebuild | `apt-get upgrade` in the mirror build |

The mirror is therefore no longer a byte-identical retag — it's a minimal hardening layer on the pinned digest (which Dependabot still tracks).

## Verification (local)

- [x] Trivy scan of the hardened build: **zero** HIGH/CRITICAL fixable vulns, zero secrets
- [x] Boots as uid 999 with mounted `/docker-entrypoint-initdb.d` scripts; roles created; `pg_isready` green

## After merge

Dispatch `marketplace-mirror.yml` — `MARKETPLACE_ECR_POSTGRES` is set and the IAM ARN is applied, so it should go green end-to-end.

Part of #1132.

Made with [Cursor](https://cursor.com)