### PR TITLE
fix(docker): move shipped images off Debian's won't-fix glibc CVEs

### DIFF
--- a/.github/workflows/marketplace-mirror.yml
+++ b/.github/workflows/marketplace-mirror.yml
@@ -58,8 +58,9 @@ jobs:
           echo "from=${FROM_LINE}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
-      # Not a pure retag: the Dockerfile strips dead-code binaries that only
-      # accumulate CVE findings (gosu, snakeoil key) and applies Debian
+      # Not a pure retag: the Dockerfile drops the entrypoint's root-stepdown
+      # helper (dead code under the chart's securityContext), remaps the
+      # postgres uid/gid to the chart's pinned 999, and applies Alpine
       # security updates on top of the pinned digest — see its header.
       - name: Build the mirror image (hardened build of the pinned digest)
         run: docker build -f deploy/docker/postgres-mirror.Dockerfile -t postgres-mirror:local deploy/docker

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -548,23 +548,29 @@ To bump the release:
 
 ## Reproducibility: the digest pin
 
-`deploy/docker/python-base.Dockerfile` pins `python:3.12-slim` **and**
-`node:22-slim` to specific sha256 digests, not just the floating tags, so a
-build today and a build in six months produce the same base layers:
+`deploy/docker/python-base.Dockerfile` pins `python:3.12-slim`,
+`node:22-slim` **and** `ubuntu:24.04` to specific sha256 digests, not just the
+floating tags, so a build today and a build in six months produce the same
+base layers. The runtime stage is Ubuntu rather than Debian-based
+`python:3.12-slim`: AWS Marketplace's scanner blocks on NVD-critical CVEs
+that Debian stable marks won't-fix (no-dsa) and therefore never patches,
+while Ubuntu backports the fixes — see the Dockerfile header. The
+builder/UI stages never ship, so they stay on the official images:
 
 ```dockerfile
-ARG PYTHON_IMAGE=python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
-ARG NODE_IMAGE=node:22-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3
+ARG PYTHON_IMAGE=python:3.12-slim@sha256:...   # builder only
+ARG NODE_IMAGE=node:22-slim@sha256:...         # UI build only
+ARG UBUNTU_IMAGE=ubuntu:24.04@sha256:...       # the runtime base that ships
 FROM ${PYTHON_IMAGE} AS builder
 ...
-FROM ${PYTHON_IMAGE} AS runtime
+FROM ${UBUNTU_IMAGE} AS runtime
 ```
 
-To bump either base image (e.g. for a CVE patch):
+To bump any base image (e.g. for a CVE patch):
 
 ```bash
-docker pull python:3.12-slim          # or node:22-slim
-docker buildx imagetools inspect python:3.12-slim
+docker pull ubuntu:24.04              # or python:3.12-slim / node:22-slim
+docker buildx imagetools inspect ubuntu:24.04
 # copy the resulting sha256:... into the matching ARG in python-base.Dockerfile
 ```
 

--- a/deploy/docker/app.Dockerfile
+++ b/deploy/docker/app.Dockerfile
@@ -2,9 +2,13 @@
 FROM python-base:runtime
 
 COPY --from=python-base:builder /build/dist/*.whl /tmp/
-RUN whl="$(ls /tmp/jentic_one-*.whl)" && \
-    pip install --no-cache-dir "${whl}" && \
+# Ubuntu's system python is PEP 668 externally-managed, so the wheel lands in
+# a venv; /opt/venv/bin on PATH keeps the `python` runtime contract.
+RUN python3.12 -m venv /opt/venv && \
+    whl="$(ls /tmp/jentic_one-*.whl)" && \
+    /opt/venv/bin/pip install --no-cache-dir "${whl}" && \
     rm /tmp/*.whl
+ENV PATH="/opt/venv/bin:${PATH}"
 
 # Writable data dir for the SQLite backend. Pre-creating it owned by the runtime
 # user means a fresh Docker volume mounted here inherits jentic ownership, so the

--- a/deploy/docker/app.multiarch.Dockerfile
+++ b/deploy/docker/app.multiarch.Dockerfile
@@ -19,11 +19,21 @@
 # drift here only affects the multi-arch release artifact; the local build and
 # `make build-*` still use the two-file split.)
 
-# Pinned to a specific digest for reproducible builds.
-# To bump: `docker pull python:3.12-slim` / `node:22-slim` then update the
-# digests below (`docker buildx imagetools inspect <image>` prints them).
+# Pinned to specific digests for reproducible builds.
+# To bump: `docker pull python:3.12-slim` / `node:22-slim` / `ubuntu:24.04`
+# then update the digests below (`docker buildx imagetools inspect <image>`
+# prints them).
+#
+# The RUNTIME base is Ubuntu, not python:3.12-slim (Debian): AWS Marketplace's
+# scanner (Inspector) rates CVEs by NVD severity, and Debian stable carries
+# glibc CVEs it has marked no-dsa/won't-fix (e.g. CVE-2026-5450, NVD 9.8) —
+# unfixable via apt, so any Debian-based image hard-fails listing validation
+# indefinitely. Ubuntu backports those fixes to its stable glibc (noble ships
+# python3.12 natively, so the runtime contract is unchanged). The BUILDER
+# stages stay on the official python/node images — they never ship.
 ARG PYTHON_IMAGE=python:3.12-slim@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36
 ARG NODE_IMAGE=node:22-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436
+ARG UBUNTU_IMAGE=ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
 
 # UI build stage — produces ui/dist, bundled into the wheel via the
 # [tool.hatch.build.targets.wheel.force-include] "ui/dist" -> jentic_one/static.
@@ -52,16 +62,18 @@ COPY --from=ui-builder /ui/dist ui/dist
 
 RUN uv build --wheel --out-dir /build/dist
 
-FROM ${PYTHON_IMAGE} AS runtime
+FROM ${UBUNTU_IMAGE} AS runtime
 
-# Apply Debian security updates for the util-linux family (kept IN LOCKSTEP with
-# python-base.Dockerfile's runtime stage). The pinned base lags the Debian
-# archive, so it still ships util-linux 2.41-5 which Trivy flags HIGH
-# (CVE-2026-53615; fixed in 2.41.5-0+deb13u1). Upgrading just this family clears
-# the image CVE gate for every published arch without a full `apt upgrade`.
+# noble's python3.12 + venv (ensurepip) is everything the app stage needs to
+# create /opt/venv and install the wheel into it (kept IN LOCKSTEP with
+# python-base.Dockerfile's runtime stage). The upgrade picks up security
+# fixes published since the pinned digest's last upstream rebuild (Ubuntu,
+# unlike Debian stable, backports NVD-critical glibc fixes).
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get upgrade -y --no-install-recommends \
-        bsdutils libblkid1 libmount1 libsmartcols1 libuuid1 mount util-linux \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        python3.12 python3.12-venv ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -r jentic && useradd --no-log-init -r -g jentic jentic
@@ -72,9 +84,13 @@ EXPOSE 8000
 FROM runtime AS app
 
 COPY --from=builder /build/dist/*.whl /tmp/
-RUN whl="$(ls /tmp/jentic_one-*.whl)" && \
-    pip install --no-cache-dir "${whl}" && \
+# Ubuntu's system python is PEP 668 externally-managed, so the wheel lands in
+# a venv; /opt/venv/bin on PATH keeps the `python` runtime contract.
+RUN python3.12 -m venv /opt/venv && \
+    whl="$(ls /tmp/jentic_one-*.whl)" && \
+    /opt/venv/bin/pip install --no-cache-dir "${whl}" && \
     rm /tmp/*.whl
+ENV PATH="/opt/venv/bin:${PATH}"
 
 # Writable data dir for the SQLite backend. Pre-creating it owned by the runtime
 # user means a fresh Docker volume mounted here inherits jentic ownership, so the

--- a/deploy/docker/postgres-mirror.Dockerfile
+++ b/deploy/docker/postgres-mirror.Dockerfile
@@ -2,27 +2,40 @@
 #
 # The Marketplace disallows docker.io pulls at install time, so the image the
 # first-party postgresql subchart runs (pinned in
-# deploy/helm/jentic-one/values.yaml and deploy/helm/values/aws-marketplace.yaml)
-# is mirrored into the listing's ECR by
-# .github/workflows/marketplace-mirror.yml, which builds this Dockerfile.
+# deploy/helm/values/aws-marketplace.yaml) is mirrored into the listing's ECR
+# by .github/workflows/marketplace-mirror.yml, which builds this Dockerfile.
 #
 # This lives in deploy/docker/ so Dependabot's docker ecosystem tracks the
 # digest (same mechanism as the python-base ARG pins). Keep the tag in
-# lockstep with the Helm values files.
+# lockstep with the Marketplace values overlay.
 #
-# The build hardens the official image just enough to pass the Trivy publish
-# gate (the workflow scans every mirror run before pushing):
-#   - drop gosu: only used by the entrypoint to step down from root, and the
-#     chart always starts the container as the postgres user (uid 999), so it
-#     is dead code — and its Go-stdlib CVE findings are a permanent treadmill
+# ALPINE, not the Debian default: AWS Marketplace's scanner (Inspector) rates
+# CVEs by NVD severity, and Debian stable ships glibc CVEs it has marked
+# no-dsa/won't-fix (e.g. CVE-2026-5450, NVD 9.8) — unfixable via apt, so any
+# Debian-based image hard-fails listing validation indefinitely. Alpine/musl
+# has no glibc at all. The umbrella chart's default for self-hosters remains
+# the official Debian image.
+#
+# The build hardens the official image just enough to pass the publish gates:
+#   - remap postgres uid/gid 70 -> 999: the postgresql subchart's StatefulSet
+#     pins runAsUser/fsGroup 999 (the Debian image's postgres uid), and the
+#     Marketplace overlay must keep working against the same chart contract.
+#   - drop gosu: only used by the entrypoint to step down from root, and
+#     the chart always starts the container as the postgres user, so it is
+#     dead code — and its Go-stdlib CVE findings are a permanent treadmill
 #     (upstream rebuilds it rarely).
-#   - drop the Debian snakeoil placeholder TLS key: unused (the chart does
-#     not enable ssl), but Trivy's secret scanner flags any private key.
-#   - apt-get upgrade: picks up Debian security fixes published since the
-#     pinned digest's last upstream rebuild.
-FROM postgres:17.11@sha256:0b657ff48d7f76a1e907f381b1693eb4f2bf54c1d2df4feb6743d7dc601768dd
-RUN rm -f /usr/local/bin/gosu /etc/ssl/private/ssl-cert-snakeoil.key \
- && apt-get update \
- && apt-get upgrade -y \
- && rm -rf /var/lib/apt/lists/*
+#   - apk upgrade: picks up Alpine security fixes published since the pinned
+#     digest's last upstream rebuild.
+FROM postgres:17.11-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73
+RUN apk upgrade --no-cache \
+ && rm -f /usr/local/bin/gosu /sbin/su-exec \
+ && apk add --no-cache shadow \
+ # Alpine assigns gid 999 to `ping` (setgid busybox helper); move it out of
+ # the way so postgres can take the gid the chart's securityContext pins.
+ && ! getent group 998 \
+ && groupmod -g 998 ping \
+ && groupmod -g 999 postgres \
+ && usermod -u 999 -g 999 postgres \
+ && apk del shadow \
+ && chown -R postgres:postgres /var/lib/postgresql /var/run/postgresql
 USER postgres

--- a/deploy/docker/python-base.Dockerfile
+++ b/deploy/docker/python-base.Dockerfile
@@ -1,9 +1,19 @@
 # syntax=docker/dockerfile:1
-# Pinned to a specific digest for reproducible builds.
-# To bump: `docker pull python:3.12-slim` / `node:22-slim` then update the
-# digests below (`docker buildx imagetools inspect <image>` prints them).
+# Pinned to specific digests for reproducible builds.
+# To bump: `docker pull python:3.12-slim` / `node:22-slim` / `ubuntu:24.04`
+# then update the digests below (`docker buildx imagetools inspect <image>`
+# prints them).
+#
+# The RUNTIME base is Ubuntu, not python:3.12-slim (Debian): AWS Marketplace's
+# scanner (Inspector) rates CVEs by NVD severity, and Debian stable carries
+# glibc CVEs it has marked no-dsa/won't-fix (e.g. CVE-2026-5450, NVD 9.8) —
+# unfixable via apt, so any Debian-based image hard-fails listing validation
+# indefinitely. Ubuntu backports those fixes to its stable glibc (noble ships
+# python3.12 natively, so the runtime contract is unchanged). The BUILDER
+# stages stay on the official python/node images — they never ship.
 ARG PYTHON_IMAGE=python:3.12-slim@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36
 ARG NODE_IMAGE=node:22-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436
+ARG UBUNTU_IMAGE=ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
 
 # UI build stage — produces ui/dist, bundled into the wheel via the
 # [tool.hatch.build.targets.wheel.force-include] "ui/dist" -> jentic_one/static.
@@ -30,18 +40,17 @@ COPY --from=ui-builder /ui/dist ui/dist
 
 RUN uv build --wheel --out-dir /build/dist
 
-FROM ${PYTHON_IMAGE} AS runtime
+FROM ${UBUNTU_IMAGE} AS runtime
 
-# Apply Debian security updates for the util-linux family on top of the pinned
-# base. The base image lags the Debian archive's security point-releases, so
-# even the latest `python:3.12-slim` still ships util-linux 2.41-5 which Trivy
-# flags HIGH (CVE-2026-53615, libblkid integer overflow; fixed in
-# 2.41.5-0+deb13u1). Upgrading just this family clears the image CVE gate
-# without a non-reproducible full `apt upgrade`. Revisit when the pinned base
-# already carries the fixed util-linux (then this becomes a no-op and can drop).
+# noble's python3.12 + venv (ensurepip) is everything the app stage needs to
+# create /opt/venv and install the wheel into it. The upgrade picks up
+# security fixes published since the pinned digest's last upstream rebuild
+# (Ubuntu, unlike Debian stable, backports NVD-critical glibc fixes).
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get upgrade -y --no-install-recommends \
-        bsdutils libblkid1 libmount1 libsmartcols1 libuuid1 mount util-linux \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        python3.12 python3.12-venv ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -r jentic && useradd --no-log-init -r -g jentic jentic

--- a/deploy/helm/jentic-one/charts/postgresql/values.yaml
+++ b/deploy/helm/jentic-one/charts/postgresql/values.yaml
@@ -11,8 +11,10 @@ image:
   # chart validator composes refs from these exact keys and chokes on an
   # empty registry.)
   repository: postgres
-  # The Marketplace mirror (deploy/docker/postgres-mirror.Dockerfile) pushes
-  # this same tag; Dependabot keeps the Dockerfile's digest pin fresh.
+  # Self-hosters get the official Debian-based image. The AWS Marketplace
+  # overlay pins the hardened Alpine mirror instead
+  # (deploy/docker/postgres-mirror.Dockerfile; Dependabot keeps its digest
+  # pin fresh).
   tag: "17.11"
 
 auth:

--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -125,4 +125,7 @@ postgresql:
   image:
     registry: "709825985650.dkr.ecr.us-east-1.amazonaws.com"
     repository: "jentic/jentic-one-psql"
-    tag: "17.11"
+    # The Alpine mirror (deploy/docker/postgres-mirror.Dockerfile) — Alpine
+    # because AWS's scanner blocks on Debian's won't-fix glibc CVEs; the
+    # mirror workflow pushes the tag it reads from that Dockerfile's FROM pin.
+    tag: "17.11-alpine"


### PR DESCRIPTION
## Summary
- AWS Marketplace blocked the 0.37.0 listing on **CVE-2026-5450** (glibc `scanf %mc` heap overflow, NVD 9.8 Critical). Debian has marked it **no-dsa/won't-fix for stable** (fixed only in forky/sid), so no rebuild or `apt upgrade` of a Debian-based image can ever clear it — and both shipped images (app + postgres mirror) carried it. Inspector rates by NVD severity, so any future Debian won't-fix critical would block us again.
- **App runtime base**: `python:3.12-slim` (Debian) → `ubuntu:24.04` (noble backports the glibc fix — `2.39-0ubuntu8.8` — and ships python3.12 natively). The wheel now installs into `/opt/venv` (noble's python is PEP 668 externally-managed) with `/opt/venv/bin` on PATH; builder/UI stages keep the official python/node images since they never ship. All three Dockerfiles (`python-base`, `app`, `app.multiarch`) stay in lockstep.
- **Postgres mirror**: `postgres:17.11` (Debian) → `17.11-alpine` (no glibc at all), with postgres uid/gid remapped 70 → 999 to keep the chart's pinned `securityContext` contract, `gosu` dropped (dead code + Go-stdlib CVE treadmill, as before), and the Marketplace overlay pinned to the new `17.11-alpine` ECR tag (fresh immutable tag — no clash with the existing `17.11`). Self-hosters keep the official Debian image as the subchart default.

## Test plan
- [x] Alpine mirror boots as uid 999 exactly like the chart runs it (`pg_isready`, schema create OK)
- [x] App image boots on sqlite config, `/health` serves the version, runs as uid 999 non-root, `ldd` confirms glibc `2.39-0ubuntu8.8` (the fixed version)
- [x] Trivy on both new images: CVE-2026-5450 **absent**, zero fixable HIGH/CRITICAL, zero secrets (the alpine base's `gosu` initially brought 22 Go-stdlib HIGHs — removed)
- [x] `make build-base build-app` (single-arch path) builds and imports
- [x] `tests/smoke/test_helm_render.py` — 14 passed
- [ ] After merge + release: re-run `marketplace-mirror` (pushes `jentic-one-psql:17.11-alpine`), then list the new version with the alpine psql URI

Made with [Cursor](https://cursor.com)