### PR TITLE
fix(ci): create the cli/vX.Y.Z tag via the REST API, not git push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -458,17 +458,24 @@ jobs:
       # app release are always lockstep-identical. Runs LAST so a tagging hiccup
       # never blocks GoReleaser publishing the binaries. The `cli/v*` tag can't
       # match this workflow's `v*.*.*` trigger, so there's no recursive release run.
+      #
+      # Created via the REST Git Data API, NOT `git push`: GitHub refuses any
+      # git-protocol ref push from an App token once the ref's history touches
+      # .github/workflows/ ("refusing to allow a GitHub App to create or update
+      # workflow … without `workflows` permission" — a permission GITHUB_TOKEN
+      # can never be granted), which broke the v0.35.0 release. The API path
+      # only applies that check to pushes uploading workflow changes; creating
+      # a ref to a commit already on the remote is fine. Lightweight rather
+      # than annotated tag as a consequence — the Go module proxy accepts both.
       - name: Tag the CLI Go module at the release version
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           CLI_TAG="cli/${GITHUB_REF_NAME}"
-          if git rev-parse -q --verify "refs/tags/${CLI_TAG}" >/dev/null; then
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${CLI_TAG}" >/dev/null 2>&1; then
             echo "${CLI_TAG} already exists — nothing to do"
           else
-            # Annotated tags need a committer identity; runners have none. Attribute
-            # to GitHub's Actions bot (matches the convention for CI-created objects).
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git tag -a "${CLI_TAG}" -m "${CLI_TAG}" "${GITHUB_SHA}"
-            git push origin "${CLI_TAG}"
+            gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/${CLI_TAG}" -f sha="${GITHUB_SHA}"
           fi


### PR DESCRIPTION
## Summary

- The [v0.35.0 release run](https://github.com/jentic/jentic-one/releases/tag/v0.35.0) failed at its final step: `git push origin cli/v0.35.0` was rejected with `refusing to allow a GitHub App to create or update workflow '.github/workflows/marketplace-chart.yml' without 'workflows' permission`. GitHub applies this check to **any git-protocol ref push** from an App token when the ref's history contains workflow-file changes — even a tag pointing at a commit already on `main` — and `GITHUB_TOKEN` can never be granted the `workflows` permission, so this would fail on every release from now on (the release commits' history now includes `marketplace-chart.yml`).
- Switch the step to create the ref via the REST Git Data API (`gh api repos/.../git/refs`), which only applies the workflow check to pushes that actually upload workflow changes. Same token, same permissions (`contents: write`), no new secrets. Lightweight instead of annotated tag — the Go module proxy accepts both.
- Idempotence guard now checks the remote via the API instead of the local clone.

Repair already done by hand: `cli/v0.35.0` pushed from a user account, verified resolving via the ref API. No other release is missing its `cli/*` tag.

## Test plan

- [x] Verified the read endpoint handles the slashed ref (`git/ref/tags/cli/v0.35.0` resolves; a missing tag 404s, driving the create path)
- [x] GoReleaser publishing is unaffected — the step still runs last
- [ ] Next release: confirm the `cli/v*` tag is created by the workflow

Made with [Cursor](https://cursor.com)