### PR TITLE
fix(helm): AWS-parseable image format for the Marketplace psql reference

### DIFF
--- a/.github/workflows/marketplace-chart.yml
+++ b/.github/workflows/marketplace-chart.yml
@@ -139,6 +139,14 @@ jobs:
             echo "::error::non-ECR image(s) rendered:"; echo "${BAD}"; exit 1
           fi
           grep -c 'image:' /tmp/rendered.yaml >/dev/null
+          # AWS's validator composes image refs from the values keys
+          # themselves: an image block with an empty registry (full path
+          # stuffed into repository) renders fine in Helm but breaks their
+          # parser (leading-/, missing tag) — reject it here first.
+          EMPTY_REG="$(yq '[.. | select(type == "!!map" and has("registry") and has("repository")) | select(.registry == "")] | length' deploy/helm/jentic-one/values.yaml)"
+          if [ "${EMPTY_REG}" != "0" ]; then
+            echo "::error::baked values.yaml has image block(s) with an empty registry — use AWS's registry/repository/tag split"; exit 1
+          fi
           # The install-time password guards must have rendered inert
           # placeholders (a live-cluster install still refuses to proceed).
           grep -q 'REQUIRED-AT-INSTALL' /tmp/rendered.yaml

--- a/deploy/helm/jentic-one/charts/postgresql/values.yaml
+++ b/deploy/helm/jentic-one/charts/postgresql/values.yaml
@@ -4,9 +4,12 @@
 
 image:
   registry: docker.io
-  # Set `repository` to a full path (and `registry` to "") when the image
-  # lives in a registry that embeds a namespace, e.g. the AWS Marketplace
-  # mirror: 709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql
+  # For registries that embed a namespace (e.g. the AWS Marketplace mirror),
+  # keep the split form — registry "709825985650.dkr.ecr.us-east-1.amazonaws.com",
+  # repository "jentic/jentic-one-psql". (Do NOT blank the registry and stuff
+  # the full path into repository: Helm renders it fine, but AWS Marketplace's
+  # chart validator composes refs from these exact keys and chokes on an
+  # empty registry.)
   repository: postgres
   # The Marketplace mirror (deploy/docker/postgres-mirror.Dockerfile) pushes
   # this same tag; Dependabot keeps the Dockerfile's digest pin fresh.

--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -94,11 +94,15 @@ gateway:
   enabled: false
 
 # Bundled in-cluster Postgres from the ECR-mirrored official image (the
-# marketplace-mirror workflow pushes it — repo jentic/jentic-one-psql). The
-# first-party subchart requires postgresql.auth.password at install.
+# marketplace-mirror workflow pushes it). registry/repository/tag are split
+# in AWS's recommended values.yaml format — their chart validator composes
+# `<registry>/<repository>:<tag>` from these exact keys, and an empty
+# registry with the full path in repository breaks its parser (leading-`/`,
+# missing tag → INVALID_HELM_UNDECLARED_IMAGES / MISSING_VALUES_IMAGE_REFERENCE).
+# The first-party subchart requires postgresql.auth.password at install.
 postgresql:
   enabled: true
   image:
-    registry: ""
-    repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-psql"
+    registry: "709825985650.dkr.ecr.us-east-1.amazonaws.com"
+    repository: "jentic/jentic-one-psql"
     tag: "17.11"


### PR DESCRIPTION
## Summary

The 0.34.0 delivery option got past lint/template validation but tripped `INVALID_HELM_UNDECLARED_IMAGES` + `MISSING_VALUES_IMAGE_REFERENCE`, both on the psql image. The giveaway was the malformed ref in the error text: `/709825985650…/jentic-one-psql` (leading slash, no tag) — AWS's validator composes `<registry>/<repository>:<tag>` from the values keys, and our overlay declared the bundled Postgres with `registry: ""` + full path in `repository`.

- Overlay now uses [AWS's recommended split](https://docs.aws.amazon.com/marketplace/latest/userguide/container-product-policies.html#helm-chart-structure-requirements): `registry: "709825985650.dkr.ecr.us-east-1.amazonaws.com"`, `repository: "jentic/jentic-one-psql"`, `tag: "17.11"`. The rendered image string is byte-identical.
- The chart publish gate now rejects any baked image block with an empty registry, so this can't recur.
- Subchart values comment updated to warn against the empty-registry pattern.

## Test plan

- [x] Baked-chart simulation: lint clean, renders the same two ECR images, zero empty-registry blocks
- [x] 9/9 render tests
- [ ] After merge: release v0.34.1, re-submit the delivery option

Part of #1132.

Made with [Cursor](https://cursor.com)