### PR TITLE
feat(helm): chart-managed credential-encryption keyset (global.encryption)

### DIFF
--- a/.github/workflows/marketplace-chart.yml
+++ b/.github/workflows/marketplace-chart.yml
@@ -150,6 +150,9 @@ jobs:
           # The install-time password guards must have rendered inert
           # placeholders (a live-cluster install still refuses to proceed).
           grep -q 'REQUIRED-AT-INSTALL' /tmp/rendered.yaml
+          # The baked defaults must auto-generate the credential-encryption
+          # keyset Secret — credential writes 500 without it.
+          grep -q 'name: jentic-encryption' /tmp/rendered.yaml
 
       - name: Package the chart
         env:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -226,7 +226,7 @@ shipped placeholder values for these — they must be set explicitly:
 
 | Secret                          | Where                                               | Why |
 | ------------------------------- | --------------------------------------------------- | --- |
-| Credential encryption keyset    | `credentials.encryption` (`active_id` + `entries`)  | AES-256-GCM envelope key for credential-at-rest. Credential **writes** fail without a non-empty keyset. Set via YAML (a list of `{id, material}`), not a single env var. |
+| Credential encryption keyset    | `credentials.encryption` (`active_id` + `entries`)  | AES-256-GCM envelope key for credential-at-rest. Credential **writes** fail without a non-empty keyset. Set via YAML (a list of `{id, material}`), not a single env var. On Kubernetes the chart can manage it — see [Credential encryption keyset on Kubernetes](#credential-encryption-keyset-on-kubernetes). |
 | Database passwords              | `JENTIC__DATABASES__<DB>__PASSWORD`                 | Needed to connect to a real Postgres. |
 
 Generate a fresh secret / encryption key material with:
@@ -992,6 +992,36 @@ The umbrella [`values.yaml`](helm/jentic-one/values.yaml) and
 [`_db-env.tpl`](helm/jentic-one/charts/common/templates/_db-env.tpl) both
 carry inline warnings about this so the dev pattern can't silently leak
 into a prod values file.
+
+### Credential encryption keyset on Kubernetes
+
+The keyset (`credentials.encryption` — see
+[Mandatory vs optional secrets](#mandatory-vs-optional-secrets)) is a *list*,
+so it cannot ride the flat `JENTIC__*` env convention; without it every
+credential write 500s. The chart offers three sources, in order of
+preference:
+
+1. **`global.encryption.generate: true`** — the chart mints a random 32-byte
+   key into a release-scoped Secret (`<release>-encryption`) on first
+   install, mounts it into the app, broker, and control pods as
+   `JENTIC_CONFIG_FILE`, and **reuses it verbatim on every upgrade** (the
+   template `lookup`s the live Secret — regenerating would orphan everything
+   already encrypted). The Secret carries `helm.sh/resource-policy: keep` so
+   `helm uninstall` leaves it (and your decryptability) behind; a same-name
+   reinstall re-adopts it. This is the AWS Marketplace overlay's default.
+   Caveat: piping `helm template` to `kubectl apply` bypasses the lookup and
+   WILL rotate the key — use `helm install`/`upgrade`.
+2. **`global.encryption.existingSecret: <name>`** — mount your own Secret
+   (created via SealedSecrets/ESO/etc.). It must hold a `config.yaml` key
+   shaped like the keyset block in the worked production config above.
+3. **Per-service `configFile.contents`** (dev overlays only) — inlines the
+   keyset into a plain ConfigMap; never for real data.
+
+The three are mutually exclusive per pod: `generate`/`existingSecret` and
+`configFile.contents` both claim `JENTIC_CONFIG_FILE`, and the chart fails
+the render rather than silently preferring one. Key **rotation** is a
+config-level operation either way: add a new entry, flip `active_id`, keep
+the old entry until all rows are re-encrypted.
 
 ## AWS Marketplace
 

--- a/deploy/helm/jentic-one/charts/app/templates/deployment.yaml
+++ b/deploy/helm/jentic-one/charts/app/templates/deployment.yaml
@@ -32,14 +32,19 @@ spec:
               value: {{ $v | quote }}
 {{- end }}
 {{ include "common.config-file.env" . | indent 12 }}
+{{ include "common.encryption.env" . | indent 12 }}
 {{ include "common.logging-env" . | indent 12 }}
 {{ include "common.metrics-env" . | indent 12 }}
 {{ include "common.db-env" . | indent 12 }}
 {{- $cfgMount := (include "common.config-file.mount" . | trim) }}
+{{- $encMount := (include "common.encryption.mount" . | trim) }}
 {{- $licMount := (include "common.awsmp-license.mount" . | trim) }}
-{{- if or $cfgMount $licMount }}
+{{- if or $cfgMount $encMount $licMount }}
           volumeMounts:
 {{- with $cfgMount }}
+{{ . | indent 12 }}
+{{- end }}
+{{- with $encMount }}
 {{ . | indent 12 }}
 {{- end }}
 {{- with $licMount }}
@@ -65,13 +70,17 @@ spec:
         {{- end }}
       {{- $otel := .Values.global.observability.otel.enabled }}
       {{- $cfg := (include "common.config-file.volume" . | trim) }}
+      {{- $enc := (include "common.encryption.volume" . | trim) }}
       {{- $lic := (include "common.awsmp-license.volume" . | trim) }}
-      {{- if or $otel $cfg $lic }}
+      {{- if or $otel $cfg $enc $lic }}
       volumes:
       {{- if $otel }}
 {{ include "common.otel-config-volume" . | indent 8 }}
       {{- end }}
       {{- with $cfg }}
+{{ . | indent 8 }}
+      {{- end }}
+      {{- with $enc }}
 {{ . | indent 8 }}
       {{- end }}
       {{- with $lic }}

--- a/deploy/helm/jentic-one/charts/broker/templates/deployment.yaml
+++ b/deploy/helm/jentic-one/charts/broker/templates/deployment.yaml
@@ -32,14 +32,19 @@ spec:
               value: {{ $v | quote }}
 {{- end }}
 {{ include "common.config-file.env" . | indent 12 }}
+{{ include "common.encryption.env" . | indent 12 }}
 {{ include "common.logging-env" . | indent 12 }}
 {{ include "common.metrics-env" . | indent 12 }}
 {{ include "common.db-env" . | indent 12 }}
 {{- $cfgMount := (include "common.config-file.mount" . | trim) }}
+{{- $encMount := (include "common.encryption.mount" . | trim) }}
 {{- $licMount := (include "common.awsmp-license.mount" . | trim) }}
-{{- if or $cfgMount $licMount }}
+{{- if or $cfgMount $encMount $licMount }}
           volumeMounts:
 {{- with $cfgMount }}
+{{ . | indent 12 }}
+{{- end }}
+{{- with $encMount }}
 {{ . | indent 12 }}
 {{- end }}
 {{- with $licMount }}
@@ -65,13 +70,17 @@ spec:
         {{- end }}
       {{- $otel := .Values.global.observability.otel.enabled }}
       {{- $cfg := (include "common.config-file.volume" . | trim) }}
+      {{- $enc := (include "common.encryption.volume" . | trim) }}
       {{- $lic := (include "common.awsmp-license.volume" . | trim) }}
-      {{- if or $otel $cfg $lic }}
+      {{- if or $otel $cfg $enc $lic }}
       volumes:
       {{- if $otel }}
 {{ include "common.otel-config-volume" . | indent 8 }}
       {{- end }}
       {{- with $cfg }}
+{{ . | indent 8 }}
+      {{- end }}
+      {{- with $enc }}
 {{ . | indent 8 }}
       {{- end }}
       {{- with $lic }}

--- a/deploy/helm/jentic-one/charts/common/templates/_config-file.tpl
+++ b/deploy/helm/jentic-one/charts/common/templates/_config-file.tpl
@@ -13,6 +13,8 @@ credential-encryption keyset so credential writes don't 500 in-cluster.
 
 DEVELOPMENT-ONLY: contents land in a plain ConfigMap (not a Secret). Fine for
 local kind/smoke clusters; never put real secrets here. See deploy/README.md.
+Production keysets use global.encryption instead (_encryption.tpl) — the two
+are mutually exclusive since both claim JENTIC_CONFIG_FILE.
 
 All three helpers no-op unless `.Values.configFile.contents` is set, so they are
 safe to include unconditionally in every service deployment template.

--- a/deploy/helm/jentic-one/charts/common/templates/_encryption.tpl
+++ b/deploy/helm/jentic-one/charts/common/templates/_encryption.tpl
@@ -1,0 +1,54 @@
+{{- /*
+common.encryption.{env,volume,mount} — mount the release's credential
+encryption keyset (see the umbrella chart's templates/encryption-secret.yaml)
+into a service pod as the JENTIC_CONFIG_FILE.
+
+Active when global.encryption.generate=true or .existingSecret is set; emits
+nothing otherwise, so every deployment template can include it
+unconditionally. Both the app/control surfaces (encrypt on credential write)
+and the broker (decrypt + re-encrypt on token refresh) need the SAME keyset,
+which is why this is a global, release-scoped mount.
+
+Mutually exclusive with configFile.contents: both claim JENTIC_CONFIG_FILE
+(the config loader reads a single file), so setting both is a config error
+we fail loudly on. Dev overlays use configFile (keyset inline, dev-only);
+Marketplace/production use this Secret.
+*/ -}}
+
+{{- define "common.encryption.enabled" -}}
+{{- $enc := (.Values.global).encryption | default dict -}}
+{{- if or $enc.generate $enc.existingSecret -}}
+{{- if and .Values.configFile .Values.configFile.contents -}}
+{{- fail "global.encryption and configFile.contents are mutually exclusive (both claim JENTIC_CONFIG_FILE) — put the keyset in one place" -}}
+{{- end -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "common.encryption.secret-name" -}}
+{{- $enc := (.Values.global).encryption | default dict -}}
+{{- $enc.existingSecret | default (printf "%s-encryption" .Release.Name) -}}
+{{- end -}}
+
+{{- define "common.encryption.env" -}}
+{{- if (include "common.encryption.enabled" .) }}
+- name: JENTIC_CONFIG_FILE
+  value: /etc/jentic/encryption/config.yaml
+{{- end }}
+{{- end -}}
+
+{{- define "common.encryption.volume" -}}
+{{- if (include "common.encryption.enabled" .) }}
+- name: jentic-encryption
+  secret:
+    secretName: {{ include "common.encryption.secret-name" . }}
+{{- end }}
+{{- end -}}
+
+{{- define "common.encryption.mount" -}}
+{{- if (include "common.encryption.enabled" .) }}
+- name: jentic-encryption
+  mountPath: /etc/jentic/encryption
+  readOnly: true
+{{- end }}
+{{- end -}}

--- a/deploy/helm/jentic-one/charts/control/templates/deployment.yaml
+++ b/deploy/helm/jentic-one/charts/control/templates/deployment.yaml
@@ -29,12 +29,20 @@ spec:
               value: {{ $v | quote }}
 {{- end }}
 {{ include "common.config-file.env" . | indent 12 }}
+{{ include "common.encryption.env" . | indent 12 }}
 {{ include "common.logging-env" . | indent 12 }}
 {{ include "common.metrics-env" . | indent 12 }}
 {{ include "common.db-env" . | indent 12 }}
-{{- with (include "common.config-file.mount" . | trim) }}
+{{- $cfgMount := (include "common.config-file.mount" . | trim) }}
+{{- $encMount := (include "common.encryption.mount" . | trim) }}
+{{- if or $cfgMount $encMount }}
           volumeMounts:
+{{- with $cfgMount }}
 {{ . | indent 12 }}
+{{- end }}
+{{- with $encMount }}
+{{ . | indent 12 }}
+{{- end }}
 {{- end }}
           readinessProbe:
             httpGet:
@@ -55,12 +63,16 @@ spec:
         {{- end }}
       {{- $otel := .Values.global.observability.otel.enabled }}
       {{- $cfg := (include "common.config-file.volume" . | trim) }}
-      {{- if or $otel $cfg }}
+      {{- $enc := (include "common.encryption.volume" . | trim) }}
+      {{- if or $otel $cfg $enc }}
       volumes:
       {{- if $otel }}
 {{ include "common.otel-config-volume" . | indent 8 }}
       {{- end }}
       {{- with $cfg }}
+{{ . | indent 8 }}
+      {{- end }}
+      {{- with $enc }}
 {{ . | indent 8 }}
       {{- end }}
       {{- end }}

--- a/deploy/helm/jentic-one/templates/encryption-secret.yaml
+++ b/deploy/helm/jentic-one/templates/encryption-secret.yaml
@@ -1,0 +1,46 @@
+{{- /*
+Release-scoped credential-encryption keyset (credentials.encryption).
+
+The keyset is a *list* config (active_id + entries[{id, material}]), which
+the flat JENTIC__* env convention cannot express, and credential writes 500
+without it — so the Marketplace/production chart needs a first-class source
+for it. Three modes, driven by global.encryption:
+
+  generate: true    -> this Secret is created with a fresh random 32-byte
+                       key on first install and REUSED VERBATIM on every
+                       upgrade (lookup) — regenerating would render all
+                       previously encrypted credentials undecryptable.
+                       "helm.sh/resource-policy": keep survives uninstall
+                       for the same reason (the Postgres PVC survives too);
+                       a same-name reinstall re-adopts it.
+  existingSecret set -> nothing rendered here; pods mount the named Secret
+                       (must hold a config.yaml with the same shape).
+  neither           -> nothing rendered or mounted (dev overlays supply the
+                       keyset via configFile.contents instead).
+
+Offline renders (helm template/lint — e.g. AWS Marketplace validation) have
+no cluster to look up, so they emit a throwaway random key; that manifest
+is valid but must not be kubectl-applied twice — `helm install` is the
+supported path (same caveat as common.require-install).
+*/ -}}
+{{- $enc := .Values.global.encryption | default dict }}
+{{- if and $enc.generate (not $enc.existingSecret) }}
+{{- $name := printf "%s-encryption" .Release.Name }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/resource-policy": keep
+type: Opaque
+data:
+{{- if and $existing $existing.data }}
+  config.yaml: {{ index $existing.data "config.yaml" }}
+{{- else }}
+{{- $material := randBytes 32 }}
+  config.yaml: {{ printf "credentials:\n  encryption:\n    active_id: v1\n    entries:\n      - id: v1\n        material: %s\n" $material | b64enc }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/jentic-one/values.yaml
+++ b/deploy/helm/jentic-one/values.yaml
@@ -131,6 +131,19 @@ global:
   # IRSA-based entitlement gate does not read it. Empty = nothing rendered.
   awsmp:
     licenseSecret: ""
+  # Credential-at-rest encryption keyset (config `credentials.encryption`) —
+  # an AES-256-GCM key list the flat JENTIC__* env convention cannot express,
+  # and without which every credential write fails. `generate: true` has the
+  # chart mint a random keyset into a release-scoped Secret on first install
+  # and reuse it verbatim on upgrades (rotating it would orphan everything
+  # already encrypted; the Secret is kept on uninstall for the same reason).
+  # `existingSecret` mounts your own Secret instead (must hold a `config.yaml`
+  # key shaped like the example in deploy/README.md). Both are mutually
+  # exclusive with per-service `configFile.contents`, which the dev overlays
+  # use to inline a throwaway keyset.
+  encryption:
+    generate: false
+    existingSecret: ""
   # Database credentials. `password` has NO default — the chart refuses to
   # install without one (see common.require-install; offline `helm template`
   # and `helm lint` render an inert REQUIRED-AT-INSTALL placeholder instead,

--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -42,6 +42,14 @@ global:
   # RDS variant: also set the three global.databases.*.host values and
   # disable the bundled DB (see the postgresql blocks).
 
+  # Credential-at-rest encryption keyset: auto-generated into a release-scoped
+  # Secret on first install and reused verbatim on upgrades, so credential
+  # writes work out of the box (the keyset is list-shaped config that env vars
+  # cannot carry). Buyers managing keys themselves: set
+  # global.encryption.existingSecret instead. See deploy/README.md.
+  encryption:
+    generate: true
+
   # AWS Marketplace launch wiring — the listing's delivery option carries
   # these two override parameters (values substituted by AWS at launch):
   #   global.serviceAccount.name = ${AWSMP_SERVICE_ACCOUNT}

--- a/tests/smoke/test_helm_render.py
+++ b/tests/smoke/test_helm_render.py
@@ -7,6 +7,7 @@ lives in-tree) — they skip cleanly when helm is absent, so a bare local
 
 from __future__ import annotations
 
+import base64
 import shutil
 import subprocess
 from pathlib import Path
@@ -173,3 +174,90 @@ def test_render_service_account_create_requires_name() -> None:
     )
     assert result.returncode != 0
     assert "global.serviceAccount.name is required" in result.stderr
+
+
+@pytest.mark.smoke
+def test_render_marketplace_encryption_secret() -> None:
+    """aws-marketplace.yaml auto-generates the credential-encryption keyset.
+
+    Credential writes 500 without credentials.encryption (a list-shaped
+    config env vars cannot carry), so the Marketplace overlay sets
+    global.encryption.generate=true: a release-scoped Secret holding a
+    config.yaml keyset, mounted as JENTIC_CONFIG_FILE into the app and
+    broker (both encrypt/decrypt tokens). The Secret must be resource-policy
+    keep — losing it orphans everything already encrypted.
+    """
+    result = _helm_template(
+        "-f",
+        str(VALUES_DIR / "aws-marketplace.yaml"),
+        "--set",
+        "global.image.tag=0.0.0-test",
+        *DEV_PASSWORD_SETS,
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "name: jentic-encryption" in out
+    assert '"helm.sh/resource-policy": keep' in out
+    # App and broker both mount the keyset and point the loader at it.
+    assert out.count("secretName: jentic-encryption") == 2
+    assert out.count("value: /etc/jentic/encryption/config.yaml") == 2
+    # The generated material decodes to exactly 32 bytes (AES-256).
+    docs = out.split("---")
+    secret_doc = next(d for d in docs if "name: jentic-encryption" in d)
+    b64 = next(
+        line.split(":", 1)[1].strip()
+        for line in secret_doc.splitlines()
+        if line.strip().startswith("config.yaml:")
+    )
+    keyset = base64.b64decode(b64).decode()
+    assert "active_id: v1" in keyset
+    material = next(
+        line.split(":", 1)[1].strip()
+        for line in keyset.splitlines()
+        if line.strip().startswith("material:")
+    )
+    assert len(base64.b64decode(material)) == 32
+
+
+@pytest.mark.smoke
+def test_render_encryption_existing_secret() -> None:
+    """existingSecret mounts the buyer's Secret and renders none of ours."""
+    result = _helm_template(
+        "-f",
+        str(VALUES_DIR / "aws-marketplace.yaml"),
+        "--set",
+        "global.image.tag=0.0.0-test",
+        "--set",
+        "global.encryption.existingSecret=buyer-keyset",
+        *DEV_PASSWORD_SETS,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.count("secretName: buyer-keyset") == 2
+    # No chart-generated Secret rendered (the pod volume name still matches
+    # "jentic-encryption", so key on the Secret's keep-annotation instead).
+    assert '"helm.sh/resource-policy": keep' not in result.stdout
+
+
+@pytest.mark.smoke
+def test_render_encryption_off_by_default() -> None:
+    """Bare renders carry no encryption Secret, mount, or JENTIC_CONFIG_FILE."""
+    result = _helm_template()
+    assert result.returncode == 0, result.stderr
+    assert "jentic-encryption" not in result.stdout
+
+
+@pytest.mark.smoke
+def test_render_encryption_conflicts_with_config_file() -> None:
+    """generate=true + a dev configFile keyset must fail loudly.
+
+    Both claim JENTIC_CONFIG_FILE (the loader reads a single file); silently
+    preferring one would ship a keyset the operator didn't choose.
+    """
+    result = _helm_template(
+        "-f",
+        str(VALUES_DIR / "local-combined.yaml"),
+        "--set",
+        "global.encryption.generate=true",
+    )
+    assert result.returncode != 0
+    assert "mutually exclusive" in result.stderr


### PR DESCRIPTION
## Summary

Part of #1132. A Marketplace `helm install` currently produces a deployment that **cannot store credentials**: the `credentials.encryption` keyset is list-shaped config the flat `JENTIC__*` env convention cannot express, and every credential write 500s without it. This gives the chart a first-class source for the keyset:

- **`global.encryption.generate: true`** — the chart mints a random 32-byte AES-256-GCM keyset into a release-scoped Secret (`<release>-encryption`) on first install and **reuses it verbatim on upgrades** (template `lookup`s the live Secret — regenerating would orphan everything already encrypted). `helm.sh/resource-policy: keep` preserves decryptability across uninstall/reinstall, mirroring the Postgres PVC behavior.
- **`global.encryption.existingSecret`** — mounts an operator-managed Secret instead (must hold a `config.yaml` shaped like the keyset block in `deploy/README.md`).
- The Secret is mounted as `JENTIC_CONFIG_FILE` into the **app, broker, and control** pods — all three encrypt/decrypt credential tokens (`control/services/credentials/connect_service.py`, `broker/services/credentials/refresh.py`).
- Mutually exclusive with the dev-only `configFile.contents` (both claim `JENTIC_CONFIG_FILE`); the render fails loudly rather than silently preferring one.
- The `aws-marketplace.yaml` overlay turns `generate` on, so the **baked Marketplace chart works out of the box**; the publish gate now asserts the baked chart renders the Secret.

Offline `helm template`/`lint` (what AWS Marketplace validation runs) still succeed — with no cluster to look up they emit a throwaway random key, same live-cluster-gating pattern as `common.require-install`.

## Test plan

- [x] 13/13 render tests pass (`tests/smoke/test_helm_render.py`), including 4 new ones: Marketplace render produces the Secret with decodable 32-byte material + mounts on app and broker; `existingSecret` renders no chart Secret; bare render carries nothing; `generate` + dev `configFile` fails with the mutual-exclusion error
- [x] Simulated the full `marketplace-chart.yml` bake + publish gate locally: lint, bare template, all-images-ECR, `REQUIRED-AT-INSTALL`, and the new encryption-Secret assertion all pass
- [ ] Post-merge: next release's baked chart renders the Secret; install on a live cluster and verify a credential write succeeds and the Secret survives `helm upgrade` unchanged

Made with [Cursor](https://cursor.com)