### PR TITLE
feat(helm): pass AWS Marketplace chart validation

### DIFF
--- a/.github/workflows/marketplace-chart.yml
+++ b/.github/workflows/marketplace-chart.yml
@@ -106,30 +106,42 @@ jobs:
       - name: Build chart dependencies
         run: helm dependency build deploy/helm/jentic-one
 
-      # Publish gate, mirroring tests/smoke/test_helm_render.py: the chart must
-      # render with the Marketplace overlay and reference ONLY ECR images —
-      # the Marketplace disallows docker.io/ghcr.io pulls at install time.
-      - name: Render gate — Marketplace overlay renders, all images from ECR
+      # AWS Marketplace requires image references to live in the chart's own
+      # values.yaml (their replication pipeline rewrites them per region and
+      # their validator extracts them from chart defaults, not from override
+      # parameters). Bake the Marketplace overlay + release tag into the
+      # packaged chart so it is self-contained: bare `helm install` pulls
+      # only from the listing's ECR.
+      - name: Bake Marketplace defaults into values.yaml
         env:
           VERSION: ${{ steps.chart.outputs.version }}
         run: |
           set -euo pipefail
-          # Dummy values for the chart's `required` password guards — render-only.
-          PW_SETS=(--set "postgresql.auth.password=x") # pragma: allowlist secret
-          for db in registry control admin; do
-            PW_SETS+=(--set "global.databases.${db}.password=x") # pragma: allowlist secret
-          done
-          helm template jentic deploy/helm/jentic-one \
-            -f deploy/helm/values/aws-marketplace.yaml \
-            --set "global.image.tag=v${VERSION}" \
-            "${PW_SETS[@]}" \
-            > /tmp/rendered.yaml
+          yq eval-all '. as $item ireduce ({}; . * $item)' \
+            deploy/helm/jentic-one/values.yaml \
+            deploy/helm/values/aws-marketplace.yaml > /tmp/values-baked.yaml
+          yq -i ".global.image.tag = \"v${VERSION}\"" /tmp/values-baked.yaml
+          mv /tmp/values-baked.yaml deploy/helm/jentic-one/values.yaml
+
+      # Publish gate = exactly what AWS runs on submission: bare `helm lint`
+      # and bare `helm template` (no overrides, no cluster) must succeed
+      # (INVALID_HELM_LINT / INVALID_HELM_TEMPLATE), and every image the
+      # baked chart renders must come from the listing's ECR — the
+      # Marketplace disallows docker.io/ghcr.io pulls at install time.
+      - name: Validation gate — helm lint + bare template, all images from ECR
+        run: |
+          set -euo pipefail
+          helm lint deploy/helm/jentic-one
+          helm template jentic deploy/helm/jentic-one > /tmp/rendered.yaml
           BAD="$(awk -F'image:' '/^[[:space:]]*image:/{gsub(/^[[:space:]"]+|["[:space:]]+$/, "", $2); print $2}' /tmp/rendered.yaml \
             | grep -v '^709825985650\.dkr\.ecr\.' || true)"
           if [ -n "${BAD}" ]; then
             echo "::error::non-ECR image(s) rendered:"; echo "${BAD}"; exit 1
           fi
           grep -c 'image:' /tmp/rendered.yaml >/dev/null
+          # The install-time password guards must have rendered inert
+          # placeholders (a live-cluster install still refuses to proceed).
+          grep -q 'REQUIRED-AT-INSTALL' /tmp/rendered.yaml
 
       - name: Package the chart
         env:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,15 +133,6 @@
     }
   ],
   "results": {
-    ".github/workflows/marketplace-chart.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/marketplace-chart.yml",
-        "hashed_secret": "f5ecf3f594543c7b536ca23b1c15fb9cb35ac0ae",
-        "is_verified": false,
-        "line_number": 115
-      }
-    ],
     "cli/client/auth/apikey.go": [
       {
         "type": "Secret Keyword",
@@ -377,6 +368,15 @@
         "hashed_secret": "99075eb0baa8cfda1cae029da06b57b93cc13a31",
         "is_verified": false,
         "line_number": 26
+      }
+    ],
+    "deploy/helm/jentic-one/charts/postgresql/templates/statefulset.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "deploy/helm/jentic-one/charts/postgresql/templates/statefulset.yaml",
+        "hashed_secret": "6bd06ba0ed7be869427a1cfdf397439ac011836b",
+        "is_verified": false,
+        "line_number": 31
       }
     ],
     "deploy/helm/observability/values.yaml": [
@@ -1930,5 +1930,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-26T14:19:11Z"
+  "generated_at": "2026-08-27T11:24:14Z"
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1085,29 +1085,40 @@ Once set:
   kept fresh by Dependabot) through the same Trivy gate;
 - [`marketplace-chart.yml`](../.github/workflows/marketplace-chart.yml)
   publishes the umbrella Helm chart as an OCI artifact after every successful
-  release run (chart version = tag minus the `v`), gated on a render check
-  that the Marketplace overlay resolves every image to the listing's ECR.
-  Backfill an already-released tag with
+  release run (chart version = tag minus the `v`). The packaged chart is NOT
+  byte-identical to the repo chart: the workflow **bakes
+  [`aws-marketplace.yaml`](helm/values/aws-marketplace.yaml) + the release
+  tag into its `values.yaml`** first — AWS requires image references to live
+  in the chart's own defaults (their validator extracts them there, and
+  their replication pipeline rewrites them per region). The publish gate
+  then runs exactly what AWS runs on submission: bare `helm lint` + bare
+  `helm template` (must succeed — the password guards are install-time only,
+  see `common.require-install`) with every rendered image from the listing's
+  ECR. Backfill an already-released tag with
   `gh workflow run marketplace-chart.yml -f tag=vX.Y.Z`.
 
 Publishing a new **listing version** stays a portal step (product → Request
 changes → *Add version*, pinning the pushed tag/digest); automate via the
 Marketplace Catalog API only after the manual loop has worked once.
 
-The version's **Helm delivery option** must carry two AWS-substituted
-override parameters (portal validation rejects paid products without them):
+Because the Marketplace chart is self-contained, the version's **Helm
+delivery option** needs only six override parameters — the two
+AWS-substituted ones (portal validation rejects paid products without them)
+and the four buyer-chosen passwords:
 
 | Override parameter key | DefaultValue |
 | ---------------------- | ------------ |
 | `global.serviceAccount.name` | `${AWSMP_SERVICE_ACCOUNT}` — the buyer's (IRSA) service account; the app/broker pods run under it (chart support: `global.serviceAccount`) |
 | `global.awsmp.licenseSecret` | `${AWSMP_LICENSE_SECRET}` — an AWS-created Secret, mounted read-only at `/var/run/secrets/aws-marketplace/license` (chart support: `global.awsmp.licenseSecret`) |
+| `postgresql.auth.password` | *(buyer-supplied — bundled DB admin password)* |
+| `global.databases.registry.password` | *(buyer-supplied)* |
+| `global.databases.control.password` | *(buyer-supplied)* |
+| `global.databases.admin.password` | *(buyer-supplied)* |
 
-plus the deployment values from
-[`aws-marketplace.yaml`](helm/values/aws-marketplace.yaml) (ECR image
-repositories, `broker.enabled=true`, the bundled Postgres, the tag pin, and
-buyer-supplied `postgresql.auth.password` + `global.databases.*.password`
-parameters — buyers preferring RDS instead disable the bundled DB and set
-the `global.databases.*.host` values).
+Everything else (ECR image repositories, `broker.enabled=true`, the bundled
+Postgres, the tag pin) is baked into the published chart's defaults. Buyers
+preferring RDS install manually instead, disabling the bundled DB and
+setting the `global.databases.*.host` values.
 
 The IAM role lives in the **seller account** and trusts GitHub's OIDC
 provider — no long-lived AWS keys anywhere. Trust policy (create the

--- a/deploy/helm/jentic-one/Chart.yaml
+++ b/deploy/helm/jentic-one/Chart.yaml
@@ -27,3 +27,9 @@ dependencies:
   - name: postgresql
     version: 0.33.0 # x-release-please-version
     condition: postgresql.enabled
+  # Template-only library used by the service subcharts (each also declares
+  # it via file://../common). Declared here too because `helm lint` (and AWS
+  # Marketplace's chart validation, which runs it) rejects charts/ content
+  # that is missing from the dependency metadata.
+  - name: common
+    version: 0.33.0 # x-release-please-version

--- a/deploy/helm/jentic-one/charts/common/templates/_db-env.tpl
+++ b/deploy/helm/jentic-one/charts/common/templates/_db-env.tpl
@@ -27,7 +27,7 @@ See deploy/README.md "Production secrets" for the migration recipe.
 - name: JENTIC__DATABASES__{{ upper $surface }}__USER
   value: {{ $db.user | quote }}
 - name: JENTIC__DATABASES__{{ upper $surface }}__PASSWORD
-  value: {{ required (printf "global.databases.%s.password is required — set it in your values file (dev files: deploy/helm/values/local-*.yaml)" $surface) $db.password | quote }}
+  value: {{ include "common.require-install" (dict "root" $ "value" $db.password "message" (printf "global.databases.%s.password is required — set it in your values file (dev files: deploy/helm/values/local-*.yaml)" $surface)) | quote }}
 - name: JENTIC__DATABASES__{{ upper $surface }}__SCHEMA_NAME
   value: {{ $db.schema_name | default $db.schema | quote }}
 {{- end }}

--- a/deploy/helm/jentic-one/charts/common/templates/_require-install.tpl
+++ b/deploy/helm/jentic-one/charts/common/templates/_require-install.tpl
@@ -1,0 +1,37 @@
+{{- /*
+common.require-install — `required` that only fires against a live cluster.
+
+AWS Marketplace validates Helm chart products by running bare `helm lint`
+and `helm template` (no overrides, no cluster) and rejects charts that fail
+either (INVALID_HELM_LINT / INVALID_HELM_TEMPLATE). A hard `required` on
+passwords therefore can't be unconditional. `lookup` returns empty during
+offline rendering but queries the API server during a real install/upgrade,
+so this helper:
+
+  - returns the value when set;
+  - fails loudly (the original `required` behavior) when unset AND a live
+    cluster is detectable — i.e. every `helm install`/`upgrade`;
+  - renders an unmistakable placeholder when unset in offline renders
+    (`helm template`/`lint`), keeping validation tooling green.
+
+The cluster probe checks the release namespace's default ServiceAccount and
+falls back to listing namespaces, so namespace-scoped installers still trip
+the guard. Anyone piping `helm template` straight into kubectl bypasses
+Helm's install path and gets the placeholder — visibly broken on purpose.
+
+Usage:
+  {{ include "common.require-install" (dict "root" $ "value" $db.password "message" "...") }}
+*/ -}}
+{{- define "common.require-install" -}}
+{{- if .value -}}
+{{- .value -}}
+{{- else -}}
+{{- $root := .root -}}
+{{- $live := or (lookup "v1" "ServiceAccount" $root.Release.Namespace "default") (lookup "v1" "Namespace" "" "") -}}
+{{- if $live -}}
+{{- required .message nil -}}
+{{- else -}}
+REQUIRED-AT-INSTALL
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/jentic-one/charts/postgresql/templates/statefulset.yaml
+++ b/deploy/helm/jentic-one/charts/postgresql/templates/statefulset.yaml
@@ -17,6 +17,20 @@ one level below the mount so a provisioner's lost+found can't break initdb.
 {{- $registry := .Values.image.registry -}}
 {{- $image := ternary (printf "%s/%s:%s" $registry .Values.image.repository .Values.image.tag) (printf "%s:%s" .Values.image.repository .Values.image.tag) (ne $registry "") -}}
 {{- $initConfigMap := .Values.primary.initdb.scriptsConfigMap | default (printf "%s-pg-init" .Release.Name) -}}
+{{- /*
+Install-time-only password guard (mirrors common.require-install, inlined to
+keep the subchart self-contained): AWS Marketplace validates charts with bare
+`helm lint`/`helm template`, so the guard must not fire in offline renders —
+`lookup` only returns data against a live cluster (install/upgrade).
+*/ -}}
+{{- $password := .Values.auth.password -}}
+{{- if not $password -}}
+{{- if or (lookup "v1" "ServiceAccount" .Release.Namespace "default") (lookup "v1" "Namespace" "" "") -}}
+{{- fail "postgresql.auth.password is required when postgresql.enabled=true — set it in your values file (dev files: deploy/helm/values/local-*.yaml)" -}}
+{{- else -}}
+{{- $password = "REQUIRED-AT-INSTALL" -}}
+{{- end -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -54,7 +68,7 @@ spec:
             - name: POSTGRES_USER
               value: {{ .Values.auth.username | quote }}
             - name: POSTGRES_PASSWORD
-              value: {{ required "postgresql.auth.password is required when postgresql.enabled=true — set it in your values file (dev files: deploy/helm/values/local-*.yaml)" .Values.auth.password | quote }}
+              value: {{ $password | quote }}
             - name: POSTGRES_DB
               value: {{ .Values.auth.database | quote }}
             - name: PGDATA

--- a/deploy/helm/jentic-one/charts/postgresql/values.yaml
+++ b/deploy/helm/jentic-one/charts/postgresql/values.yaml
@@ -14,7 +14,7 @@ image:
 
 auth:
   username: postgres
-  # No default password — the chart refuses to render without one (same
+  # No default password — the chart refuses to install without one (same
   # posture as global.databases passwords; dev files: deploy/helm/values/
   # local-*.yaml).
   database: jentic

--- a/deploy/helm/jentic-one/values.yaml
+++ b/deploy/helm/jentic-one/values.yaml
@@ -132,8 +132,10 @@ global:
   awsmp:
     licenseSecret: ""
   # Database credentials. `password` has NO default — the chart refuses to
-  # render without one (see common.db-env), so every deployment states its
-  # credentials explicitly. Dev/kind values live in
+  # install without one (see common.require-install; offline `helm template`
+  # and `helm lint` render an inert REQUIRED-AT-INSTALL placeholder instead,
+  # which AWS Marketplace's chart validation requires), so every deployment
+  # states its credentials explicitly. Dev/kind values live in
   # deploy/helm/values/local-*.yaml. In production, do NOT put real passwords
   # in a values file: replace `common.db-env` in your subchart deployments
   # with a Secret-backed `valueFrom: secretKeyRef:` block, or pass an

--- a/tests/smoke/test_helm_render.py
+++ b/tests/smoke/test_helm_render.py
@@ -40,11 +40,28 @@ def _helm_template(*args: str) -> subprocess.CompletedProcess[str]:
 
 
 @pytest.mark.smoke
-def test_render_requires_db_passwords() -> None:
-    """The chart ships no password defaults; a bare render must fail loudly."""
+def test_render_bare_passes_lint_with_placeholders() -> None:
+    """Bare `helm lint` + `helm template` succeed — AWS Marketplace runs both.
+
+    The chart ships no password defaults, but the guards are install-time
+    only (common.require-install): offline renders emit an unmistakable
+    REQUIRED-AT-INSTALL placeholder instead of failing, because AWS's chart
+    validation rejects charts that fail bare lint/template
+    (INVALID_HELM_LINT / INVALID_HELM_TEMPLATE). A real install against a
+    live cluster still refuses to proceed without passwords.
+    """
+    lint = subprocess.run(
+        ["helm", "lint", str(CHART_DIR)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert lint.returncode == 0, lint.stdout + lint.stderr
     result = _helm_template()
-    assert result.returncode != 0
-    assert "password is required" in result.stderr
+    assert result.returncode == 0, result.stderr
+    assert "REQUIRED-AT-INSTALL" in result.stdout
+    # No real password defaults sneaked in anywhere.
+    assert "postgres_pass" not in result.stdout
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Summary

The portal rejected the 0.33.0 delivery option with `Invalid Container Images`, `Invalid Helm Lint` and `Invalid Helm Template`. Root causes, per [AWS's container product policies](https://docs.aws.amazon.com/marketplace/latest/userguide/container-product-policies.html) (AWS runs **bare** `helm lint` + `helm template` on submission and extracts image references from the chart's own `values.yaml`):

1. **`helm lint` failed on `main`'s chart**: `charts/common` wasn't declared in the umbrella `Chart.yaml` dependencies → now declared (template-only library, renders nothing).
2. **Bare `helm template` failed by design**: our `required` password guards. New `common.require-install` helper (inlined in the postgresql subchart): probes for a live cluster via `lookup` — real `helm install`/`upgrade` still fails loudly without passwords; offline renders emit a `REQUIRED-AT-INSTALL` placeholder so lint/template pass.
3. **Image defaults pointed at ghcr.io/docker.io** (ECR only via override parameters, which AWS's validator never sees) → `marketplace-chart.yml` now **bakes `aws-marketplace.yaml` + the release tag into the packaged chart's `values.yaml`**, making the published chart self-contained. The publish gate now mimics AWS exactly: bare lint + bare template + ECR-only images + placeholder check.

## Consequences

- Delivery option shrinks to **6 override parameters**: `global.serviceAccount.name=${AWSMP_SERVICE_ACCOUNT}`, `global.awsmp.licenseSecret=${AWSMP_LICENSE_SECRET}`, and the four buyer passwords (`postgresql.auth.password`, `global.databases.{registry,control,admin}.password`).
- Repo chart behavior for dev/prod installs is unchanged (verified: local values render identically; kind `--dry-run=server` without passwords still refuses).
- Anyone piping bare `helm template` output into kubectl gets visibly-broken placeholder passwords instead of a render error — acceptable: Helm's install path is the supported one.

## Test plan

- [x] `helm lint` passes; bare `helm template` renders with 13 placeholders and zero real password defaults
- [x] kind `--dry-run=server`: install without passwords refused ("password is required"), with passwords renders
- [x] Baked-chart simulation: lint clean, bare template renders **only** ECR images (app v-tag + psql 17.11)
- [x] 9/9 render tests (rewrote `test_render_requires_db_passwords` → `test_render_bare_passes_lint_with_placeholders`)
- [ ] After merge + release: re-submit the delivery option with the new chart version

Part of #1132.

Made with [Cursor](https://cursor.com)