### PR TITLE
fix(deploy): set JENTIC__APPS=broker on the Marketplace broker pod

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1273,8 +1273,10 @@ and will be filled when the answers exist:
   every subchart sets an explicit `image.repository: jentic-one/<svc>` (so
   `--set global.image.registry=…` is a no-op), the common helper composes
   `<registry>/<chart-name>` which doesn't match the `jentic-one-app` package
-  name, and the broker subchart has no way to set `JENTIC__APPS=broker` on
-  the app image. Only the app subchart can be pointed at it manually
+  name, and the broker subchart doesn't set `JENTIC__APPS=broker` itself —
+  running it on the app image needs `broker.extraEnv.JENTIC__APPS=broker`
+  (the AWS Marketplace overlay does exactly that). Only the app subchart can
+  be pointed at it manually
   (`--set app.image.repository=ghcr.io/jentic/jentic-one-app --set
   app.image.tag=X.Y.Z`). Publishing per-service images (or teaching the
   chart the app-image + `JENTIC__APPS` model) is the follow-up.

--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -60,10 +60,13 @@ global:
   # have the chart create the account, then attach IAM out of band.
 
 # app and broker run the same jentic-one-app image, differentiated by the
-# JENTIC__APPS env each subchart sets. If the Marketplace portal provisions a
-# single ECR repository for the product, keep the explicit repository values
-# below identical; if it provisions one repo per name, drop the overrides and
-# let <global.image.registry>/<chart-name> resolve them instead.
+# JENTIC__APPS env. The image bakes the app roles
+# (registry,admin,control,auth), so the broker block below MUST override it —
+# the subcharts themselves don't (deploy/README.md "Helm consumption" note).
+# If the Marketplace portal provisions a single ECR repository for the
+# product, keep the explicit repository values below identical; if it
+# provisions one repo per name, drop the overrides and let
+# <global.image.registry>/<chart-name> resolve them instead.
 app:
   enabled: true
   image:
@@ -79,6 +82,16 @@ app:
   # secret. Safe here because global.appSecrets generates real values.
   extraEnv:
     JENTIC_ENV: "production"
+  # Agent registration (`jentic register`) needs the app's canonical base URL:
+  # the OAuth token exchange compares the CLI-signed audience byte-for-byte
+  # against `<canonical_base_url>/oauth/token`, and with it unset every
+  # exchange fails invalid_grant AFTER the agent is approved. The value is the
+  # URL agents actually use, so it can't be defaulted here — buyers set it
+  # post-install for their ingress/port-forward (found in the 0.37.3 buyer
+  # test, 2026-08-28):
+  #   helm upgrade jentic-one <chart> --reuse-values \
+  #     --set app.extraEnv.JENTIC__AUTH__CANONICAL_BASE_URL=https://jentic.example.com
+  # (port-forward testing: http://127.0.0.1:8000)
   # Entitlement gate wiring (plan PR 4). The listing is contract-priced with
   # dimensions `users` + `executions` (decided 2026-08-20); `contract` is the
   # config default so only the IDs need filling in. DO NOT uncomment until the
@@ -97,6 +110,11 @@ broker:
     tag: ""  # stamped by the bake step — same reasoning as app.image.tag
   extraEnv:
     JENTIC_ENV: "production"  # same reasoning as app.extraEnv above
+    # The app image bakes JENTIC__APPS=registry,admin,control,auth; without
+    # this override the "broker" pod boots a second app instance with NO
+    # forward-proxy surface, and every `jentic execute` 404s (found in the
+    # 0.37.3 buyer test, 2026-08-28).
+    JENTIC__APPS: "broker"
   # Entitlement wiring — same caveat as app above:
   #   JENTIC__ENTITLEMENT__ENABLED: "true"
   #   JENTIC__ENTITLEMENT__PRODUCT_CODE: "<product code from the portal>"

--- a/tests/smoke/test_helm_render.py
+++ b/tests/smoke/test_helm_render.py
@@ -106,6 +106,32 @@ def test_render_marketplace_images_all_ecr() -> None:
 
 
 @pytest.mark.smoke
+def test_render_marketplace_broker_role() -> None:
+    """The Marketplace broker pod must override the app image's baked role.
+
+    Both Marketplace deployments run the jentic-one-app image, which bakes
+    JENTIC__APPS=registry,admin,control,auth. The subcharts don't set the role
+    themselves, so aws-marketplace.yaml must: without the override the
+    "broker" pod boots a second app instance with no forward-proxy surface
+    and every brokered execute 404s (0.37.3 buyer test, 2026-08-28).
+    """
+    result = _helm_template(
+        "-f",
+        str(VALUES_DIR / "aws-marketplace.yaml"),
+        "--set",
+        "global.image.tag=0.0.0-test",
+    )
+    assert result.returncode == 0, result.stderr
+    docs = result.stdout.split("---")
+    broker = next(d for d in docs if "kind: Deployment" in d and "name: jentic-broker" in d)
+    app = next(d for d in docs if "kind: Deployment" in d and "name: jentic-app" in d)
+    assert "name: JENTIC__APPS" in broker
+    assert 'value: "broker"' in broker
+    # The app pod keeps the image's baked default role set.
+    assert "name: JENTIC__APPS" not in app
+
+
+@pytest.mark.smoke
 def test_render_awsmp_launch_parameters() -> None:
     """The Marketplace launch substitutions render into the pod specs.
 


### PR DESCRIPTION
## Summary

Buyer-side testing of the 0.37.3 Marketplace listing (2026-08-28, tracked in #1132) found that a Marketplace install has **no working broker**: the overlay runs the broker subchart on the `jentic-one-app` image (which bakes `JENTIC__APPS=registry,admin,control,auth`) without overriding the role, so the "broker" pod boots a second app instance with no forward-proxy surface and every `jentic execute` 404s. Verified live on an EKS buyer install — `--set broker.extraEnv.JENTIC__APPS=broker` restored end-to-end brokered execution.

## Changes

- `deploy/helm/values/aws-marketplace.yaml`: set `broker.extraEnv.JENTIC__APPS: "broker"`; fix the comment that claimed each subchart sets the role itself; document the `JENTIC__AUTH__CANONICAL_BASE_URL` post-install requirement discovered in the same test (token-exchange audience is compared byte-for-byte, so agent registration fails `invalid_grant` without it — it can't be defaulted because it is the buyer's own URL)
- `tests/smoke/test_helm_render.py`: new render test asserting the Marketplace broker Deployment carries `JENTIC__APPS=broker` and the app Deployment keeps the image's baked default
- `deploy/README.md`: correct the stale "broker subchart has no way to set `JENTIC__APPS`" note (the `extraEnv` seam does it; the overlay now uses it)

Out of scope: chart-level first-class value for `canonical_base_url` (needs a design decision about where it lives), EBS CSI / default StorageClass prerequisite for the bundled Postgres on fresh EKS (docs/usage-instructions follow-up, same buyer test).

## Risk & rollback

- Low risk: one env var on the Marketplace overlay only; self-host values and defaults untouched. Revert the squash commit to roll back.

## Test plan

- `uv run pytest tests/smoke/test_helm_render.py -m smoke --no-cov` — 15 passed (includes the new `test_render_marketplace_broker_role`)
- Manual: applied the identical `--set` via `helm upgrade` on a live EKS buyer install of 0.37.3; broker pod rebooted with the broker surface and a real brokered `jentic execute` against an upstream API succeeded

Part of #1132

Made with [Cursor](https://cursor.com)