### PR TITLE
fix(entitlement): use Count entitlements and release the checkout seat

### DIFF
--- a/deploy/helm/values/aws-marketplace.yaml
+++ b/deploy/helm/values/aws-marketplace.yaml
@@ -79,16 +79,16 @@ app:
   # secret. Safe here because global.appSecrets generates real values.
   extraEnv:
     JENTIC_ENV: "production"
-  # Entitlement gate wiring (plan PR 4). The listing is contract-priced with
-  # dimensions `users` + `executions` (decided 2026-08-20); `contract` is the
-  # config default so only the IDs need filling in. DO NOT uncomment until the
-  # deployed image ships the entitlement config: AppConfig rejects unknown
-  # config sections (extra="forbid"), so these env vars crash older images at
-  # boot.
-  #   JENTIC__ENTITLEMENT__ENABLED: "true"
-  #   JENTIC__ENTITLEMENT__PRODUCT_CODE: "<product code from the portal>"
-  #   JENTIC__ENTITLEMENT__LICENSE_SKU: "<product ID from the portal>"
-  #   JENTIC__ENTITLEMENT__LICENSE_DIMENSIONS: "users,executions"
+    # Entitlement gate (contract pricing, dimensions users + executions —
+    # decided 2026-08-20; `contract` is the config default so only the IDs are
+    # set). IDs verified against the live listing 2026-08-28. Enabled together
+    # with the checkout-shape/check-in fix — a release carrying this env MUST
+    # ship that client (Count+Value entitlements, CheckInLicense after
+    # checkout) or entitled buyers lock themselves out.
+    JENTIC__ENTITLEMENT__ENABLED: "true"
+    JENTIC__ENTITLEMENT__PRODUCT_CODE: "dwhxz1v53k58ew6pr7qzieumd"
+    JENTIC__ENTITLEMENT__LICENSE_SKU: "prod-dd2p2s65dysv6"
+    JENTIC__ENTITLEMENT__LICENSE_DIMENSIONS: "users,executions"
 
 broker:
   enabled: true
@@ -97,11 +97,11 @@ broker:
     tag: ""  # stamped by the bake step — same reasoning as app.image.tag
   extraEnv:
     JENTIC_ENV: "production"  # same reasoning as app.extraEnv above
-  # Entitlement wiring — same caveat as app above:
-  #   JENTIC__ENTITLEMENT__ENABLED: "true"
-  #   JENTIC__ENTITLEMENT__PRODUCT_CODE: "<product code from the portal>"
-  #   JENTIC__ENTITLEMENT__LICENSE_SKU: "<product ID from the portal>"
-  #   JENTIC__ENTITLEMENT__LICENSE_DIMENSIONS: "users,executions"
+    # Entitlement gate — same values and caveat as app.extraEnv above.
+    JENTIC__ENTITLEMENT__ENABLED: "true"
+    JENTIC__ENTITLEMENT__PRODUCT_CODE: "dwhxz1v53k58ew6pr7qzieumd"
+    JENTIC__ENTITLEMENT__LICENSE_SKU: "prod-dd2p2s65dysv6"
+    JENTIC__ENTITLEMENT__LICENSE_DIMENSIONS: "users,executions"
 
 registry:
   enabled: false

--- a/src/jentic_one/integrations/aws_marketplace/client.py
+++ b/src/jentic_one/integrations/aws_marketplace/client.py
@@ -7,7 +7,8 @@ One protocol, two implementations — the checker doesn't know which:
   one successful call both verifies the entitlement and starts metering.
 - :class:`LicenseManagerClient` (contract pricing) calls AWS **License
   Manager** ``CheckoutLicense`` against the license AWS Marketplace creates in
-  the buyer's account.
+  the buyer's account, then ``CheckInLicense`` to release the seat the probe
+  consumed (counted dimensions have a finite ``MaxCount``).
 
 Both are a single SigV4-signed ``x-amz-json-1.1`` POST built on the project's
 existing signer (``shared/aws/sigv4.py``) and ``httpx`` — no new dependency.
@@ -19,6 +20,7 @@ AWS. Anything ambiguous (throttle, 5xx, network, missing credentials) is
 
 from __future__ import annotations
 
+import asyncio
 import enum
 import json
 import uuid
@@ -37,6 +39,11 @@ from jentic_one.shared.config import EntitlementConfig
 _log = structlog.get_logger(__name__)
 
 _REQUEST_TIMEOUT_S = 10.0
+
+# Contract pricing only: how long to wait before the single retry that
+# disambiguates transient seat contention from a genuinely missing license
+# (both surface as NoEntitlementsAllowedException; see LicenseManagerClient).
+_SEAT_CONTENTION_RETRY_DELAY_S = 1.5
 
 # The public key AWS Marketplace vends for RegisterUsage response signatures.
 # We do not verify the (optional) response JWT — transport security is TLS and
@@ -114,25 +121,11 @@ class _BaseLicenseClient:
 
     async def check(self) -> LicenseVerdict:
         url = self._config.endpoint or self._default_url()
-        body = json.dumps(self._body()).encode()
-        try:
-            material = await self._provider.resolve()
-        except CredentialResolutionError:
-            _log.warning("entitlement.credentials_unresolved", exc_info=True)
-            return LicenseVerdict.UNKNOWN
-        headers = {
-            "content-type": "application/x-amz-json-1.1",
-            "x-amz-target": self.target,
-        }
-        headers.update(sign_request(method="POST", url=url, body=body, material=material))
-        try:
-            response = await self._http.post(
-                url, content=body, headers=headers, timeout=_REQUEST_TIMEOUT_S
-            )
-        except httpx.HTTPError:
-            _log.warning("entitlement.check_request_failed", target=self.target, exc_info=True)
+        response = await self._signed_post(url, self.target, self._body())
+        if response is None:
             return LicenseVerdict.UNKNOWN
         if response.status_code == 200:
+            await self._on_entitled(response)
             return LicenseVerdict.ENTITLED
         error_type = _aws_error_type(response)
         if error_type in self.not_entitled_errors:
@@ -149,6 +142,32 @@ class _BaseLicenseClient:
             error_type=error_type,
         )
         return LicenseVerdict.UNKNOWN
+
+    async def _signed_post(
+        self, url: str, target: str, body_dict: dict[str, object]
+    ) -> httpx.Response | None:
+        """One SigV4-signed x-amz-json-1.1 POST; ``None`` for transport failures."""
+        body = json.dumps(body_dict).encode()
+        try:
+            material = await self._provider.resolve()
+        except CredentialResolutionError:
+            _log.warning("entitlement.credentials_unresolved", exc_info=True)
+            return None
+        headers = {
+            "content-type": "application/x-amz-json-1.1",
+            "x-amz-target": target,
+        }
+        headers.update(sign_request(method="POST", url=url, body=body, material=material))
+        try:
+            return await self._http.post(
+                url, content=body, headers=headers, timeout=_REQUEST_TIMEOUT_S
+            )
+        except httpx.HTTPError:
+            _log.warning("entitlement.check_request_failed", target=target, exc_info=True)
+            return None
+
+    async def _on_entitled(self, response: httpx.Response) -> None:
+        """Hook for subclasses that must react to a successful check."""
 
 
 def _aws_error_type(response: httpx.Response) -> str | None:
@@ -195,13 +214,28 @@ class MeteringLicenseClient(_BaseLicenseClient):
 
 
 class LicenseManagerClient(_BaseLicenseClient):
-    """Contract pricing: License Manager ``CheckoutLicense`` (provisional).
+    """Contract pricing: License Manager ``CheckoutLicense`` + ``CheckInLicense``.
 
     ``ProductSKU`` is the Marketplace **product ID** from the portal
     (``config.license_sku``), not the product code. The checkout lists every
     configured dimension (``config.license_dimensions`` — the live listing
     defines ``users`` and ``executions``); License Manager grants the checkout
     only if the buyer's license covers all of them, so one call gates on both.
+
+    Two behaviours verified against the live listing (2026-08-28):
+
+    - A successful PROVISIONAL checkout **consumes a seat** from the
+      dimension's ``MaxCount`` for up to 60 minutes. A 1-seat contract plus
+      two pods re-checking hourly would lock the buyer out of their own
+      license, so every successful checkout is immediately followed by
+      ``CheckInLicense`` — the check is a pure entitlement probe and holds a
+      seat only for the round-trip.
+    - Seat contention (another holder checked out concurrently) and a
+      genuinely absent license return the **same**
+      ``NoEntitlementsAllowedException``, and a false NOT_ENTITLED is cached
+      for a full refresh interval. One short-delay retry disambiguates a
+      transient collision (e.g. app + broker booting together) from a real
+      denial.
     """
 
     service = "license-manager"
@@ -212,13 +246,15 @@ class LicenseManagerClient(_BaseLicenseClient):
         return f"https://license-manager.{self._config.region}.amazonaws.com/"
 
     def _body(self) -> dict[str, object]:
-        # "Unit": "None" matches boolean-style entitlements. The live listing's
-        # counted dimensions may instead require Unit "Count" + a Value — verify
-        # against `aws license-manager list-received-licenses` from the
-        # subscribed test account during the ENTITLEMENT_REAL_AWS smoke and
-        # adjust here if the checkout rejects the shape.
+        # Counted dimensions require Unit "Count" + a Value: the live listing's
+        # license carries `Unit: "Count", MaxCount: N` for users/executions, and
+        # a `Unit: "None"` checkout is rejected with
+        # NoEntitlementsAllowedException (verified against the live listing,
+        # 2026-08-28). Value "1" probes for one available seat, which the
+        # check-in below releases immediately.
         entitlements: list[dict[str, str]] = [
-            {"Name": dimension, "Unit": "None"} for dimension in self._config.license_dimensions
+            {"Name": dimension, "Unit": "Count", "Value": "1"}
+            for dimension in self._config.license_dimensions
         ]
         return {
             "CheckoutType": "PROVISIONAL",
@@ -227,3 +263,38 @@ class LicenseManagerClient(_BaseLicenseClient):
             "Entitlements": entitlements,
             "ClientToken": uuid.uuid4().hex,
         }
+
+    async def check(self) -> LicenseVerdict:
+        verdict = await super().check()
+        if verdict is LicenseVerdict.NOT_ENTITLED:
+            # Could be seat contention rather than a missing license (the
+            # error type is identical). Retry once after a short delay; a
+            # genuinely non-entitled deployment just answers the same twice.
+            await asyncio.sleep(_SEAT_CONTENTION_RETRY_DELAY_S)
+            verdict = await super().check()
+        return verdict
+
+    async def _on_entitled(self, response: httpx.Response) -> None:
+        """Release the seat the successful checkout just consumed."""
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = None
+        token = payload.get("LicenseConsumptionToken") if isinstance(payload, dict) else None
+        if not token:
+            # Seat auto-expires after MaxTimeToLiveInMinutes (60) — degraded
+            # but not fatal; flag it because 1-seat contracts will contend.
+            _log.warning("entitlement.checkin_token_missing")
+            return
+        url = self._config.endpoint or self._default_url()
+        checkin = await self._signed_post(
+            url,
+            "AWSLicenseManager.CheckInLicense",
+            {"LicenseConsumptionToken": token},
+        )
+        if checkin is None or checkin.status_code != 200:
+            _log.warning(
+                "entitlement.checkin_failed",
+                status_code=None if checkin is None else checkin.status_code,
+                error_type=None if checkin is None else _aws_error_type(checkin),
+            )

--- a/tests/smoke/test_helm_render.py
+++ b/tests/smoke/test_helm_render.py
@@ -162,6 +162,29 @@ def test_render_service_account_create_requires_name() -> None:
 
 
 @pytest.mark.smoke
+def test_render_marketplace_entitlement_env() -> None:
+    """The enforcing env lands on BOTH pods with the live listing's IDs.
+
+    Enforcement went live alongside the checkout-shape/check-in client fix —
+    a chart carrying this env against an older image (no entitlement config;
+    extra="forbid") crashes at boot, which is exactly why the env and the
+    client fix ride the same release.
+    """
+    result = _helm_template(
+        "-f",
+        str(VALUES_DIR / "aws-marketplace.yaml"),
+        "--set",
+        "global.image.tag=0.0.0-test",
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert out.count("name: JENTIC__ENTITLEMENT__ENABLED") == 2  # app + broker
+    assert out.count('value: "dwhxz1v53k58ew6pr7qzieumd"') == 2  # product code
+    assert out.count('value: "prod-dd2p2s65dysv6"') == 2  # product ID (SKU)
+    assert out.count('value: "users,executions"') == 2
+
+
+@pytest.mark.smoke
 def test_render_marketplace_app_secrets() -> None:
     """aws-marketplace.yaml auto-generates every secret — zero-touch install.
 

--- a/tests/unit/integrations/aws_marketplace/test_client.py
+++ b/tests/unit/integrations/aws_marketplace/test_client.py
@@ -99,11 +99,113 @@ async def test_checkout_license_request_shape(monkeypatch: pytest.MonkeyPatch) -
     body = json.loads(request.content)
     assert body["CheckoutType"] == "PROVISIONAL"
     assert body["ProductSKU"] == "prod-id-1"
+    # Counted dimensions: Unit "None" is rejected by live License Manager
+    # (NoEntitlementsAllowedException) — the shape must be Count + Value.
     assert body["Entitlements"] == [
-        {"Name": "users", "Unit": "None"},
-        {"Name": "executions", "Unit": "None"},
+        {"Name": "users", "Unit": "Count", "Value": "1"},
+        {"Name": "executions", "Unit": "Count", "Value": "1"},
     ]
     assert body["ClientToken"]
+
+
+@pytest.mark.asyncio
+async def test_checkout_success_checks_the_seat_back_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful checkout consumes a MaxCount seat — it must be released.
+
+    Without the check-in, a 1-seat contract plus two pods re-checking hourly
+    locks the buyer out of their own license (observed live 2026-08-28).
+    """
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.headers["x-amz-target"] == "AWSLicenseManager.CheckoutLicense":
+            return httpx.Response(200, json={"LicenseConsumptionToken": "tok-123"})
+        return httpx.Response(200, json={})
+
+    config = _config(
+        pricing_model="contract", license_sku="prod-id-1", license_dimensions=["users"]
+    )
+    client, _ = _client_pair(httpx.MockTransport(handler), config, monkeypatch)
+
+    verdict = await client.check()
+
+    assert verdict is LicenseVerdict.ENTITLED
+    targets = [r.headers["x-amz-target"] for r in seen]
+    assert targets == [
+        "AWSLicenseManager.CheckoutLicense",
+        "AWSLicenseManager.CheckInLicense",
+    ]
+    checkin_body = json.loads(seen[1].content)
+    assert checkin_body == {"LicenseConsumptionToken": "tok-123"}
+
+
+@pytest.mark.asyncio
+async def test_checkin_failure_does_not_change_the_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The seat auto-expires; a failed check-in is degraded, not NOT_ENTITLED."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.headers["x-amz-target"] == "AWSLicenseManager.CheckoutLicense":
+            return httpx.Response(200, json={"LicenseConsumptionToken": "tok-123"})
+        return httpx.Response(500, json={"__type": "InternalServerException"})
+
+    config = _config(
+        pricing_model="contract", license_sku="prod-id-1", license_dimensions=["users"]
+    )
+    client, _ = _client_pair(httpx.MockTransport(handler), config, monkeypatch)
+
+    assert await client.check() is LicenseVerdict.ENTITLED
+
+
+@pytest.mark.asyncio
+async def test_seat_contention_retry_recovers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """First checkout loses a seat race, the retry wins → ENTITLED.
+
+    Seat contention and a missing license return the same
+    NoEntitlementsAllowedException, so one short-delay retry disambiguates.
+    """
+    monkeypatch.setattr(
+        "jentic_one.integrations.aws_marketplace.client._SEAT_CONTENTION_RETRY_DELAY_S", 0
+    )
+    checkouts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal checkouts
+        if request.headers["x-amz-target"] == "AWSLicenseManager.CheckoutLicense":
+            checkouts += 1
+            if checkouts == 1:
+                return httpx.Response(400, json={"__type": "x#NoEntitlementsAllowedException"})
+            return httpx.Response(200, json={"LicenseConsumptionToken": "tok-123"})
+        return httpx.Response(200, json={})
+
+    config = _config(
+        pricing_model="contract", license_sku="prod-id-1", license_dimensions=["users"]
+    )
+    client, _ = _client_pair(httpx.MockTransport(handler), config, monkeypatch)
+
+    assert await client.check() is LicenseVerdict.ENTITLED
+    assert checkouts == 2
+
+
+@pytest.mark.asyncio
+async def test_persistent_not_entitled_retries_once_then_locks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "jentic_one.integrations.aws_marketplace.client._SEAT_CONTENTION_RETRY_DELAY_S", 0
+    )
+    transport, seen = _capture(400, {"__type": "x#NoEntitlementsAllowedException", "message": "no"})
+    config = _config(
+        pricing_model="contract", license_sku="prod-id-1", license_dimensions=["users"]
+    )
+    client, _ = _client_pair(transport, config, monkeypatch)
+
+    assert await client.check() is LicenseVerdict.NOT_ENTITLED
+    assert len(seen) == 2  # exactly one retry, no infinite loop
 
 
 @pytest.mark.asyncio
@@ -136,6 +238,9 @@ async def test_error_type_verdict_mapping(
     error_type: str,
     expected: LicenseVerdict,
 ) -> None:
+    monkeypatch.setattr(
+        "jentic_one.integrations.aws_marketplace.client._SEAT_CONTENTION_RETRY_DELAY_S", 0
+    )
     transport, _ = _capture(
         400, {"__type": f"com.amazonaws.services#{error_type}", "message": "no"}
     )


### PR DESCRIPTION
## Summary

Live testing against the real Marketplace license (buyer test 2026-08-28, #1132) proved the contract-pricing checker would lock out **every legitimate buyer**: the two provisional constants flagged in the code were wrong in exactly the way the comments anticipated. This PR fixes the client (verified live: ENTITLED for the subscribed test account, NOT_ENTITLED for a wrong SKU) **and enables the entitlement gate in the Marketplace overlay with the live listing's IDs** — the two must ship together, so they ride one PR.

## Changes

- `LicenseManagerClient._body`: entitlements sent as `Unit: "Count"` + `Value: "1"` — the live license carries counted dimensions (`users`/`executions`, `Unit: "Count"`, `MaxCount`), and a `Unit: "None"` checkout is rejected with `NoEntitlementsAllowedException` (i.e. the current shape reads as not-entitled for an entitled account)
- **Check the seat back in**: a successful `PROVISIONAL` checkout consumes a seat from `MaxCount` for up to 60 min (`MaxTimeToLiveInMinutes`). A 1-seat contract + app/broker pods re-checking hourly = permanent self-lockout — observed live: one manual checkout locked the test account's license for the full TTL. Every successful checkout now immediately calls `CheckInLicense` with the returned `LicenseConsumptionToken` (allowed: `AllowCheckIn: true`), making the check a pure probe. Check-in failure only logs (the seat self-expires) and never changes the verdict
- **One short-delay retry on NOT_ENTITLED**: seat contention and a genuinely missing license return the *identical* `NoEntitlementsAllowedException`, and a false NOT_ENTITLED is cached for a whole refresh interval; a single 1.5s-delayed retry disambiguates a transient collision (e.g. app + broker booting together)
- **`deploy/helm/values/aws-marketplace.yaml`: entitlement env uncommented** on app + broker with the live listing's IDs (product code `dwhxz1v53k58ew6pr7qzieumd`, product ID/SKU `prod-dd2p2s65dysv6`, dimensions `users,executions` — public identifiers, not secrets). Deliberately in this PR: a chart carrying the env without this client fix locks entitled buyers out
- Base client: extracted `_signed_post` + `_on_entitled` hook (mechanical; metering variant unchanged)
- Tests: unit — Count shape, checkout→check-in sequencing + token propagation, check-in-failure tolerance, contention-retry recovery, exactly-one-retry on persistent denial; render — the enforcing env lands on both pods with the exact IDs

Dimension semantics (decided 2026-08-28): quantities are **commercial terms** for this version — the gate is a boolean entitlement probe; nothing meters executions or counts users at runtime. App-side quota enforcement (license `MaxCount` is readable) is a scoped follow-up.

## Risk & rollback

- **This makes the next listed release the enforcing one**: a non-entitled deployment of that version locks its HTTP surface (503, health excepted) after grace. Entitled buyers are unaffected — verified live against the real license.
- The gate stays fully off for self-host installs (config default `enabled=false`; only the Marketplace overlay sets the env).
- New AWS call surface: `license-manager:CheckInLicense` — already granted by the listing's launch policy (`AWSLicenseManagerConsumptionPolicy`).
- Rollback: revert the squash commit (or re-comment the env block to disable enforcement only).

## Test plan

- `uv run pytest tests/unit/integrations/aws_marketplace/ tests/smoke/test_helm_render.py --no-cov` — 66 passed
- Live against the real listing (buyer account, SKU `prod-dd2p2s65dysv6`): old shape → `NoEntitlementsAllowedException`; `Count`+`Value` → ENTITLED; wrong SKU → NOT_ENTITLED; repeated checkout without check-in → observed seat exhaustion (the motivating bug)
- `ENTITLEMENT_REAL_AWS=1` smoke: negative control passed; entitled case currently blocked by the seat my earlier manual probe consumed (auto-expires ~60 min) — will re-run and report on this PR

Part of #1132