### PR TITLE
fix(helm): bake un-prefixed image tags into the Marketplace chart

### DIFF
--- a/.github/workflows/marketplace-chart.yml
+++ b/.github/workflows/marketplace-chart.yml
@@ -124,11 +124,15 @@ jobs:
           # only needs global.image.tag (common.image falls back to it), but
           # AWS's validator reads image tags from values.yaml literally and
           # does not follow the global indirection — a tag-less service image
-          # block fails validation with MISSING_IMAGE_TAG ("must default to
-          # chart version", which our v-prefixed image tags never equal).
-          yq -i ".global.image.tag = \"v${VERSION}\"
-            | .app.image.tag = \"v${VERSION}\"
-            | .broker.image.tag = \"v${VERSION}\"" /tmp/values-baked.yaml
+          # block fails validation with MISSING_IMAGE_TAG.
+          #
+          # NO `v` prefix: release.yml pushes the app image to Marketplace ECR
+          # tagged `${GITHUB_REF_NAME#v}` (e.g. 0.37.0), so the image tag here
+          # must match exactly — a v-prefixed tag references an image that does
+          # not exist and fails both portal validation and buyer installs.
+          yq -i ".global.image.tag = \"${VERSION}\"
+            | .app.image.tag = \"${VERSION}\"
+            | .broker.image.tag = \"${VERSION}\"" /tmp/values-baked.yaml
           mv /tmp/values-baked.yaml deploy/helm/jentic-one/values.yaml
 
       # Publish gate = exactly what AWS runs on submission: bare `helm lint`

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1138,7 +1138,8 @@ Once set:
   release run (chart version = tag minus the `v`). The packaged chart is NOT
   byte-identical to the repo chart: the workflow **bakes
   [`aws-marketplace.yaml`](helm/values/aws-marketplace.yaml) + the release
-  tag into its `values.yaml`** first — AWS requires image references to live
+  version (`X.Y.Z`, no `v` — the tag the images carry in ECR) into its
+  `values.yaml`** first — AWS requires image references to live
   in the chart's own defaults (their validator extracts them there, and
   their replication pipeline rewrites them per region). The publish gate
   then runs exactly what AWS runs on submission: bare `helm lint` + bare

--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -68,7 +68,8 @@ app:
   enabled: true
   image:
     repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/jentic/jentic-one-app"
-    # Stamped to the release tag (vX.Y.Z) by marketplace-chart.yml's bake
+    # Stamped to the release version (X.Y.Z, no v — that's the tag the image
+    # is pushed to Marketplace ECR under) by marketplace-chart.yml's bake
     # step. Empty here (falls back to global.image.tag), but the baked chart
     # needs it explicit: AWS's validator reads tags from values.yaml
     # literally and fails tag-less image blocks (MISSING_IMAGE_TAG).


### PR DESCRIPTION
## Summary
- The Marketplace chart bake stamped `v${VERSION}` into `values.yaml`, but `release.yml` pushes the app image to Marketplace ECR tagged `${GITHUB_REF_NAME#v}` (no `v`) — the chart referenced a nonexistent image tag.
- Portal symptoms (both observed on 0.37.0): declaring `jentic-one-app:v0.37.0` → `INVALID_CONTAINER_IMAGES` (image doesn't exist); declaring `jentic-one-app:0.37.0` → `INVALID_HELM_UNDECLARED_IMAGES` asking for the phantom `v0.37.0` the chart renders.
- Fix: stamp `${VERSION}` (bare `X.Y.Z`) for `global.image.tag` / `app.image.tag` / `broker.image.tag`, and correct the comments in `aws-marketplace.yaml` + `deploy/README.md` that claimed v-prefixed tags. Bonus: the explicit tag now equals the chart version, which is exactly what AWS's `MISSING_IMAGE_TAG` rule expects.

## Test plan
- [x] Simulated the full bake + gate locally: render yields exactly `…/jentic/jentic-one-app:0.37.0` and `…/jentic/jentic-one-psql:17.11` — both tags exist in ECR — and every gate check passes
- [x] `tests/smoke/test_helm_render.py` — 14 passed
- [ ] After merge: re-dispatch `marketplace-chart` with tag `v0.37.0`, then declare `:0.37.0` (no `v`) in the portal

Made with [Cursor](https://cursor.com)