### PR TITLE
fix(docker): venv-install the wheel in the per-service images too

### DIFF
--- a/deploy/docker/admin.Dockerfile
+++ b/deploy/docker/admin.Dockerfile
@@ -2,7 +2,13 @@
 FROM python-base:runtime
 
 COPY --from=python-base:builder /build/dist/*.whl /tmp/
-RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
+# Ubuntu's system python is PEP 668 externally-managed, so the wheel lands in
+# a venv; /opt/venv/bin on PATH keeps the `python` runtime contract.
+RUN python3.12 -m venv /opt/venv && \
+    whl="$(ls /tmp/jentic_one-*.whl)" && \
+    /opt/venv/bin/pip install --no-cache-dir "${whl}" && \
+    rm /tmp/*.whl
+ENV PATH="/opt/venv/bin:${PATH}"
 
 USER jentic
 # The identity plane (auth: /register, /oauth, /agents, /me, ...) rides with

--- a/deploy/docker/broker.Dockerfile
+++ b/deploy/docker/broker.Dockerfile
@@ -2,7 +2,13 @@
 FROM python-base:runtime
 
 COPY --from=python-base:builder /build/dist/*.whl /tmp/
-RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
+# Ubuntu's system python is PEP 668 externally-managed, so the wheel lands in
+# a venv; /opt/venv/bin on PATH keeps the `python` runtime contract.
+RUN python3.12 -m venv /opt/venv && \
+    whl="$(ls /tmp/jentic_one-*.whl)" && \
+    /opt/venv/bin/pip install --no-cache-dir "${whl}" && \
+    rm /tmp/*.whl
+ENV PATH="/opt/venv/bin:${PATH}"
 
 USER jentic
 ENV JENTIC__APPS=broker

--- a/deploy/docker/control.Dockerfile
+++ b/deploy/docker/control.Dockerfile
@@ -2,7 +2,13 @@
 FROM python-base:runtime
 
 COPY --from=python-base:builder /build/dist/*.whl /tmp/
-RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
+# Ubuntu's system python is PEP 668 externally-managed, so the wheel lands in
+# a venv; /opt/venv/bin on PATH keeps the `python` runtime contract.
+RUN python3.12 -m venv /opt/venv && \
+    whl="$(ls /tmp/jentic_one-*.whl)" && \
+    /opt/venv/bin/pip install --no-cache-dir "${whl}" && \
+    rm /tmp/*.whl
+ENV PATH="/opt/venv/bin:${PATH}"
 
 USER jentic
 ENV JENTIC__APPS=control

--- a/deploy/docker/registry.Dockerfile
+++ b/deploy/docker/registry.Dockerfile
@@ -2,9 +2,13 @@
 FROM python-base:runtime
 
 COPY --from=python-base:builder /build/dist/*.whl /tmp/
-RUN whl="$(ls /tmp/jentic_one-*.whl)" && \
-    pip install --no-cache-dir "${whl}" && \
+# Ubuntu's system python is PEP 668 externally-managed, so the wheel lands in
+# a venv; /opt/venv/bin on PATH keeps the `python` runtime contract.
+RUN python3.12 -m venv /opt/venv && \
+    whl="$(ls /tmp/jentic_one-*.whl)" && \
+    /opt/venv/bin/pip install --no-cache-dir "${whl}" && \
     rm /tmp/*.whl
+ENV PATH="/opt/venv/bin:${PATH}"
 
 USER jentic
 ENV JENTIC__APPS=registry


### PR DESCRIPTION
## Summary
- The [Helm smoke matrix on main](https://github.com/jentic/jentic-one/actions/runs/33157095624) (all 4 jobs) broke after #1170: `make build-broker` fails with `pip: not found`.
- Cause: #1170 moved `python-base:runtime` to Ubuntu 24.04 (PEP 668, no bare `pip`) and converted `app.Dockerfile` + `app.multiarch.Dockerfile` to a `/opt/venv` install — but missed the four parts-mode Dockerfiles (`broker`, `registry`, `control`, `admin`) that build `FROM python-base:runtime`.
- Fix: apply the identical venv install block (+ `PATH` prefix) to all four, keeping every consumer of the runtime stage in lockstep.

## Test plan
- [x] `make build-all` — base + all five service images build
- [x] Each of broker/registry/control/admin runs `python -c "import jentic_one"` as uid 999
- [ ] Helm smoke matrix green on this PR / next main push

Made with [Cursor](https://cursor.com)