### PR TITLE
feat(helm): generate the bundled-DB passwords too — zero-touch Marketplace install

### DIFF
--- a/.github/workflows/marketplace-chart.yml
+++ b/.github/workflows/marketplace-chart.yml
@@ -147,14 +147,18 @@ jobs:
           if [ "${EMPTY_REG}" != "0" ]; then
             echo "::error::baked values.yaml has image block(s) with an empty registry — use AWS's registry/repository/tag split"; exit 1
           fi
-          # The install-time password guards must have rendered inert
-          # placeholders (a live-cluster install still refuses to proceed).
-          grep -q 'REQUIRED-AT-INSTALL' /tmp/rendered.yaml
-          # The baked defaults must auto-generate the application secrets
+          # The baked defaults must be fully self-contained: the app-secrets
           # Secret (encryption keyset, admin JWT secret, invite pepper,
-          # connect state secret) — credential writes 500 and
-          # JENTIC_ENV=production refuses to boot without them.
+          # connect state secret, DB passwords) is generated and every
+          # password reaches its pod as a secretKeyRef — so NO install-time
+          # placeholder may remain anywhere in the render (a zero-touch
+          # launch is the listing's contract: only the two AWSMP override
+          # parameters are supplied, both auto-substituted).
           grep -q 'name: jentic-app-secrets' /tmp/rendered.yaml
+          grep -q 'key: db-password-postgres' /tmp/rendered.yaml
+          if grep -q 'REQUIRED-AT-INSTALL' /tmp/rendered.yaml; then
+            echo "::error::baked chart still renders REQUIRED-AT-INSTALL placeholder(s) — a password stopped resolving from the generated app-secrets Secret"; exit 1
+          fi
 
       - name: Package the chart
         env:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -376,7 +376,7 @@
         "filename": "deploy/helm/jentic-one/charts/postgresql/templates/statefulset.yaml",
         "hashed_secret": "6bd06ba0ed7be869427a1cfdf397439ac011836b",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 42
       }
     ],
     "deploy/helm/observability/values.yaml": [
@@ -1930,5 +1930,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-27T11:24:14Z"
+  "generated_at": "2026-08-27T14:10:49Z"
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1001,30 +1001,44 @@ the credential-encryption keyset (`credentials.encryption` — a *list*, so it
 cannot ride the flat `JENTIC__*` env convention; credential writes 500
 without it), the admin JWT secret, the invite pepper, and the connect state
 secret (all three ship a public placeholder that `JENTIC_ENV=production`
-refuses to boot with). The chart offers three sources, in order of
-preference:
+refuses to boot with). The same Secret also carries the **bundled-DB
+passwords** (`db-password-{registry,control,admin,postgres}` keys): for the
+in-cluster Postgres these are pure pod-to-pod wiring on a ClusterIP service
+nothing outside the cluster can reach, so generated random values beat
+anything an operator would type in. The chart offers three sources, in
+order of preference:
 
 1. **`global.appSecrets.generate: true`** — the chart mints random values
-   into a release-scoped Secret (`<release>-app-secrets`) on first install,
-   mounts it into the app, broker, and control pods as `JENTIC_CONFIG_FILE`,
-   and **reuses it verbatim on every upgrade** (the template `lookup`s the
-   live Secret — regenerating would orphan everything already encrypted and
-   revoke every live session). The Secret carries
+   into a release-scoped Secret (`<release>-app-secrets`) on first install
+   and **reuses each key verbatim on every upgrade** (the template `lookup`s
+   the live Secret and generates only missing keys — regenerating would
+   orphan everything already encrypted, revoke every live session, and break
+   DB logins). The config.yaml key mounts into the app, broker, and control
+   pods as `JENTIC_CONFIG_FILE`; the DB passwords reach the service pods and
+   the Postgres server/init script as `secretKeyRef` env, so no password
+   ever lands in a ConfigMap or plain pod env. The Secret carries
    `helm.sh/resource-policy: keep` so `helm uninstall` leaves it (and your
    decryptability) behind; a same-name reinstall re-adopts it. This is the
-   AWS Marketplace overlay's default, paired with `JENTIC_ENV=production`.
+   AWS Marketplace overlay's default, paired with `JENTIC_ENV=production` —
+   a Marketplace launch needs zero buyer-supplied values.
    Caveat: piping `helm template` to `kubectl apply` bypasses the lookup and
    WILL rotate the secrets — use `helm install`/`upgrade`.
 2. **`global.appSecrets.existingSecret: <name>`** — mount your own Secret
    (created via SealedSecrets/ESO/etc.). It must hold a `config.yaml` key
    shaped like the keyset block in the worked production config above, plus
    `admin.auth.jwt_secret`, `admin.invite.pepper`, and
-   `credentials.connect.state_secret`.
+   `credentials.connect.state_secret` — and, if the bundled Postgres is
+   enabled, the four `db-password-*` keys.
 3. **Per-service `configFile.contents`** (dev overlays only) — inlines
    secrets into a plain ConfigMap; never for real data.
 
-The three are mutually exclusive per pod: `generate`/`existingSecret` and
-`configFile.contents` both claim `JENTIC_CONFIG_FILE`, and the chart fails
+Explicit password values always win over the generated keys:
+`global.databases.<surface>.password` / `postgresql.auth.password` render as
+plain env exactly as before (this is the external-DB path, and the upgrade
+path for installs whose DB roles predate the generated passwords).
+
+The generate/existingSecret modes are mutually exclusive per pod with
+`configFile.contents`: both claim `JENTIC_CONFIG_FILE`, and the chart fails
 the render rather than silently preferring one. Encryption-key **rotation**
 is a config-level operation either way: add a new entry, flip `active_id`,
 keep the old entry until all rows are re-encrypted.
@@ -1128,33 +1142,33 @@ Once set:
   in the chart's own defaults (their validator extracts them there, and
   their replication pipeline rewrites them per region). The publish gate
   then runs exactly what AWS runs on submission: bare `helm lint` + bare
-  `helm template` (must succeed — the password guards are install-time only,
-  see `common.require-install`) with every rendered image from the listing's
-  ECR. Backfill an already-released tag with
+  `helm template` (must succeed — the baked chart generates every secret, so
+  no install-time password guard remains in its render) with every rendered
+  image from the listing's ECR. Backfill an already-released tag with
   `gh workflow run marketplace-chart.yml -f tag=vX.Y.Z`.
 
 Publishing a new **listing version** stays a portal step (product → Request
 changes → *Add version*, pinning the pushed tag/digest); automate via the
 Marketplace Catalog API only after the manual loop has worked once.
 
-Because the Marketplace chart is self-contained, the version's **Helm
-delivery option** needs only six override parameters — the two
-AWS-substituted ones (portal validation rejects paid products without them)
-and the four buyer-chosen passwords:
+Because the Marketplace chart is self-contained — every password and secret
+is generated at install (see [Generated application secrets on
+Kubernetes](#generated-application-secrets-on-kubernetes)) — the version's
+**Helm delivery option** needs only two override parameters, both
+substituted by AWS at launch (portal validation rejects paid products
+without them). A buyer supplies nothing:
 
 | Override parameter key | DefaultValue |
 | ---------------------- | ------------ |
 | `global.serviceAccount.name` | `${AWSMP_SERVICE_ACCOUNT}` — the buyer's (IRSA) service account; the app/broker pods run under it (chart support: `global.serviceAccount`) |
 | `global.awsmp.licenseSecret` | `${AWSMP_LICENSE_SECRET}` — an AWS-created Secret, mounted read-only at `/var/run/secrets/aws-marketplace/license` (chart support: `global.awsmp.licenseSecret`) |
-| `postgresql.auth.password` | *(buyer-supplied — bundled DB admin password)* |
-| `global.databases.registry.password` | *(buyer-supplied)* |
-| `global.databases.control.password` | *(buyer-supplied)* |
-| `global.databases.admin.password` | *(buyer-supplied)* |
 
 Everything else (ECR image repositories, `broker.enabled=true`, the bundled
-Postgres, the tag pin) is baked into the published chart's defaults. Buyers
-preferring RDS install manually instead, disabling the bundled DB and
-setting the `global.databases.*.host` values.
+Postgres, the secret/password generation, the tag pin) is baked into the
+published chart's defaults. Buyers preferring RDS install manually instead,
+disabling the bundled DB and setting the `global.databases.*.host` values
+plus explicit `*.password` values (explicit passwords always win over the
+generated ones).
 
 The IAM role lives in the **seller account** and trusts GitHub's OIDC
 provider — no long-lived AWS keys anywhere. Trust policy (create the

--- a/deploy/helm/jentic-one/charts/common/templates/_app-secrets.tpl
+++ b/deploy/helm/jentic-one/charts/common/templates/_app-secrets.tpl
@@ -43,6 +43,11 @@ true
 - name: jentic-app-secrets
   secret:
     secretName: {{ include "common.app-secrets.secret-name" . }}
+    # Only the config file lands on disk; the db-password-* keys in the same
+    # Secret reach pods as env (secretKeyRef in common.db-env) instead.
+    items:
+      - key: config.yaml
+        path: config.yaml
 {{- end }}
 {{- end -}}
 

--- a/deploy/helm/jentic-one/charts/common/templates/_db-env.tpl
+++ b/deploy/helm/jentic-one/charts/common/templates/_db-env.tpl
@@ -1,22 +1,25 @@
 {{- /*
 common.db-env: render JENTIC__DATABASES__* env vars for service pods.
 
-DEVELOPMENT-ONLY pattern: passwords are injected as plain env-var values
-read directly from values.yaml. This is fine for local kind clusters and
-short-lived dev/test envs, but MUST NOT carry forward to production.
+Password source, in order of precedence:
+  1. global.databases.<surface>.password set  -> plain env value. Dev-only
+     for real data (values files are not secret storage) — external-DB
+     production deployments should prefer a Secret they manage; this arm is
+     also what lets an external-DB install override the generated defaults.
+  2. global.appSecrets active                 -> secretKeyRef into the
+     release's generated app-secrets Secret (db-password-<surface> key,
+     created by templates/app-secrets.yaml). The bundled Postgres init
+     script creates the roles from the same keys, so the pair always agrees.
+  3. neither                                  -> install-time failure
+     (common.require-install; offline lint/template render an inert
+     REQUIRED-AT-INSTALL placeholder).
 
-Production guidance:
-  - Store DB credentials in a Kubernetes Secret (or external secret store
-    like AWS Secrets Manager / Vault, fronted by external-secrets).
-  - Replace the `value:` lines for *_PASSWORD (and likely *_USER) with
-    `valueFrom: { secretKeyRef: { name: ..., key: ... } }`.
-  - Keep host/port/name/schema as plain values; only credentials need
-    secret handling.
-
-See deploy/README.md "Production secrets" for the migration recipe.
+Host/port/name/schema are not secrets and stay plain values.
+See deploy/README.md "Production secrets".
 */ -}}
 {{- define "common.db-env" -}}
 {{- $pgHost := printf "%s-postgresql" .Release.Name -}}
+{{- $ctx := . -}}
 {{- range $surface, $db := .Values.global.databases }}
 - name: JENTIC__DATABASES__{{ upper $surface }}__HOST
   value: {{ (ternary $pgHost $db.host $.Values.global.postgresql.enabled) | quote }}
@@ -27,7 +30,16 @@ See deploy/README.md "Production secrets" for the migration recipe.
 - name: JENTIC__DATABASES__{{ upper $surface }}__USER
   value: {{ $db.user | quote }}
 - name: JENTIC__DATABASES__{{ upper $surface }}__PASSWORD
+{{- if $db.password }}
+  value: {{ $db.password | quote }}
+{{- else if (include "common.app-secrets.enabled" $ctx) }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "common.app-secrets.secret-name" $ctx }}
+      key: db-password-{{ $surface }}
+{{- else }}
   value: {{ include "common.require-install" (dict "root" $ "value" $db.password "message" (printf "global.databases.%s.password is required — set it in your values file (dev files: deploy/helm/values/local-*.yaml)" $surface)) | quote }}
+{{- end }}
 - name: JENTIC__DATABASES__{{ upper $surface }}__SCHEMA_NAME
   value: {{ $db.schema_name | default $db.schema | quote }}
 {{- end }}

--- a/deploy/helm/jentic-one/charts/postgresql/templates/statefulset.yaml
+++ b/deploy/helm/jentic-one/charts/postgresql/templates/statefulset.yaml
@@ -18,13 +18,24 @@ one level below the mount so a provisioner's lost+found can't break initdb.
 {{- $image := ternary (printf "%s/%s:%s" $registry .Values.image.repository .Values.image.tag) (printf "%s:%s" .Values.image.repository .Values.image.tag) (ne $registry "") -}}
 {{- $initConfigMap := .Values.primary.initdb.scriptsConfigMap | default (printf "%s-pg-init" .Release.Name) -}}
 {{- /*
+Generated-secrets wiring (mirrors charts/common's _app-secrets.tpl, inlined
+to keep the subchart self-contained): when global.appSecrets is active, the
+superuser and per-surface role passwords come from the release's generated
+Secret via secretKeyRef. Explicit values (auth.password /
+global.databases.*.password) always win, so external-DB and dev overlays
+behave exactly as before.
+*/ -}}
+{{- $sec := (.Values.global).appSecrets | default dict -}}
+{{- $secretsOn := or $sec.generate $sec.existingSecret -}}
+{{- $secretName := $sec.existingSecret | default (printf "%s-app-secrets" .Release.Name) -}}
+{{- /*
 Install-time-only password guard (mirrors common.require-install, inlined to
 keep the subchart self-contained): AWS Marketplace validates charts with bare
 `helm lint`/`helm template`, so the guard must not fire in offline renders —
 `lookup` only returns data against a live cluster (install/upgrade).
 */ -}}
 {{- $password := .Values.auth.password -}}
-{{- if not $password -}}
+{{- if and (not $password) (not $secretsOn) -}}
 {{- if or (lookup "v1" "ServiceAccount" .Release.Namespace "default") (lookup "v1" "Namespace" "" "") -}}
 {{- fail "postgresql.auth.password is required when postgresql.enabled=true — set it in your values file (dev files: deploy/helm/values/local-*.yaml)" -}}
 {{- else -}}
@@ -68,11 +79,36 @@ spec:
             - name: POSTGRES_USER
               value: {{ .Values.auth.username | quote }}
             - name: POSTGRES_PASSWORD
+{{- if .Values.auth.password }}
+              value: {{ .Values.auth.password | quote }}
+{{- else if $secretsOn }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: db-password-postgres
+{{- else }}
               value: {{ $password | quote }}
+{{- end }}
             - name: POSTGRES_DB
               value: {{ .Values.auth.database | quote }}
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata
+{{- /* Per-surface role passwords for the first-boot init script (the
+umbrella chart's pg-init ConfigMap creates the roles from these, keeping
+the SQL itself secret-free). Same precedence as the service pods' env. */}}
+{{- range $surface, $db := .Values.global.databases }}
+            - name: PGINIT_PASSWORD_{{ upper $surface }}
+{{- if $db.password }}
+              value: {{ $db.password | quote }}
+{{- else if $secretsOn }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: db-password-{{ $surface }}
+{{- else }}
+              value: "REQUIRED-AT-INSTALL"
+{{- end }}
+{{- end }}
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data

--- a/deploy/helm/jentic-one/charts/postgresql/values.yaml
+++ b/deploy/helm/jentic-one/charts/postgresql/values.yaml
@@ -19,7 +19,8 @@ auth:
   username: postgres
   # No default password — the chart refuses to install without one (same
   # posture as global.databases passwords; dev files: deploy/helm/values/
-  # local-*.yaml).
+  # local-*.yaml) UNLESS global.appSecrets is active, in which case the
+  # superuser password comes from the generated Secret via secretKeyRef..
   database: jentic
 
 primary:

--- a/deploy/helm/jentic-one/templates/app-secrets.yaml
+++ b/deploy/helm/jentic-one/templates/app-secrets.yaml
@@ -15,9 +15,24 @@ _app-secrets.tpl for the mount):
                               problem).
   credentials.connect.state_secret -- signs the OAuth connect `state`.
 
+plus one individual key per database password, consumed via secretKeyRef
+(common.db-env for the service pods, the postgresql subchart's StatefulSet
+for the server + init script):
+
+  db-password-registry / -control / -admin -- per-surface role passwords
+  db-password-postgres                     -- bundled-DB superuser password
+
+For the BUNDLED in-cluster Postgres these passwords are pure pod-to-pod
+wiring on a ClusterIP service no one outside the cluster can reach — a
+generated random value is strictly better than anything an operator types
+into a form. Deployments using an EXTERNAL database instead set
+global.databases.*.password explicitly, which always wins over these keys
+(see common.db-env).
+
 One release-scoped Secret rather than per-pod: the app, broker, and control
 pods must agree on all of these (the broker re-encrypts refreshed tokens the
-app must read back; JWTs cross surfaces).
+app must read back; JWTs cross surfaces; the DB roles are created by the
+Postgres init script with the same passwords the pods log in with).
 
 Modes, driven by global.appSecrets:
 
@@ -42,6 +57,8 @@ supported path (same caveat as common.require-install).
 {{- if and $sec.generate (not $sec.existingSecret) }}
 {{- $name := printf "%s-app-secrets" .Release.Name }}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $name }}
+{{- $data := dict }}
+{{- if and $existing $existing.data }}{{- $data = $existing.data }}{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -52,13 +69,23 @@ metadata:
     "helm.sh/resource-policy": keep
 type: Opaque
 data:
-{{- if and $existing $existing.data }}
-  config.yaml: {{ index $existing.data "config.yaml" }}
+{{- /* Reuse each key that already exists; generate only what's missing (an
+upgrade from a chart version that generated fewer keys fills the gaps
+without touching the ones in use). */}}
+{{- if hasKey $data "config.yaml" }}
+  config.yaml: {{ index $data "config.yaml" }}
 {{- else }}
 {{- $material := randBytes 32 }}
 {{- $jwt := randBytes 32 }}
 {{- $pepper := randBytes 32 }}
 {{- $state := randBytes 32 }}
   config.yaml: {{ printf "credentials:\n  encryption:\n    active_id: v1\n    entries:\n      - id: v1\n        material: %s\n  connect:\n    state_secret: %s\nadmin:\n  auth:\n    jwt_secret: %s\n  invite:\n    pepper: %s\n" $material $state $jwt $pepper | b64enc }}
+{{- end }}
+{{- range $key := list "db-password-registry" "db-password-control" "db-password-admin" "db-password-postgres" }}
+{{- if hasKey $data $key }}
+  {{ $key }}: {{ index $data $key }}
+{{- else }}
+  {{ $key }}: {{ randAlphaNum 32 | b64enc }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/jentic-one/templates/pg-init-configmap.yaml
+++ b/deploy/helm/jentic-one/templates/pg-init-configmap.yaml
@@ -19,23 +19,32 @@ data:
   # Mirrors docker/local-setup/init-schemas.sql: create per-surface schemas
   # AND the login roles + grants each surface uses to connect. initdb scripts
   # only run on first boot (empty data dir); if roles/grants change, recreate
-  # the PVC (helm uninstall + delete pvc, or a fresh kind cluster). DEV-ONLY
-  # static passwords — see global.databases in values.yaml.
-  init-schemas.sql: |
+  # the PVC (helm uninstall + delete pvc, or a fresh kind cluster).
+  #
+  # A shell script rather than a .sql file so the role passwords come from
+  # env (PGINIT_PASSWORD_*, injected by the postgresql StatefulSet from
+  # explicit values or the generated app-secrets Secret) — the ConfigMap
+  # itself holds no secrets. psql -v + :'var' quoting keeps any password
+  # byte-safe; format(%I/%L) + \gexec replaces the old DO-block guard
+  # (psql does not substitute variables inside dollar-quoted bodies).
+  init-schemas.sh: |
+    #!/bin/sh
+    set -eu
+    psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
     CREATE SCHEMA IF NOT EXISTS registry;
     CREATE SCHEMA IF NOT EXISTS control;
     CREATE SCHEMA IF NOT EXISTS admin;
+    SQL
     {{- range $surface, $db := .Values.global.databases }}
-
-    -- {{ $surface }} surface role + grants
-    DO $$ BEGIN
-      IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '{{ $db.user }}') THEN
-        CREATE ROLE {{ $db.user }} LOGIN PASSWORD '{{ $db.password }}';
-      END IF;
-    END $$;
+    # {{ $surface }} surface role + grants
+    psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+      -v role='{{ $db.user }}' -v pw="$PGINIT_PASSWORD_{{ upper $surface }}" <<'SQL'
+    SELECT format('CREATE ROLE %I LOGIN PASSWORD %L', :'role', :'pw')
+      WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = :'role')\gexec
     GRANT USAGE, CREATE ON SCHEMA {{ $db.schema_name | default $db.schema }} TO {{ $db.user }};
     ALTER DEFAULT PRIVILEGES IN SCHEMA {{ $db.schema_name | default $db.schema }} GRANT ALL ON TABLES TO {{ $db.user }};
     ALTER DEFAULT PRIVILEGES IN SCHEMA {{ $db.schema_name | default $db.schema }} GRANT ALL ON SEQUENCES TO {{ $db.user }};
     ALTER DEFAULT PRIVILEGES IN SCHEMA {{ $db.schema_name | default $db.schema }} GRANT ALL ON TYPES TO {{ $db.user }};
+    SQL
     {{- end }}
 {{- end }}

--- a/deploy/helm/jentic-one/values.yaml
+++ b/deploy/helm/jentic-one/values.yaml
@@ -132,21 +132,26 @@ global:
   awsmp:
     licenseSecret: ""
   # Generated application secrets — every scalar secret the app cannot safely
-  # default, minted once into a release-scoped Secret and mounted into the
-  # app/broker/control pods as JENTIC_CONFIG_FILE:
-  #   credentials.encryption          AES-256-GCM keyset (list-shaped config
-  #                                   env vars can't carry; credential writes
-  #                                   fail without it)
-  #   admin.auth.jwt_secret           admin/session JWT signer
-  #   admin.invite.pepper             invite-token hash pepper
-  #   credentials.connect.state_secret OAuth connect state signer
+  # default, minted once into a release-scoped Secret:
+  #   config.yaml (mounted as JENTIC_CONFIG_FILE into app/broker/control):
+  #     credentials.encryption          AES-256-GCM keyset (list-shaped config
+  #                                     env vars can't carry; credential writes
+  #                                     fail without it)
+  #     admin.auth.jwt_secret           admin/session JWT signer
+  #     admin.invite.pepper             invite-token hash pepper
+  #     credentials.connect.state_secret OAuth connect state signer
+  #   db-password-{registry,control,admin,postgres} (secretKeyRef env):
+  #     bundled-DB role + superuser passwords — pure pod-to-pod wiring on a
+  #     ClusterIP service, so generated values beat operator-invented ones.
+  #     Explicit global.databases.*.password / postgresql.auth.password
+  #     always win (external-DB deployments keep setting those).
   # `generate: true` creates the Secret with random values on first install
   # and reuses it verbatim on upgrades (rotating would orphan everything
   # already encrypted and revoke live sessions; the Secret is kept on
   # uninstall for the same reason). `existingSecret` mounts your own Secret
-  # instead (must hold a `config.yaml` key shaped like the example in
-  # deploy/README.md). Both are mutually exclusive with per-service
-  # `configFile.contents`, which the dev overlays use to inline dev secrets.
+  # instead (must hold the same keys — see deploy/README.md). Both are
+  # mutually exclusive with per-service `configFile.contents`, which the dev
+  # overlays use to inline dev secrets.
   appSecrets:
     generate: false
     existingSecret: ""

--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -33,22 +33,18 @@ global:
   # pulled from docker.io, which the Marketplace disallows. Mirror it into
   # the listing's ECR first if observability is needed.
 
-  # No database password defaults ship with the chart; set the per-surface
-  # passwords (used both by the app and by the bundled DB's init scripts) at
-  # install:
-  #   --set global.databases.registry.password=… \
-  #   --set global.databases.control.password=…  \
-  #   --set global.databases.admin.password=…
-  # RDS variant: also set the three global.databases.*.host values and
-  # disable the bundled DB (see the postgresql blocks).
-
   # Generated application secrets: the credential-encryption keyset, admin
-  # JWT secret, invite pepper, and connect state secret — minted into a
-  # release-scoped Secret on first install and reused verbatim on upgrades,
-  # so the install is secure and functional out of the box (none of these
-  # have safe defaults; JENTIC_ENV=production below refuses the shipped
-  # placeholders). Buyers managing secrets themselves: set
-  # global.appSecrets.existingSecret instead. See deploy/README.md.
+  # JWT secret, invite pepper, connect state secret, AND the bundled DB's
+  # role/superuser passwords — minted into a release-scoped Secret on first
+  # install and reused verbatim on upgrades, so the install is secure and
+  # functional with ZERO buyer-supplied values (none of these have safe
+  # defaults; JENTIC_ENV=production below refuses the shipped placeholders;
+  # the DB passwords are pure pod-to-pod wiring on a ClusterIP service).
+  # RDS variant: set the three global.databases.*.host values + explicit
+  # *.password values (explicit passwords always win over generated ones)
+  # and disable the bundled DB (see the postgresql blocks). Buyers managing
+  # secrets themselves: set global.appSecrets.existingSecret instead. See
+  # deploy/README.md.
   appSecrets:
     generate: true
 
@@ -115,7 +111,9 @@ gateway:
 # `<registry>/<repository>:<tag>` from these exact keys, and an empty
 # registry with the full path in repository breaks its parser (leading-`/`,
 # missing tag → INVALID_HELM_UNDECLARED_IMAGES / MISSING_VALUES_IMAGE_REFERENCE).
-# The first-party subchart requires postgresql.auth.password at install.
+# The first-party subchart's passwords come from the generated app-secrets
+# Secret (global.appSecrets above); set postgresql.auth.password explicitly
+# only to override.
 postgresql:
   enabled: true
   image:

--- a/tests/smoke/test_helm_render.py
+++ b/tests/smoke/test_helm_render.py
@@ -17,17 +17,6 @@ import pytest
 CHART_DIR = Path(__file__).resolve().parents[2] / "deploy" / "helm" / "jentic-one"
 VALUES_DIR = CHART_DIR.parent / "values"
 
-DEV_PASSWORD_SETS = [
-    "--set",
-    "global.databases.registry.password=x",
-    "--set",
-    "global.databases.control.password=x",
-    "--set",
-    "global.databases.admin.password=x",
-    "--set",
-    "postgresql.auth.password=x",
-]
-
 
 def _helm_template(*args: str) -> subprocess.CompletedProcess[str]:
     if shutil.which("helm") is None:
@@ -104,7 +93,6 @@ def test_render_marketplace_images_all_ecr() -> None:
         str(VALUES_DIR / "aws-marketplace.yaml"),
         "--set",
         "global.image.tag=0.0.0-test",
-        *DEV_PASSWORD_SETS,
     )
     assert result.returncode == 0, result.stderr
     images = [
@@ -135,7 +123,6 @@ def test_render_awsmp_launch_parameters() -> None:
         "global.serviceAccount.name=buyer-sa",
         "--set",
         "global.awsmp.licenseSecret=buyer-license",
-        *DEV_PASSWORD_SETS,
     )
     assert result.returncode == 0, result.stderr
     # Both enabled deployments (app + broker) carry the account and mount.
@@ -152,7 +139,6 @@ def test_render_awsmp_defaults_are_inert() -> None:
         str(VALUES_DIR / "aws-marketplace.yaml"),
         "--set",
         "global.image.tag=0.0.0-test",
-        *DEV_PASSWORD_SETS,
     )
     assert result.returncode == 0, result.stderr
     assert "serviceAccountName" not in result.stdout
@@ -170,7 +156,6 @@ def test_render_service_account_create_requires_name() -> None:
         "global.image.tag=0.0.0-test",
         "--set",
         "global.serviceAccount.create=true",
-        *DEV_PASSWORD_SETS,
     )
     assert result.returncode != 0
     assert "global.serviceAccount.name is required" in result.stderr
@@ -178,34 +163,46 @@ def test_render_service_account_create_requires_name() -> None:
 
 @pytest.mark.smoke
 def test_render_marketplace_app_secrets() -> None:
-    """aws-marketplace.yaml auto-generates the application secrets Secret.
+    """aws-marketplace.yaml auto-generates every secret — zero-touch install.
 
-    Four config values have no safe default: the credential-encryption
-    keyset (list-shaped config env vars cannot carry — credential writes
-    500 without it), the admin JWT secret, the invite pepper, and the
-    connect state secret (public placeholders that JENTIC_ENV=production
-    refuses). The overlay sets global.appSecrets.generate=true: a
-    release-scoped Secret holding a config.yaml, mounted as
-    JENTIC_CONFIG_FILE into the app and broker (both consume all four).
-    The Secret must be resource-policy keep — losing it orphans everything
-    already encrypted and revokes live sessions.
+    The generated Secret carries the four scalar app secrets (encryption
+    keyset, admin JWT secret, invite pepper, connect state secret — no safe
+    defaults; JENTIC_ENV=production refuses the placeholders) plus the four
+    bundled-DB passwords (pure pod-to-pod wiring on a ClusterIP service).
+    Nothing here is buyer-supplied: this render passes NO passwords at all,
+    and no REQUIRED-AT-INSTALL placeholder may survive. The Secret must be
+    resource-policy keep — losing it orphans everything already encrypted
+    and revokes live sessions.
     """
     result = _helm_template(
         "-f",
         str(VALUES_DIR / "aws-marketplace.yaml"),
         "--set",
         "global.image.tag=0.0.0-test",
-        *DEV_PASSWORD_SETS,
     )
     assert result.returncode == 0, result.stderr
     out = result.stdout
     assert "name: jentic-app-secrets" in out
     assert '"helm.sh/resource-policy": keep' in out
-    # App and broker both mount the Secret, point the loader at it, and run
-    # in production mode so the placeholder guards are actually enforced.
+    # Zero-touch: no password placeholder anywhere in the render.
+    assert "REQUIRED-AT-INSTALL" not in out
+    # App and broker both mount the config file, point the loader at it, and
+    # run in production mode so the placeholder guards actually enforce.
     assert out.count("secretName: jentic-app-secrets") == 2
     assert out.count("value: /etc/jentic/app-secrets/config.yaml") == 2
     assert out.count("name: JENTIC_ENV") == 2
+    # Service-pod DB passwords ride secretKeyRef (3 surfaces x app+broker),
+    # never plain env values.
+    for surface in ("registry", "control", "admin"):
+        assert out.count(f"key: db-password-{surface}") >= 2
+    # The Postgres server + init script draw from the same Secret.
+    assert "key: db-password-postgres" in out
+    for surface in ("REGISTRY", "CONTROL", "ADMIN"):
+        assert f"name: PGINIT_PASSWORD_{surface}" in out
+    # The init ConfigMap is a shell script that reads env — no inlined
+    # passwords in a (non-secret) ConfigMap.
+    assert "init-schemas.sh" in out
+    assert "PASSWORD %L" in out  # psql format()-quoted, not Helm-interpolated
     # The generated config carries all four secrets, and the encryption
     # material decodes to exactly 32 bytes (AES-256).
     docs = out.split("---")
@@ -224,6 +221,32 @@ def test_render_marketplace_app_secrets() -> None:
         if line.strip().startswith("material:")
     )
     assert len(base64.b64decode(material)) == 32
+    # All four DB password keys present in the Secret itself.
+    for key in ("registry", "control", "admin", "postgres"):
+        assert f"db-password-{key}:" in secret_doc
+
+
+@pytest.mark.smoke
+def test_render_explicit_passwords_beat_generated() -> None:
+    """Explicit passwords always win over the generated Secret.
+
+    This is the external-DB (RDS) escape hatch on the Marketplace chart —
+    and the upgrade path for pre-zero-touch installs whose DB roles were
+    created with buyer-chosen passwords.
+    """
+    result = _helm_template(
+        "-f",
+        str(VALUES_DIR / "aws-marketplace.yaml"),
+        "--set",
+        "global.image.tag=0.0.0-test",
+        "--set",
+        "global.databases.registry.password=explicit-pw",
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'value: "explicit-pw"' in result.stdout
+    assert "key: db-password-registry" not in result.stdout
+    # The other surfaces still resolve from the generated Secret.
+    assert "key: db-password-control" in result.stdout
 
 
 @pytest.mark.smoke
@@ -236,7 +259,6 @@ def test_render_app_secrets_existing_secret() -> None:
         "global.image.tag=0.0.0-test",
         "--set",
         "global.appSecrets.existingSecret=buyer-secrets",
-        *DEV_PASSWORD_SETS,
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.count("secretName: buyer-secrets") == 2


### PR DESCRIPTION
## Summary

Part of #1132, follow-up to #1160. The four DB passwords (three surface roles + the bundled Postgres superuser) were the last buyer-supplied values in the Marketplace delivery option — and for the bundled in-cluster DB they protect nothing: it's a ClusterIP service unreachable from outside the cluster, so the passwords are pure pod-to-pod wiring. A generated random value is strictly better than anything a buyer types into a portal form (which stores it in plain text). This makes the Marketplace launch **zero-touch**: the delivery option drops from six override parameters to the two AWS-substituted ones (`${AWSMP_SERVICE_ACCOUNT}`, `${AWSMP_LICENSE_SECRET}`).

- **`app-secrets.yaml`** gains `db-password-{registry,control,admin,postgres}` keys. Reuse is now per-key: existing keys are carried verbatim on upgrade and only missing keys are generated, so a 0.36-created Secret gains the new keys without touching `config.yaml`.
- **`common.db-env`** password precedence: explicit `global.databases.*.password` > generated `secretKeyRef` > install-time guard. External-DB (RDS) deployments and pre-zero-touch upgrades (whose DB roles were created with buyer-chosen passwords) keep working by setting explicit values — they always win.
- **Postgres StatefulSet** draws `POSTGRES_PASSWORD` + per-surface `PGINIT_PASSWORD_*` env from the same Secret; the **init ConfigMap becomes a shell script** reading those env vars (`psql -v` + `:'var'` quoting, `format(%I/%L)` + `\gexec` replacing the DO-block guard, since psql doesn't substitute variables inside dollar-quoted bodies) — so the non-secret ConfigMap no longer embeds passwords. Side benefit: passwords no longer appear as plain pod env or ConfigMap data anywhere.
- **Publish gate flips**: the baked chart's render must now contain NO `REQUIRED-AT-INSTALL` placeholder (previously it asserted presence). Bare/unbaked charts keep the guards unchanged.
- Docs: README override-parameter table down to 2 rows, generated-secrets section covers the DB keys, `existingSecret` contract extended.

## Test plan

- [x] 14/14 render tests, including new ones: zero-touch Marketplace render (no passwords passed, no placeholders survive, secretKeyRef wiring on all pods + Postgres, all keys in the Secret) and explicit-beats-generated precedence
- [x] Init script verified against a live `postgres:17` container: roles created from env (special-character password included), grants allow CREATE TABLE in the surface schema
- [x] Full bake + publish-gate simulation passes; all three dev overlays render unchanged
- [ ] Post-merge: cut the release, `helm install` the baked chart on a live cluster with only the two AWSMP parameters, verify app boots and credential writes work

Made with [Cursor](https://cursor.com)