### PR TITLE
fix(ci): drop stale placeholder assertion from the Marketplace chart gate

### DIFF
--- a/.github/workflows/marketplace-chart.yml
+++ b/.github/workflows/marketplace-chart.yml
@@ -164,10 +164,7 @@ jobs:
           if [ "${UNTAGGED}" != "0" ]; then
             echo "::error::baked values.yaml has ECR image block(s) without an explicit tag — stamp them in the bake step"; exit 1
           fi
-          # The install-time password guards must have rendered inert
-          # placeholders (a live-cluster install still refuses to proceed).
-          grep -q 'REQUIRED-AT-INSTALL' /tmp/rendered.yaml
-          # The baked defaults must auto-generate the application secrets
+          # The baked defaults must be fully self-contained: the app-secrets
           # Secret (encryption keyset, admin JWT secret, invite pepper,
           # connect state secret, DB passwords) is generated and every
           # password reaches its pod as a secretKeyRef — so NO install-time


### PR DESCRIPTION
## Summary
- The `marketplace-chart` publish run for v0.37.0 failed in the validation gate immediately after a clean `helm lint`, with no error message.
- Cause: a semantic (not textual) merge conflict between #1163 and #1164 — the gate ended up containing **both** the pre-zero-touch assertion `grep -q 'REQUIRED-AT-INSTALL'` (placeholders must render) and its replacement (no placeholder may remain). Since #1163 the baked chart renders zero placeholders, so the stale positive grep exits 1 and `set -euo pipefail` aborts the step silently.
- Fix: remove the stale assertion (and its comment); the zero-touch contract checks — app-secrets Secret rendered, `db-password-postgres` via secretKeyRef, and **absence** of `REQUIRED-AT-INSTALL` — remain.

## Test plan
- [x] Replicated the full bake + gate locally against the 0.37.0 chart: all checks pass with this fix
- [x] Verified the removed line is exactly what failed: `grep -q 'REQUIRED-AT-INSTALL'` exits 1 against the baked render
- [ ] After merge: re-run `marketplace-chart` via workflow_dispatch with tag `v0.37.0` to publish the chart

Made with [Cursor](https://cursor.com)